### PR TITLE
refactor: replace relative parent imports with #/ path alias

### DIFF
--- a/packages/core/src/__tests__/app.test.mts
+++ b/packages/core/src/__tests__/app.test.mts
@@ -15,11 +15,11 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import type { Router } from "express";
-import { createApp } from "../app.mjs";
-import { GrantRegistry } from "../grants/registry.mjs";
-import { createSymmetricKeyStore } from "../keys/KeyStore.mjs";
-import type { Module } from "../modules/types.mjs";
-import type { AppConfig } from "../config/application.schema.mjs";
+import { createApp } from "#/app.mjs";
+import { GrantRegistry } from "#/grants/registry.mjs";
+import { createSymmetricKeyStore } from "#/keys/KeyStore.mjs";
+import type { Module } from "#/modules/types.mjs";
+import type { AppConfig } from "#/config/application.schema.mjs";
 
 const mockExpress = {
 	Router: () =>

--- a/packages/core/src/__tests__/index.test.mts
+++ b/packages/core/src/__tests__/index.test.mts
@@ -12,7 +12,7 @@ import {
 	InMemoryCodeRepository,
 	InMemoryUserRepository,
 	RepositoryFactory,
-} from "../index.mjs";
+} from "#/index.mjs";
 
 describe("public API", () => {
 	it("exports InMemoryClientRepository class", () => {

--- a/packages/core/src/grants/__tests__/registry.test.mts
+++ b/packages/core/src/grants/__tests__/registry.test.mts
@@ -16,14 +16,14 @@
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
-import { createSymmetricKeyStore } from "../../keys/KeyStore.mjs";
-import { GrantRegistry } from "../registry.mjs";
+import { createSymmetricKeyStore } from "#/keys/KeyStore.mjs";
+import { GrantRegistry } from "#/grants/registry.mjs";
 import type {
 	GrantDependencies,
 	GrantFactory,
 	GrantHandler,
 	GrantModule,
-} from "../types.mjs";
+} from "#/grants/types.mjs";
 
 const makeHandler = (name: string): GrantHandler => ({
 	handle: vi.fn().mockResolvedValue({

--- a/packages/core/src/grants/__tests__/token.test.mts
+++ b/packages/core/src/grants/__tests__/token.test.mts
@@ -15,8 +15,8 @@
  */
 import { describe, expect, it } from "vitest";
 import { decodeJwt, decodeProtectedHeader } from "jose";
-import { createSymmetricKeyStore } from "../../keys/KeyStore.mjs";
-import { generateToken, generateTokenResponse } from "../token.mjs";
+import { createSymmetricKeyStore } from "#/keys/KeyStore.mjs";
+import { generateToken, generateTokenResponse } from "#/grants/token.mjs";
 
 const keyStore = createSymmetricKeyStore("test-secret-at-least-32-chars!!");
 

--- a/packages/core/src/keys/__tests__/KeyStore.test.mts
+++ b/packages/core/src/keys/__tests__/KeyStore.test.mts
@@ -18,8 +18,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { generateKeyPair, exportSPKI, exportPKCS8, SignJWT, jwtVerify, decodeProtectedHeader } from "jose";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { createAsymmetricKeyStore, createKeyStoreFromConfig, createSymmetricKeyStore } from "../KeyStore.mjs";
-import type { JwtConfig } from "../KeyStore.mjs";
+import { createAsymmetricKeyStore, createKeyStoreFromConfig, createSymmetricKeyStore } from "#/keys/KeyStore.mjs";
+import type { JwtConfig } from "#/keys/KeyStore.mjs";
 
 async function generateTestKeyPair(alg: string) {
 	const { privateKey, publicKey } = await generateKeyPair(alg, { extractable: true });

--- a/packages/core/src/keys/__tests__/integration.test.mts
+++ b/packages/core/src/keys/__tests__/integration.test.mts
@@ -15,8 +15,8 @@
  */
 import { describe, expect, it } from "vitest";
 import { generateKeyPair, exportSPKI, exportPKCS8, jwtVerify, decodeProtectedHeader } from "jose";
-import { createKeyStoreFromConfig } from "../KeyStore.mjs";
-import { generateToken } from "../../grants/token.mjs";
+import { createKeyStoreFromConfig } from "#/keys/KeyStore.mjs";
+import { generateToken } from "#/grants/token.mjs";
 
 async function generateTestKeyPair(alg: string) {
 	const { privateKey, publicKey } = await generateKeyPair(alg, { extractable: true });

--- a/packages/core/src/modules/__tests__/types.test.mts
+++ b/packages/core/src/modules/__tests__/types.test.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
-import type { Module, ModuleContext, PathResolver } from "../types.mjs";
+import type { Module, ModuleContext, PathResolver } from "#/modules/types.mjs";
 
 describe("Module interface", () => {
 	it("PathResolver is a function from string to string", () => {

--- a/packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts
+++ b/packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts
@@ -15,7 +15,7 @@
  */
 import bcrypt from "bcrypt";
 import { describe, expect, it } from "vitest";
-import { InMemoryClientRepository } from "../InMemoryClientRepository.mjs";
+import { InMemoryClientRepository } from "#/repositories/InMemoryClientRepository.mjs";
 
 describe("InMemoryClientRepository", () => {
 	describe("findById", () => {

--- a/packages/core/src/repositories/__tests__/InMemoryCodeRepository.test.mts
+++ b/packages/core/src/repositories/__tests__/InMemoryCodeRepository.test.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { afterEach, describe, expect, it } from "vitest";
-import { InMemoryCodeRepository } from "../InMemoryCodeRepository.mjs";
+import { InMemoryCodeRepository } from "#/repositories/InMemoryCodeRepository.mjs";
 
 describe("InMemoryCodeRepository", () => {
 	let repo: InMemoryCodeRepository;

--- a/packages/core/src/repositories/__tests__/InMemoryUserRepository.test.mts
+++ b/packages/core/src/repositories/__tests__/InMemoryUserRepository.test.mts
@@ -15,7 +15,7 @@
  */
 import bcrypt from "bcrypt";
 import { describe, expect, it } from "vitest";
-import { InMemoryUserRepository } from "../InMemoryUserRepository.mjs";
+import { InMemoryUserRepository } from "#/repositories/InMemoryUserRepository.mjs";
 
 describe("InMemoryUserRepository", () => {
 	describe("authenticate", () => {

--- a/packages/core/src/repositories/__tests__/RepositoryFactory.test.mts
+++ b/packages/core/src/repositories/__tests__/RepositoryFactory.test.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it, vi } from "vitest";
-import { RepositoryFactory } from "../RepositoryFactory.mjs";
+import { RepositoryFactory } from "#/repositories/RepositoryFactory.mjs";
 
 interface MockRepo {
 	name: string;

--- a/packages/core/src/repositories/__tests__/createDefaultFactories.test.mts
+++ b/packages/core/src/repositories/__tests__/createDefaultFactories.test.mts
@@ -17,7 +17,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createDefaultFactories } from "../RepositoryFactory.mjs";
+import { createDefaultFactories } from "#/repositories/RepositoryFactory.mjs";
 
 describe("createDefaultFactories", () => {
 	let tmpDir: string;

--- a/packages/core/src/repositories/__tests__/loadYamlMap.test.mts
+++ b/packages/core/src/repositories/__tests__/loadYamlMap.test.mts
@@ -18,7 +18,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
-import { loadYamlMap } from "../loadYamlMap.mjs";
+import { loadYamlMap } from "#/repositories/loadYamlMap.mjs";
 
 const TestSchema = z
 	.object({

--- a/packages/core/src/routes/__tests__/Jwks.test.mts
+++ b/packages/core/src/routes/__tests__/Jwks.test.mts
@@ -15,8 +15,8 @@
  */
 import { describe, expect, it } from "vitest";
 import { exportPKCS8, exportSPKI, generateKeyPair } from "jose";
-import { createAsymmetricKeyStore, createSymmetricKeyStore } from "../../keys/KeyStore.mjs";
-import { createRouter } from "../Jwks.mjs";
+import { createAsymmetricKeyStore, createSymmetricKeyStore } from "#/keys/KeyStore.mjs";
+import { createRouter } from "#/routes/Jwks.mjs";
 
 function createMockExpress() {
 	const routes: Record<string, Function> = {};

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -11,6 +11,9 @@
       "types": "./dist/index.d.mts"
     }
   },
+  "imports": {
+    "#/*": "./src/*"
+  },
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -24,7 +24,7 @@ import {
 	type GrantContext,
 	type GrantDependencies,
 } from "@o3co/auth-provider-core";
-import { createAuthorizationGrant } from "../grants/authorization.mjs";
+import { createAuthorizationGrant } from "#/grants/authorization.mjs";
 
 const mockConfig = {
 	oauth: {

--- a/packages/oauth/src/__tests__/module.test.mts
+++ b/packages/oauth/src/__tests__/module.test.mts
@@ -23,7 +23,7 @@ import {
   type ClientRepository,
   type CodeRepository,
 } from "@o3co/auth-provider-core";
-import { oauthModule } from "../module.mjs";
+import { oauthModule } from "#/module.mjs";
 
 const mockConfig = {
   oauth: {

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -22,7 +22,7 @@ import {
 	type CodeRepository,
 	type AppConfig,
 } from "@o3co/auth-provider-core";
-import { oauthAuthorizationModule } from "../oauthAuthorization.mjs";
+import { oauthAuthorizationModule } from "#/oauthAuthorization.mjs";
 
 const mockConfig = {
 	oauth: {

--- a/packages/oauth/src/__tests__/oauthSession.test.mts
+++ b/packages/oauth/src/__tests__/oauthSession.test.mts
@@ -22,7 +22,7 @@ import {
 	type ClientRepository,
 	type AppConfig,
 } from "@o3co/auth-provider-core";
-import { oauthSessionModule } from "../oauthSession.mjs";
+import { oauthSessionModule } from "#/oauthSession.mjs";
 
 const mockConfig = {
 	oauth: {

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -22,7 +22,7 @@ import {
 	type GrantContext,
 	type GrantDependencies,
 } from "@o3co/auth-provider-core";
-import { createRefreshTokenGrant } from "../grants/refreshToken.mjs";
+import { createRefreshTokenGrant } from "#/grants/refreshToken.mjs";
 
 const SECRET = "test-secret-at-least-32-chars!!";
 const keyStore = createSymmetricKeyStore(SECRET);

--- a/packages/oauth/src/__tests__/routes.test.mts
+++ b/packages/oauth/src/__tests__/routes.test.mts
@@ -22,7 +22,7 @@ import {
   type ClientRepository,
   type CodeRepository,
 } from "@o3co/auth-provider-core";
-import { createOAuthRouter } from "../routes.mjs";
+import { createOAuthRouter } from "#/routes.mjs";
 import type { PassportStatic } from "passport";
 
 const mockConfig = {

--- a/packages/oauth/src/__tests__/session.test.mts
+++ b/packages/oauth/src/__tests__/session.test.mts
@@ -22,7 +22,7 @@ import {
 	type GrantContext,
 	type GrantDependencies,
 } from "@o3co/auth-provider-core";
-import { createSessionGrant } from "../grants/session.mjs";
+import { createSessionGrant } from "#/grants/session.mjs";
 
 const mockConfig = {
 	oauth: {

--- a/packages/oauth/tsconfig.json
+++ b/packages/oauth/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/"
+    "outDir": "./dist/",
+    "paths": {
+      "#/*": ["./src/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -11,6 +11,9 @@
       "types": "./dist/index.d.mts"
     }
   },
+  "imports": {
+    "#/*": "./src/*"
+  },
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",

--- a/packages/session/src/__tests__/module.test.mts
+++ b/packages/session/src/__tests__/module.test.mts
@@ -22,7 +22,7 @@ import {
   type ModuleContext,
   type UserRepository,
 } from "@o3co/auth-provider-core";
-import { sessionModule } from "../module.mjs";
+import { sessionModule } from "#/module.mjs";
 
 const mockConfig = {
   oauth: {

--- a/packages/session/src/federations/__tests__/google.test.mts
+++ b/packages/session/src/federations/__tests__/google.test.mts
@@ -15,7 +15,7 @@
  */
 import { describe, expect, it } from "vitest";
 import type { AppConfig } from "@o3co/auth-provider-core";
-import { createGoogleProvider } from "../google.mjs";
+import { createGoogleProvider } from "#/federations/google.mjs";
 
 const baseConfig = {
   federations: {

--- a/packages/session/src/routes/Federation.mts
+++ b/packages/session/src/routes/Federation.mts
@@ -18,7 +18,7 @@ import type { Request, RequestHandler, Response, Router } from "express";
 import type { PassportStatic } from "passport";
 
 import type { AppConfig } from "@o3co/auth-provider-core";
-import type { FederationRegistry } from "../federations/types.mjs";
+import type { FederationRegistry } from "#/federations/types.mjs";
 
 declare module "express-session" {
 	interface SessionData {

--- a/packages/session/tsconfig.json
+++ b/packages/session/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/"
+    "outDir": "./dist/",
+    "paths": {
+      "#/*": ["./src/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- Replace all `../` and `../../` relative imports with `#/` path alias across core, oauth, and session packages
- Add `"imports": { "#/*": "./src/*" }` to oauth and session `package.json` (core already had it)
- 23 source files updated across 3 packages

## Rationale

Parent-relative imports (`../../keys/KeyStore.mjs`) create implicit coupling to file layout. If a file moves, every `../` reference breaks. The `#/` alias provides root-anchored resolution within each package — imports always read as absolute paths from `src/`.

## Test plan

- [x] core: 142 tests pass
- [x] oauth: 46 tests pass
- [x] session: 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)