### PR TITLE
fix: cross-platform prebuild, module resolution docs, release idempotency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
       - run: pnpm build
       - run: pnpm test
 
-      - name: Publish packages
-        run: pnpm -r publish --access public --no-git-checks --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+
+      - name: Publish packages
+        run: pnpm -r publish --access public --no-git-checks --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,20 @@
 - Never write production code without a failing test that demands it.
 - If code was written before its test, delete it and start over from the test.
 - When generating implementation plans, every task must include explicit RED → GREEN → REFACTOR steps.
+
+## Module Resolution
+
+Each package uses Node.js [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) with a conditional `development` / `default` mapping:
+
+```json
+"imports": {
+  "#/*": {
+    "development": "./src/*",
+    "default": "./dist/*"
+  }
+}
+```
+
+- **Source files** use relative imports (`./`, `../`) — not `#/` aliases. This ensures published builds resolve correctly without relying on the `development` condition.
+- **Test files** use `#/` imports. During `vitest run`, Vite 8+ includes `"development|production"` in its default resolve conditions, which expands to `"development"` (since `isProduction=false`), resolving `#/*` to `./src/*`. This is an implicit dependency on Vite's resolver — Node.js does not enable the `development` condition natively.
+- **Cross-package references** (e.g., `oauth` importing from `core`) go through `exports`, which always point to `./dist/`. Run `pnpm -r run build` before running tests in downstream packages.

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install:
 
 .PHONY: clean
 clean:
-	rm -rf packages/core/dist packages/foundation/dist templates/standalone/dist create-app/dist
+	pnpm -r exec rimraf dist
 
 .PHONY: test
 test:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.14",
+    "rimraf": "^6.1.3",
     "typedoc": "^0.28.3",
     "typedoc-plugin-markdown": "^4.6.1",
     "typescript": "^5.9.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
 		"directory": "packages/core"
 	},
 	"scripts": {
-		"prebuild": "rm -rf dist",
+		"prebuild": "rimraf dist",
 		"build": "tsc",
 		"test": "vitest run"
 	},

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
 		"directory": "packages/core"
 	},
 	"scripts": {
+		"prebuild": "rm -rf dist",
 		"build": "tsc",
 		"test": "vitest run"
 	},

--- a/packages/core/src/app.mts
+++ b/packages/core/src/app.mts
@@ -15,12 +15,12 @@
  */
 import type { RequestHandler, Router } from "express";
 
-import type { CoreConfig } from "#/config/application.schema.mjs";
-import { GrantRegistry } from "#/grants/registry.mjs";
-import type { KeyStore } from "#/keys/KeyStore.mjs";
-import type { Module, ModuleContext, PathResolver } from "#/modules/types.mjs";
-import * as healthcheck from "#/routes/Healthcheck.mjs";
-import * as jwks from "#/routes/Jwks.mjs";
+import type { CoreConfig } from "./config/application.schema.mjs";
+import { GrantRegistry } from "./grants/registry.mjs";
+import type { KeyStore } from "./keys/KeyStore.mjs";
+import type { Module, ModuleContext, PathResolver } from "./modules/types.mjs";
+import * as healthcheck from "./routes/Healthcheck.mjs";
+import * as jwks from "./routes/Jwks.mjs";
 
 type ExpressLike = {
 	Router: () => Router;

--- a/packages/core/src/grants/token.mts
+++ b/packages/core/src/grants/token.mts
@@ -15,7 +15,7 @@
  */
 import { randomUUID } from "node:crypto";
 import { SignJWT } from "jose";
-import type { KeyStore } from "#/keys/KeyStore.mjs";
+import type { KeyStore } from "../keys/KeyStore.mjs";
 
 export const formatObject = <T extends object>(data: T): Partial<T> => {
 	return Object.fromEntries(Object.entries(data).filter(([, v]) => v !== undefined && v !== null)) as Partial<T>;

--- a/packages/core/src/grants/types.mts
+++ b/packages/core/src/grants/types.mts
@@ -15,9 +15,9 @@
  */
 import type { z } from "zod";
 
-import type { CoreConfig } from "#/config/application.schema.mjs";
-import type { KeyStore } from "#/keys/KeyStore.mjs";
-import type { PathResolver } from "#/modules/types.mjs";
+import type { CoreConfig } from "../config/application.schema.mjs";
+import type { KeyStore } from "../keys/KeyStore.mjs";
+import type { PathResolver } from "../modules/types.mjs";
 
 export interface SessionData {
 	user?: Record<string, unknown>;

--- a/packages/core/src/modules/types.mts
+++ b/packages/core/src/modules/types.mts
@@ -16,9 +16,9 @@
 import type { Router } from "express";
 import type { z } from "zod";
 
-import type { CoreConfig } from "#/config/application.schema.mjs";
-import type { GrantRegistry } from "#/grants/registry.mjs";
-import type { KeyStore } from "#/keys/KeyStore.mjs";
+import type { CoreConfig } from "../config/application.schema.mjs";
+import type { GrantRegistry } from "../grants/registry.mjs";
+import type { KeyStore } from "../keys/KeyStore.mjs";
 
 /**
  * Resolves a module specifier to a URL/path that can be passed to dynamic import().

--- a/packages/core/src/routes/Jwks.mts
+++ b/packages/core/src/routes/Jwks.mts
@@ -15,7 +15,7 @@
  */
 import type { Request, Response, Router } from "express";
 import { exportJWK } from "jose";
-import type { KeyStore } from "#/keys/KeyStore.mjs";
+import type { KeyStore } from "../keys/KeyStore.mjs";
 
 export const createRouter = (
 	express: { Router: () => Router },

--- a/packages/did/package.json
+++ b/packages/did/package.json
@@ -21,6 +21,7 @@
     "directory": "packages/did"
   },
   "scripts": {
+    "prebuild": "rm -rf dist",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/packages/did/package.json
+++ b/packages/did/package.json
@@ -21,7 +21,7 @@
     "directory": "packages/did"
   },
   "scripts": {
-    "prebuild": "rm -rf dist",
+    "prebuild": "rimraf dist",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -23,7 +23,7 @@
 		"directory": "packages/foundation"
 	},
 	"scripts": {
-		"prebuild": "rm -rf dist",
+		"prebuild": "rimraf dist",
 		"build": "tsc",
 		"test": "vitest run"
 	},

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -23,6 +23,7 @@
 		"directory": "packages/foundation"
 	},
 	"scripts": {
+		"prebuild": "rm -rf dist",
 		"build": "tsc",
 		"test": "vitest run"
 	},

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -27,6 +27,7 @@
     }
   },
   "scripts": {
+    "prebuild": "rm -rf dist",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -27,7 +27,7 @@
     }
   },
   "scripts": {
-    "prebuild": "rm -rf dist",
+    "prebuild": "rimraf dist",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/packages/oauth/src/module.mts
+++ b/packages/oauth/src/module.mts
@@ -16,6 +16,7 @@
 import type { RequestHandler, Router } from "express";
 import type { PassportStatic } from "passport";
 import type {
+  AppConfig,
   ClientRepository,
   CodeRepository,
   Module,
@@ -36,6 +37,8 @@ export const oauthModule = (params: {
 }): Module => ({
   name: "oauth",
   async init(context: ModuleContext): Promise<void> {
+    const config = context.config as AppConfig;
+
     // Resolve passport via pathResolver for client credential auth on introspect
     const { default: passport } = (await import(
       context.pathResolver("passport")
@@ -73,7 +76,7 @@ export const oauthModule = (params: {
     const { router: oauthRouter } = await createOAuthRouter(express, {
       passport,
       registry: context.grantRegistry,
-      config: context.config,
+      config,
       clientRepository: params.clientRepository,
       codeRepository: params.codeRepository,
       keyStore: context.keyStore,

--- a/packages/oauth/src/oauthAuthorization.mts
+++ b/packages/oauth/src/oauthAuthorization.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import type {
+	AppConfig,
 	ClientRepository,
 	CodeRepository,
 	Module,
@@ -28,14 +29,15 @@ export const oauthAuthorizationModule = (params: {
 }): Module => ({
 	name: "oauth-authorization",
 	async init(context: ModuleContext): Promise<void> {
-		const grantsConfig = context.config.oauth.grants as Record<
+		const config = context.config as AppConfig;
+		const grantsConfig = config.oauth.grants as Record<
 			string,
 			{ enabled?: boolean }
 		>;
 
 		if (grantsConfig.authorization?.enabled !== false) {
 			const handler = createAuthorizationGrant({
-				config: context.config,
+				config,
 				keyStore: context.keyStore,
 				codeRepository: params.codeRepository,
 				clientRepository: params.clientRepository,
@@ -45,7 +47,7 @@ export const oauthAuthorizationModule = (params: {
 
 		if (grantsConfig.refresh_token?.enabled !== false) {
 			const handler = createRefreshTokenGrant({
-				config: context.config,
+				config,
 				keyStore: context.keyStore,
 			});
 			context.grantRegistry.register("refresh_token", handler);

--- a/packages/oauth/src/oauthSession.mts
+++ b/packages/oauth/src/oauthSession.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import type {
+	AppConfig,
 	ClientRepository,
 	Module,
 	ModuleContext,
@@ -25,13 +26,14 @@ export const oauthSessionModule = (params: {
 }): Module => ({
 	name: "oauth-session",
 	async init(context: ModuleContext): Promise<void> {
+		const config = context.config as AppConfig;
 		const grantConfig = (
-			context.config.oauth.grants as Record<string, { enabled?: boolean }>
+			config.oauth.grants as Record<string, { enabled?: boolean }>
 		).session;
 		if (grantConfig?.enabled === false) return;
 
 		const handler = createSessionGrant({
-			config: context.config,
+			config,
 			keyStore: context.keyStore,
 			clientRepository: params.clientRepository,
 		});

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -27,6 +27,7 @@
     }
   },
   "scripts": {
+    "prebuild": "rm -rf dist",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -27,7 +27,7 @@
     }
   },
   "scripts": {
-    "prebuild": "rm -rf dist",
+    "prebuild": "rimraf dist",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/packages/session/src/module.mts
+++ b/packages/session/src/module.mts
@@ -15,6 +15,7 @@
  */
 import type { RequestHandler, Router } from "express";
 import type {
+	AppConfig,
 	Module,
 	ModuleContext,
 	UserRepository,
@@ -41,24 +42,25 @@ export const sessionModule = (params: {
 			const mod = await import(context.pathResolver("express"));
 			return mod.default as ExpressLike;
 		})();
+		const config = context.config as AppConfig;
 
 		// Initialize passport with pathResolver
 		const passport = await createPassport({
 			pathResolver: context.pathResolver,
 			userRepository: params.userRepository,
-			config: context.config,
+			config,
 		});
 
 		// Build federation registry
 		const federationRegistry = new FederationRegistry();
-		federationRegistry.register(createGoogleProvider(context.config));
+		federationRegistry.register(createGoogleProvider(config));
 
 		// Mount session routes
 		context.router.use(
 			"/session",
 			sessionRoutes.createRouter(express, {
 				passport,
-				config: context.config,
+				config,
 			}),
 		);
 
@@ -67,7 +69,7 @@ export const sessionModule = (params: {
 			"/session",
 			federationRoutes.createRouter(express, {
 				passport,
-				config: context.config,
+				config,
 				federationRegistry,
 			}),
 		);

--- a/packages/session/src/routes/Federation.mts
+++ b/packages/session/src/routes/Federation.mts
@@ -18,7 +18,7 @@ import type { Request, RequestHandler, Response, Router } from "express";
 import type { PassportStatic } from "passport";
 
 import type { AppConfig } from "@o3co/auth-provider-core";
-import type { FederationRegistry } from "#/federations/types.mjs";
+import type { FederationRegistry } from "../federations/types.mjs";
 
 declare module "express-session" {
 	interface SessionData {


### PR DESCRIPTION
## Summary
- Replace `rm -rf dist` with `rimraf dist` in prebuild scripts (cross-platform compatibility, 5 packages)
- Add `rimraf` as workspace devDependency
- Fix `make clean` to cover all packages via `pnpm -r exec rimraf dist`
- Document module resolution conventions in AGENTS.md (source=relative imports, test=`#/` aliases, Vite 8 condition)
- Move GitHub Release step before npm publish in release workflow for idempotent re-runs

## Context
Review of Codex commit `76d787f` ("Stabilize package builds and config typing") surfaced these improvements.

## Test plan
- [x] `pnpm -r run build` — all packages build with `rimraf dist` prebuild
- [x] `pnpm -r run test` — 369 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)