### PR TITLE
feat(core)!: KeyStore remote sign semantics (TODO-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `SupportsLogout` optional capability interface (`EndSessionRequest`, `EndSessionResult`, `SupportsLogout`) and `supportsLogout(provider)` type guard helper in `@o3co/auth-provider-session`. Detects providers whose IdP exposes an OIDC RP-Initiated Logout endpoint. `supportsLogout` accepts `FederationProviderBase | undefined | null` so it can be called directly on `Map.get(name)` lookups; returns `false` on nullish input. Built-in `google` / `github` providers do not implement this capability.
 - `KeyStore.sign(options: SignJwtOptions): Promise<string>` for remote-sign support (KMS/HSM).
-- `KeyStore.getCurrentKid(): string` — cheap signing-kid accessor (fallback for legacy tokens missing `kid` header).
+- `KeyStore.getSigningKidFallback(): string` — cheap signing-kid accessor (fallback for legacy tokens missing `kid` header).
 - `JWTPayload` type (RFC 7519, jose-independent) — exported from `@o3co/auth-provider-core` root.
 - `SignJwtOptions` type for `sign()` input — exported from `@o3co/auth-provider-core` root.
 - `Algorithm` type — promoted to root export.
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **Breaking**: `VerifyUserContext` deprecated type alias in `@o3co/auth-provider-session`. Use `SetupPassportContext` (introduced in the Federation factory PR #64).
 - **Breaking**: `KeyStore.getSigningKey()`. Use `sign(options)` instead.
-- **Breaking**: `KeyStore.current`. Use `getCurrentKid()` (kid only; private key is no longer exposed).
+- **Breaking**: `KeyStore.current`. Use `getSigningKidFallback()` (kid only; private key is no longer exposed).
 - **Breaking**: `KeyStore.previous`. Use `await getVerificationKeys()` (current + active previous unified).
 
 ### Migration
@@ -57,4 +57,4 @@ const token = await new SignJWT(claims)
 const token = await keyStore.sign({ claims });
 ```
 
-Verification callers must now `await` `getVerificationKey(kid)` / `getVerificationKeys()`. Replace `keyStore.current.kid` with `keyStore.getCurrentKid()`.
+Verification callers must now `await` `getVerificationKey(kid)` / `getVerificationKeys()`. Replace `keyStore.current.kid` with `keyStore.getSigningKidFallback()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - `SupportsLogout` optional capability interface (`EndSessionRequest`, `EndSessionResult`, `SupportsLogout`) and `supportsLogout(provider)` type guard helper in `@o3co/auth-provider-session`. Detects providers whose IdP exposes an OIDC RP-Initiated Logout endpoint. `supportsLogout` accepts `FederationProviderBase | undefined | null` so it can be called directly on `Map.get(name)` lookups; returns `false` on nullish input. Built-in `google` / `github` providers do not implement this capability.
+- `KeyStore.sign(options: SignJwtOptions): Promise<string>` for remote-sign support (KMS/HSM).
+- `KeyStore.getCurrentKid(): string` — cheap signing-kid accessor (fallback for legacy tokens missing `kid` header).
+- `JWTPayload` type (RFC 7519, jose-independent) — exported from `@o3co/auth-provider-core` root.
+- `SignJwtOptions` type for `sign()` input — exported from `@o3co/auth-provider-core` root.
+- `Algorithm` type — promoted to root export.
+- `KeyLike` type — promoted to root export.
 
 ### Changed
 
 - **Breaking**: `FederationProvider` interface renamed to `FederationProviderBase` in `@o3co/auth-provider-session`. Consumers must update type imports. No runtime or behavioral change.
 - **Breaking**: `FederationProviderFactory` is now `AdapterFactory<FederationProviderBase>` (was `AdapterFactory<FederationProvider>`). The `createFederationProviderFactory()` function signature is unchanged; only the element type name differs.
+- **Breaking**: `KeyStore.getVerificationKey(kid)` is now `Promise<KeyLike>` (was sync). Callers must `await`.
+- **Breaking**: `KeyStore.getVerificationKeys()` is now `Promise<ManagedKey[]>` (was sync). Callers must `await`.
 
 ### Removed
 
 - **Breaking**: `VerifyUserContext` deprecated type alias in `@o3co/auth-provider-session`. Use `SetupPassportContext` (introduced in the Federation factory PR #64).
+- **Breaking**: `KeyStore.getSigningKey()`. Use `sign(options)` instead.
+- **Breaking**: `KeyStore.current`. Use `getCurrentKid()` (kid only; private key is no longer exposed).
+- **Breaking**: `KeyStore.previous`. Use `await getVerificationKeys()` (current + active previous unified).
 
 ### Migration
 
@@ -30,3 +41,20 @@ import type { FederationProvider, VerifyUserContext } from "@o3co/auth-provider-
 // After
 import type { FederationProviderBase, SetupPassportContext } from "@o3co/auth-provider-session";
 ```
+
+### KeyStore migration
+
+JWT signing:
+
+```ts
+// Before
+const { kid, privateKey } = keyStore.getSigningKey();
+const token = await new SignJWT(claims)
+  .setProtectedHeader({ alg: keyStore.algorithm, kid })
+  .sign(privateKey);
+
+// After
+const token = await keyStore.sign({ claims });
+```
+
+Verification callers must now `await` `getVerificationKey(kid)` / `getVerificationKeys()`. Replace `keyStore.current.kid` with `keyStore.getCurrentKid()`.

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -158,7 +158,7 @@ function formatObject<T extends object>(data: T): Partial<T>;
 
 ### キーストア
 
-`KeyStore` インターフェースは、対称鍵（HS256）と非対称鍵（RS256、ES256、EdDSA）の署名鍵を抽象化し、`previousKeys` によるキーローテーションをサポートします。
+`KeyStore` インターフェースは、対称鍵（HS256）と非対称鍵（RS256、ES256、EdDSA）の署名鍵を抽象化し、`previousKeys` によるキーローテーションをサポートします。`sign(options)` は compact JWT を返す。protected header の `alg` / `kid` は KeyStore 側で自動注入されるため、caller からの上書き不可。この契約により、private key を露出せずに remote-sign adapter (KMS/HSM) が `sign()` を実装できる。`getCurrentKid()` は `kid` header が欠落した legacy/malformed token の verify 用 fallback accessor。rotation-safe lookup には使わないこと (rotation 時は token 側の `kid` をそのまま `getVerificationKey(kid)` に渡す)。
 
 ```typescript
 type KeyLike = CryptoKey | KeyObject | Uint8Array;
@@ -169,17 +169,28 @@ interface ManagedKey {
   expiresAt?: Date;
 }
 
+interface JWTPayload {
+  iss?: string;
+  sub?: string;
+  aud?: string | string[];
+  jti?: string;
+  nbf?: number;
+  exp?: number;
+  iat?: number;
+  [propName: string]: unknown;
+}
+
+interface SignJwtOptions {
+  claims: JWTPayload;      // RFC 7519 claims
+  header?: { typ?: string }; // alg / kid are KeyStore-injected; caller cannot override
+}
+
 interface KeyStore {
   readonly algorithm: "HS256" | "RS256" | "ES256" | "EdDSA";
-  readonly current: {
-    readonly kid: string;
-    readonly privateKey: KeyLike;
-    readonly publicKey: KeyLike;
-  };
-  readonly previous: readonly ManagedKey[];
-  getSigningKey(): { kid: string; privateKey: KeyLike };
-  getVerificationKeys(): ManagedKey[];
-  getVerificationKey(kid: string): KeyLike;
+  sign(options: SignJwtOptions): Promise<string>;
+  getCurrentKid(): string;
+  getVerificationKeys(): Promise<ManagedKey[]>;
+  getVerificationKey(kid: string): Promise<KeyLike>;
 }
 
 interface AsymmetricKeyStoreOptions {

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -158,7 +158,7 @@ function formatObject<T extends object>(data: T): Partial<T>;
 
 ### キーストア
 
-`KeyStore` インターフェースは、対称鍵（HS256）と非対称鍵（RS256、ES256、EdDSA）の署名鍵を抽象化し、`previousKeys` によるキーローテーションをサポートします。`sign(options)` は compact JWT を返す。protected header の `alg` / `kid` は KeyStore 側で自動注入されるため、caller からの上書き不可。この契約により、private key を露出せずに remote-sign adapter (KMS/HSM) が `sign()` を実装できる。`getCurrentKid()` は `kid` header が欠落した legacy/malformed token の verify 用 fallback accessor。rotation-safe lookup には使わないこと (rotation 時は token 側の `kid` をそのまま `getVerificationKey(kid)` に渡す)。
+`KeyStore` インターフェースは、対称鍵（HS256）と非対称鍵（RS256、ES256、EdDSA）の署名鍵を抽象化し、`previousKeys` によるキーローテーションをサポートします。`sign(options)` は compact JWT を返す。protected header の `alg` / `kid` は KeyStore 側で自動注入されるため、caller からの上書き不可。この契約により、private key を露出せずに remote-sign adapter (KMS/HSM) が `sign()` を実装できる。`getSigningKidFallback()` は `kid` header が欠落した legacy/malformed token の verify 用に、現在の signing kid を返す fallback accessor。rotation-safe lookup には使わないこと (rotation 時は token 側の `kid` をそのまま `getVerificationKey(kid)` に渡す)。
 
 ```typescript
 type KeyLike = CryptoKey | KeyObject | Uint8Array;
@@ -188,7 +188,7 @@ interface SignJwtOptions {
 interface KeyStore {
   readonly algorithm: "HS256" | "RS256" | "ES256" | "EdDSA";
   sign(options: SignJwtOptions): Promise<string>;
-  getCurrentKid(): string;
+  getSigningKidFallback(): string;
   getVerificationKeys(): Promise<ManagedKey[]>;
   getVerificationKey(kid: string): Promise<KeyLike>;
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -158,7 +158,7 @@ function formatObject<T extends object>(data: T): Partial<T>;
 
 ### Key Store
 
-The `KeyStore` interface abstracts over symmetric (HS256) and asymmetric (RS256, ES256, EdDSA) signing keys, including key rotation via `previousKeys`. `sign(options)` returns a compact JWT; the KeyStore self-injects the `alg` and `kid` protected header fields, so callers cannot override them. This contract lets remote-sign adapters (KMS/HSM) implement `sign()` without exposing private key material. `getCurrentKid()` is a cheap fallback accessor for verifying legacy/malformed tokens missing a `kid` header — do not use it for rotation-safe lookup.
+The `KeyStore` interface abstracts over symmetric (HS256) and asymmetric (RS256, ES256, EdDSA) signing keys, including key rotation via `previousKeys`. `sign(options)` returns a compact JWT; the KeyStore self-injects the `alg` and `kid` protected header fields, so callers cannot override them. This contract lets remote-sign adapters (KMS/HSM) implement `sign()` without exposing private key material. `getSigningKidFallback()` is a cheap accessor returning the current signing kid for verifying legacy/malformed tokens that lack a `kid` header. Do not use it for rotation-safe lookup.
 
 ```typescript
 type KeyLike = CryptoKey | KeyObject | Uint8Array;
@@ -188,7 +188,7 @@ interface SignJwtOptions {
 interface KeyStore {
   readonly algorithm: "HS256" | "RS256" | "ES256" | "EdDSA";
   sign(options: SignJwtOptions): Promise<string>;
-  getCurrentKid(): string;
+  getSigningKidFallback(): string;
   getVerificationKeys(): Promise<ManagedKey[]>;
   getVerificationKey(kid: string): Promise<KeyLike>;
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -158,7 +158,7 @@ function formatObject<T extends object>(data: T): Partial<T>;
 
 ### Key Store
 
-The `KeyStore` interface abstracts over symmetric (HS256) and asymmetric (RS256, ES256, EdDSA) signing keys, including key rotation via `previousKeys`.
+The `KeyStore` interface abstracts over symmetric (HS256) and asymmetric (RS256, ES256, EdDSA) signing keys, including key rotation via `previousKeys`. `sign(options)` returns a compact JWT; the KeyStore self-injects the `alg` and `kid` protected header fields, so callers cannot override them. This contract lets remote-sign adapters (KMS/HSM) implement `sign()` without exposing private key material. `getCurrentKid()` is a cheap fallback accessor for verifying legacy/malformed tokens missing a `kid` header — do not use it for rotation-safe lookup.
 
 ```typescript
 type KeyLike = CryptoKey | KeyObject | Uint8Array;
@@ -169,17 +169,28 @@ interface ManagedKey {
   expiresAt?: Date;
 }
 
+interface JWTPayload {
+  iss?: string;
+  sub?: string;
+  aud?: string | string[];
+  jti?: string;
+  nbf?: number;
+  exp?: number;
+  iat?: number;
+  [propName: string]: unknown;
+}
+
+interface SignJwtOptions {
+  claims: JWTPayload;      // RFC 7519 claims
+  header?: { typ?: string }; // alg / kid are KeyStore-injected; caller cannot override
+}
+
 interface KeyStore {
   readonly algorithm: "HS256" | "RS256" | "ES256" | "EdDSA";
-  readonly current: {
-    readonly kid: string;
-    readonly privateKey: KeyLike;
-    readonly publicKey: KeyLike;
-  };
-  readonly previous: readonly ManagedKey[];
-  getSigningKey(): { kid: string; privateKey: KeyLike };
-  getVerificationKeys(): ManagedKey[];
-  getVerificationKey(kid: string): KeyLike;
+  sign(options: SignJwtOptions): Promise<string>;
+  getCurrentKid(): string;
+  getVerificationKeys(): Promise<ManagedKey[]>;
+  getVerificationKey(kid: string): Promise<KeyLike>;
 }
 
 interface AsymmetricKeyStoreOptions {

--- a/packages/core/src/grants/token.mts
+++ b/packages/core/src/grants/token.mts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 import { randomUUID } from "node:crypto";
-import { SignJWT } from "jose";
-import type { KeyStore } from "../keys/KeyStore.mjs";
+import type { JWTPayload, KeyStore } from "../keys/KeyStore.mjs";
 
 export const formatObject = <T extends object>(data: T): Partial<T> => {
 	return Object.fromEntries(
@@ -85,31 +84,23 @@ export const generateToken = async (
 		tokenType = undefined,
 	}: GenerateTokenOptions,
 ): Promise<Token> => {
-	const { kid, privateKey } = keyStore.getSigningKey();
-
-	let builder = new SignJWT({
-		...data,
+	const now = Math.floor(Date.now() / 1000);
+	const claims: JWTPayload = {
+		...(data as Record<string, unknown>),
 		...(authorizedParty ? { azp: authorizedParty } : {}),
 		...(scope ? { scope } : {}),
-	})
-		.setProtectedHeader({ alg: keyStore.algorithm, kid, ...(tokenType ? { typ: tokenType } : {}) })
-		.setIssuedAt()
-		.setJti(randomUUID());
+		iat: now,
+		jti: randomUUID(),
+		...(expiresIn !== undefined ? { exp: now + expiresIn } : {}),
+		...(issuer != null ? { iss: issuer } : {}),
+		...(audience != null ? { aud: audience } : {}),
+		...(subject != null ? { sub: subject } : {}),
+	};
 
-	if (expiresIn !== undefined) {
-		builder = builder.setExpirationTime(`${expiresIn}s`);
-	}
-	if (issuer != null) {
-		builder = builder.setIssuer(issuer);
-	}
-	if (audience != null) {
-		builder = builder.setAudience(audience);
-	}
-	if (subject != null) {
-		builder = builder.setSubject(subject);
-	}
-
-	const token = await builder.sign(privateKey);
+	const token = await keyStore.sign({
+		claims,
+		...(tokenType ? { header: { typ: tokenType } } : {}),
+	});
 
 	const result: Token = { token };
 

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -61,9 +61,13 @@ export type { KeyStoreFactory } from "./keys/factory.mjs";
 export { createKeyStoreFactory, registerBuiltinKeyStores } from "./keys/factory.mjs";
 // Keys
 export type {
+	Algorithm,
 	AsymmetricKeyStoreOptions,
+	JWTPayload,
+	KeyLike,
 	KeyStore,
 	ManagedKey,
+	SignJwtOptions,
 } from "./keys/KeyStore.mjs";
 export {
 	createAsymmetricKeyStore,

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -72,7 +72,6 @@ export interface KeyStore {
 	getVerificationKeys(): Promise<ManagedKey[]>;
 	/** Specific kid's public key. Throws on unknown or expired kid. */
 	getVerificationKey(kid: string): Promise<KeyLike>;
-
 }
 
 export interface AsymmetricKeyStoreOptions {

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -55,6 +55,26 @@ export type Algorithm = "HS256" | "RS256" | "ES256" | "EdDSA";
 
 export interface KeyStore {
 	readonly algorithm: Algorithm;
+	/**
+	 * Sign claims and return a compact JWT. The KeyStore self-injects `alg`
+	 * and `kid` into the protected header; callers may set only `typ`.
+	 * Remote-sign adapters (KMS/HSM) perform the remote call here.
+	 */
+	sign(options: SignJwtOptions): Promise<string>;
+	/**
+	 * Current signing kid. Intended as a fallback for verifying
+	 * legacy/malformed tokens missing a `kid` header. **Do not use for
+	 * rotation-safe lookup** — for rotation, pass the token's own `kid` to
+	 * `getVerificationKey(kid)`. Cheap, sync, does not expose any private key.
+	 */
+	getCurrentKid(): string;
+	/** Active verification keys for JWKS endpoint. Remote adapters may fetch + cache. */
+	getVerificationKeys(): Promise<ManagedKey[]>;
+	/** Specific kid's public key. Throws on unknown or expired kid. */
+	getVerificationKey(kid: string): Promise<KeyLike>;
+
+	// Legacy API — to be removed in Task 12. Kept temporarily so internal
+	// callers (token.mts, refreshToken.mts, routes.mts) still compile.
 	readonly current: {
 		readonly kid: string;
 		readonly privateKey: KeyLike;
@@ -62,8 +82,6 @@ export interface KeyStore {
 	};
 	readonly previous: readonly ManagedKey[];
 	getSigningKey(): { kid: string; privateKey: KeyLike };
-	getVerificationKeys(): ManagedKey[];
-	getVerificationKey(kid: string): KeyLike;
 }
 
 export interface AsymmetricKeyStoreOptions {
@@ -145,7 +163,7 @@ export async function createAsymmetricKeyStore(
 			}
 			return prev.publicKey;
 		},
-	} as unknown as KeyStore;
+	};
 }
 
 export function createSymmetricKeyStore(secret: string, kid = "v0"): KeyStore {
@@ -189,5 +207,5 @@ export function createSymmetricKeyStore(secret: string, kid = "v0"): KeyStore {
 			}
 			return secretKey;
 		},
-	} as unknown as KeyStore;
+	};
 }

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -73,15 +73,6 @@ export interface KeyStore {
 	/** Specific kid's public key. Throws on unknown or expired kid. */
 	getVerificationKey(kid: string): Promise<KeyLike>;
 
-	// Legacy API — to be removed in Task 12. Kept temporarily so internal
-	// callers (token.mts, refreshToken.mts, routes.mts) still compile.
-	readonly current: {
-		readonly kid: string;
-		readonly privateKey: KeyLike;
-		readonly publicKey: KeyLike;
-	};
-	readonly previous: readonly ManagedKey[];
-	getSigningKey(): { kid: string; privateKey: KeyLike };
 }
 
 export interface AsymmetricKeyStoreOptions {
@@ -137,13 +128,6 @@ export async function createAsymmetricKeyStore(
 			return kid;
 		},
 
-		current: { kid, privateKey, publicKey },
-		previous: resolvedPrevious,
-
-		getSigningKey() {
-			return { kid, privateKey };
-		},
-
 		async getVerificationKeys(): Promise<ManagedKey[]> {
 			const now = new Date();
 			const active = resolvedPrevious.filter((k) => k.expiresAt > now);
@@ -184,17 +168,6 @@ export function createSymmetricKeyStore(secret: string, kid = "v0"): KeyStore {
 
 		getCurrentKid(): string {
 			return kid;
-		},
-
-		current: {
-			kid,
-			privateKey: secretKey,
-			publicKey: secretKey,
-		},
-		previous: [],
-
-		getSigningKey() {
-			return { kid, privateKey: secretKey };
 		},
 
 		async getVerificationKeys(): Promise<ManagedKey[]> {

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -16,6 +16,23 @@
 import { createSecretKey, type KeyObject } from "node:crypto";
 import { importPKCS8, importSPKI } from "jose";
 
+/**
+ * JWT claims per RFC 7519. Standard claims are typed; custom claims are
+ * allowed via index signature. Defined here to keep the KeyStore interface
+ * jose-independent — implementations may use jose, node-jose, fast-jwt, or
+ * direct KMS SDK calls.
+ */
+export interface JWTPayload {
+	iss?: string;
+	sub?: string;
+	aud?: string | string[];
+	jti?: string;
+	nbf?: number;
+	exp?: number;
+	iat?: number;
+	[propName: string]: unknown;
+}
+
 export type KeyLike = CryptoKey | KeyObject | Uint8Array;
 
 export interface ManagedKey {

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { createSecretKey, type KeyObject } from "node:crypto";
-import { importPKCS8, importSPKI } from "jose";
+import { importPKCS8, importSPKI, SignJWT } from "jose";
 
 /**
  * JWT claims per RFC 7519. Standard claims are typed; custom claims are
@@ -104,6 +104,17 @@ export async function createAsymmetricKeyStore(
 
 	return {
 		algorithm,
+
+		async sign({ claims, header }: SignJwtOptions): Promise<string> {
+			return await new SignJWT(claims)
+				.setProtectedHeader({
+					alg: algorithm,
+					kid,
+					...(header?.typ ? { typ: header.typ } : {}),
+				})
+				.sign(privateKey);
+		},
+
 		current: { kid, privateKey, publicKey },
 		previous: resolvedPrevious,
 
@@ -138,6 +149,17 @@ export function createSymmetricKeyStore(secret: string, kid = "v0"): KeyStore {
 
 	return {
 		algorithm: "HS256",
+
+		async sign({ claims, header }: SignJwtOptions): Promise<string> {
+			return await new SignJWT(claims)
+				.setProtectedHeader({
+					alg: "HS256",
+					kid,
+					...(header?.typ ? { typ: header.typ } : {}),
+				})
+				.sign(secretKey);
+		},
+
 		current: {
 			kid,
 			privateKey: secretKey,

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -115,6 +115,10 @@ export async function createAsymmetricKeyStore(
 				.sign(privateKey);
 		},
 
+		getCurrentKid(): string {
+			return kid;
+		},
+
 		current: { kid, privateKey, publicKey },
 		previous: resolvedPrevious,
 
@@ -158,6 +162,10 @@ export function createSymmetricKeyStore(secret: string, kid = "v0"): KeyStore {
 					...(header?.typ ? { typ: header.typ } : {}),
 				})
 				.sign(secretKey);
+		},
+
+		getCurrentKid(): string {
+			return kid;
 		},
 
 		current: {

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -33,6 +33,16 @@ export interface JWTPayload {
 	[propName: string]: unknown;
 }
 
+/**
+ * Input to `KeyStore.sign()`. The KeyStore self-injects `alg` and `kid` into
+ * the protected header; callers may only set `typ`. This keeps adapter
+ * contracts stable under alg / kid rotation and remote-sign (KMS/HSM) backends.
+ */
+export interface SignJwtOptions {
+	claims: JWTPayload;
+	header?: { typ?: string };
+}
+
 export type KeyLike = CryptoKey | KeyObject | Uint8Array;
 
 export interface ManagedKey {

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -132,7 +132,7 @@ export async function createAsymmetricKeyStore(
 			return [{ kid, publicKey }, ...active];
 		},
 
-		getVerificationKey(requestedKid: string): KeyLike {
+		async getVerificationKey(requestedKid: string): Promise<KeyLike> {
 			if (requestedKid === kid) {
 				return publicKey;
 			}
@@ -145,7 +145,7 @@ export async function createAsymmetricKeyStore(
 			}
 			return prev.publicKey;
 		},
-	};
+	} as unknown as KeyStore;
 }
 
 export function createSymmetricKeyStore(secret: string, kid = "v0"): KeyStore {
@@ -183,11 +183,11 @@ export function createSymmetricKeyStore(secret: string, kid = "v0"): KeyStore {
 			return [{ kid, publicKey: secretKey }];
 		},
 
-		getVerificationKey(requestedKid: string): KeyLike {
+		async getVerificationKey(requestedKid: string): Promise<KeyLike> {
 			if (requestedKid !== kid) {
 				throw new Error(`Unknown kid: ${requestedKid}`);
 			}
 			return secretKey;
 		},
-	};
+	} as unknown as KeyStore;
 }

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -62,8 +62,8 @@ export interface KeyStore {
 	 */
 	sign(options: SignJwtOptions): Promise<string>;
 	/**
-	 * Current signing kid. Intended as a fallback for verifying
-	 * legacy/malformed tokens missing a `kid` header. **Do not use for
+	 * Returns the current signing kid as a fallback for verifying
+	 * legacy/malformed tokens that lack a `kid` header. **Do not use for
 	 * rotation-safe lookup** — for rotation, pass the token's own `kid` to
 	 * `getVerificationKey(kid)`.
 	 *
@@ -71,7 +71,7 @@ export interface KeyStore {
 	 * must cache the current kid locally and return it without any remote
 	 * call. Never exposes private key material.
 	 */
-	getCurrentKid(): string;
+	getSigningKidFallback(): string;
 	/** Active verification keys for JWKS endpoint. Remote adapters may fetch + cache. */
 	getVerificationKeys(): Promise<ManagedKey[]>;
 	/** Specific kid's public key. Throws on unknown or expired kid. */
@@ -127,7 +127,7 @@ export async function createAsymmetricKeyStore(
 				.sign(privateKey);
 		},
 
-		getCurrentKid(): string {
+		getSigningKidFallback(): string {
 			return kid;
 		},
 
@@ -169,7 +169,7 @@ export function createSymmetricKeyStore(secret: string, kid = "v0"): KeyStore {
 				.sign(secretKey);
 		},
 
-		getCurrentKid(): string {
+		getSigningKidFallback(): string {
 			return kid;
 		},
 

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -126,7 +126,7 @@ export async function createAsymmetricKeyStore(
 			return { kid, privateKey };
 		},
 
-		getVerificationKeys(): ManagedKey[] {
+		async getVerificationKeys(): Promise<ManagedKey[]> {
 			const now = new Date();
 			const active = resolvedPrevious.filter((k) => k.expiresAt > now);
 			return [{ kid, publicKey }, ...active];
@@ -179,7 +179,7 @@ export function createSymmetricKeyStore(secret: string, kid = "v0"): KeyStore {
 			return { kid, privateKey: secretKey };
 		},
 
-		getVerificationKeys(): ManagedKey[] {
+		async getVerificationKeys(): Promise<ManagedKey[]> {
 			return [{ kid, publicKey: secretKey }];
 		},
 

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -65,7 +65,11 @@ export interface KeyStore {
 	 * Current signing kid. Intended as a fallback for verifying
 	 * legacy/malformed tokens missing a `kid` header. **Do not use for
 	 * rotation-safe lookup** — for rotation, pass the token's own `kid` to
-	 * `getVerificationKey(kid)`. Cheap, sync, does not expose any private key.
+	 * `getVerificationKey(kid)`.
+	 *
+	 * **MUST be synchronous and cheap**. Remote-sign adapters (KMS/HSM)
+	 * must cache the current kid locally and return it without any remote
+	 * call. Never exposes private key material.
 	 */
 	getCurrentKid(): string;
 	/** Active verification keys for JWKS endpoint. Remote adapters may fetch + cache. */

--- a/packages/core/src/keys/__tests__/KeyStore.test.mts
+++ b/packages/core/src/keys/__tests__/KeyStore.test.mts
@@ -13,13 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-	decodeProtectedHeader,
-	exportPKCS8,
-	exportSPKI,
-	generateKeyPair,
-	jwtVerify,
-} from "jose";
+import { decodeProtectedHeader, exportPKCS8, exportSPKI, generateKeyPair, jwtVerify } from "jose";
 import { describe, expect, it } from "vitest";
 import type { SignJwtOptions } from "#/keys/KeyStore.mjs";
 import { createAsymmetricKeyStore, createSymmetricKeyStore } from "#/keys/KeyStore.mjs";

--- a/packages/core/src/keys/__tests__/KeyStore.test.mts
+++ b/packages/core/src/keys/__tests__/KeyStore.test.mts
@@ -42,7 +42,7 @@ describe("SymmetricKeyStore", () => {
 
 	it("accepts custom kid", () => {
 		const ks = createSymmetricKeyStore("test-secret", "custom-kid");
-		expect(ks.getCurrentKid()).toBe("custom-kid");
+		expect(ks.getSigningKidFallback()).toBe("custom-kid");
 	});
 
 	it("getVerificationKey returns key for current kid", async () => {
@@ -85,9 +85,9 @@ describe("SymmetricKeyStore", () => {
 		expect(header.typ).toBe("at+jwt");
 	});
 
-	it("getCurrentKid returns the current signing kid", () => {
+	it("getSigningKidFallback returns the current signing kid", () => {
 		const ks = createSymmetricKeyStore("x", "my-kid");
-		expect(ks.getCurrentKid()).toBe("my-kid");
+		expect(ks.getSigningKidFallback()).toBe("my-kid");
 	});
 });
 
@@ -106,7 +106,7 @@ describe("AsymmetricKeyStore", () => {
 		});
 
 		expect(store.algorithm).toBe(alg);
-		expect(store.getCurrentKid()).toBe("k1");
+		expect(store.getSigningKidFallback()).toBe("k1");
 
 		const token = await store.sign({ claims: { sub: "user1" } });
 		const header = decodeProtectedHeader(token);
@@ -279,7 +279,7 @@ describe("AsymmetricKeyStore", () => {
 		expect(payload.sub).toBe("carol");
 	});
 
-	it("getCurrentKid returns the current signing kid", async () => {
+	it("getSigningKidFallback returns the current signing kid", async () => {
 		const { privateKeyPem, publicKeyPem } = await generateTestKeyPair("ES256");
 		const store = await createAsymmetricKeyStore({
 			algorithm: "ES256",
@@ -287,7 +287,7 @@ describe("AsymmetricKeyStore", () => {
 			privateKeyPem,
 			publicKeyPem,
 		});
-		expect(store.getCurrentKid()).toBe("k-current-only");
+		expect(store.getSigningKidFallback()).toBe("k-current-only");
 	});
 
 	it("throws for expired kid", async () => {

--- a/packages/core/src/keys/__tests__/KeyStore.test.mts
+++ b/packages/core/src/keys/__tests__/KeyStore.test.mts
@@ -19,7 +19,6 @@ import {
 	exportSPKI,
 	generateKeyPair,
 	jwtVerify,
-	SignJWT,
 } from "jose";
 import { describe, expect, it } from "vitest";
 import { createAsymmetricKeyStore, createSymmetricKeyStore } from "#/keys/KeyStore.mjs";
@@ -39,19 +38,9 @@ describe("SymmetricKeyStore", () => {
 		expect(keyStore.algorithm).toBe("HS256");
 	});
 
-	it("has default kid v0", () => {
-		expect(keyStore.current.kid).toBe("v0");
-	});
-
 	it("accepts custom kid", () => {
 		const ks = createSymmetricKeyStore("test-secret", "custom-kid");
-		expect(ks.current.kid).toBe("custom-kid");
-	});
-
-	it("getSigningKey returns kid and privateKey", () => {
-		const signingKey = keyStore.getSigningKey();
-		expect(signingKey.kid).toBe("v0");
-		expect(signingKey.privateKey).toBeDefined();
+		expect(ks.getCurrentKid()).toBe("custom-kid");
 	});
 
 	it("getVerificationKey returns key for current kid", async () => {
@@ -67,10 +56,6 @@ describe("SymmetricKeyStore", () => {
 		const keys = await keyStore.getVerificationKeys();
 		expect(keys).toHaveLength(1);
 		expect(keys[0].kid).toBe("v0");
-	});
-
-	it("current.privateKey and current.publicKey are the same for symmetric", () => {
-		expect(keyStore.current.privateKey).toBe(keyStore.current.publicKey);
 	});
 
 	it("sign() produces a JWT verifiable with getVerificationKey", async () => {
@@ -119,17 +104,13 @@ describe("AsymmetricKeyStore", () => {
 		});
 
 		expect(store.algorithm).toBe(alg);
-		expect(store.current.kid).toBe("k1");
+		expect(store.getCurrentKid()).toBe("k1");
 
-		// Sign a JWT with the signing key
-		const { kid, privateKey } = store.getSigningKey();
-		const token = await new SignJWT({ sub: "user1" })
-			.setProtectedHeader({ alg, kid })
-			.setIssuedAt()
-			.sign(privateKey);
+		const token = await store.sign({ claims: { sub: "user1" } });
+		const header = decodeProtectedHeader(token);
+		expect(header.kid).toBe("k1");
 
-		// Verify with the verification key
-		const verificationKey = await store.getVerificationKey(kid);
+		const verificationKey = await store.getVerificationKey(header.kid as string);
 		const { payload } = await jwtVerify(token, verificationKey);
 		expect(payload.sub).toBe("user1");
 	});
@@ -186,10 +167,10 @@ describe("AsymmetricKeyStore", () => {
 		const oldPair = await generateTestKeyPair("ES256");
 		const newPair = await generateTestKeyPair("ES256");
 
-		// Sign a token with the old key
-		const { importPKCS8 } = await import("jose");
+		// Sign a token with the old key (simulating an external signer, not via KeyStore)
+		const { importPKCS8, SignJWT: JoseSignJWT } = await import("jose");
 		const oldSigningKey = await importPKCS8(oldPair.privateKeyPem, "ES256");
-		const token = await new SignJWT({ sub: "user-old" })
+		const token = await new JoseSignJWT({ sub: "user-old" })
 			.setProtectedHeader({ alg: "ES256", kid: "k-old" })
 			.setIssuedAt()
 			.sign(oldSigningKey);

--- a/packages/core/src/keys/__tests__/KeyStore.test.mts
+++ b/packages/core/src/keys/__tests__/KeyStore.test.mts
@@ -63,8 +63,8 @@ describe("SymmetricKeyStore", () => {
 		await expect(keyStore.getVerificationKey("unknown")).rejects.toThrow();
 	});
 
-	it("getVerificationKeys returns current key only (no previous keys)", () => {
-		const keys = keyStore.getVerificationKeys();
+	it("getVerificationKeys returns current key only (no previous keys)", async () => {
+		const keys = await keyStore.getVerificationKeys();
 		expect(keys).toHaveLength(1);
 		expect(keys[0].kid).toBe("v0");
 	});
@@ -152,7 +152,7 @@ describe("AsymmetricKeyStore", () => {
 			],
 		});
 
-		const keys = store.getVerificationKeys();
+		const keys = await store.getVerificationKeys();
 		expect(keys).toHaveLength(2);
 		expect(keys.map((k) => k.kid)).toContain("k1");
 		expect(keys.map((k) => k.kid)).toContain("k2");
@@ -176,7 +176,7 @@ describe("AsymmetricKeyStore", () => {
 			],
 		});
 
-		const keys = store.getVerificationKeys();
+		const keys = await store.getVerificationKeys();
 		expect(keys).toHaveLength(1);
 		expect(keys[0].kid).toBe("k2");
 	});

--- a/packages/core/src/keys/__tests__/KeyStore.test.mts
+++ b/packages/core/src/keys/__tests__/KeyStore.test.mts
@@ -72,6 +72,31 @@ describe("SymmetricKeyStore", () => {
 	it("current.privateKey and current.publicKey are the same for symmetric", () => {
 		expect(keyStore.current.privateKey).toBe(keyStore.current.publicKey);
 	});
+
+	it("sign() produces a JWT verifiable with getVerificationKey", async () => {
+		const ks = createSymmetricKeyStore("round-trip-secret", "k-sym");
+		const token = await ks.sign({ claims: { sub: "alice" } });
+
+		// Header has alg + kid injected by KeyStore
+		const header = decodeProtectedHeader(token);
+		expect(header.alg).toBe("HS256");
+		expect(header.kid).toBe("k-sym");
+
+		// Payload preserves claims
+		const key = ks.getVerificationKey("k-sym");
+		const { payload } = await jwtVerify(token, key);
+		expect(payload.sub).toBe("alice");
+	});
+
+	it("sign() injects typ when provided in header options", async () => {
+		const ks = createSymmetricKeyStore("typ-test-secret");
+		const token = await ks.sign({
+			claims: { sub: "bob" },
+			header: { typ: "at+jwt" },
+		});
+		const header = decodeProtectedHeader(token);
+		expect(header.typ).toBe("at+jwt");
+	});
 });
 
 describe("AsymmetricKeyStore", () => {
@@ -245,6 +270,25 @@ describe("AsymmetricKeyStore", () => {
 		});
 
 		expect(() => store.getVerificationKey("unknown")).toThrow("Unknown kid: unknown");
+	});
+
+	it("sign() round-trip works for asymmetric (ES256)", async () => {
+		const { privateKeyPem, publicKeyPem } = await generateTestKeyPair("ES256");
+		const store = await createAsymmetricKeyStore({
+			algorithm: "ES256",
+			kid: "asym-sign-k",
+			privateKeyPem,
+			publicKeyPem,
+		});
+
+		const token = await store.sign({ claims: { sub: "carol" } });
+		const header = decodeProtectedHeader(token);
+		expect(header.alg).toBe("ES256");
+		expect(header.kid).toBe("asym-sign-k");
+
+		const key = store.getVerificationKey("asym-sign-k");
+		const { payload } = await jwtVerify(token, key);
+		expect(payload.sub).toBe("carol");
 	});
 
 	it("throws for expired kid", async () => {

--- a/packages/core/src/keys/__tests__/KeyStore.test.mts
+++ b/packages/core/src/keys/__tests__/KeyStore.test.mts
@@ -21,7 +21,9 @@ import {
 	jwtVerify,
 } from "jose";
 import { describe, expect, it } from "vitest";
+import type { SignJwtOptions } from "#/keys/KeyStore.mjs";
 import { createAsymmetricKeyStore, createSymmetricKeyStore } from "#/keys/KeyStore.mjs";
+import { createTestKeyStore } from "./fixtures.mjs";
 
 async function generateTestKeyPair(alg: string) {
 	const { privateKey, publicKey } = await generateKeyPair(alg, { extractable: true });
@@ -307,5 +309,39 @@ describe("AsymmetricKeyStore", () => {
 		});
 
 		await expect(store.getVerificationKey("k1")).rejects.toThrow();
+	});
+});
+
+describe("KeyStore contract (via fixture)", () => {
+	it("sign() forwards options to the signer", async () => {
+		let received: SignJwtOptions | undefined;
+		const ks = createTestKeyStore({
+			algorithm: "HS256",
+			kid: "fixture-kid",
+			signer: async (opts) => {
+				received = opts;
+				return "fake.jwt.value";
+			},
+			verificationKeys: new Map(),
+		});
+
+		const result = await ks.sign({
+			claims: { sub: "fixture-user" },
+			header: { typ: "at+jwt" },
+		});
+
+		expect(result).toBe("fake.jwt.value");
+		expect(received?.claims.sub).toBe("fixture-user");
+		expect(received?.header?.typ).toBe("at+jwt");
+	});
+
+	it("getVerificationKey throws on unknown kid", async () => {
+		const ks = createTestKeyStore({
+			algorithm: "HS256",
+			kid: "k",
+			signer: async () => "",
+			verificationKeys: new Map(),
+		});
+		await expect(ks.getVerificationKey("missing")).rejects.toThrow("Unknown kid: missing");
 	});
 });

--- a/packages/core/src/keys/__tests__/KeyStore.test.mts
+++ b/packages/core/src/keys/__tests__/KeyStore.test.mts
@@ -54,13 +54,13 @@ describe("SymmetricKeyStore", () => {
 		expect(signingKey.privateKey).toBeDefined();
 	});
 
-	it("getVerificationKey returns key for current kid", () => {
-		const key = keyStore.getVerificationKey("v0");
+	it("getVerificationKey returns key for current kid", async () => {
+		const key = await keyStore.getVerificationKey("v0");
 		expect(key).toBeDefined();
 	});
 
-	it("getVerificationKey throws for unknown kid", () => {
-		expect(() => keyStore.getVerificationKey("unknown")).toThrow();
+	it("getVerificationKey throws for unknown kid", async () => {
+		await expect(keyStore.getVerificationKey("unknown")).rejects.toThrow();
 	});
 
 	it("getVerificationKeys returns current key only (no previous keys)", () => {
@@ -83,7 +83,7 @@ describe("SymmetricKeyStore", () => {
 		expect(header.kid).toBe("k-sym");
 
 		// Payload preserves claims
-		const key = ks.getVerificationKey("k-sym");
+		const key = await ks.getVerificationKey("k-sym");
 		const { payload } = await jwtVerify(token, key);
 		expect(payload.sub).toBe("alice");
 	});
@@ -129,7 +129,7 @@ describe("AsymmetricKeyStore", () => {
 			.sign(privateKey);
 
 		// Verify with the verification key
-		const verificationKey = store.getVerificationKey(kid);
+		const verificationKey = await store.getVerificationKey(kid);
 		const { payload } = await jwtVerify(token, verificationKey);
 		expect(payload.sub).toBe("user1");
 	});
@@ -212,7 +212,7 @@ describe("AsymmetricKeyStore", () => {
 		// Verify old token with previous key
 		const header = decodeProtectedHeader(token);
 		if (!header.kid) throw new Error("Expected kid in header");
-		const verificationKey = store.getVerificationKey(header.kid);
+		const verificationKey = await store.getVerificationKey(header.kid);
 		const { payload } = await jwtVerify(token, verificationKey);
 		expect(payload.sub).toBe("user-old");
 	});
@@ -274,7 +274,7 @@ describe("AsymmetricKeyStore", () => {
 			publicKeyPem,
 		});
 
-		expect(() => store.getVerificationKey("unknown")).toThrow("Unknown kid: unknown");
+		await expect(store.getVerificationKey("unknown")).rejects.toThrow("Unknown kid: unknown");
 	});
 
 	it("sign() round-trip works for asymmetric (ES256)", async () => {
@@ -291,7 +291,7 @@ describe("AsymmetricKeyStore", () => {
 		expect(header.alg).toBe("ES256");
 		expect(header.kid).toBe("asym-sign-k");
 
-		const key = store.getVerificationKey("asym-sign-k");
+		const key = await store.getVerificationKey("asym-sign-k");
 		const { payload } = await jwtVerify(token, key);
 		expect(payload.sub).toBe("carol");
 	});
@@ -325,6 +325,6 @@ describe("AsymmetricKeyStore", () => {
 			],
 		});
 
-		expect(() => store.getVerificationKey("k1")).toThrow();
+		await expect(store.getVerificationKey("k1")).rejects.toThrow();
 	});
 });

--- a/packages/core/src/keys/__tests__/KeyStore.test.mts
+++ b/packages/core/src/keys/__tests__/KeyStore.test.mts
@@ -97,6 +97,11 @@ describe("SymmetricKeyStore", () => {
 		const header = decodeProtectedHeader(token);
 		expect(header.typ).toBe("at+jwt");
 	});
+
+	it("getCurrentKid returns the current signing kid", () => {
+		const ks = createSymmetricKeyStore("x", "my-kid");
+		expect(ks.getCurrentKid()).toBe("my-kid");
+	});
 });
 
 describe("AsymmetricKeyStore", () => {
@@ -289,6 +294,17 @@ describe("AsymmetricKeyStore", () => {
 		const key = store.getVerificationKey("asym-sign-k");
 		const { payload } = await jwtVerify(token, key);
 		expect(payload.sub).toBe("carol");
+	});
+
+	it("getCurrentKid returns the current signing kid", async () => {
+		const { privateKeyPem, publicKeyPem } = await generateTestKeyPair("ES256");
+		const store = await createAsymmetricKeyStore({
+			algorithm: "ES256",
+			kid: "k-current-only",
+			privateKeyPem,
+			publicKeyPem,
+		});
+		expect(store.getCurrentKid()).toBe("k-current-only");
 	});
 
 	it("throws for expired kid", async () => {

--- a/packages/core/src/keys/__tests__/factory.test.mts
+++ b/packages/core/src/keys/__tests__/factory.test.mts
@@ -66,7 +66,7 @@ describe("registerBuiltinKeyStores - local HS256", () => {
 			previousKeys: [],
 		});
 		expect(keyStore.algorithm).toBe("HS256");
-		expect(keyStore.current.kid).toBe("v1");
+		expect(keyStore.getCurrentKid()).toBe("v1");
 	});
 
 	it("throws clear error when HS256 secret is missing", async () => {
@@ -116,7 +116,7 @@ describe("registerBuiltinKeyStores - local asymmetric", () => {
 			previousKeys: [],
 		});
 		expect(keyStore.algorithm).toBe("RS256");
-		expect(keyStore.current.kid).toBe("v1");
+		expect(keyStore.getCurrentKid()).toBe("v1");
 	});
 
 	it("builds ES256 KeyStore from PEM strings", async () => {
@@ -132,7 +132,7 @@ describe("registerBuiltinKeyStores - local asymmetric", () => {
 			previousKeys: [],
 		});
 		expect(keyStore.algorithm).toBe("ES256");
-		expect(keyStore.current.kid).toBe("v1");
+		expect(keyStore.getCurrentKid()).toBe("v1");
 	});
 
 	it("builds EdDSA KeyStore from PEM strings", async () => {
@@ -148,7 +148,7 @@ describe("registerBuiltinKeyStores - local asymmetric", () => {
 			previousKeys: [],
 		});
 		expect(keyStore.algorithm).toBe("EdDSA");
-		expect(keyStore.current.kid).toBe("v1");
+		expect(keyStore.getCurrentKid()).toBe("v1");
 	});
 
 	it("throws when asymmetric privateKey/privateKeyPath is missing", async () => {
@@ -223,7 +223,7 @@ describe("registerBuiltinKeyStores - local asymmetric", () => {
 			previousKeys: [],
 		});
 		expect(keyStore.algorithm).toBe("ES256");
-		expect(keyStore.current.kid).toBe("fp1");
+		expect(keyStore.getCurrentKid()).toBe("fp1");
 	});
 
 	it("file-path takes priority over inline PEM string when both are supplied", async () => {
@@ -248,7 +248,7 @@ describe("registerBuiltinKeyStores - local asymmetric", () => {
 			previousKeys: [],
 		});
 		expect(keyStore.algorithm).toBe("ES256");
-		expect(keyStore.current.kid).toBe("pri1");
+		expect(keyStore.getCurrentKid()).toBe("pri1");
 	});
 
 	it("previousKeys entry reads publicKey from file path", async () => {

--- a/packages/core/src/keys/__tests__/factory.test.mts
+++ b/packages/core/src/keys/__tests__/factory.test.mts
@@ -66,7 +66,7 @@ describe("registerBuiltinKeyStores - local HS256", () => {
 			previousKeys: [],
 		});
 		expect(keyStore.algorithm).toBe("HS256");
-		expect(keyStore.getCurrentKid()).toBe("v1");
+		expect(keyStore.getSigningKidFallback()).toBe("v1");
 	});
 
 	it("throws clear error when HS256 secret is missing", async () => {
@@ -116,7 +116,7 @@ describe("registerBuiltinKeyStores - local asymmetric", () => {
 			previousKeys: [],
 		});
 		expect(keyStore.algorithm).toBe("RS256");
-		expect(keyStore.getCurrentKid()).toBe("v1");
+		expect(keyStore.getSigningKidFallback()).toBe("v1");
 	});
 
 	it("builds ES256 KeyStore from PEM strings", async () => {
@@ -132,7 +132,7 @@ describe("registerBuiltinKeyStores - local asymmetric", () => {
 			previousKeys: [],
 		});
 		expect(keyStore.algorithm).toBe("ES256");
-		expect(keyStore.getCurrentKid()).toBe("v1");
+		expect(keyStore.getSigningKidFallback()).toBe("v1");
 	});
 
 	it("builds EdDSA KeyStore from PEM strings", async () => {
@@ -148,7 +148,7 @@ describe("registerBuiltinKeyStores - local asymmetric", () => {
 			previousKeys: [],
 		});
 		expect(keyStore.algorithm).toBe("EdDSA");
-		expect(keyStore.getCurrentKid()).toBe("v1");
+		expect(keyStore.getSigningKidFallback()).toBe("v1");
 	});
 
 	it("throws when asymmetric privateKey/privateKeyPath is missing", async () => {
@@ -223,7 +223,7 @@ describe("registerBuiltinKeyStores - local asymmetric", () => {
 			previousKeys: [],
 		});
 		expect(keyStore.algorithm).toBe("ES256");
-		expect(keyStore.getCurrentKid()).toBe("fp1");
+		expect(keyStore.getSigningKidFallback()).toBe("fp1");
 	});
 
 	it("file-path takes priority over inline PEM string when both are supplied", async () => {
@@ -248,7 +248,7 @@ describe("registerBuiltinKeyStores - local asymmetric", () => {
 			previousKeys: [],
 		});
 		expect(keyStore.algorithm).toBe("ES256");
-		expect(keyStore.getCurrentKid()).toBe("pri1");
+		expect(keyStore.getSigningKidFallback()).toBe("pri1");
 	});
 
 	it("previousKeys entry reads publicKey from file path", async () => {

--- a/packages/core/src/keys/__tests__/factory.test.mts
+++ b/packages/core/src/keys/__tests__/factory.test.mts
@@ -201,7 +201,7 @@ describe("registerBuiltinKeyStores - local asymmetric", () => {
 			],
 		});
 		expect(keyStore.algorithm).toBe("RS256");
-		const keys = keyStore.getVerificationKeys();
+		const keys = await keyStore.getVerificationKeys();
 		expect(keys.map((k) => k.kid)).toContain("v1");
 		expect(keys.map((k) => k.kid)).toContain("v2");
 	});
@@ -272,7 +272,7 @@ describe("registerBuiltinKeyStores - local asymmetric", () => {
 				},
 			],
 		});
-		const keys = keyStore.getVerificationKeys();
+		const keys = await keyStore.getVerificationKeys();
 		expect(keys.map((k) => k.kid)).toContain("v2");
 	});
 

--- a/packages/core/src/keys/__tests__/fixtures.mts
+++ b/packages/core/src/keys/__tests__/fixtures.mts
@@ -42,7 +42,7 @@ export function createTestKeyStore(options: TestKeyStoreOptions): KeyStore {
 		async sign(opts) {
 			return signer(opts);
 		},
-		getCurrentKid() {
+		getSigningKidFallback() {
 			return kid;
 		},
 		async getVerificationKey(requestedKid) {

--- a/packages/core/src/keys/__tests__/fixtures.mts
+++ b/packages/core/src/keys/__tests__/fixtures.mts
@@ -19,13 +19,7 @@
  * root, not shipped in `dist`. External KMS/HSM adapter authors should
  * implement the `KeyStore` interface directly per its TSDoc contract.
  */
-import type {
-	Algorithm,
-	KeyLike,
-	KeyStore,
-	ManagedKey,
-	SignJwtOptions,
-} from "../KeyStore.mjs";
+import type { Algorithm, KeyLike, KeyStore, ManagedKey, SignJwtOptions } from "../KeyStore.mjs";
 
 export interface TestKeyStoreOptions {
 	algorithm: Algorithm;

--- a/packages/core/src/keys/__tests__/fixtures.mts
+++ b/packages/core/src/keys/__tests__/fixtures.mts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal-only test fixtures for KeyStore. Not re-exported from the package
+ * root, not shipped in `dist`. External KMS/HSM adapter authors should
+ * implement the `KeyStore` interface directly per its TSDoc contract.
+ */
+import type {
+	Algorithm,
+	KeyLike,
+	KeyStore,
+	ManagedKey,
+	SignJwtOptions,
+} from "../KeyStore.mjs";
+
+export interface TestKeyStoreOptions {
+	algorithm: Algorithm;
+	kid: string;
+	signer: (options: SignJwtOptions) => Promise<string>;
+	verificationKeys: ReadonlyMap<string, KeyLike>;
+	expirations?: ReadonlyMap<string, Date>;
+}
+
+export function createTestKeyStore(options: TestKeyStoreOptions): KeyStore {
+	const { algorithm, kid, signer, verificationKeys, expirations } = options;
+	return {
+		algorithm,
+		async sign(opts) {
+			return signer(opts);
+		},
+		getCurrentKid() {
+			return kid;
+		},
+		async getVerificationKey(requestedKid) {
+			const key = verificationKeys.get(requestedKid);
+			if (!key) throw new Error(`Unknown kid: ${requestedKid}`);
+			const exp = expirations?.get(requestedKid);
+			if (exp && exp <= new Date()) throw new Error(`Expired kid: ${requestedKid}`);
+			return key;
+		},
+		async getVerificationKeys(): Promise<ManagedKey[]> {
+			const now = new Date();
+			const result: ManagedKey[] = [];
+			for (const [k, publicKey] of verificationKeys.entries()) {
+				const exp = expirations?.get(k);
+				if (exp && exp <= now) continue;
+				result.push(exp ? { kid: k, publicKey, expiresAt: exp } : { kid: k, publicKey });
+			}
+			return result;
+		},
+	};
+}

--- a/packages/core/src/keys/__tests__/integration.test.mts
+++ b/packages/core/src/keys/__tests__/integration.test.mts
@@ -18,6 +18,7 @@ import { decodeProtectedHeader, exportPKCS8, exportSPKI, generateKeyPair, jwtVer
 import { describe, expect, it } from "vitest";
 import { generateToken } from "#/grants/token.mjs";
 import { createKeyStoreFactory, registerBuiltinKeyStores } from "#/keys/factory.mjs";
+import { createAsymmetricKeyStore } from "#/keys/KeyStore.mjs";
 
 async function generateTestKeyPair(alg: string) {
 	const { privateKey, publicKey } = await generateKeyPair(alg, { extractable: true });
@@ -199,5 +200,29 @@ describe("Integration: generateToken + asymmetric KeyStore", () => {
 
 		// Attempting to verify with expired previous key should throw
 		await expect(newKeyStore.getVerificationKey("r-old")).rejects.toThrow("Expired kid: r-old");
+	});
+
+	it("generateToken overwrites caller-supplied jti with a fresh UUID", async () => {
+		const { privateKeyPem, publicKeyPem } = await generateTestKeyPair("ES256");
+		const keyStore = await createAsymmetricKeyStore({
+			algorithm: "ES256",
+			kid: "jti-test",
+			privateKeyPem,
+			publicKeyPem,
+		});
+
+		const manuallyProvidedJti = "caller-provided-jti-should-be-ignored";
+		const result = await generateToken(
+			{ sub: "u1", jti: manuallyProvidedJti },
+			{ keyStore, issuer: "https://auth.test" },
+		);
+
+		const verificationKey = await keyStore.getVerificationKey("jti-test");
+		const { payload } = await jwtVerify(result.token, verificationKey);
+
+		// jti must be a randomUUID v4 (36 chars, contains dashes), NOT the caller-supplied value
+		expect(payload.jti).not.toBe(manuallyProvidedJti);
+		expect(typeof payload.jti).toBe("string");
+		expect(payload.jti).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
 	});
 });

--- a/packages/core/src/keys/__tests__/integration.test.mts
+++ b/packages/core/src/keys/__tests__/integration.test.mts
@@ -78,7 +78,7 @@ describe("Integration: generateToken + asymmetric KeyStore", () => {
 		expect(header.typ).toBe("at+jwt");
 
 		// Verify the JWT payload using the KeyStore's verification key
-		const verificationKey = keyStore.getVerificationKey(header.kid!);
+		const verificationKey = await keyStore.getVerificationKey(header.kid!);
 		const { payload } = await jwtVerify(token.token, verificationKey, {
 			issuer: "https://auth.example.com",
 			audience: "https://api.example.com",
@@ -121,7 +121,7 @@ describe("Integration: generateToken + asymmetric KeyStore", () => {
 		const oldHeader = decodeProtectedHeader(oldToken.token);
 		expect(oldHeader.kid).toBe("k-old");
 
-		const oldVerificationKey = oldKeyStore.getVerificationKey("k-old");
+		const oldVerificationKey = await oldKeyStore.getVerificationKey("k-old");
 		const { payload: oldPayload } = await jwtVerify(oldToken.token, oldVerificationKey);
 		expect(oldPayload.sub).toBe("user-456");
 
@@ -142,7 +142,7 @@ describe("Integration: generateToken + asymmetric KeyStore", () => {
 		});
 
 		// Step 3: Verify old token still works with new KeyStore
-		const rotatedVerificationKey = newKeyStore.getVerificationKey(oldHeader.kid!);
+		const rotatedVerificationKey = await newKeyStore.getVerificationKey(oldHeader.kid!);
 		const { payload: rotatedPayload } = await jwtVerify(oldToken.token, rotatedVerificationKey);
 		expect(rotatedPayload.sub).toBe("user-456");
 		expect(rotatedPayload.role).toBe("viewer");
@@ -156,7 +156,7 @@ describe("Integration: generateToken + asymmetric KeyStore", () => {
 		const newHeader = decodeProtectedHeader(newToken.token);
 		expect(newHeader.kid).toBe("k-new");
 
-		const newVerificationKey = newKeyStore.getVerificationKey("k-new");
+		const newVerificationKey = await newKeyStore.getVerificationKey("k-new");
 		const { payload: newPayload } = await jwtVerify(newToken.token, newVerificationKey);
 		expect(newPayload.sub).toBe("user-789");
 	});
@@ -198,6 +198,6 @@ describe("Integration: generateToken + asymmetric KeyStore", () => {
 		});
 
 		// Attempting to verify with expired previous key should throw
-		expect(() => newKeyStore.getVerificationKey("r-old")).toThrow("Expired kid: r-old");
+		await expect(newKeyStore.getVerificationKey("r-old")).rejects.toThrow("Expired kid: r-old");
 	});
 });

--- a/packages/core/src/routes/Jwks.mts
+++ b/packages/core/src/routes/Jwks.mts
@@ -24,7 +24,7 @@ export const createRouter = (express: { Router: () => Router }, keyStore: KeySto
 		if (keyStore.algorithm === "HS256") {
 			return res.sendStatus(404);
 		}
-		const managedKeys = keyStore.getVerificationKeys();
+		const managedKeys = await keyStore.getVerificationKeys();
 		const keys = await Promise.all(
 			managedKeys.map(async (mk) => {
 				const jwk = await exportJWK(mk.publicKey);

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -8,5 +8,5 @@
 		}
 	},
 	"include": ["src/**/*"],
-	"exclude": ["node_modules", "dist"]
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
 }

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -55,7 +55,7 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			try {
 				const header = decodeProtectedHeader(refreshTokenValue);
 				typ = header.typ;
-				const key = keyStore.getVerificationKey(header.kid ?? keyStore.current.kid);
+				const key = await keyStore.getVerificationKey(header.kid ?? keyStore.getCurrentKid());
 				const { payload } = await jwtVerify(refreshTokenValue, key);
 				tokenPayload = payload;
 			} catch {

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -55,7 +55,7 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			try {
 				const header = decodeProtectedHeader(refreshTokenValue);
 				typ = header.typ;
-				const key = await keyStore.getVerificationKey(header.kid ?? keyStore.getCurrentKid());
+				const key = await keyStore.getVerificationKey(header.kid ?? keyStore.getSigningKidFallback());
 				const { payload } = await jwtVerify(refreshTokenValue, key);
 				tokenPayload = payload;
 			} catch {

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -55,7 +55,9 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			try {
 				const header = decodeProtectedHeader(refreshTokenValue);
 				typ = header.typ;
-				const key = await keyStore.getVerificationKey(header.kid ?? keyStore.getSigningKidFallback());
+				const key = await keyStore.getVerificationKey(
+					header.kid ?? keyStore.getSigningKidFallback(),
+				);
 				const { payload } = await jwtVerify(refreshTokenValue, key);
 				tokenPayload = payload;
 			} catch {

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -163,7 +163,9 @@ export const createOAuthRouter = async (
 				}
 				try {
 					const header = decodeProtectedHeader(token);
-					const key = await keyStore.getVerificationKey(header.kid ?? keyStore.getSigningKidFallback());
+					const key = await keyStore.getVerificationKey(
+						header.kid ?? keyStore.getSigningKidFallback(),
+					);
 					const { payload } = await jwtVerify(token, key);
 					const { exp, iat, iss, aud, sub } = payload;
 					const claims = payload as Record<string, unknown>;

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -147,7 +147,7 @@ export const createOAuthRouter = async (
 					}
 					try {
 						const { kid } = decodeProtectedHeader(bearerToken);
-						const key = keyStore.getVerificationKey(kid ?? keyStore.current.kid);
+						const key = await keyStore.getVerificationKey(kid ?? keyStore.getCurrentKid());
 						await jwtVerify(bearerToken, key);
 						return next();
 					} catch {
@@ -163,7 +163,7 @@ export const createOAuthRouter = async (
 				}
 				try {
 					const header = decodeProtectedHeader(token);
-					const key = keyStore.getVerificationKey(header.kid ?? keyStore.current.kid);
+					const key = await keyStore.getVerificationKey(header.kid ?? keyStore.getCurrentKid());
 					const { payload } = await jwtVerify(token, key);
 					const { exp, iat, iss, aud, sub } = payload;
 					const claims = payload as Record<string, unknown>;

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -147,7 +147,7 @@ export const createOAuthRouter = async (
 					}
 					try {
 						const { kid } = decodeProtectedHeader(bearerToken);
-						const key = await keyStore.getVerificationKey(kid ?? keyStore.getCurrentKid());
+						const key = await keyStore.getVerificationKey(kid ?? keyStore.getSigningKidFallback());
 						await jwtVerify(bearerToken, key);
 						return next();
 					} catch {
@@ -163,7 +163,7 @@ export const createOAuthRouter = async (
 				}
 				try {
 					const header = decodeProtectedHeader(token);
-					const key = await keyStore.getVerificationKey(header.kid ?? keyStore.getCurrentKid());
+					const key = await keyStore.getVerificationKey(header.kid ?? keyStore.getSigningKidFallback());
 					const { payload } = await jwtVerify(token, key);
 					const { exp, iat, iss, aud, sub } = payload;
 					const claims = payload as Record<string, unknown>;

--- a/packages/session/tsconfig.json
+++ b/packages/session/tsconfig.json
@@ -8,5 +8,5 @@
 		}
 	},
 	"include": ["src/**/*"],
-	"exclude": ["node_modules", "dist"]
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
 }


### PR DESCRIPTION
## Summary

TODO-B (pre-GA) refactors `KeyStore` to support **remote-sign adapters (KMS/HSM)**:

- Added `sign(options: SignJwtOptions): Promise<string>` — KeyStore self-injects `alg`/`kid` into the JWT protected header; caller cannot override.
- Added `getSigningKidFallback(): string` — cheap accessor for verifying legacy/malformed tokens that lack a `kid` header. **Not for rotation-safe lookup.**
- Removed `getSigningKey()`, `current`, `previous` — no path exposes private key material.
- Converted `getVerificationKey(kid)` / `getVerificationKeys()` to `Promise<...>` (remote-adapter compatible).
- Migrated all 4 production callers: `token.mts`, `Jwks.mts`, `refreshToken.mts`, `routes.mts` (×2).
- Added 4 public type exports to `@o3co/auth-provider-core`: `JWTPayload`, `SignJwtOptions`, `Algorithm`, `KeyLike` (promoted internal types).
- `JWTPayload` is jose-independent (RFC 7519 shape) so external adapter authors can use node-jose, fast-jwt, or direct KMS SDK calls.
- Internal-only `createTestKeyStore` fixture (not shipped in `dist`, not re-exported).
- `tsconfig.json` excludes `__tests__/**` from `dist` (fixes same issue in `packages/session` as well).

**Breaking (0.x pre-GA, no deprecation alias):**

- `getSigningKey()` → `sign({ claims })`
- `current.kid` → `getSigningKidFallback()`
- `current.privateKey` / `current.publicKey` / `previous` → removed (use `getVerificationKeys()` / `getVerificationKey(kid)`)
- Verification methods: sync → async

See [CHANGELOG.md](CHANGELOG.md) for the full migration guide.

**Spec & Plan:**
- Spec: [.claude/superpowers/specs/2026-04-21-keystore-remote-sign-semantics-design.md](https://github.com/o3co/agentscopes/blob/master/auth/.claude/superpowers/specs/2026-04-21-keystore-remote-sign-semantics-design.md)
- Plan: [.claude/superpowers/plans/2026-04-21-keystore-remote-sign-semantics.md](https://github.com/o3co/agentscopes/blob/master/auth/.claude/superpowers/plans/2026-04-21-keystore-remote-sign-semantics.md)

**Release:** v0.4.0 (bundled with TODO-A merged, TODO-C, TODO-F pending).

## Test Plan

- [x] All workspace tests pass: 530 tests (`pnpm -r test`)
  - `@o3co/auth-provider-core`: 223 pass
  - `@o3co/auth-provider-oauth`: 59 pass
  - `@o3co/auth-provider-session`: 77 pass (1 skipped)
  - Others unchanged
- [x] `tsc` build clean across all packages
- [x] Multi-agent review run (Claude + Codex)
  - Claude Important I-1 (`fixtures.mts` shipped in `dist`) → fixed via `tsconfig` exclude
  - Claude Suggestion S-4 (`getCurrentKid` → `getSigningKidFallback`) → applied
  - Claude S-1, S-2, S-6 → all applied
  - Codex: 0 discrete bugs
- [x] `grep -rn "getSigningKey|\.current\.|\.previous"` in production src → 0 matches
- [x] `dist/keys/__tests__/` no longer emitted (verified after rebuild)

## Migration for consumers

```ts
// JWT signing
// Before
const { kid, privateKey } = keyStore.getSigningKey();
const token = await new SignJWT(claims)
  .setProtectedHeader({ alg: keyStore.algorithm, kid })
  .sign(privateKey);
// After
const token = await keyStore.sign({ claims });

// Verification
// Before
const key = keyStore.getVerificationKey(kid ?? keyStore.current.kid);
// After
const key = await keyStore.getVerificationKey(kid ?? keyStore.getSigningKidFallback());
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
