### PR TITLE
fix: update @o3co/auth.utils to ^0.0.2

### DIFF
--- a/templates/standalone/package.json
+++ b/templates/standalone/package.json
@@ -24,7 +24,7 @@
 		"@o3co/auth-provider-oauth": "workspace:*",
 		"@o3co/auth-provider-session": "workspace:*",
 		"@o3co/auth-provider-foundation": "workspace:*",
-		"@o3co/auth.utils": "^0.0.1",
+		"@o3co/auth.utils": "^0.0.2",
 		"@o3co/ts.hocon": "^0.1.2",
 		"connect-redis": "^9.0.0",
 		"express": "^5.2.1",


### PR DESCRIPTION
## Summary
- Update `@o3co/auth.utils` from `^0.0.1` to `^0.0.2` in standalone
- 0.0.1 had GitHub Packages tarball URL baked into npm metadata, causing Docker build 401 errors
- 0.0.2 published via GitHub Actions with correct npmjs URL and provenance

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)