### PR TITLE
refactor: move OAuth grant modules from core to packages/oauth

### DIFF
--- a/packages/core/src/__tests__/index.test.mts
+++ b/packages/core/src/__tests__/index.test.mts
@@ -3,11 +3,8 @@ import {
 	AppConfigSchema,
 	createApp,
 	createAsymmetricKeyStore,
-	createAuthorizationGrant,
 	createDefaultFactories,
 	createKeyStoreFromConfig,
-	createRefreshTokenGrant,
-	createSessionGrant,
 	createSymmetricKeyStore,
 	formatObject,
 	GrantRegistry,
@@ -71,15 +68,4 @@ describe("public API", () => {
 		expect(typeof formatObject).toBe("function");
 	});
 
-	it("exports createSessionGrant function", () => {
-		expect(typeof createSessionGrant).toBe("function");
-	});
-
-	it("exports createAuthorizationGrant function", () => {
-		expect(typeof createAuthorizationGrant).toBe("function");
-	});
-
-	it("exports createRefreshTokenGrant function", () => {
-		expect(typeof createRefreshTokenGrant).toBe("function");
-	});
 });

--- a/packages/core/src/__tests__/index.test.mts
+++ b/packages/core/src/__tests__/index.test.mts
@@ -3,16 +3,17 @@ import {
 	AppConfigSchema,
 	createApp,
 	createAsymmetricKeyStore,
+	createAuthorizationGrant,
 	createDefaultFactories,
 	createKeyStoreFromConfig,
+	createRefreshTokenGrant,
+	createSessionGrant,
 	createSymmetricKeyStore,
 	formatObject,
 	GrantRegistry,
 	InMemoryClientRepository,
 	InMemoryCodeRepository,
 	InMemoryUserRepository,
-	oauthAuthorizationModule,
-	oauthSessionModule,
 	RepositoryFactory,
 } from "../index.mjs";
 
@@ -70,11 +71,15 @@ describe("public API", () => {
 		expect(typeof formatObject).toBe("function");
 	});
 
-	it("exports oauthSessionModule", () => {
-		expect(oauthSessionModule).toBeDefined();
+	it("exports createSessionGrant function", () => {
+		expect(typeof createSessionGrant).toBe("function");
 	});
 
-	it("exports oauthAuthorizationModule", () => {
-		expect(oauthAuthorizationModule).toBeDefined();
+	it("exports createAuthorizationGrant function", () => {
+		expect(typeof createAuthorizationGrant).toBe("function");
+	});
+
+	it("exports createRefreshTokenGrant function", () => {
+		expect(typeof createRefreshTokenGrant).toBe("function");
 	});
 });

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -38,6 +38,10 @@ export {
 	type Token,
 	type TokenResponse,
 } from "./grants/token.mjs";
+// Built-in grant factories (used by oauth package modules)
+export { createSessionGrant } from "./grants/session.mjs";
+export { createAuthorizationGrant } from "./grants/authorization.mjs";
+export { createRefreshTokenGrant } from "./grants/refreshToken.mjs";
 // Repository interfaces
 export type { ClientRepository, PublicClient } from "./repositories/ClientRepository.mjs";
 export type { CodeRepository } from "./repositories/CodeRepository.mjs";
@@ -66,8 +70,6 @@ export type { AsymmetricKeyStoreOptions, JwtConfig, KeyStore, ManagedKey } from 
 export { createAsymmetricKeyStore, createKeyStoreFromConfig, createSymmetricKeyStore } from "./keys/KeyStore.mjs";
 // Module system
 export type { Module, ModuleContext, PathResolver } from "./modules/index.mjs";
-export { oauthSessionModule } from "./modules/oauthSession.mjs";
-export { oauthAuthorizationModule } from "./modules/oauthAuthorization.mjs";
 // App factory
 export { createApp, type AppOptions, type AppResult } from "./app.mjs";
 // Token formatting utility (used by oauth package)

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -38,10 +38,6 @@ export {
 	type Token,
 	type TokenResponse,
 } from "./grants/token.mjs";
-// Built-in grant factories (used by oauth package modules)
-export { createSessionGrant } from "./grants/session.mjs";
-export { createAuthorizationGrant } from "./grants/authorization.mjs";
-export { createRefreshTokenGrant } from "./grants/refreshToken.mjs";
 // Repository interfaces
 export type { ClientRepository, PublicClient } from "./repositories/ClientRepository.mjs";
 export type { CodeRepository } from "./repositories/CodeRepository.mjs";

--- a/packages/core/src/modules/index.mts
+++ b/packages/core/src/modules/index.mts
@@ -13,6 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { oauthAuthorizationModule } from "./oauthAuthorization.mjs";
-export { oauthSessionModule } from "./oauthSession.mjs";
 export type { Module, ModuleContext, PathResolver } from "./types.mjs";

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -18,10 +18,13 @@ import crypto from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 import { decodeJwt } from "jose";
 
-import type { CodeRepository } from "../../repositories/CodeRepository.mjs";
-import { createSymmetricKeyStore } from "../../keys/KeyStore.mjs";
-import { createAuthorizationGrant } from "../authorization.mjs";
-import type { GrantContext, GrantDependencies } from "../types.mjs";
+import {
+	createSymmetricKeyStore,
+	type CodeRepository,
+	type GrantContext,
+	type GrantDependencies,
+} from "@o3co/auth-provider-core";
+import { createAuthorizationGrant } from "../grants/authorization.mjs";
 
 const mockConfig = {
 	oauth: {

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -15,11 +15,13 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import type { Router } from "express";
-import { GrantRegistry } from "../../grants/registry.mjs";
-import { createSymmetricKeyStore } from "../../keys/KeyStore.mjs";
-import type { ModuleContext } from "../types.mjs";
-import type { CodeRepository } from "../../repositories/CodeRepository.mjs";
-import type { AppConfig } from "../../config/application.schema.mjs";
+import {
+	GrantRegistry,
+	createSymmetricKeyStore,
+	type ModuleContext,
+	type CodeRepository,
+	type AppConfig,
+} from "@o3co/auth-provider-core";
 import { oauthAuthorizationModule } from "../oauthAuthorization.mjs";
 
 const mockConfig = {

--- a/packages/oauth/src/__tests__/oauthSession.test.mts
+++ b/packages/oauth/src/__tests__/oauthSession.test.mts
@@ -15,11 +15,13 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import type { Router } from "express";
-import { GrantRegistry } from "../../grants/registry.mjs";
-import { createSymmetricKeyStore } from "../../keys/KeyStore.mjs";
-import type { ModuleContext } from "../types.mjs";
-import type { ClientRepository } from "../../repositories/ClientRepository.mjs";
-import type { AppConfig } from "../../config/application.schema.mjs";
+import {
+	GrantRegistry,
+	createSymmetricKeyStore,
+	type ModuleContext,
+	type ClientRepository,
+	type AppConfig,
+} from "@o3co/auth-provider-core";
 import { oauthSessionModule } from "../oauthSession.mjs";
 
 const mockConfig = {

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -17,9 +17,12 @@ import { createSecretKey } from "node:crypto";
 import { SignJWT } from "jose";
 import { describe, expect, it } from "vitest";
 
-import { createSymmetricKeyStore } from "../../keys/KeyStore.mjs";
-import { createRefreshTokenGrant } from "../refreshToken.mjs";
-import type { GrantContext, GrantDependencies } from "../types.mjs";
+import {
+	createSymmetricKeyStore,
+	type GrantContext,
+	type GrantDependencies,
+} from "@o3co/auth-provider-core";
+import { createRefreshTokenGrant } from "../grants/refreshToken.mjs";
 
 const SECRET = "test-secret-at-least-32-chars!!";
 const keyStore = createSymmetricKeyStore(SECRET);

--- a/packages/oauth/src/__tests__/session.test.mts
+++ b/packages/oauth/src/__tests__/session.test.mts
@@ -16,10 +16,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { decodeJwt } from "jose";
 
-import type { ClientRepository } from "../../repositories/ClientRepository.mjs";
-import { createSymmetricKeyStore } from "../../keys/KeyStore.mjs";
-import { createSessionGrant } from "../session.mjs";
-import type { GrantContext, GrantDependencies } from "../types.mjs";
+import {
+	createSymmetricKeyStore,
+	type ClientRepository,
+	type GrantContext,
+	type GrantDependencies,
+} from "@o3co/auth-provider-core";
+import { createSessionGrant } from "../grants/session.mjs";
 
 const mockConfig = {
 	oauth: {

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -15,15 +15,15 @@
  */
 import crypto from "node:crypto";
 
-import type { CodeRepository } from "#/repositories/CodeRepository.mjs";
-
-import { generateToken, generateTokenResponse } from "./token.mjs";
-import type {
-	GrantContext,
-	GrantDependencies,
-	GrantHandler,
-	GrantHandlerResult,
-} from "./types.mjs";
+import {
+	generateToken,
+	generateTokenResponse,
+	type CodeRepository,
+	type GrantContext,
+	type GrantDependencies,
+	type GrantHandler,
+	type GrantHandlerResult,
+} from "@o3co/auth-provider-core";
 
 export const createAuthorizationGrant = (deps: GrantDependencies & { codeRepository: CodeRepository }): GrantHandler => {
 	const { config, codeRepository, keyStore } = deps;

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -15,13 +15,14 @@
  */
 import { decodeProtectedHeader, jwtVerify, type JWTPayload } from "jose";
 
-import { generateToken, generateTokenResponse } from "./token.mjs";
-import type {
-	GrantContext,
-	GrantDependencies,
-	GrantHandler,
-	GrantHandlerResult,
-} from "./types.mjs";
+import {
+	generateToken,
+	generateTokenResponse,
+	type GrantContext,
+	type GrantDependencies,
+	type GrantHandler,
+	type GrantHandlerResult,
+} from "@o3co/auth-provider-core";
 
 export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler => {
 	const { config, keyStore } = deps;

--- a/packages/oauth/src/grants/session.mts
+++ b/packages/oauth/src/grants/session.mts
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ClientRepository } from "#/repositories/ClientRepository.mjs";
-
-import { generateToken, generateTokenResponse } from "./token.mjs";
-import type {
-	GrantContext,
-	GrantDependencies,
-	GrantHandler,
-	GrantHandlerResult,
-} from "./types.mjs";
+import {
+	generateToken,
+	generateTokenResponse,
+	type ClientRepository,
+	type GrantContext,
+	type GrantDependencies,
+	type GrantHandler,
+	type GrantHandlerResult,
+} from "@o3co/auth-provider-core";
 
 export const createSessionGrant = (deps: GrantDependencies & { clientRepository: ClientRepository }): GrantHandler => {
 	const { config, clientRepository, keyStore } = deps;

--- a/packages/oauth/src/index.mts
+++ b/packages/oauth/src/index.mts
@@ -14,4 +14,6 @@
  * limitations under the License.
  */
 export { oauthModule } from "./module.mjs";
+export { oauthSessionModule } from "./oauthSession.mjs";
+export { oauthAuthorizationModule } from "./oauthAuthorization.mjs";
 export { createOAuthRouter } from "./routes.mjs";

--- a/packages/oauth/src/oauthAuthorization.mts
+++ b/packages/oauth/src/oauthAuthorization.mts
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-	createAuthorizationGrant,
-	createRefreshTokenGrant,
-	type CodeRepository,
-	type Module,
-	type ModuleContext,
+import type {
+	CodeRepository,
+	Module,
+	ModuleContext,
 } from "@o3co/auth-provider-core";
+import { createAuthorizationGrant } from "./grants/authorization.mjs";
+import { createRefreshTokenGrant } from "./grants/refreshToken.mjs";
 
 export const oauthAuthorizationModule = (params: {
 	codeRepository: CodeRepository;

--- a/packages/oauth/src/oauthAuthorization.mts
+++ b/packages/oauth/src/oauthAuthorization.mts
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { CodeRepository } from "#/repositories/CodeRepository.mjs";
-import { createAuthorizationGrant } from "#/grants/authorization.mjs";
-import { createRefreshTokenGrant } from "#/grants/refreshToken.mjs";
-import type { Module, ModuleContext } from "./types.mjs";
+import {
+	createAuthorizationGrant,
+	createRefreshTokenGrant,
+	type CodeRepository,
+	type Module,
+	type ModuleContext,
+} from "@o3co/auth-provider-core";
 
 export const oauthAuthorizationModule = (params: {
 	codeRepository: CodeRepository;

--- a/packages/oauth/src/oauthSession.mts
+++ b/packages/oauth/src/oauthSession.mts
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ClientRepository } from "#/repositories/ClientRepository.mjs";
-import { createSessionGrant } from "#/grants/session.mjs";
-import type { Module, ModuleContext } from "./types.mjs";
+import {
+	createSessionGrant,
+	type ClientRepository,
+	type Module,
+	type ModuleContext,
+} from "@o3co/auth-provider-core";
 
 export const oauthSessionModule = (params: {
 	clientRepository: ClientRepository;

--- a/packages/oauth/src/oauthSession.mts
+++ b/packages/oauth/src/oauthSession.mts
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-	createSessionGrant,
-	type ClientRepository,
-	type Module,
-	type ModuleContext,
+import type {
+	ClientRepository,
+	Module,
+	ModuleContext,
 } from "@o3co/auth-provider-core";
+import { createSessionGrant } from "./grants/session.mjs";
 
 export const oauthSessionModule = (params: {
 	clientRepository: ClientRepository;

--- a/templates/standalone/src/app.mts
+++ b/templates/standalone/src/app.mts
@@ -21,11 +21,13 @@ import {
   createApp,
   createDefaultFactories,
   createKeyStoreFromConfig,
-  oauthSessionModule,
-  oauthAuthorizationModule,
 } from "@o3co/auth-provider-core";
 import { oauthDidModule } from "@o3co/auth-provider-did";
-import { oauthModule } from "@o3co/auth-provider-oauth";
+import {
+  oauthModule,
+  oauthSessionModule,
+  oauthAuthorizationModule,
+} from "@o3co/auth-provider-oauth";
 import { sessionModule } from "@o3co/auth-provider-session";
 import { registerBuiltinRepositories } from "@o3co/auth-provider-repositories";
 import { gracefulShutdown } from "@o3co/auth.utils";


### PR DESCRIPTION
## Summary

- Move `oauthSessionModule` and `oauthAuthorizationModule` from `packages/core` to `packages/oauth`
- Core now only owns protocol-agnostic abstractions (`GrantRegistry`, `Module`, `createApp`)
- OAuth-specific grant registrations belong in the OAuth package

## Context

Separation criterion should be **conceptual ownership**, not external dependency presence. These modules wrap OAuth grant factories — they belong with OAuth.

Closes #32

## Test plan

- [x] core: 180 tests pass
- [x] oauth: 11 tests pass (8 moved from core + 3 existing)
- [x] session: 6 tests pass
- [x] did: 27 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)