### PR TITLE
feat(did): add ed25519_prehash verifier and verifierRegistry inject point

### DIFF
--- a/packages/did/src/__tests__/did.test.mts
+++ b/packages/did/src/__tests__/did.test.mts
@@ -628,9 +628,11 @@ describe("createDidGrant", () => {
 			const publicKey = await ed.getPublicKeyAsync(privateKey);
 			const resolver = buildResolver(did, publicKey);
 
-			// Create a mock verifier that always succeeds
+			// Track whether the mock verifier was called
+			let verifyCalled = false;
 			const mockVerifier: SignatureVerifier = {
 				async verify(ctx: VerificationContext): Promise<VerificationResult> {
+					verifyCalled = true;
 					const parsedMessage = JSON.parse(ctx.body.message as string);
 					return {
 						valid: true,
@@ -655,14 +657,33 @@ describe("createDidGrant", () => {
 				},
 			} as unknown as GrantDependencies["config"];
 
-			// This would fail with default registry ("custom_alg" not registered)
-			// but succeeds with injected registry
 			const handler = createDidGrant(
 				{ config, keyStore: createSymmetricKeyStore("test-secret") },
 				{ resolver, verifierRegistry: customRegistry },
 			);
 
-			expect(typeof handler.handle).toBe("function");
+			const message = JSON.stringify({
+				did,
+				timestamp: new Date().toISOString(),
+				nonce: `nonce-custom-${Date.now()}-${Math.random()}`,
+			});
+
+			const ctx: GrantContext = {
+				body: {
+					did,
+					message,
+					signature: "dummy-signature",
+					algorithm: "custom_alg",
+				},
+				session: {},
+				issuer: "localhost",
+				metadata: { ip: "127.0.0.1" },
+			};
+
+			const { result } = await handler.handle(ctx);
+			expect(verifyCalled).toBe(true);
+			expect(result.status).toBe(200);
+			expect("tokens" in result).toBe(true);
 		});
 
 		it("falls back to default registry when verifierRegistry is not provided", async () => {

--- a/packages/did/src/__tests__/did.test.mts
+++ b/packages/did/src/__tests__/did.test.mts
@@ -25,7 +25,11 @@ import { describe, expect, it } from "vitest";
 import { createDidGrant } from "../did.mjs";
 import type { DidDocument, DidDocumentResolver, JsonWebKey } from "../resolver/types.mjs";
 import { VerifierRegistry } from "../verifiers/registry.mjs";
-import type { SignatureVerifier, VerificationContext, VerificationResult } from "../verifiers/types.mjs";
+import type {
+	SignatureVerifier,
+	VerificationContext,
+	VerificationResult,
+} from "../verifiers/types.mjs";
 
 const mockConfig = {
 	oauth: {

--- a/packages/did/src/__tests__/did.test.mts
+++ b/packages/did/src/__tests__/did.test.mts
@@ -517,6 +517,110 @@ describe("createDidGrant", () => {
 		});
 	});
 
+	describe("handle – ed25519_prehash", () => {
+		it("accepts ed25519_prehash when supportedAlgorithms includes it", async () => {
+			const did = "did:key:z6MkPrehashE2E";
+			const privateKey = ed.utils.randomSecretKey();
+			const publicKey = await ed.getPublicKeyAsync(privateKey);
+			const resolver = buildResolver(did, publicKey);
+
+			const message = JSON.stringify({
+				did,
+				timestamp: new Date().toISOString(),
+				nonce: `nonce-prehash-${Date.now()}-${Math.random()}`,
+			});
+
+			// SHA-256 hash the message, then sign the hash
+			const messageBytes = new TextEncoder().encode(message);
+			const hashBuffer = await crypto.subtle.digest("SHA-256", messageBytes);
+			const hash = new Uint8Array(hashBuffer);
+			const signature = await ed.signAsync(hash, privateKey);
+
+			const config = {
+				oauth: {
+					jwt: { secret: "test-secret" },
+					accessToken: { expiresIn: 3600 },
+					grants: {
+						did: { enabled: true, supportedAlgorithms: ["ed25519_prehash"] },
+					},
+				},
+			} as unknown as GrantDependencies["config"];
+
+			const handler = createDidGrant(
+				{ config, keyStore: createSymmetricKeyStore("test-secret") },
+				{ resolver },
+			);
+
+			const ctx: GrantContext = {
+				body: {
+					did,
+					message,
+					signature: Buffer.from(signature).toString("base64"),
+					prehash: "sha256",
+				},
+				session: {},
+				issuer: "localhost",
+				metadata: { ip: "127.0.0.1" },
+			};
+
+			const { result } = await handler.handle(ctx);
+			expect(result.status).toBe(200);
+			expect("tokens" in result).toBe(true);
+		});
+
+		it("rejects ed25519_prehash when not in supportedAlgorithms", async () => {
+			const did = "did:key:z6MkPrehashReject";
+			const privateKey = ed.utils.randomSecretKey();
+			const publicKey = await ed.getPublicKeyAsync(privateKey);
+			const resolver = buildResolver(did, publicKey);
+
+			const message = JSON.stringify({
+				did,
+				timestamp: new Date().toISOString(),
+				nonce: `nonce-prehash-reject-${Date.now()}`,
+			});
+
+			const messageBytes = new TextEncoder().encode(message);
+			const hashBuffer = await crypto.subtle.digest("SHA-256", messageBytes);
+			const hash = new Uint8Array(hashBuffer);
+			const signature = await ed.signAsync(hash, privateKey);
+
+			// Only ed25519_raw is supported — prehash should be rejected
+			const config = {
+				oauth: {
+					jwt: { secret: "test-secret" },
+					accessToken: { expiresIn: 3600 },
+					grants: {
+						did: { enabled: true, supportedAlgorithms: ["ed25519_raw"] },
+					},
+				},
+			} as unknown as GrantDependencies["config"];
+
+			const handler = createDidGrant(
+				{ config, keyStore: createSymmetricKeyStore("test-secret") },
+				{ resolver },
+			);
+
+			const ctx: GrantContext = {
+				body: {
+					did,
+					message,
+					signature: Buffer.from(signature).toString("base64"),
+					prehash: "sha256",
+				},
+				session: {},
+				issuer: "localhost",
+				metadata: { ip: "127.0.0.1" },
+			};
+
+			const { result } = await handler.handle(ctx);
+			expect(result.status).toBe(400);
+			expect("error" in result && result.error).toBe("invalid_request");
+			expect("errorDescription" in result && result.errorDescription).toContain("ed25519_prehash");
+			expect("errorDescription" in result && result.errorDescription).toContain("not supported");
+		});
+	});
+
 	describe("handle – custom verifierRegistry", () => {
 		it("uses injected verifierRegistry instead of default", async () => {
 			const did = "did:key:z6MkCustom";

--- a/packages/did/src/__tests__/did.test.mts
+++ b/packages/did/src/__tests__/did.test.mts
@@ -24,6 +24,8 @@ import { describe, expect, it } from "vitest";
 
 import { createDidGrant } from "../did.mjs";
 import type { DidDocument, DidDocumentResolver, JsonWebKey } from "../resolver/types.mjs";
+import { VerifierRegistry } from "../verifiers/registry.mjs";
+import type { SignatureVerifier, VerificationContext, VerificationResult } from "../verifiers/types.mjs";
 
 const mockConfig = {
 	oauth: {
@@ -505,6 +507,72 @@ describe("createDidGrant", () => {
 			} as unknown as GrantDependencies["config"];
 
 			const { ctx, resolver } = await makeSignedCtx("did:key:z6MkBackCompat");
+			const handler = createDidGrant(
+				{ config, keyStore: createSymmetricKeyStore("test-secret") },
+				{ resolver },
+			);
+
+			const { result } = await handler.handle(ctx);
+			expect(result.status).toBe(200);
+		});
+	});
+
+	describe("handle – custom verifierRegistry", () => {
+		it("uses injected verifierRegistry instead of default", async () => {
+			const did = "did:key:z6MkCustom";
+			const privateKey = ed.utils.randomSecretKey();
+			const publicKey = await ed.getPublicKeyAsync(privateKey);
+			const resolver = buildResolver(did, publicKey);
+
+			// Create a mock verifier that always succeeds
+			const mockVerifier: SignatureVerifier = {
+				async verify(ctx: VerificationContext): Promise<VerificationResult> {
+					const parsedMessage = JSON.parse(ctx.body.message as string);
+					return {
+						valid: true,
+						subject: ctx.did,
+						audience: parsedMessage.audience,
+						parsedMessage,
+					};
+				},
+			};
+
+			// Create a registry with only a custom algorithm
+			const customRegistry = new VerifierRegistry();
+			customRegistry.register("custom_alg", async () => mockVerifier);
+
+			const config = {
+				oauth: {
+					jwt: { secret: "test-secret" },
+					accessToken: { expiresIn: 3600 },
+					grants: {
+						did: { enabled: true, supportedAlgorithms: ["custom_alg"] },
+					},
+				},
+			} as unknown as GrantDependencies["config"];
+
+			// This would fail with default registry ("custom_alg" not registered)
+			// but succeeds with injected registry
+			const handler = createDidGrant(
+				{ config, keyStore: createSymmetricKeyStore("test-secret") },
+				{ resolver, verifierRegistry: customRegistry },
+			);
+
+			expect(typeof handler.handle).toBe("function");
+		});
+
+		it("falls back to default registry when verifierRegistry is not provided", async () => {
+			const { ctx, resolver } = await makeSignedCtx("did:key:z6MkFallback");
+			const config = {
+				oauth: {
+					jwt: { secret: "test-secret" },
+					accessToken: { expiresIn: 3600 },
+					grants: {
+						did: { enabled: true, supportedAlgorithms: ["ed25519_raw"] },
+					},
+				},
+			} as unknown as GrantDependencies["config"];
+
 			const handler = createDidGrant(
 				{ config, keyStore: createSymmetricKeyStore("test-secret") },
 				{ resolver },

--- a/packages/did/src/did.mts
+++ b/packages/did/src/did.mts
@@ -25,10 +25,12 @@ import { extractVerificationKey } from "./resolver/extractKey.mjs";
 import type { DidDocumentResolver } from "./resolver/types.mjs";
 import { detectAlgorithm } from "./verifiers/detect.mjs";
 import { createDefaultVerifierRegistry } from "./verifiers/factory.mjs";
+import type { VerifierRegistry } from "./verifiers/registry.mjs";
 import type { SignatureVerifier } from "./verifiers/types.mjs";
 
 export interface DidGrantOptions {
 	resolver: DidDocumentResolver;
+	verifierRegistry?: VerifierRegistry;
 }
 
 export const createDidGrant = (deps: GrantDependencies, options: DidGrantOptions): GrantHandler => {
@@ -44,7 +46,7 @@ export const createDidGrant = (deps: GrantDependencies, options: DidGrantOptions
 		((didConfig?.messageMaxAgeSec as number | undefined) ?? DEFAULT_MESSAGE_MAX_AGE_SEC) * 1000;
 	const allowedAudiences = (didConfig?.allowedAudiences as string[] | undefined) ?? [];
 
-	const verifierRegistry = createDefaultVerifierRegistry();
+	const verifierRegistry = options.verifierRegistry ?? createDefaultVerifierRegistry();
 
 	// Resolve supportedAlgorithms with backward-compatible alias for the old `algorithm` field.
 	const rawSupported = didConfig?.supportedAlgorithms as string[] | undefined;

--- a/packages/did/src/index.mts
+++ b/packages/did/src/index.mts
@@ -18,6 +18,7 @@ export { type DidModuleOptions, didConfigSchema, oauthDidModule } from "./module
 export { type ExtractedKey, extractVerificationKey } from "./resolver/extractKey.mjs";
 export type { DidDocument, DidDocumentResolver, VerificationMethod } from "./resolver/types.mjs";
 export { detectAlgorithm } from "./verifiers/detect.mjs";
+export { extractEd25519PublicKeyBytes } from "./verifiers/ed25519Utils.mjs";
 export {
 	type Algorithm,
 	createDefaultVerifierRegistry,

--- a/packages/did/src/module.mts
+++ b/packages/did/src/module.mts
@@ -18,6 +18,7 @@ import type { Module, ModuleContext } from "@o3co/auth-provider-core";
 import { z } from "zod";
 import { createDidGrant } from "./did.mjs";
 import type { DidDocumentResolver } from "./resolver/types.mjs";
+import type { VerifierRegistry } from "./verifiers/registry.mjs";
 
 export const didConfigSchema = z.object({
 	did: z
@@ -39,8 +40,8 @@ export const didConfigSchema = z.object({
 });
 
 export type DidModuleOptions =
-	| { resolver: DidDocumentResolver }
-	| { resolverFactory: (config: Record<string, unknown>) => DidDocumentResolver };
+	| { resolver: DidDocumentResolver; verifierRegistry?: VerifierRegistry }
+	| { resolverFactory: (config: Record<string, unknown>) => DidDocumentResolver; verifierRegistry?: VerifierRegistry };
 
 /**
  * Module that registers the DID grant handler.
@@ -67,7 +68,7 @@ export const oauthDidModule = (options: DidModuleOptions): Module => ({
 				keyStore: context.keyStore,
 				pathResolver: context.pathResolver,
 			},
-			{ resolver },
+			{ resolver, verifierRegistry: options.verifierRegistry },
 		);
 		context.grantRegistry.register("did", handler);
 	},

--- a/packages/did/src/module.mts
+++ b/packages/did/src/module.mts
@@ -41,7 +41,10 @@ export const didConfigSchema = z.object({
 
 export type DidModuleOptions =
 	| { resolver: DidDocumentResolver; verifierRegistry?: VerifierRegistry }
-	| { resolverFactory: (config: Record<string, unknown>) => DidDocumentResolver; verifierRegistry?: VerifierRegistry };
+	| {
+			resolverFactory: (config: Record<string, unknown>) => DidDocumentResolver;
+			verifierRegistry?: VerifierRegistry;
+	  };
 
 /**
  * Module that registers the DID grant handler.

--- a/packages/did/src/verifiers/__tests__/detect.test.mts
+++ b/packages/did/src/verifiers/__tests__/detect.test.mts
@@ -69,4 +69,19 @@ describe("detectAlgorithm", () => {
 		const body = { signature: "abc", message: "hello", jws: "some.jws.token" };
 		expect(detectAlgorithm(body)).toBe("ed25519_raw");
 	});
+
+	it("returns 'ed25519_prehash' when signature, message, and prehash='sha256' are present", () => {
+		const body = { signature: "abc123", message: "hello", prehash: "sha256" };
+		expect(detectAlgorithm(body)).toBe("ed25519_prehash");
+	});
+
+	it("returns 'ed25519_raw' when signature and message are present but prehash is absent", () => {
+		const body = { signature: "abc123", message: "hello" };
+		expect(detectAlgorithm(body)).toBe("ed25519_raw");
+	});
+
+	it("returns 'ed25519_raw' when prehash has an unrecognized value", () => {
+		const body = { signature: "abc123", message: "hello", prehash: "sha512" };
+		expect(detectAlgorithm(body)).toBe("ed25519_raw");
+	});
 });

--- a/packages/did/src/verifiers/__tests__/detect.test.mts
+++ b/packages/did/src/verifiers/__tests__/detect.test.mts
@@ -28,6 +28,22 @@ async function makeJws(alg: "EdDSA" | "ES256"): Promise<string> {
 }
 
 describe("detectAlgorithm", () => {
+	it("returns explicit body.algorithm when present", () => {
+		const body = { algorithm: "custom_alg", did: "did:key:abc" };
+		expect(detectAlgorithm(body)).toBe("custom_alg");
+	});
+
+	it("prefers explicit body.algorithm over shape-based detection", () => {
+		// Even though signature+message are present, explicit algorithm wins
+		const body = { algorithm: "custom_alg", signature: "abc", message: "hello" };
+		expect(detectAlgorithm(body)).toBe("custom_alg");
+	});
+
+	it("falls through to shape-based detection when algorithm is absent", () => {
+		const body = { signature: "abc", message: "hello" };
+		expect(detectAlgorithm(body)).toBe("ed25519_raw");
+	});
+
 	it("returns 'ed25519_raw' when signature and message are present", () => {
 		const body = { signature: "abc123", message: "hello" };
 		expect(detectAlgorithm(body)).toBe("ed25519_raw");

--- a/packages/did/src/verifiers/__tests__/ed25519Prehash.test.mts
+++ b/packages/did/src/verifiers/__tests__/ed25519Prehash.test.mts
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as ed from "@noble/ed25519";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import type { ExtractedKey } from "../../resolver/extractKey.mjs";
+import { Ed25519PrehashVerifier } from "../ed25519Prehash.mjs";
+
+/**
+ * Helper: create a pre-hashed signed DID request.
+ * 1. Build the JSON message string
+ * 2. SHA-256 hash the UTF-8 bytes of the message
+ * 3. Sign the 32-byte hash with Ed25519
+ */
+async function createPrehashSignedRequest(
+	did: string,
+	privateKey: Uint8Array,
+	overrides?: { audience?: string },
+): Promise<{ message: string; signature: string; resolvedKey: ExtractedKey }> {
+	const publicKeyBytes = await ed.getPublicKeyAsync(privateKey);
+	const x = Buffer.from(publicKeyBytes).toString("base64url");
+	const resolvedKey: ExtractedKey = {
+		format: "jwk",
+		key: { kty: "OKP", crv: "Ed25519", x },
+	};
+
+	const message = JSON.stringify({
+		did,
+		timestamp: new Date().toISOString(),
+		nonce: crypto.randomUUID(),
+		...(overrides?.audience ? { audience: overrides.audience } : {}),
+	});
+
+	// SHA-256 hash the message bytes
+	const messageBytes = new TextEncoder().encode(message);
+	const hashBuffer = await crypto.subtle.digest("SHA-256", messageBytes);
+	const hash = new Uint8Array(hashBuffer);
+
+	// Sign the hash (not the raw message)
+	const signatureBytes = await ed.signAsync(hash, privateKey);
+
+	return {
+		message,
+		signature: Buffer.from(signatureBytes).toString("base64"),
+		resolvedKey,
+	};
+}
+
+describe("Ed25519PrehashVerifier", () => {
+	const did = "did:key:z6MkPrehash";
+	let privateKey: Uint8Array;
+
+	beforeAll(() => {
+		privateKey = ed.utils.randomSecretKey();
+	});
+
+	it("returns valid result for correct pre-hashed signature (JWK)", async () => {
+		const verifier = new Ed25519PrehashVerifier();
+		const { message, signature, resolvedKey } = await createPrehashSignedRequest(did, privateKey);
+
+		const result = await verifier.verify({
+			body: { signature, message, prehash: "sha256" },
+			did,
+			resolvedKey,
+		});
+
+		expect(result.valid).toBe(true);
+		if (result.valid) {
+			expect(result.subject).toBe(did);
+			expect(result.parsedMessage.did).toBe(did);
+			expect(result.parsedMessage.nonce).toBeDefined();
+			expect(result.parsedMessage.timestamp).toBeDefined();
+		}
+	});
+
+	it("returns valid result with audience when present", async () => {
+		const verifier = new Ed25519PrehashVerifier();
+		const audience = "https://api.example.com";
+		const { message, signature, resolvedKey } = await createPrehashSignedRequest(
+			did,
+			privateKey,
+			{ audience },
+		);
+
+		const result = await verifier.verify({
+			body: { signature, message, prehash: "sha256" },
+			did,
+			resolvedKey,
+		});
+
+		expect(result.valid).toBe(true);
+		if (result.valid) {
+			expect(result.audience).toBe(audience);
+			expect(result.parsedMessage.audience).toBe(audience);
+		}
+	});
+
+	it("returns invalid when signature is wrong", async () => {
+		const verifier = new Ed25519PrehashVerifier();
+		const { message, resolvedKey } = await createPrehashSignedRequest(did, privateKey);
+
+		// Sign with a different key
+		const wrongKey = ed.utils.randomSecretKey();
+		const messageBytes = new TextEncoder().encode(message);
+		const hashBuffer = await crypto.subtle.digest("SHA-256", messageBytes);
+		const hash = new Uint8Array(hashBuffer);
+		const wrongSigBytes = await ed.signAsync(hash, wrongKey);
+		const wrongSignature = Buffer.from(wrongSigBytes).toString("base64");
+
+		const result = await verifier.verify({
+			body: { signature: wrongSignature, message, prehash: "sha256" },
+			did,
+			resolvedKey,
+		});
+
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.error).toBe("invalid_grant");
+		}
+	});
+
+	it("returns error when signature field is missing", async () => {
+		const verifier = new Ed25519PrehashVerifier();
+		const { message, resolvedKey } = await createPrehashSignedRequest(did, privateKey);
+
+		const result = await verifier.verify({
+			body: { message, prehash: "sha256" },
+			did,
+			resolvedKey,
+		});
+
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.error).toBe("invalid_request");
+			expect(result.errorDescription).toContain("signature");
+		}
+	});
+
+	it("returns error when message is not valid JSON", async () => {
+		const verifier = new Ed25519PrehashVerifier();
+		const publicKeyBytes = await ed.getPublicKeyAsync(privateKey);
+		const x = Buffer.from(publicKeyBytes).toString("base64url");
+		const resolvedKey: ExtractedKey = {
+			format: "jwk",
+			key: { kty: "OKP", crv: "Ed25519", x },
+		};
+
+		const result = await verifier.verify({
+			body: { signature: "dW51c2Vk", message: "not-json", prehash: "sha256" },
+			did,
+			resolvedKey,
+		});
+
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.error).toBe("invalid_request");
+			expect(result.errorDescription).toContain("JSON");
+		}
+	});
+
+	it("returns error when message.did does not match ctx.did", async () => {
+		const verifier = new Ed25519PrehashVerifier();
+		const { message, signature, resolvedKey } = await createPrehashSignedRequest(
+			"did:key:z6MkOther",
+			privateKey,
+		);
+
+		const result = await verifier.verify({
+			body: { signature, message, prehash: "sha256" },
+			did, // "did:key:z6MkPrehash" — does not match "did:key:z6MkOther"
+			resolvedKey,
+		});
+
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.error).toBe("invalid_request");
+			expect(result.errorDescription).toContain("did");
+		}
+	});
+});

--- a/packages/did/src/verifiers/__tests__/ed25519Prehash.test.mts
+++ b/packages/did/src/verifiers/__tests__/ed25519Prehash.test.mts
@@ -89,11 +89,9 @@ describe("Ed25519PrehashVerifier", () => {
 	it("returns valid result with audience when present", async () => {
 		const verifier = new Ed25519PrehashVerifier();
 		const audience = "https://api.example.com";
-		const { message, signature, resolvedKey } = await createPrehashSignedRequest(
-			did,
-			privateKey,
-			{ audience },
-		);
+		const { message, signature, resolvedKey } = await createPrehashSignedRequest(did, privateKey, {
+			audience,
+		});
 
 		const result = await verifier.verify({
 			body: { signature, message, prehash: "sha256" },

--- a/packages/did/src/verifiers/__tests__/factory.test.mts
+++ b/packages/did/src/verifiers/__tests__/factory.test.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
+import { Ed25519PrehashVerifier } from "../ed25519Prehash.mjs";
 import { Ed25519RawVerifier } from "../ed25519Raw.mjs";
 import { createVerifier } from "../factory.mjs";
 import { JwsVerifier } from "../jws.mjs";
@@ -43,5 +44,10 @@ describe("createVerifier", () => {
 		const pathResolver = (s: string) => s;
 		const verifier = await createVerifier("ed25519_raw", pathResolver);
 		expect(verifier).toBeDefined();
+	});
+
+	it("returns Ed25519PrehashVerifier for ed25519_prehash", async () => {
+		const verifier = await createVerifier("ed25519_prehash");
+		expect(verifier).toBeInstanceOf(Ed25519PrehashVerifier);
 	});
 });

--- a/packages/did/src/verifiers/detect.mts
+++ b/packages/did/src/verifiers/detect.mts
@@ -28,7 +28,10 @@ import { decodeProtectedHeader } from "jose";
  * Returns `null` if detection fails (e.g. invalid JWS, unknown alg).
  */
 export function detectAlgorithm(body: Record<string, unknown>): string | null {
-	if (body.signature && body.message) return "ed25519_raw";
+	if (body.signature && body.message) {
+		if (body.prehash === "sha256") return "ed25519_prehash";
+		return "ed25519_raw";
+	}
 
 	if (body.jws) {
 		try {

--- a/packages/did/src/verifiers/detect.mts
+++ b/packages/did/src/verifiers/detect.mts
@@ -18,16 +18,23 @@ import { decodeProtectedHeader } from "jose";
 /**
  * Detect which DID signature algorithm was used based on the request body.
  *
- * - `body.signature` + `body.message` present → `"ed25519_raw"`
- * - `body.jws` present → inspect the JWS protected header's `alg` field:
- *   - EdDSA  → `"ed25519_jws"`
- *   - ES256  → `"es256_jws"`
- *   - ES256K → `"es256k_jws"`
- * - otherwise → `null`
+ * Detection order:
+ * 1. `body.algorithm` is a non-empty string → return it directly (explicit override,
+ *    enables custom algorithms registered via `verifierRegistry`)
+ * 2. `body.signature` + `body.message` + `body.prehash === "sha256"` → `"ed25519_prehash"`
+ * 3. `body.signature` + `body.message` (no prehash) → `"ed25519_raw"`
+ * 4. `body.jws` present → inspect the JWS protected header's `alg` field:
+ *    - EdDSA  → `"ed25519_jws"`
+ *    - ES256  → `"es256_jws"`
+ *    - ES256K → `"es256k_jws"`
+ * 5. otherwise → `null`
  *
  * Returns `null` if detection fails (e.g. invalid JWS, unknown alg).
  */
 export function detectAlgorithm(body: Record<string, unknown>): string | null {
+	// Explicit algorithm field takes precedence over shape-based detection
+	if (typeof body.algorithm === "string" && body.algorithm) return body.algorithm;
+
 	if (body.signature && body.message) {
 		if (body.prehash === "sha256") return "ed25519_prehash";
 		return "ed25519_raw";

--- a/packages/did/src/verifiers/ed25519Prehash.mts
+++ b/packages/did/src/verifiers/ed25519Prehash.mts
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { PathResolver } from "@o3co/auth-provider-core";
+
+import { extractEd25519PublicKeyBytes } from "./ed25519Utils.mjs";
+import type {
+	ParsedMessage,
+	SignatureVerifier,
+	VerificationContext,
+	VerificationResult,
+} from "./types.mjs";
+
+export class Ed25519PrehashVerifier implements SignatureVerifier {
+	private verifyAsync:
+		| ((sig: Uint8Array, msg: Uint8Array, pub: Uint8Array) => Promise<boolean>)
+		| undefined;
+	private pathResolver: PathResolver | undefined;
+
+	constructor(pathResolver?: PathResolver) {
+		this.pathResolver = pathResolver;
+	}
+
+	private async loadVerifyAsync(): Promise<
+		(sig: Uint8Array, msg: Uint8Array, pub: Uint8Array) => Promise<boolean>
+	> {
+		if (this.verifyAsync) return this.verifyAsync;
+
+		const specifier = "@noble/ed25519";
+		const mod = this.pathResolver
+			? ((await import(this.pathResolver(specifier))) as {
+					verifyAsync: (sig: Uint8Array, msg: Uint8Array, pub: Uint8Array) => Promise<boolean>;
+				})
+			: ((await import(specifier)) as {
+					verifyAsync: (sig: Uint8Array, msg: Uint8Array, pub: Uint8Array) => Promise<boolean>;
+				});
+
+		this.verifyAsync = mod.verifyAsync;
+		return this.verifyAsync;
+	}
+
+	async verify(ctx: VerificationContext): Promise<VerificationResult> {
+		const { body, did, resolvedKey } = ctx;
+
+		// 1. Validate signature and message are present
+		if (typeof body.signature !== "string" || !body.signature) {
+			return { valid: false, error: "invalid_request", errorDescription: "signature is required" };
+		}
+		if (typeof body.message !== "string" || !body.message) {
+			return { valid: false, error: "invalid_request", errorDescription: "message is required" };
+		}
+
+		// 2. Parse message as JSON
+		let parsedMessage: ParsedMessage;
+		try {
+			parsedMessage = JSON.parse(body.message) as ParsedMessage;
+		} catch {
+			return {
+				valid: false,
+				error: "invalid_request",
+				errorDescription: "message must be valid JSON",
+			};
+		}
+
+		// 3. Validate message.did matches ctx.did
+		if (parsedMessage.did !== did) {
+			return {
+				valid: false,
+				error: "invalid_request",
+				errorDescription: "message.did must match did",
+			};
+		}
+
+		// 4. Extract public key bytes from resolvedKey
+		let publicKeyBytes: Uint8Array;
+		try {
+			publicKeyBytes = extractEd25519PublicKeyBytes(resolvedKey);
+		} catch (err) {
+			return {
+				valid: false,
+				error: "invalid_request",
+				errorDescription: err instanceof Error ? err.message : "invalid public key",
+			};
+		}
+
+		// 5. Compute SHA-256 hash of message, then verify Ed25519 signature against the hash
+		try {
+			const verifyAsync = await this.loadVerifyAsync();
+			const signatureBytes = Buffer.from(body.signature, "base64");
+			const messageBytes = new TextEncoder().encode(body.message);
+			const hashBuffer = await crypto.subtle.digest("SHA-256", messageBytes);
+			const hash = new Uint8Array(hashBuffer);
+
+			const valid = await verifyAsync(signatureBytes, hash, publicKeyBytes);
+			if (!valid) {
+				return {
+					valid: false,
+					error: "invalid_grant",
+					errorDescription: "signature verification failed",
+				};
+			}
+		} catch {
+			return {
+				valid: false,
+				error: "invalid_grant",
+				errorDescription: "signature verification error",
+			};
+		}
+
+		// 6. Return success
+		return { valid: true, subject: did, audience: parsedMessage.audience, parsedMessage };
+	}
+}

--- a/packages/did/src/verifiers/ed25519Raw.mts
+++ b/packages/did/src/verifiers/ed25519Raw.mts
@@ -14,73 +14,14 @@
  * limitations under the License.
  */
 import type { PathResolver } from "@o3co/auth-provider-core";
-import type { ExtractedKey } from "../resolver/extractKey.mjs";
+
+import { extractEd25519PublicKeyBytes } from "./ed25519Utils.mjs";
 import type {
 	ParsedMessage,
 	SignatureVerifier,
 	VerificationContext,
 	VerificationResult,
 } from "./types.mjs";
-
-// Base58btc alphabet (Bitcoin alphabet)
-const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-const BASE58_MAP: Record<string, number> = {};
-for (let i = 0; i < BASE58_ALPHABET.length; i++) {
-	BASE58_MAP[BASE58_ALPHABET[i]] = i;
-}
-
-function decodeBase58btc(input: string): Uint8Array {
-	const bytes = [0];
-	for (const char of input) {
-		const value = BASE58_MAP[char];
-		if (value === undefined) throw new Error(`Invalid base58 character: ${char}`);
-		let carry = value;
-		for (let i = 0; i < bytes.length; i++) {
-			carry += bytes[i] * 58;
-			bytes[i] = carry & 0xff;
-			carry >>= 8;
-		}
-		while (carry > 0) {
-			bytes.push(carry & 0xff);
-			carry >>= 8;
-		}
-	}
-	// Add leading zeros for leading '1's in input
-	for (const char of input) {
-		if (char === "1") bytes.push(0);
-		else break;
-	}
-	return new Uint8Array(bytes.reverse());
-}
-
-/**
- * Extract raw Ed25519 public key bytes from a resolved key.
- *
- * - JWK format: the `x` field is base64url-encoded raw 32-byte key.
- * - Multibase format: base58btc string (prefixed with 'z'), multicodec-prefixed (0xed 0x01).
- */
-function extractEd25519PublicKeyBytes(resolvedKey: ExtractedKey): Uint8Array {
-	if (resolvedKey.format === "jwk") {
-		const jwk = resolvedKey.key;
-		if (!jwk.x) throw new Error("JWK is missing x field");
-		// base64url decode
-		const padded = jwk.x.replace(/-/g, "+").replace(/_/g, "/");
-		const base64 = padded.padEnd(padded.length + ((4 - (padded.length % 4)) % 4), "=");
-		return Uint8Array.from(Buffer.from(base64, "base64"));
-	}
-
-	// Multibase: 'z' prefix indicates base58btc encoding
-	const multibaseStr = resolvedKey.key;
-	if (!multibaseStr.startsWith("z")) {
-		throw new Error("Only base58btc multibase ('z' prefix) is supported for Ed25519 keys");
-	}
-	const decoded = decodeBase58btc(multibaseStr.slice(1));
-	// Multicodec prefix for Ed25519 public key is 0xed 0x01
-	if (decoded.length < 2 || decoded[0] !== 0xed || decoded[1] !== 0x01) {
-		throw new Error("Invalid multicodec prefix for Ed25519 public key");
-	}
-	return decoded.slice(2);
-}
 
 export class Ed25519RawVerifier implements SignatureVerifier {
 	private verifyAsync:

--- a/packages/did/src/verifiers/ed25519Utils.mts
+++ b/packages/did/src/verifiers/ed25519Utils.mts
@@ -1,0 +1,61 @@
+import type { ExtractedKey } from "../resolver/extractKey.mjs";
+
+// Base58btc alphabet (Bitcoin alphabet)
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const BASE58_MAP: Record<string, number> = {};
+for (let i = 0; i < BASE58_ALPHABET.length; i++) {
+	BASE58_MAP[BASE58_ALPHABET[i]] = i;
+}
+
+export function decodeBase58btc(input: string): Uint8Array {
+	const bytes = [0];
+	for (const char of input) {
+		const value = BASE58_MAP[char];
+		if (value === undefined) throw new Error(`Invalid base58 character: ${char}`);
+		let carry = value;
+		for (let i = 0; i < bytes.length; i++) {
+			carry += bytes[i] * 58;
+			bytes[i] = carry & 0xff;
+			carry >>= 8;
+		}
+		while (carry > 0) {
+			bytes.push(carry & 0xff);
+			carry >>= 8;
+		}
+	}
+	// Add leading zeros for leading '1's in input
+	for (const char of input) {
+		if (char === "1") bytes.push(0);
+		else break;
+	}
+	return new Uint8Array(bytes.reverse());
+}
+
+/**
+ * Extract raw Ed25519 public key bytes from a resolved key.
+ *
+ * - JWK format: the `x` field is base64url-encoded raw 32-byte key.
+ * - Multibase format: base58btc string (prefixed with 'z'), multicodec-prefixed (0xed 0x01).
+ */
+export function extractEd25519PublicKeyBytes(resolvedKey: ExtractedKey): Uint8Array {
+	if (resolvedKey.format === "jwk") {
+		const jwk = resolvedKey.key;
+		if (!jwk.x) throw new Error("JWK is missing x field");
+		// base64url decode
+		const padded = jwk.x.replace(/-/g, "+").replace(/_/g, "/");
+		const base64 = padded.padEnd(padded.length + ((4 - (padded.length % 4)) % 4), "=");
+		return Uint8Array.from(Buffer.from(base64, "base64"));
+	}
+
+	// Multibase: 'z' prefix indicates base58btc encoding
+	const multibaseStr = resolvedKey.key;
+	if (!multibaseStr.startsWith("z")) {
+		throw new Error("Only base58btc multibase ('z' prefix) is supported for Ed25519 keys");
+	}
+	const decoded = decodeBase58btc(multibaseStr.slice(1));
+	// Multicodec prefix for Ed25519 public key is 0xed 0x01
+	if (decoded.length < 2 || decoded[0] !== 0xed || decoded[1] !== 0x01) {
+		throw new Error("Invalid multicodec prefix for Ed25519 public key");
+	}
+	return decoded.slice(2);
+}

--- a/packages/did/src/verifiers/ed25519Utils.mts
+++ b/packages/did/src/verifiers/ed25519Utils.mts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import type { ExtractedKey } from "../resolver/extractKey.mjs";
 
 // Base58btc alphabet (Bitcoin alphabet)

--- a/packages/did/src/verifiers/ed25519Utils.mts
+++ b/packages/did/src/verifiers/ed25519Utils.mts
@@ -22,7 +22,7 @@ for (let i = 0; i < BASE58_ALPHABET.length; i++) {
 	BASE58_MAP[BASE58_ALPHABET[i]] = i;
 }
 
-export function decodeBase58btc(input: string): Uint8Array {
+function decodeBase58btc(input: string): Uint8Array {
 	const bytes = [0];
 	for (const char of input) {
 		const value = BASE58_MAP[char];

--- a/packages/did/src/verifiers/ed25519Utils.mts
+++ b/packages/did/src/verifiers/ed25519Utils.mts
@@ -53,24 +53,31 @@ function decodeBase58btc(input: string): Uint8Array {
  * - Multibase format: base58btc string (prefixed with 'z'), multicodec-prefixed (0xed 0x01).
  */
 export function extractEd25519PublicKeyBytes(resolvedKey: ExtractedKey): Uint8Array {
+	let keyBytes: Uint8Array;
+
 	if (resolvedKey.format === "jwk") {
 		const jwk = resolvedKey.key;
 		if (!jwk.x) throw new Error("JWK is missing x field");
 		// base64url decode
 		const padded = jwk.x.replace(/-/g, "+").replace(/_/g, "/");
 		const base64 = padded.padEnd(padded.length + ((4 - (padded.length % 4)) % 4), "=");
-		return Uint8Array.from(Buffer.from(base64, "base64"));
+		keyBytes = Uint8Array.from(Buffer.from(base64, "base64"));
+	} else {
+		// Multibase: 'z' prefix indicates base58btc encoding
+		const multibaseStr = resolvedKey.key;
+		if (!multibaseStr.startsWith("z")) {
+			throw new Error("Only base58btc multibase ('z' prefix) is supported for Ed25519 keys");
+		}
+		const decoded = decodeBase58btc(multibaseStr.slice(1));
+		// Multicodec prefix for Ed25519 public key is 0xed 0x01
+		if (decoded.length < 2 || decoded[0] !== 0xed || decoded[1] !== 0x01) {
+			throw new Error("Invalid multicodec prefix for Ed25519 public key");
+		}
+		keyBytes = decoded.slice(2);
 	}
 
-	// Multibase: 'z' prefix indicates base58btc encoding
-	const multibaseStr = resolvedKey.key;
-	if (!multibaseStr.startsWith("z")) {
-		throw new Error("Only base58btc multibase ('z' prefix) is supported for Ed25519 keys");
+	if (keyBytes.length !== 32) {
+		throw new Error(`Expected 32-byte Ed25519 public key, got ${keyBytes.length} bytes`);
 	}
-	const decoded = decodeBase58btc(multibaseStr.slice(1));
-	// Multicodec prefix for Ed25519 public key is 0xed 0x01
-	if (decoded.length < 2 || decoded[0] !== 0xed || decoded[1] !== 0x01) {
-		throw new Error("Invalid multicodec prefix for Ed25519 public key");
-	}
-	return decoded.slice(2);
+	return keyBytes;
 }

--- a/packages/did/src/verifiers/factory.mts
+++ b/packages/did/src/verifiers/factory.mts
@@ -54,6 +54,29 @@ export function createDefaultVerifierRegistry(): VerifierRegistry {
 		}
 	});
 
+	registry.register("ed25519_prehash", async (pathResolver?: PathResolver) => {
+		try {
+			const { Ed25519PrehashVerifier } = await import("./ed25519Prehash.mjs");
+			return new Ed25519PrehashVerifier(pathResolver);
+		} catch (err) {
+			const code =
+				typeof err === "object" && err !== null && "code" in err
+					? (err as { code: unknown }).code
+					: undefined;
+			const message = err instanceof Error ? err.message : String(err);
+			if (
+				(code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") &&
+				message.includes("@noble/ed25519")
+			) {
+				throw new Error(
+					"ed25519_prehash algorithm requires @noble/ed25519 package. " +
+						"Install it with: pnpm add @noble/ed25519 — or switch to a JWS algorithm (ed25519_jws, es256_jws, es256k_jws).",
+				);
+			}
+			throw err;
+		}
+	});
+
 	registry.register("ed25519_jws", async () => new JwsVerifier(JWS_ALG_MAP.ed25519_jws));
 	registry.register("es256_jws", async () => new JwsVerifier(JWS_ALG_MAP.es256_jws));
 	registry.register("es256k_jws", async () => new JwsVerifier(JWS_ALG_MAP.es256k_jws));

--- a/packages/did/src/verifiers/index.mts
+++ b/packages/did/src/verifiers/index.mts
@@ -16,8 +16,9 @@
 
 export { extractEd25519PublicKeyBytes } from "./ed25519Utils.mjs";
 export { type Algorithm, createVerifier } from "./factory.mjs";
-// Ed25519RawVerifier intentionally NOT re-exported — it statically imports @noble/ed25519
-// which is an optional peer dep. Use createVerifier("ed25519_raw") or import directly.
+// Ed25519RawVerifier and Ed25519PrehashVerifier intentionally NOT re-exported — they
+// dynamically import @noble/ed25519 at runtime, which is an optional peer dep.
+// Use createVerifier("ed25519_raw") / createVerifier("ed25519_prehash") or import directly.
 export { JwsVerifier } from "./jws.mjs";
 export type {
 	ParsedMessage,

--- a/packages/did/src/verifiers/index.mts
+++ b/packages/did/src/verifiers/index.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export { extractEd25519PublicKeyBytes } from "./ed25519Utils.mjs";
 export { type Algorithm, createVerifier } from "./factory.mjs";
 // Ed25519RawVerifier intentionally NOT re-exported — it statically imports @noble/ed25519
 // which is an optional peer dep. Use createVerifier("ed25519_raw") or import directly.


### PR DESCRIPTION
## Summary

- Add `ed25519_prehash` built-in verifier — SHA-256 pre-hash + Ed25519 signature verification for environments where raw data should not transit the network
- Add `verifierRegistry` inject point on `DidGrantOptions` and `DidModuleOptions` — consumers can register custom verifier algorithms without modifying `packages/did` source
- Add explicit `body.algorithm` detection — custom algorithms registered via `verifierRegistry` are selectable by request
- Extract shared Ed25519 key utilities (`extractEd25519PublicKeyBytes`) to `ed25519Utils.mts` for reuse by custom verifier consumers

## Changes

### New files
- `packages/did/src/verifiers/ed25519Utils.mts` — shared key extraction (JWK base64url, multibase base58btc)
- `packages/did/src/verifiers/ed25519Prehash.mts` — `Ed25519PrehashVerifier` class
- `packages/did/src/verifiers/__tests__/ed25519Prehash.test.mts` — 6 unit tests

### Modified files
- `packages/did/src/verifiers/detect.mts` — `body.algorithm` explicit detection + `prehash` branch
- `packages/did/src/verifiers/factory.mts` — register `ed25519_prehash`
- `packages/did/src/verifiers/ed25519Raw.mts` — import from shared `ed25519Utils.mts`
- `packages/did/src/verifiers/index.mts` — re-export `extractEd25519PublicKeyBytes`
- `packages/did/src/index.mts` — re-export `extractEd25519PublicKeyBytes`
- `packages/did/src/did.mts` — `verifierRegistry?` on `DidGrantOptions`
- `packages/did/src/module.mts` — `verifierRegistry?` on `DidModuleOptions`

## Test plan

- [x] `Ed25519PrehashVerifier` unit tests: valid signature, wrong key, missing fields, bad JSON, DID mismatch, audience propagation
- [x] `detectAlgorithm` tests: explicit `body.algorithm`, `prehash: "sha256"`, precedence, fallthrough
- [x] `createVerifier("ed25519_prehash")` returns correct class
- [x] Custom `verifierRegistry` inject: mock verifier with `body.algorithm` — `handle()` invokes the mock and returns 200
- [x] E2E integration: `ed25519_prehash` through full grant handler (200 success + 400 rejection)
- [x] Full regression: 117 passed, 0 failures
- [x] Typecheck: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>