### PR TITLE
fix(standalone): add @types/express to fix TypeScript build

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
         specifier: ^5.10.0
         version: 5.11.0
     devDependencies:
+      '@types/express':
+        specifier: ^5
+        version: 5.0.6
       '@types/express-session':
         specifier: ^1
         version: 1.18.2

--- a/templates/standalone/package.json
+++ b/templates/standalone/package.json
@@ -36,6 +36,7 @@
 		"redis": "^5.10.0"
 	},
 	"devDependencies": {
+		"@types/express": "^5.0.6",
 		"@types/express-session": "^1",
 		"@types/node": "^25.1.0",
 		"tsx": "^4.21.0",


### PR DESCRIPTION
## Summary

- Add `@types/express` v5 to standalone template devDependencies
- Fixes `TS7016: Could not find a declaration file for module 'express'`
- Fixes `TS2740: Type 'RedisStore' is missing properties from type 'Store'` (resolved by express types providing correct session Store type)

## Test plan

- [x] `pnpm -r run build`: all 5 packages build with 0 errors
- [x] Unblocks `make test-e2e` in auth E2E repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)