### PR TITLE
feat(config)!: rename clients.* to repositories.* (TODO-D)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -72,7 +72,7 @@ import { oauthModule } from "@o3co/auth-provider-oauth";
 const config = validate(parseFile("./config/application.conf"), AppConfigSchema);
 
 // flatten() はネストされたアダプターサブセクションを { type, ...fields } に正規化する。
-// `type` (clients.*, session.storage) と `provider` (oauth.jwt.signingKey) の
+// `type` (repositories.*, session.storage) と `provider` (oauth.jwt.signingKey) の
 // 両方のセレクターを受け付ける。完全な定義は packages/core/README.md を参照。
 const flatten = (section: { type?: string; provider?: string } & Record<string, unknown>) => {
   const selector = section.type ?? section.provider;

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ import { oauthModule } from "@o3co/auth-provider-oauth";
 const config = validate(parseFile("./config/application.conf"), AppConfigSchema);
 
 // flatten() normalises the nested adapter sub-section to { type, ...fields }.
-// Accepts both `type` (clients.*, session.storage) and `provider`
+// Accepts both `type` (repositories.*, session.storage) and `provider`
 // (oauth.jwt.signingKey) selectors. See packages/core/README.md for the
 // full helper definition.
 const flatten = (section: { type?: string; provider?: string } & Record<string, unknown>) => {

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -35,7 +35,7 @@ const config: AppConfig = AppConfigSchema.parse(rawConfig);
 | `session` | Express セッション設定 — secret、maxAge、secure、sameSite、domain、storage |
 | `rateLimit` | `login`、`token`、`authorize` エンドポイントのレート制限設定 |
 | `federations` | フェデレーションプロバイダー — `z.record(string, { enabled, type?, ...passthrough })`。組み込みタイプ: `"google"`, `"github"`。 |
-| `clients` | client、user、code の Repository 設定 |
+| `repositories` | client、user、code の Repository 設定 |
 | `endpoints` | `login`、`client`、`authCallback` ルートのパスオーバーライド |
 | `cors.allowedOrigins` | CORS 許可オリジン |
 
@@ -394,7 +394,7 @@ import {
 
 const config = AppConfigSchema.parse(rawConfig);
 
-// clients.* は 'type' セレクター、oauth.jwt.signingKey は 'provider' セレクターを使う。
+// repositories.* は 'type' セレクター、oauth.jwt.signingKey は 'provider' セレクターを使う。
 // flatten() はどちらも { type, ...サブセクションフィールド } に正規化してから factory に渡す:
 const flatten = (
   section: ({ type: string } | { provider: string }) & Record<string, unknown>,
@@ -419,9 +419,9 @@ const keyStore = await keyStoreFactory.create(flatten(config.oauth.jwt.signingKe
 
 const { clientFactory, userFactory, codeFactory } = createDefaultFactories();
 
-const clientRepository = await clientFactory.create(flatten(config.clients.client));
-const userRepository = await userFactory.create(flatten(config.clients.user));
-const codeRepository = await codeFactory.create(flatten(config.clients.code));
+const clientRepository = await clientFactory.create(flatten(config.repositories.client));
+const userRepository = await userFactory.create(flatten(config.repositories.user));
+const codeRepository = await codeFactory.create(flatten(config.repositories.code));
 
 const app = createApp(express, {
   config,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -35,7 +35,7 @@ Top-level fields:
 | `session` | Express session — secret, maxAge, secure, sameSite, domain, storage |
 | `rateLimit` | Rate limit config for `login`, `token`, and `authorize` endpoints |
 | `federations` | Federation providers — `z.record(string, { enabled, type?, ...passthrough })`. Built-in types: `"google"`, `"github"`. |
-| `clients` | Repository config for clients, users, and codes |
+| `repositories` | Repository config for clients, users, and codes |
 | `endpoints` | Path overrides for `login`, `client`, and `authCallback` routes |
 | `cors.allowedOrigins` | CORS allowed origins |
 
@@ -394,7 +394,7 @@ import {
 
 const config = AppConfigSchema.parse(rawConfig);
 
-// Both clients.* (uses 'type') and oauth.jwt.signingKey (uses 'provider') follow
+// Both repositories.* (uses 'type') and oauth.jwt.signingKey (uses 'provider') follow
 // the same nested adapter sub-section pattern. flatten() normalises either selector
 // to { type, ...subSectionFields } before forwarding to the factory:
 const flatten = (
@@ -420,9 +420,9 @@ const keyStore = await keyStoreFactory.create(flatten(config.oauth.jwt.signingKe
 
 const { clientFactory, userFactory, codeFactory } = createDefaultFactories();
 
-const clientRepository = await clientFactory.create(flatten(config.clients.client));
-const userRepository = await userFactory.create(flatten(config.clients.user));
-const codeRepository = await codeFactory.create(flatten(config.clients.code));
+const clientRepository = await clientFactory.create(flatten(config.repositories.client));
+const userRepository = await userFactory.create(flatten(config.repositories.user));
+const codeRepository = await codeFactory.create(flatten(config.repositories.code));
 
 const app = createApp(express, {
   config,

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -84,7 +84,7 @@ federations {
   }
 }
 
-clients {
+repositories {
   client {
     type = "yaml"
     type = ${?CLIENT_TYPE}

--- a/packages/core/src/__tests__/config-composition.test.mts
+++ b/packages/core/src/__tests__/config-composition.test.mts
@@ -77,11 +77,11 @@ describe("CoreConfigSchema", () => {
 		}
 	});
 
-	it("does not require clients", () => {
+	it("does not require repositories", () => {
 		const result = CoreConfigSchema.safeParse(minimalDIDConfig);
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect((result.data as Record<string, unknown>).clients).toBeUndefined();
+			expect((result.data as Record<string, unknown>).repositories).toBeUndefined();
 		}
 	});
 
@@ -231,7 +231,7 @@ describe("AppConfigSchema backward compatibility", () => {
 			federations: {
 				google: { enabled: false },
 			},
-			clients: {
+			repositories: {
 				client: { type: "yaml", path: "./config/clients.yaml" },
 				user: {
 					type: "yaml",

--- a/packages/core/src/__tests__/config-composition.test.mts
+++ b/packages/core/src/__tests__/config-composition.test.mts
@@ -232,13 +232,9 @@ describe("AppConfigSchema backward compatibility", () => {
 				google: { enabled: false },
 			},
 			repositories: {
-				client: { type: "yaml", path: "./config/clients.yaml" },
-				user: {
-					type: "yaml",
-					path: "./config/users.yaml",
-					timeout: 5000,
-				},
-				code: { type: "memory", defaultExpiresIn: 600 },
+				client: { type: "yaml", yaml: { path: "./config/clients.yaml" } },
+				user: { type: "yaml", yaml: { path: "./config/users.yaml" } },
+				code: { type: "memory", memory: { defaultExpiresIn: 600 } },
 			},
 			endpoints: {
 				login: {},

--- a/packages/core/src/__tests__/config.test.mts
+++ b/packages/core/src/__tests__/config.test.mts
@@ -67,7 +67,7 @@ describe("provider config", () => {
 		// federation entries is tested in federations-schema.test.mts.
 	});
 
-	it("clients.client.type defaults to yaml", () => {
+	it("repositories.client.type defaults to yaml", () => {
 		const raw = parseFile(new URL("../../config/application.conf", import.meta.url).pathname, {
 			env: {
 				OAUTH_JWT_SECRET: "test-secret",
@@ -77,10 +77,10 @@ describe("provider config", () => {
 			},
 		});
 		const config = validate(raw, AppConfigSchema);
-		expect(config.clients.client.type).toBe("yaml");
+		expect(config.repositories.client.type).toBe("yaml");
 	});
 
-	it("clients.user.type defaults to yaml", () => {
+	it("repositories.user.type defaults to yaml", () => {
 		const raw = parseFile(new URL("../../config/application.conf", import.meta.url).pathname, {
 			env: {
 				OAUTH_JWT_SECRET: "test-secret",
@@ -88,10 +88,10 @@ describe("provider config", () => {
 			},
 		});
 		const config = validate(raw, AppConfigSchema);
-		expect(config.clients.user.type).toBe("yaml");
+		expect(config.repositories.user.type).toBe("yaml");
 	});
 
-	it("clients.code.type defaults to memory", () => {
+	it("repositories.code.type defaults to memory", () => {
 		const raw = parseFile(new URL("../../config/application.conf", import.meta.url).pathname, {
 			env: {
 				OAUTH_JWT_SECRET: "test-secret",
@@ -99,7 +99,7 @@ describe("provider config", () => {
 			},
 		});
 		const config = validate(raw, AppConfigSchema);
-		expect(config.clients.code.type).toBe("memory");
+		expect(config.repositories.code.type).toBe("memory");
 	});
 });
 

--- a/packages/core/src/config/__tests__/federations-schema.test.mts
+++ b/packages/core/src/config/__tests__/federations-schema.test.mts
@@ -43,7 +43,7 @@ const minimalConfig = {
 		token: { windowMs: 60000, limit: 10 },
 		authorize: { windowMs: 60000, limit: 10 },
 	},
-	clients: {
+	repositories: {
 		client: {},
 		user: {},
 		code: {},

--- a/packages/core/src/config/__tests__/schema-open-type.test.mts
+++ b/packages/core/src/config/__tests__/schema-open-type.test.mts
@@ -86,7 +86,9 @@ describe("schema open type", () => {
 		const result = AppConfigSchema.safeParse({
 			http: { port: 3000, trustProxy: false },
 			oauth: {
-				jwt: { signingKey: { provider: "local", local: { algorithm: "HS256", kid: "v0", secret: "s" } } },
+				jwt: {
+					signingKey: { provider: "local", local: { algorithm: "HS256", kid: "v0", secret: "s" } },
+				},
 				accessToken: { expiresIn: 3600 },
 				refreshToken: { expiresIn: 86400 },
 				grants: {
@@ -112,8 +114,8 @@ describe("schema open type", () => {
 			// Legacy key — must fail. The renamed key `repositories` is absent.
 			clients: {
 				client: { type: "yaml", yaml: { path: "./config/clients.yaml" } },
-				user:   { type: "yaml", yaml: { path: "./config/users.yaml" } },
-				code:   { type: "memory" },
+				user: { type: "yaml", yaml: { path: "./config/users.yaml" } },
+				code: { type: "memory" },
 			},
 			endpoints: { login: { url: "/login" } },
 			cors: { allowedOrigins: [] },

--- a/packages/core/src/config/__tests__/schema-open-type.test.mts
+++ b/packages/core/src/config/__tests__/schema-open-type.test.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
-import { fullSectionsSchema } from "#/config/application.schema.mjs";
+import { AppConfigSchema, fullSectionsSchema } from "#/config/application.schema.mjs";
 
 describe("schema open type", () => {
 	it("accepts non-builtin session storage type (validated at factory level, not schema)", () => {
@@ -80,6 +80,52 @@ describe("schema open type", () => {
 		});
 		expect(parsed.user.type).toBe("ldap");
 		expect(parsed.code.type).toBe("dynamodb");
+	});
+
+	it("rejects legacy top-level `clients` key once renamed to `repositories`", () => {
+		const result = AppConfigSchema.safeParse({
+			http: { port: 3000, trustProxy: false },
+			oauth: {
+				jwt: { signingKey: { provider: "local", local: { algorithm: "HS256", kid: "v0", secret: "s" } } },
+				accessToken: { expiresIn: 3600 },
+				refreshToken: { expiresIn: 86400 },
+				grants: {
+					session: { enabled: true },
+					authorization: { enabled: true, pkce: { requireS256: false } },
+					refresh_token: { enabled: true },
+				},
+			},
+			session: {
+				secret: "x",
+				maxAge: 3600000,
+				secure: true,
+				sameSite: "lax",
+				domain: null,
+				storage: { type: "memory" },
+			},
+			rateLimit: {
+				login: { windowMs: 900000, limit: 20 },
+				token: { windowMs: 60000, limit: 60 },
+				authorize: { windowMs: 60000, limit: 30 },
+			},
+			federations: {},
+			// Legacy key — must fail. The renamed key `repositories` is absent.
+			clients: {
+				client: { type: "yaml", yaml: { path: "./config/clients.yaml" } },
+				user:   { type: "yaml", yaml: { path: "./config/users.yaml" } },
+				code:   { type: "memory" },
+			},
+			endpoints: { login: { url: "/login" } },
+			cors: { allowedOrigins: [] },
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			// The parse error must mention the missing `repositories` path,
+			// not silently accept the legacy `clients` key.
+			const paths = result.error.issues.map((i) => i.path.join("."));
+			expect(paths).toContain("repositories");
+		}
 	});
 });
 

--- a/packages/core/src/config/__tests__/schema-open-type.test.mts
+++ b/packages/core/src/config/__tests__/schema-open-type.test.mts
@@ -63,8 +63,8 @@ describe("schema open type", () => {
 		}
 	});
 
-	it("accepts non-builtin clients.client.type", () => {
-		const parsed = fullSectionsSchema.shape.clients.parse({
+	it("accepts non-builtin repositories.client.type", () => {
+		const parsed = fullSectionsSchema.shape.repositories.parse({
 			client: { type: "postgres", postgres: { dsn: "..." } },
 			user: { type: "yaml", yaml: { path: "./config/users.yaml" } },
 			code: { type: "memory", memory: {} },
@@ -72,8 +72,8 @@ describe("schema open type", () => {
 		expect(parsed.client.type).toBe("postgres");
 	});
 
-	it("accepts non-builtin clients.user.type and clients.code.type", () => {
-		const parsed = fullSectionsSchema.shape.clients.parse({
+	it("accepts non-builtin repositories.user.type and repositories.code.type", () => {
+		const parsed = fullSectionsSchema.shape.repositories.parse({
 			client: { type: "yaml", yaml: { path: "./clients.yaml" } },
 			user: { type: "ldap", ldap: { url: "ldap://..." } },
 			code: { type: "dynamodb", dynamodb: { region: "us-east-1" } },
@@ -129,9 +129,9 @@ describe("schema open type", () => {
 	});
 });
 
-describe("schema nested clients", () => {
-	it("accepts nested clients.client.yaml sub-section", () => {
-		const parsed = fullSectionsSchema.shape.clients.parse({
+describe("schema nested repositories", () => {
+	it("accepts nested repositories.client.yaml sub-section", () => {
+		const parsed = fullSectionsSchema.shape.repositories.parse({
 			client: {
 				type: "yaml",
 				yaml: { path: "./config/clients.yaml" },
@@ -150,8 +150,8 @@ describe("schema nested clients", () => {
 		expect(parsed.code.type).toBe("memory");
 	});
 
-	it("accepts nested clients.user.http sub-section with http-specific fields", () => {
-		const parsed = fullSectionsSchema.shape.clients.parse({
+	it("accepts nested repositories.user.http sub-section with http-specific fields", () => {
+		const parsed = fullSectionsSchema.shape.repositories.parse({
 			client: {
 				type: "yaml",
 				yaml: { path: "./config/clients.yaml" },
@@ -171,8 +171,8 @@ describe("schema nested clients", () => {
 		expect(parsed.user.type).toBe("http");
 	});
 
-	it("accepts nested clients.code.redis sub-section", () => {
-		const parsed = fullSectionsSchema.shape.clients.parse({
+	it("accepts nested repositories.code.redis sub-section", () => {
+		const parsed = fullSectionsSchema.shape.repositories.parse({
 			client: {
 				type: "yaml",
 				yaml: { path: "./config/clients.yaml" },
@@ -193,7 +193,7 @@ describe("schema nested clients", () => {
 	});
 
 	it("allows coexistence of multiple adapter sub-sections (operators can swap type without losing config)", () => {
-		const parsed = fullSectionsSchema.shape.clients.parse({
+		const parsed = fullSectionsSchema.shape.repositories.parse({
 			client: {
 				type: "yaml",
 				yaml: { path: "./config/clients.yaml" },

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -182,7 +182,7 @@ export const fullSectionsSchema = z.object({
 		authorize: rateLimitSchema,
 	}),
 	federations: z.record(z.string(), federationEntrySchema).default({}),
-	clients: z.object({
+	repositories: z.object({
 		client: z
 			.object({
 				type: z.string().default("yaml"),

--- a/packages/core/src/repositories/__tests__/nested-migration-error.test.mts
+++ b/packages/core/src/repositories/__tests__/nested-migration-error.test.mts
@@ -84,7 +84,8 @@ describe("nested repositories.* migration: builder-level error self-diagnosis", 
 			http: { authenticateUrl: "https://auth.example.com/verify" },
 		};
 		const adapterCfg =
-			(nestedRepositoriesUser[nestedRepositoriesUser.type as "http"] as Record<string, unknown>) ?? {};
+			(nestedRepositoriesUser[nestedRepositoriesUser.type as "http"] as Record<string, unknown>) ??
+			{};
 		const flattened = { type: nestedRepositoriesUser.type, ...adapterCfg };
 
 		const repo = await userFactory.create(flattened);

--- a/packages/core/src/repositories/__tests__/nested-migration-error.test.mts
+++ b/packages/core/src/repositories/__tests__/nested-migration-error.test.mts
@@ -32,9 +32,13 @@ import { describe, expect, it } from "vitest";
 describe("nested repositories.* migration: builder-level error self-diagnosis", () => {
 	it("http user builder emits a clear error when authenticateUrl is missing", async () => {
 		// Simulate a caller that forwarded the legacy flat `repositories.user` section
-		// which has only `type` at the top level after the Task 3 schema migration
-		// (the old `authenticateUrl`/`authenticateByTokenUrl` fields were stripped
-		// or never forwarded without flattening).
+		// to the builder without first flattening the nested adapter sub-section.
+		// The schema uses `.passthrough()` on `repositories.user`, so flat fields
+		// like `authenticateUrl` are not stripped at parse time — they're simply
+		// missing from the builder input because the wiring code expects the shape
+		// `{ type, <type>: { ...adapter-specific fields } }` and flattens it.
+		// A legacy flat config (`{ type: "http", authenticateUrl: "..." }`) that
+		// bypasses flattening effectively forwards only `type` to the builder.
 		const userFactory = createAdapterFactory<UserRepository>("UserRepository");
 		userFactory.register("http", (config) => {
 			if (typeof config.authenticateUrl !== "string") {

--- a/packages/core/src/repositories/__tests__/nested-migration-error.test.mts
+++ b/packages/core/src/repositories/__tests__/nested-migration-error.test.mts
@@ -79,13 +79,13 @@ describe("nested repositories.* migration: builder-level error self-diagnosis", 
 		// config: `{ type: "http", http: { authenticateUrl: "..." } }` →
 		// `{ type: "http", authenticateUrl: "..." }` before forwarding to the
 		// builder.
-		const nestedClientsUser = {
+		const nestedRepositoriesUser = {
 			type: "http",
 			http: { authenticateUrl: "https://auth.example.com/verify" },
 		};
 		const adapterCfg =
-			(nestedClientsUser[nestedClientsUser.type as "http"] as Record<string, unknown>) ?? {};
-		const flattened = { type: nestedClientsUser.type, ...adapterCfg };
+			(nestedRepositoriesUser[nestedRepositoriesUser.type as "http"] as Record<string, unknown>) ?? {};
+		const flattened = { type: nestedRepositoriesUser.type, ...adapterCfg };
 
 		const repo = await userFactory.create(flattened);
 		expect(repo).toBeDefined();

--- a/packages/core/src/repositories/__tests__/nested-migration-error.test.mts
+++ b/packages/core/src/repositories/__tests__/nested-migration-error.test.mts
@@ -18,7 +18,7 @@ import { createAdapterFactory } from "@o3co/auth-provider-core";
 import { describe, expect, it } from "vitest";
 
 /**
- * These tests document the self-diagnosing behaviour of the nested clients.*
+ * These tests document the self-diagnosing behaviour of the nested repositories.*
  * migration. After PR #3 (this spec's Task 3 schema change), wiring code MUST
  * flatten the adapter sub-section before calling factory.create(...). If a
  * caller accidentally forwards a legacy flat config, the adapter-specific
@@ -29,9 +29,9 @@ import { describe, expect, it } from "vitest";
  * that pin the migration's error semantics so future refactors don't erode
  * the operator-facing error message quality.
  */
-describe("nested clients.* migration: builder-level error self-diagnosis", () => {
+describe("nested repositories.* migration: builder-level error self-diagnosis", () => {
 	it("http user builder emits a clear error when authenticateUrl is missing", async () => {
-		// Simulate a caller that forwarded the legacy flat `clients.user` section
+		// Simulate a caller that forwarded the legacy flat `repositories.user` section
 		// which has only `type` at the top level after the Task 3 schema migration
 		// (the old `authenticateUrl`/`authenticateByTokenUrl` fields were stripped
 		// or never forwarded without flattening).
@@ -75,7 +75,7 @@ describe("nested clients.* migration: builder-level error self-diagnosis", () =>
 			} as UserRepository;
 		});
 
-		// Simulate the wiring code's flattening of the nested clients.user
+		// Simulate the wiring code's flattening of the nested repositories.user
 		// config: `{ type: "http", http: { authenticateUrl: "..." } }` →
 		// `{ type: "http", authenticateUrl: "..." }` before forwarding to the
 		// builder.

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -85,7 +85,7 @@ federations {
   }
 }
 
-clients {
+repositories {
   client {
     type = "yaml"
     type = ${?CLIENT_TYPE}

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -68,7 +68,7 @@ const config: AppConfig = {
 	federations: {
 		google: { enabled: false },
 	},
-	clients: {
+	repositories: {
 		client: { type: "yaml", path: "./config/clients.yaml" },
 		user: { type: "yaml", path: "./config/users.yaml", timeout: 5000 },
 		code: { type: "memory", defaultExpiresIn: 600 },

--- a/templates/standalone/src/app.mts
+++ b/templates/standalone/src/app.mts
@@ -73,17 +73,17 @@ await (async (): Promise<void> => {
 	registerBuiltinAdapters({ userFactory, codeFactory, pathResolver: import.meta.resolve });
 
 	const clientConfig = flattenAdapterConfig(
-		config.clients.client as { type: string } & Record<string, unknown>,
+		config.repositories.client as { type: string } & Record<string, unknown>,
 	);
 	if (typeof clientConfig.path === "string") {
 		clientConfig.path = path.resolve(appDir, "..", clientConfig.path);
 	}
 	const clientRepository = await clientFactory.create(clientConfig);
 	const userRepository = await userFactory.create(
-		flattenAdapterConfig(config.clients.user as { type: string } & Record<string, unknown>),
+		flattenAdapterConfig(config.repositories.user as { type: string } & Record<string, unknown>),
 	);
 	const codeRepository = await codeFactory.create(
-		flattenAdapterConfig(config.clients.code as { type: string } & Record<string, unknown>),
+		flattenAdapterConfig(config.repositories.code as { type: string } & Record<string, unknown>),
 	);
 
 	const app = express();


### PR DESCRIPTION
## Summary

- Renames the top-level HOCON config section `clients.*` → `repositories.*` (Pre-GA TODO-D).
- Sub-section names (`client`, `user`, `code`) and class/type/import names (`ClientRepository`, `UserRepository`, `CodeRepository`, `InMemoryClientRepository`) are unchanged.
- Adds a regression test locking fail-fast semantics for the legacy `clients` key: `AppConfigSchema.safeParse({ ...clients: {...} })` → parse error with `repositories` path required.

Spec: `.claude/superpowers/specs/2026-04-20-auth-provider-repositories-rename-design.md` (agentscope workspace).
Parent spec: `.claude/superpowers/specs/2026-04-19-auth-provider-extensibility-design.md` (Pre-GA TODO-D, extensibility overhaul complete with Plan #1-#4).

## Breaking changes

### Config

```diff
- clients {
+ repositories {
    client { type = "yaml", yaml { path = "..." } }
    user   { type = "http", http { ... } }
    code   { type = "redis", redis { ... } }
  }
```

### TypeScript

- `AppConfig["clients"]` → `AppConfig["repositories"]`
- `fullSectionsSchema.shape.clients` → `fullSectionsSchema.shape.repositories`

Any consumer that reads `config.clients.*` must rename to `config.repositories.*`.

## Migration

```diff
- const clientRepo = await clientFactory.create(flattenAdapterConfig(config.clients.client));
- const userRepo   = await userFactory.create(flattenAdapterConfig(config.clients.user));
- const codeRepo   = await codeFactory.create(flattenAdapterConfig(config.clients.code));
+ const clientRepo = await clientFactory.create(flattenAdapterConfig(config.repositories.client));
+ const userRepo   = await userFactory.create(flattenAdapterConfig(config.repositories.user));
+ const codeRepo   = await codeFactory.create(flattenAdapterConfig(config.repositories.code));
```

No deprecation layer (0.x pre-GA rename, same pattern as Plan #1-#4).

## Follow-up

- `dplaas.auth` will catch up in a separate PR, bundled with Plan #1-#4 accumulated breaking changes.
- `endpoints.*` cleanup (provider-own endpoints vs relying-party redirect URLs are currently mixed) is deferred to a separate pre-GA task.

## Test plan

- [x] `pnpm -r test` — 578 passed across all workspace packages
- [x] `pnpm -r build` — green
- [x] Regression test `"rejects legacy top-level clients key once renamed to repositories"` locks fail-fast semantics
- [x] Standalone template builds and boots with renamed config
- [x] Multi-agent review (Claude + Codex): both approved, one minor suggestion (stale local var) fixed pre-PR

## Related

Completes Pre-GA TODO-D. Previous Extensibility Overhaul PRs: #61 (AdapterFactory foundation), #62 (nested clients config + SessionStoreFactory), #63 (KeyStoreFactory), #64 (FederationProviderFactory + GitHub). Remaining pre-GA TODOs: A (FederationProvider capability segregation), B (KeyStore remote sign semantics), C (extension surface decisions for MFA/audit/metrics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
