### PR TITLE
feat: migrate to @o3co/auth.utils

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,6 @@
 	},
 	"dependencies": {
 		"@noble/ed25519": "^3.0.1",
-		"@o3co/js.util.log": "^0.5.0",
 		"bcrypt": "^6.0.0",
 		"express-rate-limit": "^8.3.1",
 		"jose": "^6.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       '@noble/ed25519':
         specifier: ^3.0.1
         version: 3.0.1
-      '@o3co/js.util.log':
-        specifier: ^0.5.0
-        version: 0.5.0(pino@10.3.1)
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
@@ -127,9 +124,9 @@ importers:
       '@o3co/auth-provider-repositories':
         specifier: workspace:*
         version: link:../../packages/repositories
-      '@o3co/js.util.log':
-        specifier: ^0.5.0
-        version: 0.5.0(pino@10.3.1)
+      '@o3co/auth.utils':
+        specifier: ^0.0.1
+        version: 0.0.1(express@5.2.1)(pino@10.3.1)
       '@o3co/ts.hocon':
         specifier: ^0.1.2
         version: 0.1.3(zod@4.3.6)
@@ -455,10 +452,11 @@ packages:
   '@noble/ed25519@3.0.1':
     resolution: {integrity: sha512-t/T8LuK0ym8ALQudCCQCtrRdMSxBnRgHXw+wg+YsSlE6d+on7sX3flqlSJ2mOs9xEuchM36kj9SuX5MG7pXQMA==}
 
-  '@o3co/js.util.log@0.5.0':
-    resolution: {integrity: sha512-e/mdt0jOrPL2gFYb3pE3ykJJnhqUK8BN48zpmE9tmUKNbqrEqKyTSif3kMiimclwFIhtBRi14wg6rCpx4HlkVg==, tarball: https://npm.pkg.github.com/download/@o3co/js.util.log/0.5.0/fa1e3cc37212be47088b8d5d64c3b778dffc140c}
+  '@o3co/auth.utils@0.0.1':
+    resolution: {integrity: sha512-4rU9Rhnn1NzUNDMQra8VXs9Qp5mLBbvU8LrQWNsBhzMGPDAlYF80hXaq1EDlURXQ/IvoPEo8etctMOrrq55WJg==, tarball: https://npm.pkg.github.com/download/@o3co/auth.utils/0.0.1/c5e8b3766bafcb010f5c6aea644188356f7ee452}
     peerDependencies:
-      pino: 10.*
+      express: ^5.0.0
+      pino: ^10.0.0
 
   '@o3co/ts.hocon@0.1.3':
     resolution: {integrity: sha512-8+dVbW+ILHSsGrBuaXVEbY/XOavCscQjqBGUqIZKrzuZjotdtbhcpFvK2pkxPBoQ1XWZHYuQaCh66K34grjegA==, tarball: https://npm.pkg.github.com/download/@o3co/ts.hocon/0.1.3/cad4f61fcb4255fc2e42f168b22d5b71f2ec3e68}
@@ -1746,8 +1744,9 @@ snapshots:
 
   '@noble/ed25519@3.0.1': {}
 
-  '@o3co/js.util.log@0.5.0(pino@10.3.1)':
+  '@o3co/auth.utils@0.0.1(express@5.2.1)(pino@10.3.1)':
     dependencies:
+      express: 5.2.1
       pino: 10.3.1
 
   '@o3co/ts.hocon@0.1.3(zod@4.3.6)':

--- a/templates/standalone/package.json
+++ b/templates/standalone/package.json
@@ -20,7 +20,7 @@
 	"dependencies": {
 		"@o3co/auth-provider-core": "workspace:*",
 		"@o3co/auth-provider-repositories": "workspace:*",
-		"@o3co/js.util.log": "^0.5.0",
+		"@o3co/auth.utils": "^0.0.1",
 		"@o3co/ts.hocon": "^0.1.2",
 		"connect-redis": "^9.0.0",
 		"express": "^5.2.1",

--- a/templates/standalone/package.json
+++ b/templates/standalone/package.json
@@ -30,12 +30,12 @@
 		"passport-local": "^1.0.0",
 		"passport-oauth2-client-password": "^0.1.2",
 		"passport-google-oauth20": "^2.0.0",
+		"pino": "^10.3.1",
 		"redis": "^5.10.0"
 	},
 	"devDependencies": {
 		"@types/express-session": "^1",
 		"@types/node": "^25.1.0",
-		"pino": "^10.3.1",
 		"tsx": "^4.21.0",
 		"typescript": "^5.9.3",
 		"vitest": "^4.1.2"

--- a/templates/standalone/src/app.mts
+++ b/templates/standalone/src/app.mts
@@ -24,6 +24,7 @@ import {
 	createKeyStoreFromConfig,
 } from "@o3co/auth-provider-core";
 import { registerBuiltinRepositories } from "@o3co/auth-provider-repositories";
+import { gracefulShutdown } from "@o3co/auth.utils";
 import { parseFile } from "@o3co/ts.hocon";
 import { validate } from "@o3co/ts.hocon/zod";
 import { RedisStore } from "connect-redis";
@@ -124,10 +125,5 @@ await (async (): Promise<void> => {
 		logger.info(`Server is running on http://localhost:${config.http.port}`);
 	});
 
-	const shutdown = (): void => {
-		grantRegistry.cleanup();
-		server.close(() => process.exit(0));
-	};
-	process.on("SIGTERM", shutdown);
-	process.on("SIGINT", shutdown);
+	gracefulShutdown(server, () => grantRegistry.cleanup());
 })();

--- a/templates/standalone/src/logger.mts
+++ b/templates/standalone/src/logger.mts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { initLogger } from "@o3co/js.util.log";
-import type { Logger } from "pino";
+import { createLogger } from "@o3co/auth.utils";
 
-const logger: Logger = initLogger("provider", { level: process.env.LOG_LEVEL ?? "info" });
-export default logger;
+export default createLogger("provider");


### PR DESCRIPTION
## Summary
- Replace `@o3co/js.util.log` with `@o3co/auth.utils` in `templates/standalone` for logger (`createLogger`) and shutdown (`gracefulShutdown`)
- Remove unused `@o3co/js.util.log` dependency from `packages/core`
- All 194 core tests pass

## Test plan
- [x] `pnpm vitest run` in `packages/core` — 17 test files, 194 tests passed
- [ ] Manual smoke test of standalone template startup and shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)