### PR TITLE
fix: add missing @types/passport to standalone devDependencies

### DIFF
--- a/templates/standalone/package.json
+++ b/templates/standalone/package.json
@@ -40,6 +40,7 @@
 	"devDependencies": {
 		"@types/express": "^5.0.6",
 		"@types/express-session": "^1",
+		"@types/passport": "^1",
 		"@types/node": "^25.1.0",
 		"tsx": "^4.21.0",
 		"typescript": "^5.9.3",


### PR DESCRIPTION
## Summary
- Add `@types/passport` to `templates/standalone/package.json` devDependencies
- Fixes TS7016 build error on `import passport from "passport"`

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)