### PR TITLE
fix: use Node 24 LTS in Dockerfile

### DIFF
--- a/templates/standalone/Dockerfile
+++ b/templates/standalone/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:25-alpine AS node-base
+FROM node:24-alpine AS node-base
 
 ENV HOME=/home/node
 


### PR DESCRIPTION
## Summary

- Change base image from `node:25-alpine` to `node:24-alpine` in `templates/standalone/Dockerfile`
- Node 25 is the current/unstable release line; Node 24 (Krypton) is the active LTS
- `create-app/templates/` is auto-generated from the main templates via prebuild, so it picks up this fix automatically

## Test plan

- [ ] Verify `docker build` succeeds with `node:24-alpine`
- [ ] Verify create-app prebuild copies the updated Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)