### PR TITLE
feat: RS256/ES256/EdDSA asymmetric signing + JWKS + key rotation

### DIFF
--- a/packages/core/src/__tests__/config.test.mts
+++ b/packages/core/src/__tests__/config.test.mts
@@ -93,7 +93,7 @@ describe("provider config", () => {
 
 describe("jwt config schema", () => {
 	it("algorithm defaults to HS256", () => {
-		const result = jwtSchema.parse({});
+		const result = jwtSchema.parse({ secret: "test-secret" });
 		expect(result.algorithm).toBe("HS256");
 	});
 
@@ -109,18 +109,20 @@ describe("jwt config schema", () => {
 	});
 
 	it("accepts ES256 and EdDSA algorithms", () => {
-		expect(jwtSchema.parse({ algorithm: "ES256" }).algorithm).toBe("ES256");
-		expect(jwtSchema.parse({ algorithm: "EdDSA" }).algorithm).toBe("EdDSA");
+		expect(jwtSchema.parse({ algorithm: "ES256", privateKey: "pk", publicKey: "pub" }).algorithm).toBe("ES256");
+		expect(jwtSchema.parse({ algorithm: "EdDSA", privateKey: "pk", publicKey: "pub" }).algorithm).toBe("EdDSA");
 	});
 
 	it("previousKeys defaults to empty array", () => {
-		const result = jwtSchema.parse({});
+		const result = jwtSchema.parse({ secret: "test-secret" });
 		expect(result.previousKeys).toEqual([]);
 	});
 
 	it("accepts previousKeys array with valid entries", () => {
 		const result = jwtSchema.parse({
 			algorithm: "ES256",
+			privateKey: "pk",
+			publicKey: "pub",
 			previousKeys: [
 				{
 					kid: "v0",
@@ -139,13 +141,38 @@ describe("jwt config schema", () => {
 		expect(result.previousKeys[1].publicKeyPath).toBe("/path/to/key.pem");
 	});
 
-	it("secret is optional", () => {
-		const result = jwtSchema.parse({ algorithm: "ES256" });
+	it("secret is optional for asymmetric algorithms", () => {
+		const result = jwtSchema.parse({ algorithm: "ES256", privateKey: "pk", publicKey: "pub" });
 		expect(result.secret).toBeUndefined();
 	});
 
 	it("kid defaults to v0", () => {
-		const result = jwtSchema.parse({});
+		const result = jwtSchema.parse({ secret: "test-secret" });
 		expect(result.kid).toBe("v0");
+	});
+
+	it("rejects HS256 without secret", () => {
+		const result = jwtSchema.safeParse({});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects asymmetric algorithm without privateKey", () => {
+		const result = jwtSchema.safeParse({ algorithm: "ES256", publicKey: "pub" });
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects asymmetric algorithm without publicKey", () => {
+		const result = jwtSchema.safeParse({ algorithm: "RS256", privateKey: "pk" });
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects previousKeys entry without publicKey or publicKeyPath", () => {
+		const result = jwtSchema.safeParse({
+			algorithm: "ES256",
+			privateKey: "pk",
+			publicKey: "pub",
+			previousKeys: [{ kid: "old", expiresAt: "2099-01-01T00:00:00Z" }],
+		});
+		expect(result.success).toBe(false);
 	});
 });

--- a/packages/core/src/__tests__/config.test.mts
+++ b/packages/core/src/__tests__/config.test.mts
@@ -3,6 +3,8 @@ import { validate } from "@o3co/ts.hocon/zod";
 import { describe, expect, it } from "vitest";
 import { AppConfigSchema } from "#/config/application.schema.mjs";
 
+const jwtSchema = AppConfigSchema.shape.oauth.shape.jwt;
+
 describe("provider config", () => {
 	it("loads and validates application.conf with required env vars", () => {
 		const raw = parseFile(new URL("../../config/application.conf", import.meta.url).pathname, {
@@ -86,5 +88,64 @@ describe("provider config", () => {
 		});
 		const config = validate(raw, AppConfigSchema);
 		expect(config.clients.code.type).toBe("memory");
+	});
+});
+
+describe("jwt config schema", () => {
+	it("algorithm defaults to HS256", () => {
+		const result = jwtSchema.parse({});
+		expect(result.algorithm).toBe("HS256");
+	});
+
+	it("accepts RS256 with key fields", () => {
+		const result = jwtSchema.parse({
+			algorithm: "RS256",
+			privateKey: "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----",
+			publicKey: "-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----",
+		});
+		expect(result.algorithm).toBe("RS256");
+		expect(result.privateKey).toBeDefined();
+		expect(result.publicKey).toBeDefined();
+	});
+
+	it("accepts ES256 and EdDSA algorithms", () => {
+		expect(jwtSchema.parse({ algorithm: "ES256" }).algorithm).toBe("ES256");
+		expect(jwtSchema.parse({ algorithm: "EdDSA" }).algorithm).toBe("EdDSA");
+	});
+
+	it("previousKeys defaults to empty array", () => {
+		const result = jwtSchema.parse({});
+		expect(result.previousKeys).toEqual([]);
+	});
+
+	it("accepts previousKeys array with valid entries", () => {
+		const result = jwtSchema.parse({
+			algorithm: "ES256",
+			previousKeys: [
+				{
+					kid: "v0",
+					publicKey: "-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----",
+					expiresAt: "2026-12-31T00:00:00Z",
+				},
+				{
+					kid: "v1",
+					publicKeyPath: "/path/to/key.pem",
+					expiresAt: "2027-06-01T00:00:00Z",
+				},
+			],
+		});
+		expect(result.previousKeys).toHaveLength(2);
+		expect(result.previousKeys[0].kid).toBe("v0");
+		expect(result.previousKeys[1].publicKeyPath).toBe("/path/to/key.pem");
+	});
+
+	it("secret is optional", () => {
+		const result = jwtSchema.parse({ algorithm: "ES256" });
+		expect(result.secret).toBeUndefined();
+	});
+
+	it("kid defaults to v0", () => {
+		const result = jwtSchema.parse({});
+		expect(result.kid).toBe("v0");
 	});
 });

--- a/packages/core/src/__tests__/index.test.mts
+++ b/packages/core/src/__tests__/index.test.mts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
 	AppConfigSchema,
+	createAsymmetricKeyStore,
 	createDefaultFactories,
 	createGoogleProvider,
+	createKeyStoreFromConfig,
 	createPassport,
 	createRouter,
 	createSymmetricKeyStore,
@@ -67,5 +69,13 @@ describe("public API", () => {
 
 	it("exports createSymmetricKeyStore function", () => {
 		expect(typeof createSymmetricKeyStore).toBe("function");
+	});
+
+	it("exports createAsymmetricKeyStore function", () => {
+		expect(typeof createAsymmetricKeyStore).toBe("function");
+	});
+
+	it("exports createKeyStoreFromConfig function", () => {
+		expect(typeof createKeyStoreFromConfig).toBe("function");
 	});
 });

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -27,9 +27,20 @@ export const AppConfigSchema = z.object({
 	}),
 	oauth: z.object({
 		jwt: z.object({
-			secret: z.string(),
+			algorithm: z.enum(["HS256", "RS256", "ES256", "EdDSA"]).default("HS256"),
+			secret: z.string().optional(),
 			issuer: z.string().optional(),
 			kid: z.string().default("v0"),
+			privateKey: z.string().optional(),
+			privateKeyPath: z.string().optional(),
+			publicKey: z.string().optional(),
+			publicKeyPath: z.string().optional(),
+			previousKeys: z.array(z.object({
+				kid: z.string(),
+				publicKey: z.string().optional(),
+				publicKeyPath: z.string().optional(),
+				expiresAt: z.string(),
+			})).default([]),
 		}),
 		accessToken: z.object({
 			expiresIn: z.coerce.number().default(3600),

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -41,6 +41,40 @@ export const AppConfigSchema = z.object({
 				publicKeyPath: z.string().optional(),
 				expiresAt: z.string(),
 			})).default([]),
+		}).superRefine((data, ctx) => {
+			if (data.algorithm === "HS256" && !data.secret) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "secret is required for HS256 algorithm",
+					path: ["secret"],
+				});
+			}
+			const isAsymmetric = data.algorithm === "RS256" || data.algorithm === "ES256" || data.algorithm === "EdDSA";
+			if (isAsymmetric) {
+				if (!data.privateKey && !data.privateKeyPath) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: "privateKey or privateKeyPath is required for asymmetric algorithms",
+						path: ["privateKey"],
+					});
+				}
+				if (!data.publicKey && !data.publicKeyPath) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: "publicKey or publicKeyPath is required for asymmetric algorithms",
+						path: ["publicKey"],
+					});
+				}
+			}
+			for (const [i, key] of data.previousKeys.entries()) {
+				if (!key.publicKey && !key.publicKeyPath) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: "publicKey or publicKeyPath is required for each previousKeys entry",
+						path: ["previousKeys", i, "publicKey"],
+					});
+				}
+			}
 		}),
 		accessToken: z.object({
 			expiresIn: z.coerce.number().default(3600),

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -59,7 +59,7 @@ export {
 export type { Client, Code, CodeData, User } from "./repositories/types.mjs";
 export type { UserRepository } from "./repositories/UserRepository.mjs";
 // Keys
-export type { AsymmetricKeyStoreOptions, KeyStore, ManagedKey } from "./keys/KeyStore.mjs";
-export { createAsymmetricKeyStore, createSymmetricKeyStore } from "./keys/KeyStore.mjs";
+export type { AsymmetricKeyStoreOptions, JwtConfig, KeyStore, ManagedKey } from "./keys/KeyStore.mjs";
+export { createAsymmetricKeyStore, createKeyStoreFromConfig, createSymmetricKeyStore } from "./keys/KeyStore.mjs";
 // Router factory
 export { createRouter } from "./routes/index.mjs";

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -59,7 +59,7 @@ export {
 export type { Client, Code, CodeData, User } from "./repositories/types.mjs";
 export type { UserRepository } from "./repositories/UserRepository.mjs";
 // Keys
-export type { KeyStore, ManagedKey } from "./keys/KeyStore.mjs";
-export { createSymmetricKeyStore } from "./keys/KeyStore.mjs";
+export type { AsymmetricKeyStoreOptions, KeyStore, ManagedKey } from "./keys/KeyStore.mjs";
+export { createAsymmetricKeyStore, createSymmetricKeyStore } from "./keys/KeyStore.mjs";
 // Router factory
 export { createRouter } from "./routes/index.mjs";

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -114,7 +114,13 @@ export interface JwtConfig {
 }
 
 function readKeyValue(pemString?: string, filePath?: string): string | undefined {
-	if (filePath) return readFileSync(filePath, "utf-8");
+	if (filePath) {
+		try {
+			return readFileSync(filePath, "utf-8");
+		} catch (err) {
+			throw new Error(`Failed to read key file: ${filePath}`, { cause: err });
+		}
+	}
 	return pemString;
 }
 
@@ -142,10 +148,14 @@ export async function createKeyStoreFromConfig(config: JwtConfig): Promise<KeySt
 		if (!pubPem) {
 			throw new Error(`publicKey or publicKeyPath is required for previous key ${prev.kid}`);
 		}
+		const expiresAt = new Date(prev.expiresAt);
+		if (Number.isNaN(expiresAt.getTime())) {
+			throw new Error(`Invalid expiresAt for previous key "${prev.kid}": ${prev.expiresAt}`);
+		}
 		return {
 			kid: prev.kid,
 			publicKeyPem: pubPem,
-			expiresAt: new Date(prev.expiresAt),
+			expiresAt,
 		};
 	});
 

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { type KeyObject, createSecretKey } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { importPKCS8, importSPKI } from "jose";
 
 export type KeyLike = CryptoKey | KeyObject | Uint8Array;
@@ -93,6 +94,68 @@ export async function createAsymmetricKeyStore(options: AsymmetricKeyStoreOption
 			return prev.publicKey;
 		},
 	};
+}
+
+export interface JwtConfig {
+	algorithm: "HS256" | "RS256" | "ES256" | "EdDSA";
+	secret?: string;
+	kid: string;
+	issuer?: string;
+	privateKey?: string;
+	privateKeyPath?: string;
+	publicKey?: string;
+	publicKeyPath?: string;
+	previousKeys: Array<{
+		kid: string;
+		publicKey?: string;
+		publicKeyPath?: string;
+		expiresAt: string;
+	}>;
+}
+
+function readKeyValue(pemString?: string, filePath?: string): string | undefined {
+	if (filePath) return readFileSync(filePath, "utf-8");
+	return pemString;
+}
+
+export async function createKeyStoreFromConfig(config: JwtConfig): Promise<KeyStore> {
+	if (config.algorithm === "HS256") {
+		if (!config.secret) {
+			throw new Error("secret is required for HS256 algorithm");
+		}
+		return createSymmetricKeyStore(config.secret, config.kid);
+	}
+
+	// Asymmetric algorithms: RS256, ES256, EdDSA
+	const privateKeyPem = readKeyValue(config.privateKey, config.privateKeyPath);
+	if (!privateKeyPem) {
+		throw new Error(`privateKey or privateKeyPath is required for ${config.algorithm} algorithm`);
+	}
+
+	const publicKeyPem = readKeyValue(config.publicKey, config.publicKeyPath);
+	if (!publicKeyPem) {
+		throw new Error(`publicKey or publicKeyPath is required for ${config.algorithm} algorithm`);
+	}
+
+	const previousKeys = config.previousKeys.map((prev) => {
+		const pubPem = readKeyValue(prev.publicKey, prev.publicKeyPath);
+		if (!pubPem) {
+			throw new Error(`publicKey or publicKeyPath is required for previous key ${prev.kid}`);
+		}
+		return {
+			kid: prev.kid,
+			publicKeyPem: pubPem,
+			expiresAt: new Date(prev.expiresAt),
+		};
+	});
+
+	return createAsymmetricKeyStore({
+		algorithm: config.algorithm,
+		kid: config.kid,
+		privateKeyPem,
+		publicKeyPem,
+		previousKeys,
+	});
 }
 
 export function createSymmetricKeyStore(secret: string, kid = "v0"): KeyStore {

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { type KeyObject, createSecretKey } from "node:crypto";
+import { importPKCS8, importSPKI } from "jose";
 
 export type KeyLike = CryptoKey | KeyObject | Uint8Array;
 
@@ -34,6 +35,64 @@ export interface KeyStore {
 	getSigningKey(): { kid: string; privateKey: KeyLike };
 	getVerificationKeys(): ManagedKey[];
 	getVerificationKey(kid: string): KeyLike;
+}
+
+export interface AsymmetricKeyStoreOptions {
+	algorithm: string;
+	kid: string;
+	privateKeyPem: string;
+	publicKeyPem: string;
+	previousKeys?: Array<{
+		kid: string;
+		publicKeyPem: string;
+		expiresAt: Date;
+	}>;
+}
+
+export async function createAsymmetricKeyStore(options: AsymmetricKeyStoreOptions): Promise<KeyStore> {
+	const { algorithm, kid, privateKeyPem, publicKeyPem, previousKeys = [] } = options;
+
+	const privateKey = await importPKCS8(privateKeyPem, algorithm);
+	const publicKey = await importSPKI(publicKeyPem, algorithm);
+
+	// Import all previous public keys upfront
+	const resolvedPrevious: Array<ManagedKey & { expiresAt: Date }> = await Promise.all(
+		previousKeys.map(async (prev) => ({
+			kid: prev.kid,
+			publicKey: await importSPKI(prev.publicKeyPem, algorithm) as KeyLike,
+			expiresAt: prev.expiresAt,
+		})),
+	);
+
+	return {
+		algorithm,
+		current: { kid, privateKey, publicKey },
+		previous: resolvedPrevious,
+
+		getSigningKey() {
+			return { kid, privateKey };
+		},
+
+		getVerificationKeys(): ManagedKey[] {
+			const now = new Date();
+			const active = resolvedPrevious.filter((k) => k.expiresAt > now);
+			return [{ kid, publicKey }, ...active];
+		},
+
+		getVerificationKey(requestedKid: string): KeyLike {
+			if (requestedKid === kid) {
+				return publicKey;
+			}
+			const prev = resolvedPrevious.find((k) => k.kid === requestedKid);
+			if (!prev) {
+				throw new Error(`Unknown kid: ${requestedKid}`);
+			}
+			if (prev.expiresAt <= new Date()) {
+				throw new Error(`Expired kid: ${requestedKid}`);
+			}
+			return prev.publicKey;
+		},
+	};
 }
 
 export function createSymmetricKeyStore(secret: string, kid = "v0"): KeyStore {

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -25,8 +25,10 @@ export interface ManagedKey {
 	expiresAt?: Date;
 }
 
+export type Algorithm = "HS256" | "RS256" | "ES256" | "EdDSA";
+
 export interface KeyStore {
-	readonly algorithm: string;
+	readonly algorithm: Algorithm;
 	readonly current: {
 		readonly kid: string;
 		readonly privateKey: KeyLike;
@@ -39,7 +41,7 @@ export interface KeyStore {
 }
 
 export interface AsymmetricKeyStoreOptions {
-	algorithm: string;
+	algorithm: "RS256" | "ES256" | "EdDSA";
 	kid: string;
 	privateKeyPem: string;
 	publicKeyPem: string;
@@ -52,6 +54,13 @@ export interface AsymmetricKeyStoreOptions {
 
 export async function createAsymmetricKeyStore(options: AsymmetricKeyStoreOptions): Promise<KeyStore> {
 	const { algorithm, kid, privateKeyPem, publicKeyPem, previousKeys = [] } = options;
+
+	// Validate kid uniqueness
+	const allKids = [kid, ...previousKeys.map((k) => k.kid)];
+	const duplicates = allKids.filter((k, i) => allKids.indexOf(k) !== i);
+	if (duplicates.length > 0) {
+		throw new Error(`Duplicate kid values: ${[...new Set(duplicates)].join(", ")}`);
+	}
 
 	const privateKey = await importPKCS8(privateKeyPem, algorithm);
 	const publicKey = await importSPKI(publicKeyPem, algorithm);

--- a/packages/core/src/keys/__tests__/KeyStore.test.mts
+++ b/packages/core/src/keys/__tests__/KeyStore.test.mts
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { generateKeyPair, exportSPKI, exportPKCS8, SignJWT, jwtVerify, decodeProtectedHeader } from "jose";
-import { describe, expect, it } from "vitest";
-import { createSymmetricKeyStore, createAsymmetricKeyStore } from "../KeyStore.mjs";
-import type { AsymmetricKeyStoreOptions } from "../KeyStore.mjs";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createAsymmetricKeyStore, createKeyStoreFromConfig, createSymmetricKeyStore } from "../KeyStore.mjs";
+import type { JwtConfig } from "../KeyStore.mjs";
 
 async function generateTestKeyPair(alg: string) {
 	const { privateKey, publicKey } = await generateKeyPair(alg, { extractable: true });
@@ -208,5 +211,192 @@ describe("AsymmetricKeyStore", () => {
 		});
 
 		expect(() => store.getVerificationKey("k1")).toThrow();
+	});
+});
+
+describe("createKeyStoreFromConfig", () => {
+	let tmpDir: string;
+
+	beforeAll(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "keystore-test-"));
+	});
+
+	afterAll(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("HS256 with secret creates symmetric key store", async () => {
+		const config: JwtConfig = {
+			algorithm: "HS256",
+			secret: "my-test-secret",
+			kid: "v0",
+			previousKeys: [],
+		};
+		const store = await createKeyStoreFromConfig(config);
+		expect(store.algorithm).toBe("HS256");
+		expect(store.current.kid).toBe("v0");
+	});
+
+	it("HS256 without secret throws", async () => {
+		const config: JwtConfig = {
+			algorithm: "HS256",
+			kid: "v0",
+			previousKeys: [],
+		};
+		await expect(createKeyStoreFromConfig(config)).rejects.toThrow();
+	});
+
+	it("ES256 with privateKey and publicKey creates asymmetric key store", async () => {
+		const { privateKeyPem, publicKeyPem } = await generateTestKeyPair("ES256");
+		const config: JwtConfig = {
+			algorithm: "ES256",
+			kid: "k1",
+			privateKey: privateKeyPem,
+			publicKey: publicKeyPem,
+			previousKeys: [],
+		};
+		const store = await createKeyStoreFromConfig(config);
+		expect(store.algorithm).toBe("ES256");
+
+		// Verify round-trip
+		const { kid, privateKey } = store.getSigningKey();
+		const token = await new SignJWT({ sub: "u1" })
+			.setProtectedHeader({ alg: "ES256", kid })
+			.sign(privateKey);
+		const verificationKey = store.getVerificationKey(kid);
+		const { payload } = await jwtVerify(token, verificationKey);
+		expect(payload.sub).toBe("u1");
+	});
+
+	it("RS256 with keys creates asymmetric key store", async () => {
+		const { privateKeyPem, publicKeyPem } = await generateTestKeyPair("RS256");
+		const config: JwtConfig = {
+			algorithm: "RS256",
+			kid: "r1",
+			privateKey: privateKeyPem,
+			publicKey: publicKeyPem,
+			previousKeys: [],
+		};
+		const store = await createKeyStoreFromConfig(config);
+		expect(store.algorithm).toBe("RS256");
+	});
+
+	it("ES256 without privateKey throws", async () => {
+		const { publicKeyPem } = await generateTestKeyPair("ES256");
+		const config: JwtConfig = {
+			algorithm: "ES256",
+			kid: "k1",
+			publicKey: publicKeyPem,
+			previousKeys: [],
+		};
+		await expect(createKeyStoreFromConfig(config)).rejects.toThrow();
+	});
+
+	it("ES256 without publicKey throws", async () => {
+		const { privateKeyPem } = await generateTestKeyPair("ES256");
+		const config: JwtConfig = {
+			algorithm: "ES256",
+			kid: "k1",
+			privateKey: privateKeyPem,
+			previousKeys: [],
+		};
+		await expect(createKeyStoreFromConfig(config)).rejects.toThrow();
+	});
+
+	it("reads keys from file paths", async () => {
+		const { privateKeyPem, publicKeyPem } = await generateTestKeyPair("ES256");
+		const privPath = join(tmpDir, "private.pem");
+		const pubPath = join(tmpDir, "public.pem");
+		writeFileSync(privPath, privateKeyPem);
+		writeFileSync(pubPath, publicKeyPem);
+
+		const config: JwtConfig = {
+			algorithm: "ES256",
+			kid: "f1",
+			privateKeyPath: privPath,
+			publicKeyPath: pubPath,
+			previousKeys: [],
+		};
+		const store = await createKeyStoreFromConfig(config);
+		expect(store.algorithm).toBe("ES256");
+		expect(store.current.kid).toBe("f1");
+	});
+
+	it("file path takes priority over PEM string", async () => {
+		const pair1 = await generateTestKeyPair("ES256");
+		const pair2 = await generateTestKeyPair("ES256");
+		const privPath = join(tmpDir, "private-priority.pem");
+		const pubPath = join(tmpDir, "public-priority.pem");
+		writeFileSync(privPath, pair1.privateKeyPem);
+		writeFileSync(pubPath, pair1.publicKeyPem);
+
+		const config: JwtConfig = {
+			algorithm: "ES256",
+			kid: "p1",
+			privateKey: pair2.privateKeyPem,  // different key — should be ignored
+			privateKeyPath: privPath,
+			publicKey: pair2.publicKeyPem,
+			publicKeyPath: pubPath,
+			previousKeys: [],
+		};
+		const store = await createKeyStoreFromConfig(config);
+
+		// Sign with store and verify with pair1's public key (from file)
+		const { kid, privateKey } = store.getSigningKey();
+		const token = await new SignJWT({ sub: "priority" })
+			.setProtectedHeader({ alg: "ES256", kid })
+			.sign(privateKey);
+
+		const { importSPKI: importSPKIFn } = await import("jose");
+		const pubKeyFromFile = await importSPKIFn(pair1.publicKeyPem, "ES256");
+		const { payload } = await jwtVerify(token, pubKeyFromFile);
+		expect(payload.sub).toBe("priority");
+	});
+
+	it("previousKeys with expiresAt loaded correctly", async () => {
+		const current = await generateTestKeyPair("ES256");
+		const prev = await generateTestKeyPair("ES256");
+
+		const config: JwtConfig = {
+			algorithm: "ES256",
+			kid: "k2",
+			privateKey: current.privateKeyPem,
+			publicKey: current.publicKeyPem,
+			previousKeys: [
+				{
+					kid: "k1",
+					publicKey: prev.publicKeyPem,
+					expiresAt: "2099-12-31T00:00:00Z",
+				},
+			],
+		};
+		const store = await createKeyStoreFromConfig(config);
+		const keys = store.getVerificationKeys();
+		expect(keys).toHaveLength(2);
+		expect(keys.map((k) => k.kid)).toContain("k1");
+	});
+
+	it("previousKeys with publicKeyPath reads from file", async () => {
+		const current = await generateTestKeyPair("ES256");
+		const prev = await generateTestKeyPair("ES256");
+		const prevPubPath = join(tmpDir, "prev-public.pem");
+		writeFileSync(prevPubPath, prev.publicKeyPem);
+
+		const config: JwtConfig = {
+			algorithm: "ES256",
+			kid: "k2",
+			privateKey: current.privateKeyPem,
+			publicKey: current.publicKeyPem,
+			previousKeys: [
+				{
+					kid: "k1",
+					publicKeyPath: prevPubPath,
+					expiresAt: "2099-12-31T00:00:00Z",
+				},
+			],
+		};
+		const store = await createKeyStoreFromConfig(config);
+		const keys = store.getVerificationKeys();
+		expect(keys).toHaveLength(2);
 	});
 });

--- a/packages/core/src/keys/__tests__/KeyStore.test.mts
+++ b/packages/core/src/keys/__tests__/KeyStore.test.mts
@@ -13,8 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { generateKeyPair, exportSPKI, exportPKCS8, SignJWT, jwtVerify, decodeProtectedHeader } from "jose";
 import { describe, expect, it } from "vitest";
-import { createSymmetricKeyStore } from "../KeyStore.mjs";
+import { createSymmetricKeyStore, createAsymmetricKeyStore } from "../KeyStore.mjs";
+import type { AsymmetricKeyStoreOptions } from "../KeyStore.mjs";
+
+async function generateTestKeyPair(alg: string) {
+	const { privateKey, publicKey } = await generateKeyPair(alg, { extractable: true });
+	return {
+		privateKeyPem: await exportPKCS8(privateKey),
+		publicKeyPem: await exportSPKI(publicKey),
+	};
+}
 
 describe("SymmetricKeyStore", () => {
 	const keyStore = createSymmetricKeyStore("test-secret");
@@ -55,5 +65,148 @@ describe("SymmetricKeyStore", () => {
 
 	it("current.privateKey and current.publicKey are the same for symmetric", () => {
 		expect(keyStore.current.privateKey).toBe(keyStore.current.publicKey);
+	});
+});
+
+describe("AsymmetricKeyStore", () => {
+	it.each(["ES256", "RS256", "EdDSA"] as const)("creates %s key store and signs/verifies round-trip", async (alg) => {
+		const { privateKeyPem, publicKeyPem } = await generateTestKeyPair(alg);
+		const store = await createAsymmetricKeyStore({
+			algorithm: alg,
+			kid: "k1",
+			privateKeyPem,
+			publicKeyPem,
+		});
+
+		expect(store.algorithm).toBe(alg);
+		expect(store.current.kid).toBe("k1");
+
+		// Sign a JWT with the signing key
+		const { kid, privateKey } = store.getSigningKey();
+		const token = await new SignJWT({ sub: "user1" })
+			.setProtectedHeader({ alg, kid })
+			.setIssuedAt()
+			.sign(privateKey);
+
+		// Verify with the verification key
+		const verificationKey = store.getVerificationKey(kid);
+		const { payload } = await jwtVerify(token, verificationKey);
+		expect(payload.sub).toBe("user1");
+	});
+
+	it("includes previous keys in getVerificationKeys", async () => {
+		const current = await generateTestKeyPair("ES256");
+		const prev = await generateTestKeyPair("ES256");
+
+		const store = await createAsymmetricKeyStore({
+			algorithm: "ES256",
+			kid: "k2",
+			privateKeyPem: current.privateKeyPem,
+			publicKeyPem: current.publicKeyPem,
+			previousKeys: [
+				{
+					kid: "k1",
+					publicKeyPem: prev.publicKeyPem,
+					expiresAt: new Date(Date.now() + 86400_000), // tomorrow
+				},
+			],
+		});
+
+		const keys = store.getVerificationKeys();
+		expect(keys).toHaveLength(2);
+		expect(keys.map((k) => k.kid)).toContain("k1");
+		expect(keys.map((k) => k.kid)).toContain("k2");
+	});
+
+	it("excludes expired previous keys from getVerificationKeys", async () => {
+		const current = await generateTestKeyPair("ES256");
+		const prev = await generateTestKeyPair("ES256");
+
+		const store = await createAsymmetricKeyStore({
+			algorithm: "ES256",
+			kid: "k2",
+			privateKeyPem: current.privateKeyPem,
+			publicKeyPem: current.publicKeyPem,
+			previousKeys: [
+				{
+					kid: "k1",
+					publicKeyPem: prev.publicKeyPem,
+					expiresAt: new Date(Date.now() - 1000), // already expired
+				},
+			],
+		});
+
+		const keys = store.getVerificationKeys();
+		expect(keys).toHaveLength(1);
+		expect(keys[0].kid).toBe("k2");
+	});
+
+	it("token signed with previous key can be verified", async () => {
+		// Generate two key pairs — simulate rotation
+		const oldPair = await generateTestKeyPair("ES256");
+		const newPair = await generateTestKeyPair("ES256");
+
+		// Sign a token with the old key
+		const { importPKCS8 } = await import("jose");
+		const oldSigningKey = await importPKCS8(oldPair.privateKeyPem, "ES256");
+		const token = await new SignJWT({ sub: "user-old" })
+			.setProtectedHeader({ alg: "ES256", kid: "k-old" })
+			.setIssuedAt()
+			.sign(oldSigningKey);
+
+		// Create store with newPair as current, oldPair as previous
+		const store = await createAsymmetricKeyStore({
+			algorithm: "ES256",
+			kid: "k-new",
+			privateKeyPem: newPair.privateKeyPem,
+			publicKeyPem: newPair.publicKeyPem,
+			previousKeys: [
+				{
+					kid: "k-old",
+					publicKeyPem: oldPair.publicKeyPem,
+					expiresAt: new Date(Date.now() + 86400_000),
+				},
+			],
+		});
+
+		// Verify old token with previous key
+		const header = decodeProtectedHeader(token);
+		if (!header.kid) throw new Error("Expected kid in header");
+		const verificationKey = store.getVerificationKey(header.kid);
+		const { payload } = await jwtVerify(token, verificationKey);
+		expect(payload.sub).toBe("user-old");
+	});
+
+	it("throws for unknown kid", async () => {
+		const { privateKeyPem, publicKeyPem } = await generateTestKeyPair("ES256");
+		const store = await createAsymmetricKeyStore({
+			algorithm: "ES256",
+			kid: "k1",
+			privateKeyPem,
+			publicKeyPem,
+		});
+
+		expect(() => store.getVerificationKey("unknown")).toThrow("Unknown kid: unknown");
+	});
+
+	it("throws for expired kid", async () => {
+		const current = await generateTestKeyPair("ES256");
+		const prev = await generateTestKeyPair("ES256");
+
+		const store = await createAsymmetricKeyStore({
+			algorithm: "ES256",
+			kid: "k2",
+			privateKeyPem: current.privateKeyPem,
+			publicKeyPem: current.publicKeyPem,
+			previousKeys: [
+				{
+					kid: "k1",
+					publicKeyPem: prev.publicKeyPem,
+					expiresAt: new Date(Date.now() - 1000),
+				},
+			],
+		});
+
+		expect(() => store.getVerificationKey("k1")).toThrow();
 	});
 });

--- a/packages/core/src/keys/__tests__/KeyStore.test.mts
+++ b/packages/core/src/keys/__tests__/KeyStore.test.mts
@@ -180,6 +180,40 @@ describe("AsymmetricKeyStore", () => {
 		expect(payload.sub).toBe("user-old");
 	});
 
+	it("throws on duplicate kid between current and previousKeys", async () => {
+		const keys = await generateTestKeyPair("ES256");
+		const prev = await generateTestKeyPair("ES256");
+
+		await expect(createAsymmetricKeyStore({
+			algorithm: "ES256",
+			kid: "same-kid",
+			privateKeyPem: keys.privateKeyPem,
+			publicKeyPem: keys.publicKeyPem,
+			previousKeys: [{
+				kid: "same-kid",
+				publicKeyPem: prev.publicKeyPem,
+				expiresAt: new Date(Date.now() + 86400000),
+			}],
+		})).rejects.toThrow("Duplicate kid");
+	});
+
+	it("throws on duplicate kid within previousKeys", async () => {
+		const keys = await generateTestKeyPair("ES256");
+		const prev1 = await generateTestKeyPair("ES256");
+		const prev2 = await generateTestKeyPair("ES256");
+
+		await expect(createAsymmetricKeyStore({
+			algorithm: "ES256",
+			kid: "current",
+			privateKeyPem: keys.privateKeyPem,
+			publicKeyPem: keys.publicKeyPem,
+			previousKeys: [
+				{ kid: "dup", publicKeyPem: prev1.publicKeyPem, expiresAt: new Date(Date.now() + 86400000) },
+				{ kid: "dup", publicKeyPem: prev2.publicKeyPem, expiresAt: new Date(Date.now() + 86400000) },
+			],
+		})).rejects.toThrow("Duplicate kid");
+	});
+
 	it("throws for unknown kid", async () => {
 		const { privateKeyPem, publicKeyPem } = await generateTestKeyPair("ES256");
 		const store = await createAsymmetricKeyStore({

--- a/packages/core/src/keys/__tests__/KeyStore.test.mts
+++ b/packages/core/src/keys/__tests__/KeyStore.test.mts
@@ -399,4 +399,34 @@ describe("createKeyStoreFromConfig", () => {
 		const keys = store.getVerificationKeys();
 		expect(keys).toHaveLength(2);
 	});
+
+	it("throws on invalid expiresAt in previousKeys", async () => {
+		const current = await generateTestKeyPair("ES256");
+		const prev = await generateTestKeyPair("ES256");
+		const config: JwtConfig = {
+			algorithm: "ES256",
+			kid: "k1",
+			privateKey: current.privateKeyPem,
+			publicKey: current.publicKeyPem,
+			previousKeys: [
+				{
+					kid: "old",
+					publicKey: prev.publicKeyPem,
+					expiresAt: "not-a-date",
+				},
+			],
+		};
+		await expect(createKeyStoreFromConfig(config)).rejects.toThrow("Invalid expiresAt");
+	});
+
+	it("throws descriptive error for nonexistent key file", async () => {
+		const config: JwtConfig = {
+			algorithm: "ES256",
+			kid: "k1",
+			privateKeyPath: "/nonexistent/private.pem",
+			publicKeyPath: "/nonexistent/public.pem",
+			previousKeys: [],
+		};
+		await expect(createKeyStoreFromConfig(config)).rejects.toThrow("Failed to read key file");
+	});
 });

--- a/packages/core/src/keys/__tests__/integration.test.mts
+++ b/packages/core/src/keys/__tests__/integration.test.mts
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from "vitest";
+import { generateKeyPair, exportSPKI, exportPKCS8, jwtVerify, decodeProtectedHeader } from "jose";
+import { createKeyStoreFromConfig } from "../KeyStore.mjs";
+import { generateToken } from "../../grants/token.mjs";
+
+async function generateTestKeyPair(alg: string) {
+	const { privateKey, publicKey } = await generateKeyPair(alg, { extractable: true });
+	return {
+		privateKeyPem: await exportPKCS8(privateKey),
+		publicKeyPem: await exportSPKI(publicKey),
+	};
+}
+
+describe("Integration: generateToken + asymmetric KeyStore", () => {
+	it.each(["ES256", "RS256", "EdDSA"] as const)(
+		"%s: createKeyStoreFromConfig -> generateToken -> jwtVerify round-trip",
+		async (alg) => {
+			const { privateKeyPem, publicKeyPem } = await generateTestKeyPair(alg);
+
+			const keyStore = await createKeyStoreFromConfig({
+				algorithm: alg,
+				kid: `${alg.toLowerCase()}-v1`,
+				privateKey: privateKeyPem,
+				publicKey: publicKeyPem,
+				previousKeys: [],
+			});
+
+			const token = await generateToken(
+				{ sub: "user-123", role: "admin" },
+				{
+					keyStore,
+					issuer: "https://auth.example.com",
+					audience: "https://api.example.com",
+					scopes: ["read", "write"],
+					expiresIn: 3600,
+					type: "access",
+				},
+			);
+
+			expect(token.token).toBeDefined();
+			expect(token.issuer).toBe("https://auth.example.com");
+			expect(token.audience).toBe("https://api.example.com");
+			expect(token.scopes).toEqual(["read", "write"]);
+			expect(token.expiresIn).toBe(3600);
+			expect(token.type).toBe("access");
+
+			// Verify the JWT header
+			const header = decodeProtectedHeader(token.token);
+			expect(header.alg).toBe(alg);
+			expect(header.kid).toBe(`${alg.toLowerCase()}-v1`);
+
+			// Verify the JWT payload using the KeyStore's verification key
+			const verificationKey = keyStore.getVerificationKey(header.kid!);
+			const { payload } = await jwtVerify(token.token, verificationKey, {
+				issuer: "https://auth.example.com",
+				audience: "https://api.example.com",
+			});
+
+			expect(payload.sub).toBe("user-123");
+			expect(payload.role).toBe("admin");
+			expect(payload.scopes).toEqual(["read", "write"]);
+			expect(payload.type).toBe("access");
+			expect(payload.iss).toBe("https://auth.example.com");
+			expect(payload.aud).toBe("https://api.example.com");
+			expect(payload.iat).toBeTypeOf("number");
+			expect(payload.exp).toBeTypeOf("number");
+		},
+	);
+
+	it("key rotation: token signed with old key is verifiable after rotation", async () => {
+		const oldPair = await generateTestKeyPair("ES256");
+		const newPair = await generateTestKeyPair("ES256");
+
+		// Step 1: Create KeyStore with old key and sign a token
+		const oldKeyStore = await createKeyStoreFromConfig({
+			algorithm: "ES256",
+			kid: "k-old",
+			privateKey: oldPair.privateKeyPem,
+			publicKey: oldPair.publicKeyPem,
+			previousKeys: [],
+		});
+
+		const oldToken = await generateToken(
+			{ sub: "user-456", role: "viewer" },
+			{
+				keyStore: oldKeyStore,
+				issuer: "https://auth.example.com",
+				expiresIn: 7200,
+			},
+		);
+
+		// Verify old token works with old KeyStore
+		const oldHeader = decodeProtectedHeader(oldToken.token);
+		expect(oldHeader.kid).toBe("k-old");
+
+		const oldVerificationKey = oldKeyStore.getVerificationKey("k-old");
+		const { payload: oldPayload } = await jwtVerify(oldToken.token, oldVerificationKey);
+		expect(oldPayload.sub).toBe("user-456");
+
+		// Step 2: Rotate keys — new KeyStore with old key in previousKeys
+		const newKeyStore = await createKeyStoreFromConfig({
+			algorithm: "ES256",
+			kid: "k-new",
+			privateKey: newPair.privateKeyPem,
+			publicKey: newPair.publicKeyPem,
+			previousKeys: [
+				{
+					kid: "k-old",
+					publicKey: oldPair.publicKeyPem,
+					expiresAt: "2099-12-31T00:00:00Z",
+				},
+			],
+		});
+
+		// Step 3: Verify old token still works with new KeyStore
+		const rotatedVerificationKey = newKeyStore.getVerificationKey(oldHeader.kid!);
+		const { payload: rotatedPayload } = await jwtVerify(oldToken.token, rotatedVerificationKey);
+		expect(rotatedPayload.sub).toBe("user-456");
+		expect(rotatedPayload.role).toBe("viewer");
+
+		// Step 4: New tokens are signed with the new key
+		const newToken = await generateToken(
+			{ sub: "user-789" },
+			{ keyStore: newKeyStore, expiresIn: 3600 },
+		);
+
+		const newHeader = decodeProtectedHeader(newToken.token);
+		expect(newHeader.kid).toBe("k-new");
+
+		const newVerificationKey = newKeyStore.getVerificationKey("k-new");
+		const { payload: newPayload } = await jwtVerify(newToken.token, newVerificationKey);
+		expect(newPayload.sub).toBe("user-789");
+	});
+
+	it("key rotation: expired previous key is rejected", async () => {
+		const oldPair = await generateTestKeyPair("RS256");
+		const newPair = await generateTestKeyPair("RS256");
+
+		// Sign a token with old key
+		const oldKeyStore = await createKeyStoreFromConfig({
+			algorithm: "RS256",
+			kid: "r-old",
+			privateKey: oldPair.privateKeyPem,
+			publicKey: oldPair.publicKeyPem,
+			previousKeys: [],
+		});
+
+		const oldToken = await generateToken(
+			{ sub: "user-expired" },
+			{ keyStore: oldKeyStore, expiresIn: 3600 },
+		);
+
+		// Rotate with expired previous key
+		const newKeyStore = await createKeyStoreFromConfig({
+			algorithm: "RS256",
+			kid: "r-new",
+			privateKey: newPair.privateKeyPem,
+			publicKey: newPair.publicKeyPem,
+			previousKeys: [
+				{
+					kid: "r-old",
+					publicKey: oldPair.publicKeyPem,
+					expiresAt: new Date(Date.now() - 1000).toISOString(),
+				},
+			],
+		});
+
+		// Attempting to verify with expired previous key should throw
+		expect(() => newKeyStore.getVerificationKey("r-old")).toThrow("Expired kid: r-old");
+	});
+});

--- a/packages/core/src/routes/Jwks.mts
+++ b/packages/core/src/routes/Jwks.mts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { Request, Response, Router } from "express";
+import { exportJWK } from "jose";
+import type { KeyStore } from "#/keys/KeyStore.mjs";
+
+export const createRouter = (
+	express: { Router: () => Router },
+	keyStore: KeyStore,
+): Router => {
+	const router = express.Router();
+
+	router.get("/.well-known/jwks.json", async (_req: Request, res: Response) => {
+		if (keyStore.algorithm === "HS256") {
+			return res.sendStatus(404);
+		}
+		const managedKeys = keyStore.getVerificationKeys();
+		const keys = await Promise.all(
+			managedKeys.map(async (mk) => {
+				const jwk = await exportJWK(mk.publicKey);
+				return { ...jwk, kid: mk.kid, use: "sig", alg: keyStore.algorithm };
+			}),
+		);
+		return res.json({ keys });
+	});
+
+	return router;
+};

--- a/packages/core/src/routes/__tests__/Jwks.test.mts
+++ b/packages/core/src/routes/__tests__/Jwks.test.mts
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from "vitest";
+import { exportPKCS8, exportSPKI, generateKeyPair } from "jose";
+import { createAsymmetricKeyStore, createSymmetricKeyStore } from "../../keys/KeyStore.mjs";
+import { createRouter } from "../Jwks.mjs";
+
+function createMockExpress() {
+	const routes: Record<string, Function> = {};
+	const router = {
+		get(path: string, handler: Function) {
+			routes[path] = handler;
+			return router;
+		},
+	};
+	return { Router: () => router, routes };
+}
+
+function createMockRes() {
+	let statusCode = 200;
+	let body: unknown;
+	return {
+		status(code: number) {
+			statusCode = code;
+			return this;
+		},
+		json(data: unknown) {
+			body = data;
+			return this;
+		},
+		sendStatus(code: number) {
+			statusCode = code;
+			return this;
+		},
+		getStatusCode: () => statusCode,
+		getBody: () => body,
+	};
+}
+
+describe("JWKS endpoint", () => {
+	it("returns 404 for HS256", () => {
+		const ks = createSymmetricKeyStore("test-secret");
+		const express = createMockExpress();
+		createRouter(express as any, ks);
+		const handler = express.routes["/.well-known/jwks.json"];
+		const res = createMockRes();
+		handler({}, res);
+		expect(res.getStatusCode()).toBe(404);
+	});
+
+	it("returns JWK set for ES256", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("ES256", { extractable: true });
+		const ks = await createAsymmetricKeyStore({
+			algorithm: "ES256",
+			kid: "test-key",
+			privateKeyPem: await exportPKCS8(privateKey),
+			publicKeyPem: await exportSPKI(publicKey),
+		});
+		const express = createMockExpress();
+		createRouter(express as any, ks);
+		const handler = express.routes["/.well-known/jwks.json"];
+		const res = createMockRes();
+		await handler({}, res);
+		const body = res.getBody() as { keys: Array<Record<string, unknown>> };
+		expect(body.keys).toHaveLength(1);
+		expect(body.keys[0].kid).toBe("test-key");
+		expect(body.keys[0].kty).toBe("EC");
+		expect(body.keys[0].use).toBe("sig");
+		expect(body.keys[0].alg).toBe("ES256");
+		expect(body.keys[0].d).toBeUndefined(); // no private key
+	});
+
+	it("includes non-expired previous keys", async () => {
+		const current = await generateKeyPair("ES256", { extractable: true });
+		const prev = await generateKeyPair("ES256", { extractable: true });
+		const ks = await createAsymmetricKeyStore({
+			algorithm: "ES256",
+			kid: "current",
+			privateKeyPem: await exportPKCS8(current.privateKey),
+			publicKeyPem: await exportSPKI(current.publicKey),
+			previousKeys: [
+				{
+					kid: "old",
+					publicKeyPem: await exportSPKI(prev.publicKey),
+					expiresAt: new Date(Date.now() + 86400000),
+				},
+			],
+		});
+		const express = createMockExpress();
+		createRouter(express as any, ks);
+		const res = createMockRes();
+		await express.routes["/.well-known/jwks.json"]({}, res);
+		const body = res.getBody() as { keys: Array<Record<string, unknown>> };
+		expect(body.keys).toHaveLength(2);
+		expect(body.keys.map((k) => k.kid)).toContain("current");
+		expect(body.keys.map((k) => k.kid)).toContain("old");
+	});
+
+	it("excludes expired previous keys", async () => {
+		const current = await generateKeyPair("ES256", { extractable: true });
+		const prev = await generateKeyPair("ES256", { extractable: true });
+		const ks = await createAsymmetricKeyStore({
+			algorithm: "ES256",
+			kid: "current",
+			privateKeyPem: await exportPKCS8(current.privateKey),
+			publicKeyPem: await exportSPKI(current.publicKey),
+			previousKeys: [
+				{
+					kid: "expired",
+					publicKeyPem: await exportSPKI(prev.publicKey),
+					expiresAt: new Date(Date.now() - 1000),
+				},
+			],
+		});
+		const express = createMockExpress();
+		createRouter(express as any, ks);
+		const res = createMockRes();
+		await express.routes["/.well-known/jwks.json"]({}, res);
+		const body = res.getBody() as { keys: Array<Record<string, unknown>> };
+		expect(body.keys).toHaveLength(1);
+		expect(body.keys[0].kid).toBe("current");
+	});
+});

--- a/packages/core/src/routes/index.mts
+++ b/packages/core/src/routes/index.mts
@@ -24,6 +24,7 @@ import type { ClientRepository } from "#/repositories/ClientRepository.mjs";
 import type { CodeRepository } from "#/repositories/CodeRepository.mjs";
 import * as federation from "./Federation.mjs";
 import * as healthcheck from "./Healthcheck.mjs";
+import * as jwks from "./Jwks.mjs";
 import * as oauth from "./OAuth.mjs";
 import * as session from "./Session.mjs";
 
@@ -54,6 +55,7 @@ export const createRouter = (
 
 	router
 		.use(healthcheck.createRouter(express))
+		.use(jwks.createRouter(express, params.keyStore))
 		.use("/oauth", oauthRouter)
 		.use(
 			"/session",

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -7,8 +7,17 @@ http {
 
 oauth {
   jwt {
+    algorithm = "HS256"
+    algorithm = ${?OAUTH_JWT_ALGORITHM}
     secret = ${?OAUTH_JWT_SECRET}
     issuer = ${?OAUTH_JWT_ISSUER}
+    kid = "v0"
+    kid = ${?OAUTH_JWT_KID}
+    privateKey = ${?OAUTH_JWT_PRIVATE_KEY}
+    privateKeyPath = ${?OAUTH_JWT_PRIVATE_KEY_PATH}
+    publicKey = ${?OAUTH_JWT_PUBLIC_KEY}
+    publicKeyPath = ${?OAUTH_JWT_PUBLIC_KEY_PATH}
+    previousKeys = []
   }
   accessToken {
     expiresIn = 3600

--- a/templates/standalone/src/app.mts
+++ b/templates/standalone/src/app.mts
@@ -21,7 +21,7 @@ import {
 	createDefaultFactories,
 	createPassport,
 	createRouter,
-	createSymmetricKeyStore,
+	createKeyStoreFromConfig,
 } from "@o3co/auth-provider-core";
 import { registerBuiltinRepositories } from "@o3co/auth-provider-repositories";
 import { parseFile } from "@o3co/ts.hocon";
@@ -108,7 +108,7 @@ await (async (): Promise<void> => {
 	app.use(passport.session());
 
 	// Initialize KeyStore
-	const keyStore = createSymmetricKeyStore(config.oauth.jwt.secret, config.oauth.jwt.kid);
+	const keyStore = await createKeyStoreFromConfig(config.oauth.jwt);
 
 	// Initialize Routes with DI
 	const { router, grantRegistry } = createRouter(express, {


### PR DESCRIPTION
## Summary

Phase 2 of #9: Asymmetric JWT signing support.

- Extend config schema with `algorithm` (HS256/RS256/ES256/EdDSA), key path/PEM fields, `previousKeys` for rotation
- Add `createAsymmetricKeyStore()` — async factory using jose `importPKCS8`/`importSPKI`
- Add `createKeyStoreFromConfig()` — reads config, returns appropriate KeyStore (HS256 or asymmetric)
- Add `GET /.well-known/jwks.json` endpoint (404 for HS256, serves public keys for asymmetric)
- Key rotation via `previousKeys` with `expiresAt`-based graceful transition
- Validate `expiresAt` (reject Invalid Date), descriptive errors for missing key files
- Update standalone template to use `createKeyStoreFromConfig`

## Test plan

- [x] 181 tests pass (17 test files)
- [x] Round-trip sign→verify for ES256, RS256, EdDSA
- [x] Key rotation: old token verified via previousKeys
- [x] Expired previous keys excluded from JWKS and rejected in verification
- [x] Invalid expiresAt rejected at startup
- [x] Missing key file produces descriptive error
- [x] JWKS returns 404 for HS256
- [x] JWKS excludes private key material (`d` field absent)
- [x] Config validation: missing secret/keys throws at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>