### PR TITLE
feat: standardize JWT claims to RFC 7519/9068 (sub, azp, scope, typ)

### DIFF
--- a/packages/core/src/grants/__tests__/authorization.test.mts
+++ b/packages/core/src/grants/__tests__/authorization.test.mts
@@ -16,6 +16,7 @@
 import crypto from "node:crypto";
 
 import { describe, expect, it, vi } from "vitest";
+import { decodeJwt } from "jose";
 
 import { createSymmetricKeyStore } from "../../keys/KeyStore.mjs";
 import { createAuthorizationGrant } from "../authorization.mjs";
@@ -136,6 +137,9 @@ describe("createAuthorizationGrant", () => {
 			if ("tokens" in result) {
 				expect(result.tokens.access_token).toBeDefined();
 				expect(result.tokens.refresh_token).toBeDefined();
+				const decoded = decodeJwt(result.tokens.access_token);
+				expect(decoded.sub).toBe("u1");
+				expect((decoded as Record<string, unknown>).azp).toBe("client1");
 			}
 			// Session must be cleared
 			expect(sessionMutation).toBeDefined();

--- a/packages/core/src/grants/__tests__/refreshToken.test.mts
+++ b/packages/core/src/grants/__tests__/refreshToken.test.mts
@@ -47,8 +47,8 @@ const mockDeps: GrantDependencies = {
 };
 
 async function makeRefreshToken(overrides: Record<string, unknown> = {}): Promise<string> {
-	return new SignJWT({ type: "refresh", user: { id: "u1" }, ...overrides })
-		.setProtectedHeader({ alg: "HS256", kid: "v0" })
+	return new SignJWT({ sub: "u1", scope: "read write", ...overrides })
+		.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
 		.setExpirationTime("24h")
 		.sign(secretKey);
 }
@@ -84,9 +84,9 @@ describe("createRefreshTokenGrant", () => {
 			expect(result.status).toBe(400);
 		});
 
-		it("returns 400 when JWT type is not refresh", async () => {
-			const accessToken = await new SignJWT({ type: "access", user: { id: "u1" } })
-				.setProtectedHeader({ alg: "HS256", kid: "v0" })
+		it("returns 400 when JWT typ header is not rt+jwt", async () => {
+			const accessToken = await new SignJWT({ sub: "u1" })
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "at+jwt" })
 				.setExpirationTime("1h")
 				.sign(secretKey);
 			const handler = createRefreshTokenGrant(mockDeps);
@@ -103,8 +103,8 @@ describe("createRefreshTokenGrant", () => {
 		});
 
 		it("returns 400 when client_id does not match token audience", async () => {
-			const token = await new SignJWT({ type: "refresh", user: { id: "u1" } })
-				.setProtectedHeader({ alg: "HS256", kid: "v0" })
+			const token = await new SignJWT({ sub: "u1" })
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
 				.setAudience("client1")
 				.setExpirationTime("24h")
 				.sign(secretKey);
@@ -142,8 +142,8 @@ describe("createRefreshTokenGrant", () => {
 		});
 
 		it("returns 200 when client_id matches token audience", async () => {
-			const token = await new SignJWT({ type: "refresh", user: { id: "u1" } })
-				.setProtectedHeader({ alg: "HS256", kid: "v0" })
+			const token = await new SignJWT({ sub: "u1" })
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
 				.setAudience("client1")
 				.setExpirationTime("24h")
 				.sign(secretKey);
@@ -161,7 +161,7 @@ describe("createRefreshTokenGrant", () => {
 		});
 
 		it("allows scope reduction via scope parameter", async () => {
-			const token = await makeRefreshToken({ scopes: ["read", "write"] });
+			const token = await makeRefreshToken({ scope: "read write" });
 			const handler = createRefreshTokenGrant(mockDeps);
 			const ctx: GrantContext = {
 				body: { refresh_token: token, scope: "read" },
@@ -180,7 +180,7 @@ describe("createRefreshTokenGrant", () => {
 		});
 
 		it("rejects scope that exceeds original grant", async () => {
-			const token = await makeRefreshToken({ scopes: ["read"] });
+			const token = await makeRefreshToken({ scope: "read" });
 			const handler = createRefreshTokenGrant(mockDeps);
 			const ctx: GrantContext = {
 				body: { refresh_token: token, scope: "read write" },
@@ -198,7 +198,7 @@ describe("createRefreshTokenGrant", () => {
 		});
 
 		it("deduplicates requested scope values", async () => {
-			const token = await makeRefreshToken({ scopes: ["read", "write"] });
+			const token = await makeRefreshToken({ scope: "read write" });
 			const handler = createRefreshTokenGrant(mockDeps);
 			const ctx: GrantContext = {
 				body: { refresh_token: token, scope: "read read" },
@@ -217,7 +217,7 @@ describe("createRefreshTokenGrant", () => {
 		});
 
 		it("treats empty scope string as no scope change", async () => {
-			const token = await makeRefreshToken({ scopes: ["read", "write"] });
+			const token = await makeRefreshToken({ scope: "read write" });
 			const handler = createRefreshTokenGrant(mockDeps);
 			const ctx: GrantContext = {
 				body: { refresh_token: token, scope: "" },
@@ -238,8 +238,8 @@ describe("createRefreshTokenGrant", () => {
 		it("accepts legacy tokens without kid header", async () => {
 			// Tokens issued before jose migration have no kid in the protected header.
 			// The fallback uses keyStore.current.kid to resolve the verification key.
-			const legacyToken = await new SignJWT({ type: "refresh", user: { id: "u1" } })
-				.setProtectedHeader({ alg: "HS256" })
+			const legacyToken = await new SignJWT({ sub: "u1" })
+				.setProtectedHeader({ alg: "HS256", typ: "rt+jwt" })
 				.setExpirationTime("24h")
 				.sign(secretKey);
 			const handler = createRefreshTokenGrant(mockDeps);

--- a/packages/core/src/grants/__tests__/refreshToken.test.mts
+++ b/packages/core/src/grants/__tests__/refreshToken.test.mts
@@ -235,9 +235,28 @@ describe("createRefreshTokenGrant", () => {
 			}
 		});
 
+		it("accepts legacy tokens with type payload instead of typ header", async () => {
+			// Tokens issued before claims standardization use type: "refresh" in payload
+			// instead of typ: "rt+jwt" in the protected header.
+			const legacyToken = await new SignJWT({ type: "refresh", sub: "u1" })
+				.setProtectedHeader({ alg: "HS256", kid: "v0" })
+				.setExpirationTime("24h")
+				.sign(secretKey);
+			const handler = createRefreshTokenGrant(mockDeps);
+			const ctx: GrantContext = {
+				body: { refresh_token: legacyToken },
+				session: {},
+				issuer: "localhost",
+				metadata: { ip: "127.0.0.1" },
+			};
+
+			const { result } = await handler.handle(ctx);
+
+			expect(result.status).toBe(200);
+			expect("tokens" in result).toBe(true);
+		});
+
 		it("accepts legacy tokens without kid header", async () => {
-			// Tokens issued before jose migration have no kid in the protected header.
-			// The fallback uses keyStore.current.kid to resolve the verification key.
 			const legacyToken = await new SignJWT({ sub: "u1" })
 				.setProtectedHeader({ alg: "HS256", typ: "rt+jwt" })
 				.setExpirationTime("24h")

--- a/packages/core/src/grants/__tests__/session.test.mts
+++ b/packages/core/src/grants/__tests__/session.test.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it, vi } from "vitest";
+import { decodeJwt } from "jose";
 
 import { createSymmetricKeyStore } from "../../keys/KeyStore.mjs";
 import { createSessionGrant } from "../session.mjs";
@@ -142,9 +143,10 @@ describe("createSessionGrant", () => {
 			expect(result.status).toBe(200);
 			expect("tokens" in result).toBe(true);
 			if ("tokens" in result) {
-				const { decodeJwt } = await import("jose");
 				const decoded = decodeJwt(result.tokens.access_token);
 				expect(decoded.aud).toBe("my-app");
+				expect(decoded.sub).toBe("u1");
+				expect((decoded as Record<string, unknown>).azp).toBe("my-app");
 			}
 		});
 

--- a/packages/core/src/grants/__tests__/token.test.mts
+++ b/packages/core/src/grants/__tests__/token.test.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
-import { decodeProtectedHeader } from "jose";
+import { decodeJwt, decodeProtectedHeader } from "jose";
 import { createSymmetricKeyStore } from "../../keys/KeyStore.mjs";
 import { generateToken, generateTokenResponse } from "../token.mjs";
 
@@ -22,10 +22,10 @@ const keyStore = createSymmetricKeyStore("test-secret-at-least-32-chars!!");
 
 describe("generateToken", () => {
 	it("returns a Token with a valid JWT string", async () => {
-		const token = await generateToken({ user: "alice" }, {
+		const token = await generateToken({}, {
 			keyStore,
 			expiresIn: 3600,
-			type: "access",
+			tokenType: "at+jwt",
 		});
 
 		expect(token.token).toBeDefined();
@@ -34,9 +34,9 @@ describe("generateToken", () => {
 	});
 
 	it("sets kid in JWT protected header", async () => {
-		const token = await generateToken({ user: "alice" }, {
+		const token = await generateToken({}, {
 			keyStore,
-			type: "access",
+			tokenType: "at+jwt",
 		});
 
 		const header = decodeProtectedHeader(token.token);
@@ -46,50 +46,124 @@ describe("generateToken", () => {
 
 	it("sets custom kid from keyStore", async () => {
 		const ks = createSymmetricKeyStore("test-secret-at-least-32-chars!!", "v2");
-		const token = await generateToken({ user: "alice" }, {
+		const token = await generateToken({}, {
 			keyStore: ks,
-			type: "access",
+			tokenType: "at+jwt",
 		});
 
 		const header = decodeProtectedHeader(token.token);
 		expect(header.kid).toBe("v2");
 	});
 
-	it("includes expiresIn, audience, issuer, scopes, type in result", async () => {
-		const token = await generateToken({ user: "alice" }, {
+	it("sets sub claim via subject option", async () => {
+		const token = await generateToken({}, {
+			keyStore,
+			subject: "user-123",
+			tokenType: "at+jwt",
+		});
+
+		const payload = decodeJwt(token.token);
+		expect(payload.sub).toBe("user-123");
+		expect(token.subject).toBe("user-123");
+	});
+
+	it("sets azp claim via authorizedParty option", async () => {
+		const token = await generateToken({}, {
+			keyStore,
+			authorizedParty: "client-abc",
+			tokenType: "at+jwt",
+		});
+
+		const payload = decodeJwt(token.token);
+		expect((payload as Record<string, unknown>).azp).toBe("client-abc");
+	});
+
+	it("sets scope claim as string in payload", async () => {
+		const token = await generateToken({}, {
+			keyStore,
+			scope: "read write",
+			tokenType: "at+jwt",
+		});
+
+		const payload = decodeJwt(token.token);
+		expect((payload as Record<string, unknown>).scope).toBe("read write");
+		expect(token.scope).toBe("read write");
+	});
+
+	it("sets typ in protected header via tokenType option", async () => {
+		const token = await generateToken({}, {
+			keyStore,
+			tokenType: "at+jwt",
+		});
+
+		const header = decodeProtectedHeader(token.token);
+		expect(header.typ).toBe("at+jwt");
+		expect(token.tokenType).toBe("at+jwt");
+	});
+
+	it("sets typ to rt+jwt for refresh tokens", async () => {
+		const token = await generateToken({}, {
+			keyStore,
+			tokenType: "rt+jwt",
+		});
+
+		const header = decodeProtectedHeader(token.token);
+		expect(header.typ).toBe("rt+jwt");
+		expect(token.tokenType).toBe("rt+jwt");
+	});
+
+	it("does not include legacy user, client, scopes, type, ip in payload", async () => {
+		const token = await generateToken({}, {
+			keyStore,
+			subject: "user-123",
+			authorizedParty: "client-abc",
+			scope: "read",
+			tokenType: "at+jwt",
+		});
+
+		const payload = decodeJwt(token.token) as Record<string, unknown>;
+		expect(payload.user).toBeUndefined();
+		expect(payload.client).toBeUndefined();
+		expect(payload.scopes).toBeUndefined();
+		expect(payload.type).toBeUndefined();
+		expect(payload.ip).toBeUndefined();
+	});
+
+	it("includes expiresIn, audience, issuer, scope, tokenType in result", async () => {
+		const token = await generateToken({}, {
 			keyStore,
 			expiresIn: 3600,
 			issuer: "auth.provider",
 			audience: "client1",
-			scopes: ["read", "write"],
-			type: "access",
+			scope: "read write",
+			tokenType: "at+jwt",
 		});
 
 		expect(token.expiresIn).toBe(3600);
 		expect(token.issuer).toBe("auth.provider");
 		expect(token.audience).toBe("client1");
-		expect(token.scopes).toEqual(["read", "write"]);
-		expect(token.type).toBe("access");
+		expect(token.scope).toBe("read write");
+		expect(token.tokenType).toBe("at+jwt");
 	});
 
 	it("omits optional fields when not provided", async () => {
-		const token = await generateToken({ user: "alice" }, { keyStore });
+		const token = await generateToken({}, { keyStore, tokenType: "at+jwt" });
 
 		expect(token.expiresIn).toBeUndefined();
 		expect(token.issuer).toBeUndefined();
 		expect(token.audience).toBeUndefined();
-		expect(token.scopes).toBeUndefined();
-		expect(token.type).toBeUndefined();
+		expect(token.scope).toBeUndefined();
+		expect(token.subject).toBeUndefined();
 	});
 });
 
 describe("generateTokenResponse", () => {
 	it("formats access token response", async () => {
-		const accessToken = await generateToken({ user: "alice" }, {
+		const accessToken = await generateToken({}, {
 			keyStore,
 			expiresIn: 3600,
-			scopes: ["read"],
-			type: "access",
+			scope: "read",
+			tokenType: "at+jwt",
 		});
 
 		const response = generateTokenResponse({ accessToken });
@@ -102,8 +176,8 @@ describe("generateTokenResponse", () => {
 	});
 
 	it("includes refresh token when provided", async () => {
-		const accessToken = await generateToken({}, { keyStore, type: "access" });
-		const refreshToken = await generateToken({}, { keyStore, type: "refresh" });
+		const accessToken = await generateToken({}, { keyStore, tokenType: "at+jwt" });
+		const refreshToken = await generateToken({}, { keyStore, tokenType: "rt+jwt" });
 
 		const response = generateTokenResponse({ accessToken, refreshToken });
 

--- a/packages/core/src/grants/authorization.mts
+++ b/packages/core/src/grants/authorization.mts
@@ -131,7 +131,8 @@ export const createAuthorizationGrant = (deps: GrantDependencies): GrantHandler 
 				}
 			}
 
-			const userId = (session.user as Record<string, unknown> | undefined)?.id as string | undefined;
+			const rawUserId = (session.user as Record<string, unknown> | undefined)?.id;
+			const userId = typeof rawUserId === "string" ? rawUserId : undefined;
 
 			return {
 				result: {

--- a/packages/core/src/grants/authorization.mts
+++ b/packages/core/src/grants/authorization.mts
@@ -15,7 +15,7 @@
  */
 import crypto from "node:crypto";
 
-import { formatObject, generateToken, generateTokenResponse } from "./token.mjs";
+import { generateToken, generateTokenResponse } from "./token.mjs";
 import type {
 	GrantContext,
 	GrantDependencies,
@@ -28,7 +28,7 @@ export const createAuthorizationGrant = (deps: GrantDependencies): GrantHandler 
 
 	return {
 		async handle(ctx: GrantContext): Promise<GrantHandlerResult> {
-			const { body, session, issuer, metadata } = ctx;
+			const { body, session, issuer } = ctx;
 			const {
 				code,
 				code_verifier = null,
@@ -131,31 +131,31 @@ export const createAuthorizationGrant = (deps: GrantDependencies): GrantHandler 
 				}
 			}
 
-			const payload = formatObject({
-				user: session.user,
-				client: session.client,
-				...metadata,
-			});
+			const userId = (session.user as Record<string, unknown> | undefined)?.id as string | undefined;
 
 			return {
 				result: {
 					status: 200,
 					tokens: generateTokenResponse({
-						accessToken: await generateToken(payload, {
+						accessToken: await generateToken({}, {
 							expiresIn: config.oauth.accessToken.expiresIn,
 							keyStore,
 							issuer,
 							audience: client_id,
-							scopes: grantedScopes,
-							type: "access",
+							subject: userId ?? null,
+							authorizedParty: client_id ?? null,
+							scope: grantedScopes?.join(" ") ?? null,
+							tokenType: "at+jwt",
 						}),
-						refreshToken: await generateToken(payload, {
+						refreshToken: await generateToken({}, {
 							expiresIn: config.oauth.refreshToken.expiresIn,
 							keyStore,
 							issuer,
 							audience: client_id,
-							scopes: grantedScopes,
-							type: "refresh",
+							subject: userId ?? null,
+							authorizedParty: client_id ?? null,
+							scope: grantedScopes?.join(" ") ?? null,
+							tokenType: "rt+jwt",
 						}),
 					}),
 				},

--- a/packages/core/src/grants/did.mts
+++ b/packages/core/src/grants/did.mts
@@ -15,7 +15,7 @@
  */
 import { verifyAsync } from "@noble/ed25519";
 
-import { formatObject, generateToken, generateTokenResponse } from "./token.mjs";
+import { generateToken, generateTokenResponse } from "./token.mjs";
 import type {
 	GrantContext,
 	GrantDependencies,
@@ -40,7 +40,7 @@ export const createDidGrant = (deps: GrantDependencies): GrantHandler => {
 
 	return {
 		async handle(ctx: GrantContext): Promise<GrantHandlerResult> {
-			const { body, issuer, metadata } = ctx;
+			const { body, issuer } = ctx;
 			const {
 				did,
 				signature,
@@ -173,20 +173,17 @@ export const createDidGrant = (deps: GrantDependencies): GrantHandler => {
 			nonceStore.set(nonceKey, Date.now());
 
 			// 9. Generate token (M2M: access token only, no refresh token)
-			const didPayload = formatObject({
-				did,
-				...metadata,
-			});
-
 			return {
 				result: {
 					status: 200,
 					tokens: generateTokenResponse({
-						accessToken: await generateToken(didPayload, {
+						accessToken: await generateToken({}, {
 							expiresIn: config.oauth.accessToken.expiresIn,
 							keyStore,
 							issuer,
-							type: "access",
+							subject: did,
+							authorizedParty: parsedMessage.audience ?? null,
+							tokenType: "at+jwt",
 							audience: parsedMessage.audience,
 						}),
 					}),

--- a/packages/core/src/grants/refreshToken.mts
+++ b/packages/core/src/grants/refreshToken.mts
@@ -67,7 +67,9 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				};
 			}
 
-			if (typ !== "rt+jwt") {
+			// Accept both new typ header ("rt+jwt") and legacy type payload ("refresh")
+			const legacyType = (tokenPayload as Record<string, unknown>).type;
+			if (typ !== "rt+jwt" && legacyType !== "refresh") {
 				return {
 					result: {
 						status: 400,

--- a/packages/core/src/grants/refreshToken.mts
+++ b/packages/core/src/grants/refreshToken.mts
@@ -103,6 +103,16 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				: Array.isArray(claims.scopes) ? (claims.scopes as string[]).join(" ")
 				: undefined;
 
+			if (!subjectStr) {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_grant",
+						errorDescription: "refresh token has no subject",
+					},
+				};
+			}
+
 			// RFC 6749 Section 6: requested scope MUST NOT exceed original scope
 			let grantedScope = scopeStr ?? null;
 			if (requestedScope) {

--- a/packages/core/src/grants/refreshToken.mts
+++ b/packages/core/src/grants/refreshToken.mts
@@ -15,7 +15,7 @@
  */
 import { decodeProtectedHeader, jwtVerify, type JWTPayload } from "jose";
 
-import { formatObject, generateToken, generateTokenResponse } from "./token.mjs";
+import { generateToken, generateTokenResponse } from "./token.mjs";
 import type {
 	GrantContext,
 	GrantDependencies,
@@ -28,7 +28,7 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 
 	return {
 		async handle(ctx: GrantContext): Promise<GrantHandlerResult> {
-			const { body, issuer, metadata } = ctx;
+			const { body, issuer } = ctx;
 			const {
 				refresh_token: refreshTokenValue,
 				client_id,
@@ -50,9 +50,11 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			}
 
 			let tokenPayload: JWTPayload;
+			let typ: string | undefined;
 			try {
-				const { kid } = decodeProtectedHeader(refreshTokenValue);
-				const key = keyStore.getVerificationKey(kid ?? keyStore.current.kid);
+				const header = decodeProtectedHeader(refreshTokenValue);
+				typ = header.typ;
+				const key = keyStore.getVerificationKey(header.kid ?? keyStore.current.kid);
 				const { payload } = await jwtVerify(refreshTokenValue, key);
 				tokenPayload = payload;
 			} catch {
@@ -65,7 +67,7 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				};
 			}
 
-			if (tokenPayload.type !== "refresh") {
+			if (typ !== "rt+jwt") {
 				return {
 					result: {
 						status: 400,
@@ -87,15 +89,15 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				};
 			}
 
-			const user = tokenPayload.user as Record<string, unknown> | undefined;
-			const client = tokenPayload.client as Record<string, unknown> | undefined;
-			const existingScopes = tokenPayload.scopes as string[] | undefined;
+			const subjectStr = typeof tokenPayload.sub === "string" ? tokenPayload.sub : undefined;
+			const azpStr = typeof (tokenPayload as Record<string, unknown>).azp === "string" ? (tokenPayload as Record<string, unknown>).azp as string : undefined;
+			const scopeStr = typeof (tokenPayload as Record<string, unknown>).scope === "string" ? (tokenPayload as Record<string, unknown>).scope as string : undefined;
 
 			// RFC 6749 Section 6: requested scope MUST NOT exceed original scope
-			let grantedScopes = existingScopes as string[] | null;
+			let grantedScope = scopeStr ?? null;
 			if (requestedScope) {
 				const requested = [...new Set(requestedScope.split(" ").filter(Boolean))];
-				const original = Array.isArray(existingScopes) ? existingScopes : [];
+				const original = scopeStr ? scopeStr.split(" ") : [];
 				const invalid = requested.filter((s) => !original.includes(s));
 				if (invalid.length > 0) {
 					return {
@@ -106,30 +108,32 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 						},
 					};
 				}
-				grantedScopes = requested;
+				grantedScope = requested.join(" ");
 			}
-
-			const refreshPayload = formatObject({ user, client, ...metadata });
 
 			return {
 				result: {
 					status: 200,
 					tokens: generateTokenResponse({
-						accessToken: await generateToken(refreshPayload, {
+						accessToken: await generateToken({}, {
 							expiresIn: config.oauth.accessToken.expiresIn,
 							keyStore,
 							issuer,
 							audience: tokenAud ?? client_id ?? null,
-							scopes: grantedScopes,
-							type: "access",
+							subject: subjectStr ?? null,
+							authorizedParty: azpStr ?? null,
+							scope: grantedScope,
+							tokenType: "at+jwt",
 						}),
-						refreshToken: await generateToken(refreshPayload, {
+						refreshToken: await generateToken({}, {
 							expiresIn: config.oauth.refreshToken.expiresIn,
 							keyStore,
 							issuer,
 							audience: tokenAud ?? client_id ?? null,
-							scopes: grantedScopes,
-							type: "refresh",
+							subject: subjectStr ?? null,
+							authorizedParty: azpStr ?? null,
+							scope: grantedScope,
+							tokenType: "rt+jwt",
 						}),
 					}),
 				},

--- a/packages/core/src/grants/refreshToken.mts
+++ b/packages/core/src/grants/refreshToken.mts
@@ -91,9 +91,17 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				};
 			}
 
-			const subjectStr = typeof tokenPayload.sub === "string" ? tokenPayload.sub : undefined;
-			const azpStr = typeof (tokenPayload as Record<string, unknown>).azp === "string" ? (tokenPayload as Record<string, unknown>).azp as string : undefined;
-			const scopeStr = typeof (tokenPayload as Record<string, unknown>).scope === "string" ? (tokenPayload as Record<string, unknown>).scope as string : undefined;
+			const claims = tokenPayload as Record<string, unknown>;
+			// Read standard claims, with legacy fallback for pre-standardization tokens
+			const subjectStr = typeof tokenPayload.sub === "string" ? tokenPayload.sub
+				: typeof (claims.user as Record<string, unknown> | undefined)?.id === "string" ? (claims.user as Record<string, unknown>).id as string
+				: undefined;
+			const azpStr = typeof claims.azp === "string" ? claims.azp as string
+				: typeof (claims.client as Record<string, unknown> | undefined)?.id === "string" ? (claims.client as Record<string, unknown>).id as string
+				: undefined;
+			const scopeStr = typeof claims.scope === "string" ? claims.scope as string
+				: Array.isArray(claims.scopes) ? (claims.scopes as string[]).join(" ")
+				: undefined;
 
 			// RFC 6749 Section 6: requested scope MUST NOT exceed original scope
 			let grantedScope = scopeStr ?? null;

--- a/packages/core/src/grants/session.mts
+++ b/packages/core/src/grants/session.mts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { formatObject, generateToken, generateTokenResponse } from "./token.mjs";
+import { generateToken, generateTokenResponse } from "./token.mjs";
 import type {
 	GrantContext,
 	GrantDependencies,
@@ -26,7 +26,7 @@ export const createSessionGrant = (deps: GrantDependencies): GrantHandler => {
 
 	return {
 		async handle(ctx: GrantContext): Promise<GrantHandlerResult> {
-			const { body, session, issuer, metadata } = ctx;
+			const { body, session, issuer } = ctx;
 			const { client_id, scope: requestedScope } = body as {
 				client_id?: string;
 				scope?: string;
@@ -74,23 +74,21 @@ export const createSessionGrant = (deps: GrantDependencies): GrantHandler => {
 				}
 			}
 
-			const payload = formatObject({
-				user: session.user,
-				client: session.client,
-				...metadata,
-			});
+			const userId = (session.user as Record<string, unknown> | undefined)?.id as string | undefined;
 
 			return {
 				result: {
 					status: 200,
 					tokens: generateTokenResponse({
-						accessToken: await generateToken(payload, {
+						accessToken: await generateToken({}, {
 							keyStore,
 							expiresIn: config.oauth.accessToken.expiresIn,
 							issuer,
 							audience: client_id ?? null,
-							scopes: scopes ?? null,
-							type: "access",
+							subject: userId ?? null,
+							authorizedParty: client_id ?? null,
+							scope: scopes?.join(" ") ?? null,
+							tokenType: "at+jwt",
 						}),
 					}),
 				},

--- a/packages/core/src/grants/session.mts
+++ b/packages/core/src/grants/session.mts
@@ -74,7 +74,8 @@ export const createSessionGrant = (deps: GrantDependencies): GrantHandler => {
 				}
 			}
 
-			const userId = (session.user as Record<string, unknown> | undefined)?.id as string | undefined;
+			const rawUserId = (session.user as Record<string, unknown> | undefined)?.id;
+			const userId = typeof rawUserId === "string" ? rawUserId : undefined;
 
 			return {
 				result: {

--- a/packages/core/src/grants/token.mts
+++ b/packages/core/src/grants/token.mts
@@ -23,8 +23,9 @@ export const formatObject = <T extends object>(data: T): Partial<T> => {
 export interface Token {
 	token: string;
 	expiresIn?: number;
-	scopes?: string[];
-	type?: "access" | "refresh";
+	subject?: string;
+	scope?: string;
+	tokenType?: "at+jwt" | "rt+jwt";
 	audience?: string;
 	issuer?: string;
 }
@@ -50,7 +51,7 @@ export const generateTokenResponse = ({
 		access_token: accessToken.token,
 		token_type: "Bearer",
 		...formatObject({
-			scope: accessToken.scopes?.join(" "),
+			scope: accessToken.scope,
 			refresh_token: refreshToken ? refreshToken.token : null,
 			expires_in: accessToken.expiresIn,
 		}),
@@ -62,8 +63,10 @@ export interface GenerateTokenOptions {
 	keyStore: KeyStore;
 	issuer?: string | null;
 	audience?: string | null;
-	scopes?: string[] | null;
-	type?: "access" | "refresh" | null;
+	subject?: string | null;
+	authorizedParty?: string | null;
+	scope?: string | null;
+	tokenType?: "at+jwt" | "rt+jwt";
 }
 
 export const generateToken = async (
@@ -73,18 +76,20 @@ export const generateToken = async (
 		keyStore,
 		issuer = null,
 		audience = null,
-		scopes = null,
-		type = null,
+		subject = null,
+		authorizedParty = null,
+		scope = null,
+		tokenType = undefined,
 	}: GenerateTokenOptions,
 ): Promise<Token> => {
 	const { kid, privateKey } = keyStore.getSigningKey();
 
 	let builder = new SignJWT({
 		...data,
-		...(scopes ? { scopes } : {}),
-		...(type ? { type } : {}),
+		...(authorizedParty ? { azp: authorizedParty } : {}),
+		...(scope ? { scope } : {}),
 	})
-		.setProtectedHeader({ alg: keyStore.algorithm, kid })
+		.setProtectedHeader({ alg: keyStore.algorithm, kid, ...(tokenType ? { typ: tokenType } : {}) })
 		.setIssuedAt();
 
 	if (expiresIn !== undefined) {
@@ -96,6 +101,9 @@ export const generateToken = async (
 	if (audience != null) {
 		builder = builder.setAudience(audience);
 	}
+	if (subject != null) {
+		builder = builder.setSubject(subject);
+	}
 
 	const token = await builder.sign(privateKey);
 
@@ -104,8 +112,9 @@ export const generateToken = async (
 	if (expiresIn !== undefined) result.expiresIn = expiresIn;
 	if (audience !== null && audience !== undefined) result.audience = audience;
 	if (issuer !== null && issuer !== undefined) result.issuer = issuer;
-	if (scopes !== null && scopes !== undefined) result.scopes = scopes;
-	if (type !== null && type !== undefined) result.type = type;
+	if (subject !== null && subject !== undefined) result.subject = subject;
+	if (scope !== null && scope !== undefined) result.scope = scope;
+	if (tokenType !== undefined) result.tokenType = tokenType;
 
 	return result;
 };

--- a/packages/core/src/keys/__tests__/integration.test.mts
+++ b/packages/core/src/keys/__tests__/integration.test.mts
@@ -41,28 +41,30 @@ describe("Integration: generateToken + asymmetric KeyStore", () => {
 			});
 
 			const token = await generateToken(
-				{ sub: "user-123", role: "admin" },
+				{ role: "admin" },
 				{
 					keyStore,
 					issuer: "https://auth.example.com",
 					audience: "https://api.example.com",
-					scopes: ["read", "write"],
+					subject: "user-123",
+					scope: "read write",
 					expiresIn: 3600,
-					type: "access",
+					tokenType: "at+jwt",
 				},
 			);
 
 			expect(token.token).toBeDefined();
 			expect(token.issuer).toBe("https://auth.example.com");
 			expect(token.audience).toBe("https://api.example.com");
-			expect(token.scopes).toEqual(["read", "write"]);
+			expect(token.scope).toBe("read write");
 			expect(token.expiresIn).toBe(3600);
-			expect(token.type).toBe("access");
+			expect(token.tokenType).toBe("at+jwt");
 
 			// Verify the JWT header
 			const header = decodeProtectedHeader(token.token);
 			expect(header.alg).toBe(alg);
 			expect(header.kid).toBe(`${alg.toLowerCase()}-v1`);
+			expect(header.typ).toBe("at+jwt");
 
 			// Verify the JWT payload using the KeyStore's verification key
 			const verificationKey = keyStore.getVerificationKey(header.kid!);
@@ -73,8 +75,7 @@ describe("Integration: generateToken + asymmetric KeyStore", () => {
 
 			expect(payload.sub).toBe("user-123");
 			expect(payload.role).toBe("admin");
-			expect(payload.scopes).toEqual(["read", "write"]);
-			expect(payload.type).toBe("access");
+			expect((payload as Record<string, unknown>).scope).toBe("read write");
 			expect(payload.iss).toBe("https://auth.example.com");
 			expect(payload.aud).toBe("https://api.example.com");
 			expect(payload.iat).toBeTypeOf("number");

--- a/packages/core/src/routes/OAuth.mts
+++ b/packages/core/src/routes/OAuth.mts
@@ -145,8 +145,9 @@ export const createRouter = (
 					const key = keyStore.getVerificationKey(header.kid ?? keyStore.current.kid);
 					const { payload } = await jwtVerify(token, key);
 					const { exp, iss, aud, sub } = payload;
-					const azp = (payload as Record<string, unknown>).azp as string | undefined;
-					const scope = (payload as Record<string, unknown>).scope as string | undefined;
+					const claims = payload as Record<string, unknown>;
+					const azp = typeof claims.azp === "string" ? claims.azp : undefined;
+					const scope = typeof claims.scope === "string" ? claims.scope : undefined;
 					return res.status(200).json(
 						formatObject({
 							active: true,

--- a/packages/core/src/routes/OAuth.mts
+++ b/packages/core/src/routes/OAuth.mts
@@ -141,15 +141,12 @@ export const createRouter = (
 					return res.status(200).json({ active: false });
 				}
 				try {
-					const { kid } = decodeProtectedHeader(token);
-					const key = keyStore.getVerificationKey(kid ?? keyStore.current.kid);
+					const header = decodeProtectedHeader(token);
+					const key = keyStore.getVerificationKey(header.kid ?? keyStore.current.kid);
 					const { payload } = await jwtVerify(token, key);
 					const { exp, iss, aud, sub } = payload;
-					const scopes = payload.scopes as string[] | string | undefined;
-					const type = payload.type as string | undefined;
-					const user = payload.user as Record<string, unknown> | undefined;
-					const client = payload.client as Record<string, unknown> | undefined;
-					const ip = payload.ip as string | undefined;
+					const azp = (payload as Record<string, unknown>).azp as string | undefined;
+					const scope = (payload as Record<string, unknown>).scope as string | undefined;
 					return res.status(200).json(
 						formatObject({
 							active: true,
@@ -157,12 +154,9 @@ export const createRouter = (
 							iss,
 							aud,
 							sub,
-							// RFC 7662 Section 2.2: scope is a space-separated string
-							scope: Array.isArray(scopes) ? scopes.join(" ") : scopes,
-							type,
-							user,
-							client,
-							ip,
+							azp,
+							scope,
+							token_type: header.typ,
 						}),
 					);
 				} catch {


### PR DESCRIPTION
## Summary

Replace custom JWT claims with RFC 7519/9068 standard claims across auth.provider.

- `user.id` → `sub` (JWT subject)
- `client.id` → `azp` (authorized party)
- `scopes: ["read"]` → `scope: "read"` (space-separated string)
- `type: "access"` → `typ: "at+jwt"` in JWT header (RFC 9068)
- `type: "refresh"` → `typ: "rt+jwt"` in JWT header
- `ip` removed from token payload
- Introspect response returns `sub`, `azp`, `scope`, `token_type`
- Legacy refresh token fallback: accepts `type: "refresh"` payload for backward compatibility

Part of cross-repo claims standardization. Related PRs in auth.policy-verifier and grpc.authz.

## Test plan

- [x] 194 tests pass (17 test files)
- [x] Token payload contains sub/azp/scope, no user/client/scopes/type/ip
- [x] JWT header contains typ (at+jwt or rt+jwt)
- [x] Introspect returns sub/azp/scope/token_type
- [x] refreshToken grant accepts both typ header and legacy type payload
- [x] All grant handlers pass standard claims

🤖 Generated with [Claude Code](https://claude.com/claude-code)