### PR TITLE
fix: repository layer follow-up improvements

### DIFF
--- a/src/repositories/ClientRepository.mts
+++ b/src/repositories/ClientRepository.mts
@@ -16,9 +16,9 @@
 
 import type { Client } from "./types.mjs";
 
-export type AuthenticatedClient = Omit<Client, "clientSecret">;
+export type PublicClient = Omit<Client, "clientSecret">;
 
 export interface ClientRepository {
-	findById(clientId: string): Promise<Client | null>;
-	authenticate(clientId: string, secret: string): Promise<AuthenticatedClient | null>;
+	findById(clientId: string): Promise<PublicClient | null>;
+	authenticate(clientId: string, secret: string): Promise<PublicClient | null>;
 }

--- a/src/repositories/CodeRepository.mts
+++ b/src/repositories/CodeRepository.mts
@@ -23,5 +23,6 @@ export interface CodeRepository {
 		expiresIn?: number;
 	}): Promise<Code>;
 	getByCode(code: string): Promise<Code | null>;
+	consumeByCode(code: string): Promise<Code | null>;
 	removeByCode(code: string): Promise<void>;
 }

--- a/src/repositories/RedisCodeRepository.mts
+++ b/src/repositories/RedisCodeRepository.mts
@@ -74,6 +74,19 @@ export class RedisCodeRepository implements CodeRepository {
 
 	async getByCode(code: string): Promise<Code | null> {
 		const value = await this.redis.get(KEY_PREFIX + code);
+		return this.parseCodeValue(code, value);
+	}
+
+	async consumeByCode(code: string): Promise<Code | null> {
+		const value = await this.redis.getDel(KEY_PREFIX + code);
+		return this.parseCodeValue(code, value);
+	}
+
+	async removeByCode(code: string): Promise<void> {
+		await this.redis.del(KEY_PREFIX + code);
+	}
+
+	private parseCodeValue(code: string, value: string | null): Code | null {
 		if (!value) return null;
 		try {
 			return { ...JSON.parse(value), code } as Code;
@@ -81,9 +94,5 @@ export class RedisCodeRepository implements CodeRepository {
 			console.error(`RedisCodeRepository: corrupted data for code ${code}`, err);
 			return null;
 		}
-	}
-
-	async removeByCode(code: string): Promise<void> {
-		await this.redis.del(KEY_PREFIX + code);
 	}
 }

--- a/src/repositories/RedisCodeRepository.mts
+++ b/src/repositories/RedisCodeRepository.mts
@@ -77,7 +77,8 @@ export class RedisCodeRepository implements CodeRepository {
 		if (!value) return null;
 		try {
 			return { ...JSON.parse(value), code } as Code;
-		} catch {
+		} catch (err) {
+			console.error(`RedisCodeRepository: corrupted data for code ${code}`, err);
 			return null;
 		}
 	}

--- a/src/repositories/RedisCodeRepository.mts
+++ b/src/repositories/RedisCodeRepository.mts
@@ -19,6 +19,8 @@ import { createClient, type RedisClientType } from "redis";
 import type { CodeRepository } from "./CodeRepository.mjs";
 import type { Code } from "./types.mjs";
 
+const KEY_PREFIX = "oauth:code:";
+
 export class RedisCodeRepository implements CodeRepository {
 	private redis: RedisClientType;
 	private defaultExpiresIn: number;
@@ -62,7 +64,7 @@ export class RedisCodeRepository implements CodeRepository {
 		const code = crypto.randomBytes(32).toString("base64url");
 
 		await this.redis.set(
-			code,
+			KEY_PREFIX + code,
 			JSON.stringify({ code_challenge, code_challenge_method }),
 			{ EX: expiresIn },
 		);
@@ -71,12 +73,16 @@ export class RedisCodeRepository implements CodeRepository {
 	}
 
 	async getByCode(code: string): Promise<Code | null> {
-		const value = await this.redis.get(code);
+		const value = await this.redis.get(KEY_PREFIX + code);
 		if (!value) return null;
-		return { ...JSON.parse(value), code } as Code;
+		try {
+			return { ...JSON.parse(value), code } as Code;
+		} catch {
+			return null;
+		}
 	}
 
 	async removeByCode(code: string): Promise<void> {
-		await this.redis.del(code);
+		await this.redis.del(KEY_PREFIX + code);
 	}
 }

--- a/src/repositories/RedisCodeRepository.mts
+++ b/src/repositories/RedisCodeRepository.mts
@@ -91,7 +91,8 @@ export class RedisCodeRepository implements CodeRepository {
 		try {
 			return { ...JSON.parse(value), code } as Code;
 		} catch (err) {
-			console.error(`RedisCodeRepository: corrupted data for code ${code}`, err);
+			const codeHash = crypto.createHash("sha256").update(code).digest("hex").slice(0, 16);
+			console.error(`RedisCodeRepository: corrupted data for code (hash=${codeHash})`, err);
 			return null;
 		}
 	}

--- a/src/repositories/StaticClientRepository.mts
+++ b/src/repositories/StaticClientRepository.mts
@@ -21,11 +21,13 @@ import yaml from "js-yaml";
 import { z } from "zod";
 import type { ClientRepository, PublicClient } from "./ClientRepository.mjs";
 
-const ClientEntrySchema = z.object({
-	clientSecret: z.string().min(1),
-	allowedRedirectUris: z.array(z.string()).default([]),
-	allowedScopes: z.array(z.string()).default([]),
-});
+const ClientEntrySchema = z
+	.object({
+		clientSecret: z.string().min(1),
+		allowedRedirectUris: z.array(z.string()).default([]),
+		allowedScopes: z.array(z.string()).default([]),
+	})
+	.strict();
 
 type ClientEntry = z.infer<typeof ClientEntrySchema>;
 

--- a/src/repositories/StaticClientRepository.mts
+++ b/src/repositories/StaticClientRepository.mts
@@ -18,14 +18,17 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import bcrypt from "bcrypt";
 import yaml from "js-yaml";
+import { z } from "zod";
 import type { AuthenticatedClient, ClientRepository } from "./ClientRepository.mjs";
 import type { Client } from "./types.mjs";
 
-interface ClientEntry {
-	clientSecret: string;
-	allowedRedirectUris: string[];
-	allowedScopes: string[];
-}
+const ClientEntrySchema = z.object({
+	clientSecret: z.string(),
+	allowedRedirectUris: z.array(z.string()),
+	allowedScopes: z.array(z.string()),
+});
+
+type ClientEntry = z.infer<typeof ClientEntrySchema>;
 
 export class StaticClientRepository implements ClientRepository {
 	private clients: Map<string, ClientEntry>;
@@ -36,8 +39,17 @@ export class StaticClientRepository implements ClientRepository {
 		if (raw !== null && raw !== undefined && (typeof raw !== "object" || Array.isArray(raw))) {
 			throw new Error(`Invalid client configuration in ${filePath}: expected a YAML mapping`);
 		}
-		const data = (raw ?? {}) as Record<string, ClientEntry>;
-		this.clients = new Map(Object.entries(data));
+		const data = (raw ?? {}) as Record<string, unknown>;
+		this.clients = new Map<string, ClientEntry>();
+		for (const [clientId, entry] of Object.entries(data)) {
+			const result = ClientEntrySchema.safeParse(entry);
+			if (!result.success) {
+				throw new Error(
+					`Invalid client entry "${clientId}" in ${filePath}: ${result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join(", ")}`,
+				);
+			}
+			this.clients.set(clientId, result.data);
+		}
 	}
 
 	async findById(clientId: string): Promise<Client | null> {
@@ -46,8 +58,8 @@ export class StaticClientRepository implements ClientRepository {
 		return {
 			clientId,
 			clientSecret: entry.clientSecret,
-			allowedRedirectUris: entry.allowedRedirectUris ?? [],
-			allowedScopes: entry.allowedScopes ?? [],
+			allowedRedirectUris: entry.allowedRedirectUris,
+			allowedScopes: entry.allowedScopes,
 		};
 	}
 

--- a/src/repositories/StaticClientRepository.mts
+++ b/src/repositories/StaticClientRepository.mts
@@ -19,8 +19,7 @@ import fs from "node:fs";
 import bcrypt from "bcrypt";
 import yaml from "js-yaml";
 import { z } from "zod";
-import type { AuthenticatedClient, ClientRepository } from "./ClientRepository.mjs";
-import type { Client } from "./types.mjs";
+import type { ClientRepository, PublicClient } from "./ClientRepository.mjs";
 
 const ClientEntrySchema = z.object({
 	clientSecret: z.string(),
@@ -52,22 +51,21 @@ export class StaticClientRepository implements ClientRepository {
 		}
 	}
 
-	async findById(clientId: string): Promise<Client | null> {
+	async findById(clientId: string): Promise<PublicClient | null> {
 		const entry = this.clients.get(clientId);
 		if (!entry) return null;
 		return {
 			clientId,
-			clientSecret: entry.clientSecret,
 			allowedRedirectUris: entry.allowedRedirectUris,
 			allowedScopes: entry.allowedScopes,
 		};
 	}
 
-	async authenticate(clientId: string, secret: string): Promise<AuthenticatedClient | null> {
-		const client = await this.findById(clientId);
-		if (!client) return null;
+	async authenticate(clientId: string, secret: string): Promise<PublicClient | null> {
+		const entry = this.clients.get(clientId);
+		if (!entry) return null;
 
-		const stored = client.clientSecret;
+		const stored = entry.clientSecret;
 		const isBcrypt = /^\$2[aby]\$/.test(stored);
 
 		let match: boolean;
@@ -81,7 +79,10 @@ export class StaticClientRepository implements ClientRepository {
 
 		if (!match) return null;
 
-		const { clientSecret: _, ...authenticated } = client;
-		return authenticated;
+		return {
+			clientId,
+			allowedRedirectUris: entry.allowedRedirectUris,
+			allowedScopes: entry.allowedScopes,
+		};
 	}
 }

--- a/src/repositories/StaticClientRepository.mts
+++ b/src/repositories/StaticClientRepository.mts
@@ -22,9 +22,9 @@ import { z } from "zod";
 import type { ClientRepository, PublicClient } from "./ClientRepository.mjs";
 
 const ClientEntrySchema = z.object({
-	clientSecret: z.string(),
-	allowedRedirectUris: z.array(z.string()),
-	allowedScopes: z.array(z.string()),
+	clientSecret: z.string().min(1),
+	allowedRedirectUris: z.array(z.string()).default([]),
+	allowedScopes: z.array(z.string()).default([]),
 });
 
 type ClientEntry = z.infer<typeof ClientEntrySchema>;

--- a/src/repositories/__tests__/RedisCodeRepository.test.mts
+++ b/src/repositories/__tests__/RedisCodeRepository.test.mts
@@ -16,6 +16,8 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const KEY_PREFIX = "oauth:code:";
+
 // In-memory store simulating Redis
 const store = new Map<string, string>();
 
@@ -28,6 +30,11 @@ vi.mock("redis", () => {
 		}),
 		get: vi.fn().mockImplementation((key: string) => {
 			return Promise.resolve(store.get(key) ?? null);
+		}),
+		getDel: vi.fn().mockImplementation((key: string) => {
+			const value = store.get(key) ?? null;
+			store.delete(key);
+			return Promise.resolve(value);
 		}),
 		del: vi.fn().mockImplementation((key: string) => {
 			store.delete(key);
@@ -55,7 +62,7 @@ describe("RedisCodeRepository", () => {
 			expect(typeof result.code).toBe("string");
 			expect(result.code.length).toBeGreaterThan(0);
 			// Verify it was stored with namespace prefix
-			expect(store.has(`oauth:code:${result.code}`)).toBe(true);
+			expect(store.has(`${KEY_PREFIX}${result.code}`)).toBe(true);
 		});
 
 		it("returns code with code_challenge and code_challenge_method", async () => {
@@ -74,7 +81,7 @@ describe("RedisCodeRepository", () => {
 				code_challenge_method: "S256",
 			});
 
-			const stored = store.get(`oauth:code:${result.code}`);
+			const stored = store.get(`${KEY_PREFIX}${result.code}`);
 			expect(stored).toBeDefined();
 			const parsed = JSON.parse(stored!);
 			expect(parsed.code_challenge).toBe("challenge-value");
@@ -113,19 +120,49 @@ describe("RedisCodeRepository", () => {
 		});
 
 		it("returns null for corrupted data", async () => {
-			store.set("oauth:code:corrupted", "not-valid-json{{{");
+			store.set(`${KEY_PREFIX}corrupted`, "not-valid-json{{{");
 			const result = await repo.getByCode("corrupted");
 			expect(result).toBeNull();
+		});
+	});
+
+	describe("consumeByCode", () => {
+		it("returns code data and removes it atomically", async () => {
+			const created = await repo.createCode({
+				code_challenge: "consume-test",
+				code_challenge_method: "S256",
+			});
+
+			const consumed = await repo.consumeByCode(created.code);
+			expect(consumed).not.toBeNull();
+			expect(consumed?.code).toBe(created.code);
+			expect(consumed?.code_challenge).toBe("consume-test");
+
+			// Should be gone from store
+			expect(store.has(`${KEY_PREFIX}${created.code}`)).toBe(false);
+		});
+
+		it("returns null for unknown code", async () => {
+			expect(await repo.consumeByCode("nonexistent")).toBeNull();
+		});
+
+		it("second consume returns null (replay prevention)", async () => {
+			const created = await repo.createCode({});
+			const first = await repo.consumeByCode(created.code);
+			expect(first).not.toBeNull();
+
+			const second = await repo.consumeByCode(created.code);
+			expect(second).toBeNull();
 		});
 	});
 
 	describe("removeByCode", () => {
 		it("removes a stored code", async () => {
 			const created = await repo.createCode({ code_challenge: "c" });
-			expect(store.has(`oauth:code:${created.code}`)).toBe(true);
+			expect(store.has(`${KEY_PREFIX}${created.code}`)).toBe(true);
 
 			await repo.removeByCode(created.code);
-			expect(store.has(`oauth:code:${created.code}`)).toBe(false);
+			expect(store.has(`${KEY_PREFIX}${created.code}`)).toBe(false);
 		});
 
 		it("does not throw for unknown code", async () => {

--- a/src/repositories/__tests__/RedisCodeRepository.test.mts
+++ b/src/repositories/__tests__/RedisCodeRepository.test.mts
@@ -54,8 +54,8 @@ describe("RedisCodeRepository", () => {
 
 			expect(typeof result.code).toBe("string");
 			expect(result.code.length).toBeGreaterThan(0);
-			// Verify it was stored
-			expect(store.has(result.code)).toBe(true);
+			// Verify it was stored with namespace prefix
+			expect(store.has(`oauth:code:${result.code}`)).toBe(true);
 		});
 
 		it("returns code with code_challenge and code_challenge_method", async () => {
@@ -74,7 +74,7 @@ describe("RedisCodeRepository", () => {
 				code_challenge_method: "S256",
 			});
 
-			const stored = store.get(result.code);
+			const stored = store.get(`oauth:code:${result.code}`);
 			expect(stored).toBeDefined();
 			const parsed = JSON.parse(stored!);
 			expect(parsed.code_challenge).toBe("challenge-value");
@@ -111,15 +111,21 @@ describe("RedisCodeRepository", () => {
 			const result = await repo.getByCode("nonexistent-code");
 			expect(result).toBeNull();
 		});
+
+		it("returns null for corrupted data", async () => {
+			store.set("oauth:code:corrupted", "not-valid-json{{{");
+			const result = await repo.getByCode("corrupted");
+			expect(result).toBeNull();
+		});
 	});
 
 	describe("removeByCode", () => {
 		it("removes a stored code", async () => {
 			const created = await repo.createCode({ code_challenge: "c" });
-			expect(store.has(created.code)).toBe(true);
+			expect(store.has(`oauth:code:${created.code}`)).toBe(true);
 
 			await repo.removeByCode(created.code);
-			expect(store.has(created.code)).toBe(false);
+			expect(store.has(`oauth:code:${created.code}`)).toBe(false);
 		});
 
 		it("does not throw for unknown code", async () => {

--- a/src/repositories/__tests__/StaticClientRepository.test.mts
+++ b/src/repositories/__tests__/StaticClientRepository.test.mts
@@ -145,4 +145,27 @@ bcrypt-client:
 			expect(client).toBeNull();
 		});
 	});
+
+	describe("validation", () => {
+		it("throws on invalid entry (missing clientSecret)", () => {
+			expect(() =>
+				createRepo(`
+bad-client:
+  allowedRedirectUris: []
+  allowedScopes: []
+`),
+			).toThrow(/Invalid client entry "bad-client"/);
+		});
+
+		it("throws on invalid entry (allowedRedirectUris is string)", () => {
+			expect(() =>
+				createRepo(`
+bad-client:
+  clientSecret: "secret"
+  allowedRedirectUris: "not-an-array"
+  allowedScopes: []
+`),
+			).toThrow(/Invalid client entry "bad-client"/);
+		});
+	});
 });

--- a/src/repositories/__tests__/StaticClientRepository.test.mts
+++ b/src/repositories/__tests__/StaticClientRepository.test.mts
@@ -67,7 +67,7 @@ test-app:
 			const client = await repo.findById("test-app");
 			expect(client).not.toBeNull();
 			expect(client?.clientId).toBe("test-app");
-			expect(client?.clientSecret).toBe("test-secret");
+			expect(client).not.toHaveProperty("clientSecret");
 			expect(client?.allowedRedirectUris).toEqual(["http://localhost:3000/callback"]);
 			expect(client?.allowedScopes).toEqual(["read", "write"]);
 		});

--- a/src/repositories/index.mts
+++ b/src/repositories/index.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 export type { Client, User, Code, CodeData } from "./types.mjs";
-export type { AuthenticatedClient, ClientRepository } from "./ClientRepository.mjs";
+export type { ClientRepository, PublicClient } from "./ClientRepository.mjs";
 export type { UserRepository } from "./UserRepository.mjs";
 export type { CodeRepository } from "./CodeRepository.mjs";
 export { StaticClientRepository } from "./StaticClientRepository.mjs";

--- a/src/routes/OAuth.mts
+++ b/src/routes/OAuth.mts
@@ -19,9 +19,8 @@ import jwt, { type JwtPayload } from "jsonwebtoken";
 
 import type { PassportStatic } from "passport";
 
-import type { ClientRepository } from "#/repositories/ClientRepository.mjs";
+import type { ClientRepository, PublicClient } from "#/repositories/ClientRepository.mjs";
 import type { CodeRepository } from "#/repositories/CodeRepository.mjs";
-import type { Client } from "#/repositories/types.mjs";
 import type { AppConfig } from "#/config/application.schema.mjs";
 import { createGrantRegistry, type GrantRegistry } from "./grants/registry.mjs";
 import { formatObject } from "./grants/token.mjs";
@@ -159,7 +158,7 @@ export const createRouter = (
 					return res.status(400).json({ message: "invalid redirect_uri" });
 				}
 
-				let client: Client | null;
+				let client: PublicClient | null;
 				try {
 					client = await clientRepository.findById(client_id);
 				} catch {

--- a/src/routes/OAuth.mts
+++ b/src/routes/OAuth.mts
@@ -33,8 +33,6 @@ declare module "express-session" {
 		user?: Record<string, unknown>;
 		code?: string;
 		code_client_id?: string;
-		code_challenge?: string;
-		code_challenge_method?: string;
 		granted_scopes?: string[];
 		isAuthenticated?: boolean;
 	}
@@ -199,8 +197,6 @@ export const createRouter = (
 
 				req.session.code = issue.code;
 				req.session.code_client_id = client_id;
-				req.session.code_challenge = issue.code_challenge;
-				req.session.code_challenge_method = issue.code_challenge_method;
 				req.session.granted_scopes = grantedScopes.length > 0 ? grantedScopes : undefined;
 
 				const url = new URL(redirect_uri);

--- a/src/routes/grants/authorization.mts
+++ b/src/routes/grants/authorization.mts
@@ -19,7 +19,7 @@ import { formatObject, generateToken, generateTokenResponse } from "./token.mjs"
 import type { GrantContext, GrantDependencies, GrantHandler } from "./types.mjs";
 
 export const createAuthorizationGrant = (deps: GrantDependencies): GrantHandler => {
-	const { config } = deps;
+	const { config, codeRepository } = deps;
 
 	return {
 		async handle({ req, res, issuer }: GrantContext): Promise<void> {
@@ -35,14 +35,22 @@ export const createAuthorizationGrant = (deps: GrantDependencies): GrantHandler 
 				return;
 			}
 
-			// Mark code as used (replay attack prevention)
+			// Load code data from repository
+			const codeData = await codeRepository.getByCode(code);
+			if (!codeData) {
+				res.status(400).json({ message: "invalid code" });
+				return;
+			}
+
+			// Consume code: remove from both repository and session (replay attack prevention)
+			await codeRepository.removeByCode(code);
 			const grantedScopes = req.session.granted_scopes;
 			req.session.code = undefined;
 			req.session.code_client_id = undefined;
 			req.session.granted_scopes = undefined;
 
-			// Validate code_verifier
-			if (req.session.code_challenge_method) {
+			// Validate code_verifier using code data from repository
+			if (codeData.code_challenge_method) {
 				if (!code_verifier) {
 					res.status(400).json({ message: "code_verifier required" });
 					return;
@@ -52,18 +60,18 @@ export const createAuthorizationGrant = (deps: GrantDependencies): GrantHandler 
 					res.status(400).json({ message: "invalid code_verifier format" });
 					return;
 				}
-				switch (req.session.code_challenge_method) {
+				switch (codeData.code_challenge_method) {
 					case "S256": {
 						const hash = crypto.createHash("sha256").update(code_verifier).digest();
 						const base64url = hash.toString("base64url");
-						if (base64url !== req.session.code_challenge) {
+						if (base64url !== codeData.code_challenge) {
 							res.status(400).json({ message: "invalid code_verifier" });
 							return;
 						}
 						break;
 					}
 					case "plain":
-						if (code_verifier !== req.session.code_challenge) {
+						if (code_verifier !== codeData.code_challenge) {
 							res.status(400).json({ message: "invalid code_verifier" });
 							return;
 						}

--- a/src/routes/grants/authorization.mts
+++ b/src/routes/grants/authorization.mts
@@ -35,15 +35,13 @@ export const createAuthorizationGrant = (deps: GrantDependencies): GrantHandler 
 				return;
 			}
 
-			// Load code data from repository
-			const codeData = await codeRepository.getByCode(code);
+			// Atomically consume code data from repository (replay attack prevention)
+			const codeData = await codeRepository.consumeByCode(code);
 			if (!codeData) {
 				res.status(400).json({ message: "invalid code" });
 				return;
 			}
 
-			// Consume code: remove from both repository and session (replay attack prevention)
-			await codeRepository.removeByCode(code);
 			const grantedScopes = req.session.granted_scopes;
 			req.session.code = undefined;
 			req.session.code_client_id = undefined;


### PR DESCRIPTION
## Summary

- Add `oauth:code:` key prefix to Redis code storage (prevent key collision with session store)
- Add defensive `JSON.parse` in `getByCode` (return null on corrupted data)
- Add Zod schema validation for YAML client entries at startup
- Migrate authorization grant to use `codeRepository` for code validation and PKCE (session no longer stores PKCE data)
- `findById` and `authenticate` now return `PublicClient` (without `clientSecret`)

Closes #6

## Test plan

- [ ] `pnpm build` compiles without errors
- [ ] `pnpm test` — 29 tests pass
- [ ] Verify Redis keys are prefixed with `oauth:code:`
- [ ] Verify corrupted Redis data returns null instead of throwing
- [ ] Verify malformed YAML entries throw clear error at startup
- [ ] Verify `findById` result does not contain `clientSecret`
- [ ] Verify authorization code grant loads PKCE from codeRepository, not session

🤖 Generated with [Claude Code](https://claude.com/claude-code)