### PR TITLE
fix: exclude template dir from create-app vitest scan

### DIFF
--- a/create-app/vitest.config.mts
+++ b/create-app/vitest.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		exclude: ["templates/**", "node_modules/**"],
+	},
+});


### PR DESCRIPTION
## Summary

- Add `vitest.config.mts` to `create-app/` that excludes `templates/**` from test discovery
- Prevents prebuild-copied E2E test files from failing due to missing dependencies (`axios`, etc.)

## Test plan

- [x] `pnpm --filter create-o3co-auth-provider run test` — 4 tests pass, no template failures

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)