### PR TITLE
feat(session)!: FederationProvider capability segregation (TODO-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Added
+
+- `SupportsLogout` optional capability interface (`EndSessionRequest`, `EndSessionResult`, `SupportsLogout`) and `supportsLogout(provider)` type guard helper in `@o3co/auth-provider-session`. Detects providers whose IdP exposes an OIDC RP-Initiated Logout endpoint. Built-in `google` / `github` providers do not implement this capability.
+
+### Changed
+
+- **Breaking**: `FederationProvider` interface renamed to `FederationProviderBase` in `@o3co/auth-provider-session`. Consumers must update type imports. No runtime or behavioral change.
+- **Breaking**: `FederationProviderFactory` is now `AdapterFactory<FederationProviderBase>` (was `AdapterFactory<FederationProvider>`). The `createFederationProviderFactory()` function signature is unchanged; only the element type name differs.
+
+### Removed
+
+- **Breaking**: `VerifyUserContext` deprecated type alias in `@o3co/auth-provider-session`. Use `SetupPassportContext` (introduced in the Federation factory PR #64).
+
+### Migration
+
+Replace `FederationProvider` with `FederationProviderBase` and `VerifyUserContext` with `SetupPassportContext` at every type import site. No runtime or config change is required.
+
+```ts
+// Before
+import type { FederationProvider, VerifyUserContext } from "@o3co/auth-provider-session";
+
+// After
+import type { FederationProviderBase, SetupPassportContext } from "@o3co/auth-provider-session";
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- `SupportsLogout` optional capability interface (`EndSessionRequest`, `EndSessionResult`, `SupportsLogout`) and `supportsLogout(provider)` type guard helper in `@o3co/auth-provider-session`. Detects providers whose IdP exposes an OIDC RP-Initiated Logout endpoint. Built-in `google` / `github` providers do not implement this capability.
+- `SupportsLogout` optional capability interface (`EndSessionRequest`, `EndSessionResult`, `SupportsLogout`) and `supportsLogout(provider)` type guard helper in `@o3co/auth-provider-session`. Detects providers whose IdP exposes an OIDC RP-Initiated Logout endpoint. `supportsLogout` accepts `FederationProviderBase | undefined | null` so it can be called directly on `Map.get(name)` lookups; returns `false` on nullish input. Built-in `google` / `github` providers do not implement this capability.
 
 ### Changed
 

--- a/packages/session/README.ja.md
+++ b/packages/session/README.ja.md
@@ -187,7 +187,7 @@ interface SupportsLogout {
 }
 
 function supportsLogout(
-  provider: FederationProviderBase,
+  provider: FederationProviderBase | undefined | null,
 ): provider is FederationProviderBase & SupportsLogout;
 ```
 

--- a/packages/session/README.ja.md
+++ b/packages/session/README.ja.md
@@ -66,8 +66,8 @@ function sessionModule(params: {
 ```typescript
 function createPassport(options: {
   userRepository: UserRepository;
-  federationProviders: ReadonlyMap<string, FederationProvider>;
-  pathResolver: PathResolver;  // 必須; passport/passport-local の dynamic import に使用され、FederationProvider.setupPassportStrategy にも転送される
+  federationProviders: ReadonlyMap<string, FederationProviderBase>;
+  pathResolver: PathResolver;  // 必須; passport/passport-local の dynamic import に使用され、FederationProviderBase.setupPassportStrategy にも転送される
 }): Promise<PassportStatic>;
 ```
 
@@ -84,7 +84,7 @@ Passport インスタンスを生成・設定する。
 function createFederationProviderFactory(): FederationProviderFactory;
 ```
 
-組み込みタイプが未登録の空の `FederationProviderFactory`（`AdapterFactory<FederationProvider>`）を返す。`registerBuiltinFederations(factory)` を呼び出して組み込みの `"google"` と `"github"` を登録し、`factory.register(type, builder)` で独自タイプを追加できる。
+組み込みタイプが未登録の空の `FederationProviderFactory`（`AdapterFactory<FederationProviderBase>`）を返す。`registerBuiltinFederations(factory)` を呼び出して組み込みの `"google"` と `"github"` を登録し、`factory.register(type, builder)` で独自タイプを追加できる。
 
 ---
 
@@ -114,10 +114,10 @@ function createGoogleProvider(config: {
   sessionDomain?: string;
   authCallbackUrl?: string;
   clientUrl?: string;
-}): FederationProvider;
+}): FederationProviderBase;
 ```
 
-Google OAuth 2.0 用の `FederationProvider` を生成する。ストラテジーは `config.name` の名前で Passport に登録されるため、マルチテナント構成（例: `google` と `google-work` を別インスタンスとして共存）が可能。
+Google OAuth 2.0 用の `FederationProviderBase` を生成する。ストラテジーは `config.name` の名前で Passport に登録されるため、マルチテナント構成（例: `google` と `google-work` を別インスタンスとして共存）が可能。
 
 ---
 
@@ -132,17 +132,17 @@ function createGithubProvider(config: {
   sessionDomain?: string;
   authCallbackUrl?: string;
   clientUrl?: string;
-}): FederationProvider;
+}): FederationProviderBase;
 ```
 
-GitHub OAuth 2.0 用の `FederationProvider` を生成する。`passport-github2`（オプションの peer dep）が必要なため、別途インストールすること。デフォルトのスコープは `["read:user", "user:email"]`。`externalId` のフォーマットは `"github:" + profile.id`。
+GitHub OAuth 2.0 用の `FederationProviderBase` を生成する。`passport-github2`（オプションの peer dep）が必要なため、別途インストールすること。デフォルトのスコープは `["read:user", "user:email"]`。`externalId` のフォーマットは `"github:" + profile.id`。
 
 ---
 
-### `FederationProvider` (interface)
+### `FederationProviderBase` (interface)
 
 ```typescript
-interface FederationProvider {
+interface FederationProviderBase {
   readonly name: string;
   readonly scope: readonly string[];
   validateRedirect(url: string): FederationResult<void>;
@@ -156,7 +156,7 @@ interface SetupPassportContext {
 }
 ```
 
-カスタムの OAuth 2.0 / OIDC フェデレーションプロバイダーを追加する場合はこのインターフェースを実装する。
+カスタムの OAuth 2.0 / OIDC フェデレーションプロバイダーを追加する場合はこのインターフェースを実装する。IdP が end-session endpoint を公開している場合は `SupportsLogout` を mix-in できる。
 
 - `name` — Passport ストラテジーの一意な識別子。`federationProviders` の Map キーと `passport.use()` に渡すストラテジー名の両方に使用される。
 - `scope` — OAuth 2.0 スコープ。
@@ -166,13 +166,83 @@ interface SetupPassportContext {
 
 ---
 
+### `SupportsLogout` (オプショナル capability)
+
+IdP が OIDC RP-Initiated Logout (end-session) endpoint を公開している provider 向けのオプショナル capability。
+
+```ts
+interface EndSessionRequest {
+  idTokenHint?: string;
+  postLogoutRedirectUri?: string;
+  state?: string;
+}
+
+interface EndSessionResult {
+  url: URL;
+  method: "GET";
+}
+
+interface SupportsLogout {
+  endSession(req: EndSessionRequest): Promise<EndSessionResult>;
+}
+
+function supportsLogout(
+  provider: FederationProviderBase,
+): provider is FederationProviderBase & SupportsLogout;
+```
+
+組み込みの `"google"` / `"github"` は `SupportsLogout` を **実装しない**。Google は OIDC end-session endpoint を公開しておらず、GitHub は OAuth2 only のため、それぞれ end_session endpoint を持たない。Microsoft Entra ID / Auth0 / Okta 等の integration ではカスタム provider 側で capability を足すことで対応する。
+
+カスタム provider の最小実装例:
+
+```ts
+import type {
+  FederationProviderBase,
+  SupportsLogout,
+  EndSessionRequest,
+  EndSessionResult,
+} from "@o3co/auth-provider-session";
+
+function createMyIdPProvider(): FederationProviderBase & SupportsLogout {
+  return {
+    name: "myidp",
+    scope: ["openid"],
+    validateRedirect(url) { /* ... */ },
+    resolveCallbackRedirect(session) { /* ... */ },
+    async setupPassportStrategy(passport, ctx) { /* ... */ },
+    async endSession(req: EndSessionRequest): Promise<EndSessionResult> {
+      const url = new URL("https://myidp.example/oidc/logout");
+      if (req.idTokenHint) url.searchParams.set("id_token_hint", req.idTokenHint);
+      if (req.postLogoutRedirectUri) url.searchParams.set("post_logout_redirect_uri", req.postLogoutRedirectUri);
+      if (req.state) url.searchParams.set("state", req.state);
+      return { url, method: "GET" };
+    },
+  };
+}
+```
+
+Consumer 側は capability の有無を call site で判定する:
+
+```ts
+import { supportsLogout } from "@o3co/auth-provider-session";
+
+if (supportsLogout(provider)) {
+  const { url } = await provider.endSession({ idTokenHint, postLogoutRedirectUri, state });
+  res.redirect(url.toString());
+} else {
+  // local session destroy のみにフォールバック
+}
+```
+
+---
+
 ### `FederationProviderFactory` (type)
 
 ```typescript
-type FederationProviderFactory = AdapterFactory<FederationProvider>;
+type FederationProviderFactory = AdapterFactory<FederationProviderBase>;
 ```
 
-`AdapterFactory<FederationProvider>` の型エイリアス。`factory.register(type, builder)` でカスタムプロバイダータイプを登録できる。
+`AdapterFactory<FederationProviderBase>` の型エイリアス。`factory.register(type, builder)` でカスタムプロバイダータイプを登録できる。
 
 ---
 
@@ -184,7 +254,7 @@ type FederationResult<T> =
   | { ok: false; status: number; error: string; errorDescription: string };
 ```
 
-`FederationProvider` のメソッドが返す判別共用体。`value` にアクセスする前に `ok` を確認すること。
+`FederationProviderBase` のメソッドが返す判別共用体。`value` にアクセスする前に `ok` を確認すること。
 
 ## 使い方
 
@@ -265,7 +335,7 @@ federations {
 import {
   createFederationProviderFactory,
   registerBuiltinFederations,
-  type FederationProvider,
+  type FederationProviderBase,
   type FederationProviderFactory,
 } from "@o3co/auth-provider-session";
 
@@ -275,7 +345,7 @@ registerBuiltinFederations(factory);
 
 // カスタムプロバイダータイプを登録
 factory.register("microsoft", async (config) => {
-  // FederationProvider を構築して返す
+  // FederationProviderBase を構築して返す
   return {
     name: config.name as string,
     scope: ["openid", "profile", "email"],
@@ -288,7 +358,7 @@ factory.register("microsoft", async (config) => {
 });
 
 // config からプロバイダー Map を構築 — module.mts の正規化ロジックを反映
-const federationProviders = new Map<string, FederationProvider>();
+const federationProviders = new Map<string, FederationProviderBase>();
 for (const [name, section] of Object.entries(config.federations)) {
   if (!section.enabled) continue;
 

--- a/packages/session/README.md
+++ b/packages/session/README.md
@@ -66,8 +66,8 @@ The `:name` path parameter corresponds to the federation key in `config.federati
 ```typescript
 function createPassport(options: {
   userRepository: UserRepository;
-  federationProviders: ReadonlyMap<string, FederationProvider>;
-  pathResolver: PathResolver;  // required; used for dynamic imports of passport/passport-local and threaded through to FederationProvider.setupPassportStrategy
+  federationProviders: ReadonlyMap<string, FederationProviderBase>;
+  pathResolver: PathResolver;  // required; used for dynamic imports of passport/passport-local and threaded through to FederationProviderBase.setupPassportStrategy
 }): Promise<PassportStatic>;
 ```
 
@@ -84,7 +84,7 @@ Creates and configures a Passport instance.
 function createFederationProviderFactory(): FederationProviderFactory;
 ```
 
-Creates an empty `FederationProviderFactory` (an `AdapterFactory<FederationProvider>` with no built-in types registered). Call `registerBuiltinFederations(factory)` to register the built-in `"google"` and `"github"` types, then call `factory.register(type, builder)` to add your own.
+Creates an empty `FederationProviderFactory` (an `AdapterFactory<FederationProviderBase>` with no built-in types registered). Call `registerBuiltinFederations(factory)` to register the built-in `"google"` and `"github"` types, then call `factory.register(type, builder)` to add your own.
 
 ---
 
@@ -114,10 +114,10 @@ function createGoogleProvider(config: {
   sessionDomain?: string;
   authCallbackUrl?: string;
   clientUrl?: string;
-}): FederationProvider;
+}): FederationProviderBase;
 ```
 
-Creates a `FederationProvider` for Google OAuth 2.0. The strategy is registered in Passport under `config.name`, which enables multi-tenant usage (e.g. `google` and `google-work` as separate instances).
+Creates a `FederationProviderBase` for Google OAuth 2.0. The strategy is registered in Passport under `config.name`, which enables multi-tenant usage (e.g. `google` and `google-work` as separate instances).
 
 ---
 
@@ -132,17 +132,17 @@ function createGithubProvider(config: {
   sessionDomain?: string;
   authCallbackUrl?: string;
   clientUrl?: string;
-}): FederationProvider;
+}): FederationProviderBase;
 ```
 
-Creates a `FederationProvider` for GitHub OAuth 2.0. Uses `passport-github2` (optional peer dep — must be installed separately). The default scope is `["read:user", "user:email"]`. The `externalId` format is `"github:" + profile.id`.
+Creates a `FederationProviderBase` for GitHub OAuth 2.0. Uses `passport-github2` (optional peer dep — must be installed separately). The default scope is `["read:user", "user:email"]`. The `externalId` format is `"github:" + profile.id`.
 
 ---
 
-### `FederationProvider` (interface)
+### `FederationProviderBase` (interface)
 
 ```typescript
-interface FederationProvider {
+interface FederationProviderBase {
   readonly name: string;
   readonly scope: readonly string[];
   validateRedirect(url: string): FederationResult<void>;
@@ -156,7 +156,7 @@ interface SetupPassportContext {
 }
 ```
 
-Implement this interface to add a custom OAuth 2.0 / OIDC federation provider.
+Implement this interface to add a custom OAuth 2.0 / OIDC federation provider. Optionally mix in `SupportsLogout` for IdPs that expose an end-session endpoint.
 
 - `name` — unique passport strategy identifier. Used as both the Map key in `federationProviders` and the strategy name passed to `passport.use()`.
 - `scope` — OAuth 2.0 scopes to request.
@@ -166,13 +166,83 @@ Implement this interface to add a custom OAuth 2.0 / OIDC federation provider.
 
 ---
 
+### `SupportsLogout` (optional capability)
+
+Optional capability for providers whose IdP exposes an OIDC RP-Initiated Logout (end-session) endpoint.
+
+```ts
+interface EndSessionRequest {
+  idTokenHint?: string;
+  postLogoutRedirectUri?: string;
+  state?: string;
+}
+
+interface EndSessionResult {
+  url: URL;
+  method: "GET";
+}
+
+interface SupportsLogout {
+  endSession(req: EndSessionRequest): Promise<EndSessionResult>;
+}
+
+function supportsLogout(
+  provider: FederationProviderBase,
+): provider is FederationProviderBase & SupportsLogout;
+```
+
+The built-in `"google"` and `"github"` providers **do not** implement `SupportsLogout`: Google has no public OIDC end-session endpoint, and GitHub is OAuth2-only. External integrations (Microsoft Entra ID, Auth0, Okta, …) can add the capability by mixing it into their custom provider.
+
+Minimum custom provider example:
+
+```ts
+import type {
+  FederationProviderBase,
+  SupportsLogout,
+  EndSessionRequest,
+  EndSessionResult,
+} from "@o3co/auth-provider-session";
+
+function createMyIdPProvider(): FederationProviderBase & SupportsLogout {
+  return {
+    name: "myidp",
+    scope: ["openid"],
+    validateRedirect(url) { /* ... */ },
+    resolveCallbackRedirect(session) { /* ... */ },
+    async setupPassportStrategy(passport, ctx) { /* ... */ },
+    async endSession(req: EndSessionRequest): Promise<EndSessionResult> {
+      const url = new URL("https://myidp.example/oidc/logout");
+      if (req.idTokenHint) url.searchParams.set("id_token_hint", req.idTokenHint);
+      if (req.postLogoutRedirectUri) url.searchParams.set("post_logout_redirect_uri", req.postLogoutRedirectUri);
+      if (req.state) url.searchParams.set("state", req.state);
+      return { url, method: "GET" };
+    },
+  };
+}
+```
+
+Consumers detect the capability at the call site:
+
+```ts
+import { supportsLogout } from "@o3co/auth-provider-session";
+
+if (supportsLogout(provider)) {
+  const { url } = await provider.endSession({ idTokenHint, postLogoutRedirectUri, state });
+  res.redirect(url.toString());
+} else {
+  // fall back to local session destroy only
+}
+```
+
+---
+
 ### `FederationProviderFactory` (type)
 
 ```typescript
-type FederationProviderFactory = AdapterFactory<FederationProvider>;
+type FederationProviderFactory = AdapterFactory<FederationProviderBase>;
 ```
 
-An `AdapterFactory<FederationProvider>`. Register custom provider types via `factory.register(type, builder)`.
+An `AdapterFactory<FederationProviderBase>`. Register custom provider types via `factory.register(type, builder)`.
 
 ---
 
@@ -184,7 +254,7 @@ type FederationResult<T> =
   | { ok: false; status: number; error: string; errorDescription: string };
 ```
 
-Discriminated union returned by `FederationProvider` methods. Check `ok` before accessing `value`.
+Discriminated union returned by `FederationProviderBase` methods. Check `ok` before accessing `value`.
 
 ## Usage Example
 
@@ -265,7 +335,7 @@ Mixed shape — top-level fields alongside a nested sub-section — is rejected 
 import {
   createFederationProviderFactory,
   registerBuiltinFederations,
-  type FederationProvider,
+  type FederationProviderBase,
   type FederationProviderFactory,
 } from "@o3co/auth-provider-session";
 
@@ -275,7 +345,7 @@ registerBuiltinFederations(factory);
 
 // Register a custom provider type
 factory.register("microsoft", async (config) => {
-  // build and return a FederationProvider
+  // build and return a FederationProviderBase
   return {
     name: config.name as string,
     scope: ["openid", "profile", "email"],
@@ -288,7 +358,7 @@ factory.register("microsoft", async (config) => {
 });
 
 // Build the provider map from config — mirrors the normalization in module.mts
-const federationProviders = new Map<string, FederationProvider>();
+const federationProviders = new Map<string, FederationProviderBase>();
 for (const [name, section] of Object.entries(config.federations)) {
   if (!section.enabled) continue;
 

--- a/packages/session/README.md
+++ b/packages/session/README.md
@@ -187,7 +187,7 @@ interface SupportsLogout {
 }
 
 function supportsLogout(
-  provider: FederationProviderBase,
+  provider: FederationProviderBase | undefined | null,
 ): provider is FederationProviderBase & SupportsLogout;
 ```
 

--- a/packages/session/src/__tests__/index.test.mts
+++ b/packages/session/src/__tests__/index.test.mts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+describe("package public surface (@o3co/auth-provider-session)", () => {
+	it("exports supportsLogout as a runtime helper", async () => {
+		const mod = await import("#/index.mjs");
+		expect(typeof (mod as { supportsLogout?: unknown }).supportsLogout).toBe("function");
+	});
+
+	it("does not export the removed FederationProvider / VerifyUserContext names as runtime values", async () => {
+		const mod = await import("#/index.mjs");
+		// These are type-only exports and would not appear as runtime values anyway;
+		// this assertion documents the intended invariant.
+		expect((mod as Record<string, unknown>).FederationProvider).toBeUndefined();
+		expect((mod as Record<string, unknown>).VerifyUserContext).toBeUndefined();
+	});
+});

--- a/packages/session/src/__tests__/passport.test.mts
+++ b/packages/session/src/__tests__/passport.test.mts
@@ -16,7 +16,7 @@
 
 import type { UserRepository } from "@o3co/auth-provider-core";
 import { describe, expect, it, vi } from "vitest";
-import type { FederationProvider } from "#/federations/types.mjs";
+import type { FederationProviderBase } from "#/federations/types.mjs";
 import { _createPassportImpl } from "#/passport.mjs";
 
 /** Minimal passport stub that tracks strategy registrations. */
@@ -36,7 +36,7 @@ function makePassportStub() {
 	return stub;
 }
 
-function makeFederationProvider(name: string): FederationProvider {
+function makeFederationProvider(name: string): FederationProviderBase {
 	return {
 		name,
 		scope: ["profile"],
@@ -56,7 +56,7 @@ describe("_createPassportImpl", () => {
 
 		const providerA = makeFederationProvider("google");
 		const providerB = makeFederationProvider("github");
-		const federationProviders: ReadonlyMap<string, FederationProvider> = new Map([
+		const federationProviders: ReadonlyMap<string, FederationProviderBase> = new Map([
 			["google", providerA],
 			["github", providerB],
 		]);
@@ -91,7 +91,7 @@ describe("_createPassportImpl", () => {
 			},
 		);
 
-		const federationProviders: ReadonlyMap<string, FederationProvider> = new Map([
+		const federationProviders: ReadonlyMap<string, FederationProviderBase> = new Map([
 			["google", provider],
 		]);
 

--- a/packages/session/src/federations/__tests__/factory.test.mts
+++ b/packages/session/src/federations/__tests__/factory.test.mts
@@ -109,3 +109,24 @@ describe("registerBuiltinFederations", () => {
 		).rejects.toThrow(/clientId|clientSecret|callbackURL/i);
 	});
 });
+
+describe("FederationProviderBase assignability", () => {
+	it("typed element is FederationProviderBase", async () => {
+		const { createFederationProviderFactory } = await import("#/federations/factory.mjs");
+		const factory = createFederationProviderFactory();
+		// If `create`'s return type is Promise<FederationProviderBase>, this local variable
+		// typed as FederationProviderBase is trivially assignable.
+		factory.register("stub", async () => ({
+			name: "stub",
+			scope: [],
+			validateRedirect: () => ({ ok: true, value: undefined }),
+			resolveCallbackRedirect: () => ({ ok: true, value: "/" }),
+			async setupPassportStrategy() {},
+		}));
+		const base: import("#/federations/types.mjs").FederationProviderBase = await factory.create({
+			type: "stub",
+			name: "stub",
+		});
+		expect(base.name).toBe("stub");
+	});
+});

--- a/packages/session/src/federations/__tests__/factory.test.mts
+++ b/packages/session/src/federations/__tests__/factory.test.mts
@@ -18,8 +18,10 @@ import { AdapterFactoryError } from "@o3co/auth-provider-core";
 import { describe, expect, it } from "vitest";
 import {
 	createFederationProviderFactory,
+	type FederationProviderFactory,
 	registerBuiltinFederations,
 } from "#/federations/factory.mjs";
+import type { FederationProviderBase } from "#/federations/types.mjs";
 
 describe("createFederationProviderFactory", () => {
 	it("returns an AdapterFactory with no registered types", () => {
@@ -35,6 +37,31 @@ describe("createFederationProviderFactory", () => {
 				err.reason === "unknown" &&
 				err.kind === "FederationProvider",
 		);
+	});
+
+	it("factory element type is exactly FederationProviderBase", async () => {
+		type Elem = Awaited<ReturnType<FederationProviderFactory["create"]>>;
+
+		// Bidirectional assignability: any FederationProviderBase is Elem and vice versa.
+		// A regression that over-narrows the factory's generic (e.g. to
+		// `FederationProviderBase & SupportsLogout`) would break the first direction;
+		// a regression that over-widens (e.g. to `unknown`) would break the second.
+		const baseValue: FederationProviderBase = {
+			name: "stub",
+			scope: [],
+			validateRedirect: () => ({ ok: true, value: undefined }),
+			resolveCallbackRedirect: () => ({ ok: true, value: "/" }),
+			async setupPassportStrategy() {},
+		};
+		const asElem: Elem = baseValue;
+		const asBase: FederationProviderBase = asElem;
+
+		const factory = createFederationProviderFactory();
+		factory.register("stub", async () => baseValue);
+		const created = await factory.create({ type: "stub", name: "stub" });
+
+		expect(asBase.name).toBe("stub");
+		expect(created.name).toBe("stub");
 	});
 });
 
@@ -107,26 +134,5 @@ describe("registerBuiltinFederations", () => {
 				name: "github",
 			}),
 		).rejects.toThrow(/clientId|clientSecret|callbackURL/i);
-	});
-});
-
-describe("FederationProviderBase assignability", () => {
-	it("typed element is FederationProviderBase", async () => {
-		const { createFederationProviderFactory } = await import("#/federations/factory.mjs");
-		const factory = createFederationProviderFactory();
-		// If `create`'s return type is Promise<FederationProviderBase>, this local variable
-		// typed as FederationProviderBase is trivially assignable.
-		factory.register("stub", async () => ({
-			name: "stub",
-			scope: [],
-			validateRedirect: () => ({ ok: true, value: undefined }),
-			resolveCallbackRedirect: () => ({ ok: true, value: "/" }),
-			async setupPassportStrategy() {},
-		}));
-		const base: import("#/federations/types.mjs").FederationProviderBase = await factory.create({
-			type: "stub",
-			name: "stub",
-		});
-		expect(base.name).toBe("stub");
 	});
 });

--- a/packages/session/src/federations/__tests__/fixtures.mts
+++ b/packages/session/src/federations/__tests__/fixtures.mts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+	EndSessionRequest,
+	EndSessionResult,
+	FederationProviderBase,
+	SupportsLogout,
+} from "../types.mjs";
+
+/**
+ * Test fixture: a minimal provider that implements only the Base contract.
+ * Used to exercise the `supportsLogout(p) === false` path and as a starting shape
+ * that external implementers can copy when writing a custom provider without the
+ * logout capability.
+ */
+export function createTestBaseProvider(name: string): FederationProviderBase {
+	return {
+		name,
+		scope: [],
+		validateRedirect: () => ({ ok: true, value: undefined }),
+		resolveCallbackRedirect: () => ({ ok: true, value: "/" }),
+		async setupPassportStrategy() {},
+	};
+}
+
+/**
+ * Test fixture: a minimal provider implementing the {@link SupportsLogout} capability.
+ *
+ * Reference implementation — built-in providers (Google / GitHub) do not implement
+ * this capability because their IdPs do not expose an end-session endpoint.
+ * External OSS users writing Microsoft / Auth0 / Okta integrations should mirror
+ * the `endSession()` body below.
+ */
+export function createTestLogoutProvider(opts: {
+	name: string;
+	endSessionEndpoint: string;
+}): FederationProviderBase & SupportsLogout {
+	return {
+		...createTestBaseProvider(opts.name),
+		async endSession(req: EndSessionRequest): Promise<EndSessionResult> {
+			const url = new URL(opts.endSessionEndpoint);
+			if (req.idTokenHint) url.searchParams.set("id_token_hint", req.idTokenHint);
+			if (req.postLogoutRedirectUri)
+				url.searchParams.set("post_logout_redirect_uri", req.postLogoutRedirectUri);
+			if (req.state) url.searchParams.set("state", req.state);
+			return { url, method: "GET" };
+		},
+	};
+}

--- a/packages/session/src/federations/__tests__/fixtures.mts
+++ b/packages/session/src/federations/__tests__/fixtures.mts
@@ -33,7 +33,7 @@ export function createTestBaseProvider(name: string): FederationProviderBase {
 		scope: [],
 		validateRedirect: () => ({ ok: true, value: undefined }),
 		resolveCallbackRedirect: () => ({ ok: true, value: "/" }),
-		async setupPassportStrategy() {},
+		async setupPassportStrategy(_passport, _ctx) {},
 	};
 }
 

--- a/packages/session/src/federations/__tests__/supportsLogout.test.mts
+++ b/packages/session/src/federations/__tests__/supportsLogout.test.mts
@@ -97,3 +97,26 @@ describe("EndSessionResult URL construction (reference implementation behaviour)
 		expect(url.searchParams.has("state")).toBe(false);
 	});
 });
+
+describe("fixture module (packages/session/src/federations/__tests__/fixtures.mts)", () => {
+	it("exports createTestBaseProvider and createTestLogoutProvider", async () => {
+		const fixtures = await import("./fixtures.mjs");
+		expect(typeof fixtures.createTestBaseProvider).toBe("function");
+		expect(typeof fixtures.createTestLogoutProvider).toBe("function");
+	});
+
+	it("createTestLogoutProvider returns a provider that passes supportsLogout()", async () => {
+		const { createTestLogoutProvider } = await import("./fixtures.mjs");
+		const p = createTestLogoutProvider({
+			name: "fixture-idp",
+			endSessionEndpoint: "https://fixture.example/oidc/logout",
+		});
+		expect(supportsLogout(p)).toBe(true);
+	});
+
+	it("createTestBaseProvider returns a provider that fails supportsLogout()", async () => {
+		const { createTestBaseProvider } = await import("./fixtures.mjs");
+		const p = createTestBaseProvider("fixture-plain");
+		expect(supportsLogout(p)).toBe(false);
+	});
+});

--- a/packages/session/src/federations/__tests__/supportsLogout.test.mts
+++ b/packages/session/src/federations/__tests__/supportsLogout.test.mts
@@ -16,11 +16,11 @@
 
 import { describe, expect, it } from "vitest";
 import {
-	supportsLogout,
 	type EndSessionRequest,
 	type EndSessionResult,
 	type FederationProviderBase,
 	type SupportsLogout,
+	supportsLogout,
 } from "#/federations/types.mjs";
 
 function makeBaseProvider(name: string): FederationProviderBase {
@@ -62,10 +62,7 @@ describe("supportsLogout()", () => {
 	});
 
 	it("narrows the type so endSession is callable without cast", async () => {
-		const p: FederationProviderBase = makeLogoutProvider(
-			"myidp",
-			"https://myidp.example/logout",
-		);
+		const p: FederationProviderBase = makeLogoutProvider("myidp", "https://myidp.example/logout");
 		if (supportsLogout(p)) {
 			// Inside this branch, TypeScript narrows `p` to `FederationProviderBase & SupportsLogout`.
 			const result = await p.endSession({ idTokenHint: "abc" });

--- a/packages/session/src/federations/__tests__/supportsLogout.test.mts
+++ b/packages/session/src/federations/__tests__/supportsLogout.test.mts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	supportsLogout,
+	type EndSessionRequest,
+	type EndSessionResult,
+	type FederationProviderBase,
+	type SupportsLogout,
+} from "#/federations/types.mjs";
+
+function makeBaseProvider(name: string): FederationProviderBase {
+	return {
+		name,
+		scope: [],
+		validateRedirect: () => ({ ok: true, value: undefined }),
+		resolveCallbackRedirect: () => ({ ok: true, value: "/" }),
+		async setupPassportStrategy() {},
+	};
+}
+
+function makeLogoutProvider(
+	name: string,
+	endpoint: string,
+): FederationProviderBase & SupportsLogout {
+	return {
+		...makeBaseProvider(name),
+		async endSession(req: EndSessionRequest): Promise<EndSessionResult> {
+			const url = new URL(endpoint);
+			if (req.idTokenHint) url.searchParams.set("id_token_hint", req.idTokenHint);
+			if (req.postLogoutRedirectUri)
+				url.searchParams.set("post_logout_redirect_uri", req.postLogoutRedirectUri);
+			if (req.state) url.searchParams.set("state", req.state);
+			return { url, method: "GET" };
+		},
+	};
+}
+
+describe("supportsLogout()", () => {
+	it("returns true for a provider implementing SupportsLogout", () => {
+		const p = makeLogoutProvider("myidp", "https://myidp.example/logout");
+		expect(supportsLogout(p)).toBe(true);
+	});
+
+	it("returns false for a provider without endSession", () => {
+		const p = makeBaseProvider("plain");
+		expect(supportsLogout(p)).toBe(false);
+	});
+
+	it("narrows the type so endSession is callable without cast", async () => {
+		const p: FederationProviderBase = makeLogoutProvider(
+			"myidp",
+			"https://myidp.example/logout",
+		);
+		if (supportsLogout(p)) {
+			// Inside this branch, TypeScript narrows `p` to `FederationProviderBase & SupportsLogout`.
+			const result = await p.endSession({ idTokenHint: "abc" });
+			expect(result.method).toBe("GET");
+		} else {
+			throw new Error("expected supportsLogout to narrow to true");
+		}
+	});
+});
+
+describe("EndSessionResult URL construction (reference implementation behaviour)", () => {
+	it("encodes all three optional parameters when present", async () => {
+		const p = makeLogoutProvider("myidp", "https://myidp.example/logout");
+		const { url, method } = await p.endSession({
+			idTokenHint: "id-abc",
+			postLogoutRedirectUri: "https://app.example/after-logout",
+			state: "nonce-1",
+		});
+		expect(method).toBe("GET");
+		expect(url.searchParams.get("id_token_hint")).toBe("id-abc");
+		expect(url.searchParams.get("post_logout_redirect_uri")).toBe(
+			"https://app.example/after-logout",
+		);
+		expect(url.searchParams.get("state")).toBe("nonce-1");
+	});
+
+	it("omits parameters that are not provided", async () => {
+		const p = makeLogoutProvider("myidp", "https://myidp.example/logout");
+		const { url } = await p.endSession({ idTokenHint: "only-hint" });
+		expect(url.searchParams.get("id_token_hint")).toBe("only-hint");
+		expect(url.searchParams.has("post_logout_redirect_uri")).toBe(false);
+		expect(url.searchParams.has("state")).toBe(false);
+	});
+});

--- a/packages/session/src/federations/__tests__/supportsLogout.test.mts
+++ b/packages/session/src/federations/__tests__/supportsLogout.test.mts
@@ -71,6 +71,14 @@ describe("supportsLogout()", () => {
 			throw new Error("expected supportsLogout to narrow to true");
 		}
 	});
+
+	it("returns false for undefined (no throw)", () => {
+		expect(supportsLogout(undefined)).toBe(false);
+	});
+
+	it("returns false for null (no throw)", () => {
+		expect(supportsLogout(null)).toBe(false);
+	});
 });
 
 describe("EndSessionResult URL construction (reference implementation behaviour)", () => {

--- a/packages/session/src/federations/__tests__/types.test.mts
+++ b/packages/session/src/federations/__tests__/types.test.mts
@@ -17,16 +17,14 @@
 import type { PassportStatic } from "passport";
 import { describe, expect, it } from "vitest";
 import type {
-	FederationProvider,
 	FederationProviderBase,
 	SetupPassportContext,
-	VerifyUserContext,
 } from "#/federations/types.mjs";
 
-describe("FederationProvider interface", () => {
+describe("FederationProviderBase interface", () => {
 	it("requires name, scope, validateRedirect, resolveCallbackRedirect, setupPassportStrategy — no enabled or strategyName", () => {
 		// Type-only structural test: the literal must type-check under the new shape.
-		const provider: FederationProvider = {
+		const provider: FederationProviderBase = {
 			name: "google",
 			scope: ["profile", "email"],
 			validateRedirect: () => ({ ok: true, value: undefined }),
@@ -42,7 +40,7 @@ describe("FederationProvider interface", () => {
 	it("setupPassportStrategy accepts a PassportStatic and SetupPassportContext", () => {
 		// Type-only: annotate a function with the expected signature so tsc would fail
 		// if setupPassportStrategy's shape were to drift.
-		const setup: FederationProvider["setupPassportStrategy"] = async (
+		const setup: FederationProviderBase["setupPassportStrategy"] = async (
 			_passport: PassportStatic,
 			_ctx: SetupPassportContext,
 		) => {};
@@ -69,26 +67,5 @@ describe("FederationProvider interface", () => {
 		expect(ctx.pathResolver!("passport-google-oauth20")).toBe(
 			"/custom/path/passport-google-oauth20",
 		);
-	});
-
-	it("VerifyUserContext is a type alias for SetupPassportContext (backward compat)", () => {
-		// VerifyUserContext and SetupPassportContext are structurally identical —
-		// a value typed as one is assignable to the other.
-		const ctx: SetupPassportContext = { verifyUser: async () => null };
-		const asLegacy: VerifyUserContext = ctx;
-		expect(typeof asLegacy.verifyUser).toBe("function");
-	});
-});
-
-describe("FederationProviderBase interface (Task 1)", () => {
-	it("FederationProviderBase has the same structural shape as the pre-rename FederationProvider", () => {
-		const provider: FederationProviderBase = {
-			name: "google",
-			scope: ["profile", "email"],
-			validateRedirect: () => ({ ok: true, value: undefined }),
-			resolveCallbackRedirect: () => ({ ok: true, value: "/" }),
-			setupPassportStrategy: async () => {},
-		};
-		expect(provider.name).toBe("google");
 	});
 });

--- a/packages/session/src/federations/__tests__/types.test.mts
+++ b/packages/session/src/federations/__tests__/types.test.mts
@@ -18,6 +18,7 @@ import type { PassportStatic } from "passport";
 import { describe, expect, it } from "vitest";
 import type {
 	FederationProvider,
+	FederationProviderBase,
 	SetupPassportContext,
 	VerifyUserContext,
 } from "#/federations/types.mjs";
@@ -76,5 +77,18 @@ describe("FederationProvider interface", () => {
 		const ctx: SetupPassportContext = { verifyUser: async () => null };
 		const asLegacy: VerifyUserContext = ctx;
 		expect(typeof asLegacy.verifyUser).toBe("function");
+	});
+});
+
+describe("FederationProviderBase interface (Task 1)", () => {
+	it("FederationProviderBase has the same structural shape as the pre-rename FederationProvider", () => {
+		const provider: FederationProviderBase = {
+			name: "google",
+			scope: ["profile", "email"],
+			validateRedirect: () => ({ ok: true, value: undefined }),
+			resolveCallbackRedirect: () => ({ ok: true, value: "/" }),
+			setupPassportStrategy: async () => {},
+		};
+		expect(provider.name).toBe("google");
 	});
 });

--- a/packages/session/src/federations/__tests__/types.test.mts
+++ b/packages/session/src/federations/__tests__/types.test.mts
@@ -16,10 +16,7 @@
 
 import type { PassportStatic } from "passport";
 import { describe, expect, it } from "vitest";
-import type {
-	FederationProviderBase,
-	SetupPassportContext,
-} from "#/federations/types.mjs";
+import type { FederationProviderBase, SetupPassportContext } from "#/federations/types.mjs";
 
 describe("FederationProviderBase interface", () => {
 	it("requires name, scope, validateRedirect, resolveCallbackRedirect, setupPassportStrategy — no enabled or strategyName", () => {

--- a/packages/session/src/federations/factory.mts
+++ b/packages/session/src/federations/factory.mts
@@ -17,12 +17,12 @@
 import { type AdapterFactory, createAdapterFactory } from "@o3co/auth-provider-core";
 import { createGithubProvider } from "./github.mjs";
 import { createGoogleProvider } from "./google.mjs";
-import type { FederationProvider } from "./types.mjs";
+import type { FederationProviderBase } from "./types.mjs";
 
-export type FederationProviderFactory = AdapterFactory<FederationProvider>;
+export type FederationProviderFactory = AdapterFactory<FederationProviderBase>;
 
 export function createFederationProviderFactory(): FederationProviderFactory {
-	return createAdapterFactory<FederationProvider>("FederationProvider");
+	return createAdapterFactory<FederationProviderBase>("FederationProvider");
 }
 
 /**

--- a/packages/session/src/federations/github.mts
+++ b/packages/session/src/federations/github.mts
@@ -16,7 +16,7 @@
 
 import type { PassportStatic } from "passport";
 import { resolveCallbackRedirect, validateRedirect } from "./helpers.mjs";
-import type { FederationProvider, SetupPassportContext } from "./types.mjs";
+import type { FederationProviderBase, SetupPassportContext } from "./types.mjs";
 
 export interface GithubProviderConfig {
 	/** Passport strategy identifier — use a unique name per tenant for multi-tenant setups. */
@@ -32,7 +32,7 @@ export interface GithubProviderConfig {
 	clientUrl?: string;
 }
 
-export function createGithubProvider(config: GithubProviderConfig): FederationProvider {
+export function createGithubProvider(config: GithubProviderConfig): FederationProviderBase {
 	if (!config.clientId || !config.clientSecret || !config.callbackURL) {
 		throw new Error(
 			`GitHub federation "${config.name}" requires clientId, clientSecret, and callbackURL`,

--- a/packages/session/src/federations/google.mts
+++ b/packages/session/src/federations/google.mts
@@ -15,7 +15,7 @@
  */
 
 import { resolveCallbackRedirect, validateRedirect } from "./helpers.mjs";
-import type { FederationProvider, SetupPassportContext } from "./types.mjs";
+import type { FederationProviderBase, SetupPassportContext } from "./types.mjs";
 
 export interface GoogleProviderConfig {
 	/** Passport strategy identifier — use a unique name per tenant for multi-tenant setups. */
@@ -31,7 +31,7 @@ export interface GoogleProviderConfig {
 	clientUrl?: string;
 }
 
-export const createGoogleProvider = (config: GoogleProviderConfig): FederationProvider => {
+export const createGoogleProvider = (config: GoogleProviderConfig): FederationProviderBase => {
 	if (!config.clientId || !config.clientSecret || !config.callbackURL) {
 		throw new Error(
 			`Google federation "${config.name}" requires clientId, clientSecret, and callbackURL`,

--- a/packages/session/src/federations/types.mts
+++ b/packages/session/src/federations/types.mts
@@ -32,12 +32,6 @@ export interface SetupPassportContext {
 }
 
 /**
- * @deprecated Will be removed in Task 8 of this plan. Use {@link SetupPassportContext}.
- * Temporary alias kept while callers are migrated in Tasks 2–7 to avoid a non-building intermediate state.
- */
-export type VerifyUserContext = SetupPassportContext;
-
-/**
  * Minimum contract implemented by every federation provider.
  * Provider-specific optional features are layered via `SupportsX` capability interfaces.
  */
@@ -48,12 +42,6 @@ export interface FederationProviderBase {
 	resolveCallbackRedirect(session: { redirectTo?: string }): FederationResult<string>;
 	setupPassportStrategy(passport: PassportStatic, ctx: SetupPassportContext): Promise<void>;
 }
-
-/**
- * @deprecated Will be removed in Task 8 of this plan. Use {@link FederationProviderBase}.
- * Temporary alias kept while callers are migrated in Tasks 2–7 to avoid a non-building intermediate state.
- */
-export type FederationProvider = FederationProviderBase;
 
 /**
  * Arguments for an OIDC RP-Initiated Logout (end-session) request.

--- a/packages/session/src/federations/types.mts
+++ b/packages/session/src/federations/types.mts
@@ -84,12 +84,15 @@ export interface SupportsLogout {
 /**
  * Type guard: does `provider` implement the {@link SupportsLogout} capability?
  *
- * Returns `true` when `provider.endSession` is a function. Inside a `true` branch,
- * TypeScript narrows `provider` to `FederationProviderBase & SupportsLogout`, so
- * `provider.endSession(...)` is callable without a cast.
+ * Returns `false` for `null` / `undefined` so consumers can call this directly on
+ * `Map.get(name)` results without an explicit existence check. When `provider` is
+ * non-null, returns `true` when `provider.endSession` is a function. Inside a `true`
+ * branch, TypeScript narrows `provider` to `FederationProviderBase & SupportsLogout`,
+ * so `provider.endSession(...)` is callable without a cast.
  */
 export function supportsLogout(
-	provider: FederationProviderBase,
+	provider: FederationProviderBase | undefined | null,
 ): provider is FederationProviderBase & SupportsLogout {
+	if (provider == null) return false;
 	return typeof (provider as { endSession?: unknown }).endSession === "function";
 }

--- a/packages/session/src/federations/types.mts
+++ b/packages/session/src/federations/types.mts
@@ -31,13 +31,26 @@ export interface SetupPassportContext {
 	pathResolver?: (spec: string) => string;
 }
 
-/** @deprecated Use SetupPassportContext instead. */
+/**
+ * @deprecated Will be removed in Task 8 of this plan. Use {@link SetupPassportContext}.
+ * Temporary alias kept while callers are migrated in Tasks 2–7 to avoid a non-building intermediate state.
+ */
 export type VerifyUserContext = SetupPassportContext;
 
-export interface FederationProvider {
+/**
+ * Minimum contract implemented by every federation provider.
+ * Provider-specific optional features are layered via `SupportsX` capability interfaces.
+ */
+export interface FederationProviderBase {
 	readonly name: string;
 	readonly scope: readonly string[];
 	validateRedirect(url: string): FederationResult<void>;
 	resolveCallbackRedirect(session: { redirectTo?: string }): FederationResult<string>;
 	setupPassportStrategy(passport: PassportStatic, ctx: SetupPassportContext): Promise<void>;
 }
+
+/**
+ * @deprecated Will be removed in Task 8 of this plan. Use {@link FederationProviderBase}.
+ * Temporary alias kept while callers are migrated in Tasks 2–7 to avoid a non-building intermediate state.
+ */
+export type FederationProvider = FederationProviderBase;

--- a/packages/session/src/federations/types.mts
+++ b/packages/session/src/federations/types.mts
@@ -54,3 +54,54 @@ export interface FederationProviderBase {
  * Temporary alias kept while callers are migrated in Tasks 2–7 to avoid a non-building intermediate state.
  */
 export type FederationProvider = FederationProviderBase;
+
+/**
+ * Arguments for an OIDC RP-Initiated Logout (end-session) request.
+ *
+ * All fields are optional per the OIDC spec. Consumers should generate a `state`
+ * value and verify it on the post-logout redirect to mitigate CSRF.
+ */
+export interface EndSessionRequest {
+	/** ID token previously issued by the IdP, used to identify the session to terminate. */
+	idTokenHint?: string;
+	/** URL the IdP redirects the user agent to after logout completes. */
+	postLogoutRedirectUri?: string;
+	/** Opaque value round-tripped by the IdP for CSRF protection. */
+	state?: string;
+}
+
+/**
+ * Outcome of building an end-session redirect.
+ *
+ * `method` is currently always `"GET"` (OIDC RP-Initiated Logout 1.0). Future extensions
+ * (e.g. POST logout for SAML interop) can widen the union additively.
+ */
+export interface EndSessionResult {
+	/** Fully-qualified end-session URL with all parameters encoded. */
+	url: URL;
+	/** HTTP method the consumer should use when driving the redirect. */
+	method: "GET";
+}
+
+/**
+ * Optional capability: OIDC RP-Initiated Logout (end-session).
+ *
+ * Providers whose IdP exposes an end_session endpoint implement this capability by
+ * returning a redirect URL. Consumers detect the capability with {@link supportsLogout}.
+ */
+export interface SupportsLogout {
+	endSession(req: EndSessionRequest): Promise<EndSessionResult>;
+}
+
+/**
+ * Type guard: does `provider` implement the {@link SupportsLogout} capability?
+ *
+ * Returns `true` when `provider.endSession` is a function. Inside a `true` branch,
+ * TypeScript narrows `provider` to `FederationProviderBase & SupportsLogout`, so
+ * `provider.endSession(...)` is callable without a cast.
+ */
+export function supportsLogout(
+	provider: FederationProviderBase,
+): provider is FederationProviderBase & SupportsLogout {
+	return typeof (provider as { endSession?: unknown }).endSession === "function";
+}

--- a/packages/session/src/index.mts
+++ b/packages/session/src/index.mts
@@ -23,11 +23,14 @@ export type { GithubProviderConfig } from "./federations/github.mjs";
 export { createGithubProvider } from "./federations/github.mjs";
 export { createGoogleProvider } from "./federations/google.mjs";
 export type {
-	FederationProvider,
+	EndSessionRequest,
+	EndSessionResult,
+	FederationProviderBase,
 	FederationResult,
 	SetupPassportContext,
-	VerifyUserContext,
+	SupportsLogout,
 } from "./federations/types.mjs";
+export { supportsLogout } from "./federations/types.mjs";
 export { sessionModule } from "./module.mjs";
 export { createPassport } from "./passport.mjs";
 export type { SessionStoreFactory } from "./store/factory.mjs";

--- a/packages/session/src/module.mts
+++ b/packages/session/src/module.mts
@@ -27,7 +27,7 @@ import {
 	type FederationProviderFactory,
 	registerBuiltinFederations,
 } from "./federations/factory.mjs";
-import type { FederationProvider } from "./federations/types.mjs";
+import type { FederationProviderBase } from "./federations/types.mjs";
 import { createPassport } from "./passport.mjs";
 import * as federationRoutes from "./routes/Federation.mjs";
 import * as sessionRoutes from "./routes/Session.mjs";
@@ -82,7 +82,7 @@ export const _sessionModuleImpl = (params: SessionModuleInternalOptions): Module
 			})();
 
 		// Normalize federation config entries and build the provider Map.
-		const federationProviders = new Map<string, FederationProvider>();
+		const federationProviders = new Map<string, FederationProviderBase>();
 		for (const [name, section] of Object.entries(config.federations)) {
 			if (!section.enabled) continue;
 
@@ -149,11 +149,11 @@ export const _sessionModuleImpl = (params: SessionModuleInternalOptions): Module
 
 			// Invariant guard: the provider's name must equal the config key so that
 			// routes/Federation.mts can look up the provider by the :name route param.
-			// Custom builders must propagate config.name to FederationProvider.name.
+			// Custom builders must propagate config.name to FederationProviderBase.name.
 			if (provider.name !== name) {
 				throw new Error(
 					`federations.${name}: provider builder returned name="${provider.name}", expected "${name}". ` +
-						`Custom builders must propagate config.name to FederationProvider.name to preserve the config-key ↔ passport-strategy-name invariant.`,
+						`Custom builders must propagate config.name to FederationProviderBase.name to preserve the config-key ↔ passport-strategy-name invariant.`,
 				);
 			}
 

--- a/packages/session/src/passport.mts
+++ b/packages/session/src/passport.mts
@@ -16,7 +16,7 @@
 
 import type { PathResolver, UserRepository } from "@o3co/auth-provider-core";
 import type { PassportStatic } from "passport";
-import type { FederationProvider, SetupPassportContext } from "./federations/types.mjs";
+import type { FederationProviderBase, SetupPassportContext } from "./federations/types.mjs";
 
 declare global {
 	namespace Express {
@@ -27,7 +27,7 @@ declare global {
 export type CreatePassportOptions = {
 	pathResolver: PathResolver;
 	userRepository: UserRepository;
-	federationProviders: ReadonlyMap<string, FederationProvider>;
+	federationProviders: ReadonlyMap<string, FederationProviderBase>;
 };
 
 /**

--- a/packages/session/src/routes/Federation.mts
+++ b/packages/session/src/routes/Federation.mts
@@ -17,7 +17,7 @@ import crypto from "node:crypto";
 import type { AppConfig } from "@o3co/auth-provider-core";
 import type { Request, RequestHandler, Response, Router } from "express";
 import type { PassportStatic } from "passport";
-import type { FederationProvider } from "../federations/types.mjs";
+import type { FederationProviderBase } from "../federations/types.mjs";
 
 declare module "express-session" {
 	interface SessionData {
@@ -41,7 +41,7 @@ export const createRouter = (
 	}: {
 		passport: PassportStatic;
 		config: AppConfig;
-		federationProviders: ReadonlyMap<string, FederationProvider>;
+		federationProviders: ReadonlyMap<string, FederationProviderBase>;
 	},
 ): Router => {
 	const router = express.Router();

--- a/packages/session/src/routes/__tests__/Federation.test.mts
+++ b/packages/session/src/routes/__tests__/Federation.test.mts
@@ -19,11 +19,11 @@ import express from "express";
 import type { PassportStatic } from "passport";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { FederationProvider } from "#/federations/types.mjs";
+import type { FederationProviderBase } from "#/federations/types.mjs";
 import { createRouter } from "#/routes/Federation.mjs";
 
-/** Minimal mock for a FederationProvider */
-function makeMockProvider(name: string, scope: string[]): FederationProvider {
+/** Minimal mock for a FederationProviderBase */
+function makeMockProvider(name: string, scope: string[]): FederationProviderBase {
 	return {
 		name,
 		scope,
@@ -48,7 +48,7 @@ const stubConfig: AppConfig = {
  * real OAuth redirects, so we can assert call arguments.
  */
 function buildApp(
-	federationProviders: ReadonlyMap<string, FederationProvider>,
+	federationProviders: ReadonlyMap<string, FederationProviderBase>,
 	passportStub: {
 		authenticate: ReturnType<typeof vi.fn>;
 	},


### PR DESCRIPTION
Closes #66

## Summary

Refactor `@o3co/auth-provider-session`'s `FederationProvider` interface into a capability-segregation pattern so future optional capabilities can be added additively without breaking every implementer. First capability — `SupportsLogout` — is included with a `supportsLogout(provider)` type-guard helper. Parent spec Section 8 TODO-A.

- **Breaking (0.x)**: `FederationProvider` → `FederationProviderBase` pure rename; `VerifyUserContext` deprecated alias removed.
- **Added**: `EndSessionRequest` / `EndSessionResult { url; method: "GET" }` / `SupportsLogout` / `supportsLogout` (runtime helper; accepts `FederationProviderBase | undefined | null`).
- **Not implemented**: built-in `google` / `github` providers deliberately don't implement `SupportsLogout` — neither exposes a public OIDC end-session endpoint. Reference implementation lives in `__tests__/fixtures.mts` for external integrators (Microsoft Entra ID / Auth0 / Okta).
- **Out of scope (TODO-F, separate spec)**: federation → JWT claim propagation, federation token lifecycle, built-in `/oauth/federation/:name/logout` route, `SupportsClaimMapping` / `SupportsRefresh` capabilities.

Spec: `.claude/superpowers/specs/2026-04-20-federation-capability-segregation-design.md`
Plan: `.claude/superpowers/plans/2026-04-20-federation-capability-segregation.md`

## Migration (for consumers)

Type-import rename only; no runtime or config change.

```ts
// Before
import type { FederationProvider, VerifyUserContext } from "@o3co/auth-provider-session";

// After
import type { FederationProviderBase, SetupPassportContext } from "@o3co/auth-provider-session";
```

## Implementation notes

- 14 tasks executed subagent-driven; all spec-compliance + code-quality reviews passed.
- Multi-agent review (Claude + Codex) before PR — Codex P2 (`supportsLogout` not accepting `undefined` / `null` → crash on `Map.get()` lookups) fixed in `19f2cf2` + CHANGELOG note in `2bfd7c6`.
- Tests: `auth-provider-session` 152 passed + 2 skipped. Full `pnpm -r run build` clean. `pnpm lint` no errors.

## Test plan

- [x] `pnpm --filter @o3co/auth-provider-session test` — 152 passed + 2 skipped
- [x] `pnpm -r run build` — all 7 workspace packages clean
- [x] `pnpm lint` — no errors
- [x] `dist/index.d.mts` verified — exports `FederationProviderBase`, `EndSessionRequest`, `EndSessionResult`, `SupportsLogout`, `supportsLogout`; no stale `FederationProvider` / `VerifyUserContext`
- [x] Bidirectional assignability test pins the `FederationProviderFactory` element type to exactly `FederationProviderBase` (catches over-narrowing and over-widening)
- [x] `supportsLogout(undefined)` / `supportsLogout(null)` return `false` (no throw) — covers the `Map.get(name)` call pattern
- [ ] dplaas.auth pinning `"<0.4.0"` before v0.4.0 publish (separate first-party PR; tracked in memory)

## Release gate note (spec Section 9)

Before v0.4.0 publish: pin dplaas.auth to `"<0.4.0"` in a preceding first-party PR so the 0.4.0 publish does not auto-upgrade that consumer. dplaas.auth's accumulated migration (Plan #1–#4 + TODO-D + TODO-A + TODO-B if included) runs before 1.0 GA.
