### PR TITLE
fix: add conditional imports for #/ path alias in library packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,10 @@
 		"test": "vitest run"
 	},
 	"imports": {
-		"#/*": "./src/*"
+		"#/*": {
+			"development": "./src/*",
+			"default": "./dist/*"
+		}
 	},
 	"dependencies": {
 		"bcrypt": "^6.0.0",

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -16,7 +16,10 @@
 		"test": "vitest run"
 	},
 	"imports": {
-		"#/*": "./src/*"
+		"#/*": {
+			"development": "./src/*",
+			"default": "./dist/*"
+		}
 	},
 	"peerDependencies": {
 		"@o3co/auth-provider-core": "^0.0.0",

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -12,7 +12,10 @@
     }
   },
   "imports": {
-    "#/*": "./src/*"
+    "#/*": {
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "scripts": {
     "build": "tsc",

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -12,7 +12,10 @@
     }
   },
   "imports": {
-    "#/*": "./src/*"
+    "#/*": {
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary
- Fix `packages/core`, `packages/foundation`, `packages/oauth`, `packages/session` imports
- Change `"#/*": "./src/*"` to `{ "development": "./src/*", "default": "./dist/*" }`
- Fixes ERR_MODULE_NOT_FOUND in Docker production images where only `dist/` exists

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)