### PR TITLE
fix(did): resolve TypeScript build errors in packages/did

### DIFF
--- a/packages/did/src/module.mts
+++ b/packages/did/src/module.mts
@@ -27,7 +27,8 @@ export const didConfigSchema = z.object({
 			"es256k_jws",
 		]).default("ed25519_raw"),
 		messageMaxAgeSec: z.coerce.number().default(300),
-	}).default({}),
+	// Full default object required by zod v4 typing — field-level defaults are authoritative
+	}).default({ enabled: true, algorithm: "ed25519_raw", messageMaxAgeSec: 300 }),
 });
 
 export const didModule: GrantModule = {

--- a/packages/did/src/verifiers/jws.mts
+++ b/packages/did/src/verifiers/jws.mts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { compactVerify, decodeProtectedHeader, importJWK, type JWK, type KeyLike } from "jose";
+import { compactVerify, decodeProtectedHeader, importJWK, type JWK } from "jose";
 
 import type { ParsedMessage, SignatureVerifier, VerificationContext, VerificationResult } from "./types.mjs";
 
@@ -64,7 +64,7 @@ export class JwsVerifier implements SignatureVerifier {
 		}
 
 		// 4. Import public key from JWK JSON string
-		let publicKey: KeyLike | Uint8Array;
+		let publicKey: CryptoKey | Uint8Array;
 		try {
 			const jwk = JSON.parse(body.publicKey) as JWK;
 			publicKey = await importJWK(jwk, this.expectedAlg);


### PR DESCRIPTION
## Summary

- Fix zod v4 `.default()` type in `module.mts`: provide full default object instead of `{}`
- Fix jose v6 type in `jws.mts`: replace `KeyLike` (removed in v6) with `CryptoKey`

## Test plan

- [x] `tsc` build: 0 errors for core + did
- [x] Core: 189 tests pass
- [x] DID: 52 tests pass (+ 2 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)