### PR TITLE
feat(core): add UserSessionStore + FederationTokenStore adapters (TODO-F-1)

### DIFF
--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -535,6 +535,15 @@ v0.4.0 で追加された 5 つの拡張ポイント (詳細:
 
 全 adapter は optional — 未設定時は no-op default。
 
+### UserSessionStore / FederationTokenStore (TODO-F)
+
+Federation + OIDC 対応のために `AppOptions` に追加された 2 つのオプション:
+
+- `userSessionStore`: sid キーの session metadata (auth_time、active RP、family ID、OIDC claim)。Built-in: `memory`、`redis`。
+- `federationTokenStore`: `(sid, federationName)` キーの upstream IdP token。Built-in: `memory`、`redis` (refresh_token は AES-256-GCM による暗号化必須。`allow-plaintext` は opt-in で警告を出力)。
+
+両 store は TODO-F-3 (cascading revoke)、F-4 (id_token + /userinfo)、F-5 (logout)、F-6 (/oauth/federation/:name/token) で消費される。本 F-1 では plumbing のみを追加する。詳細な interface + encryption contract は [TODO-F spec](../../.claude/superpowers/specs/2026-04-21-todo-f-federation-token-lifecycle-design.md) を参照。
+
 ## 関連
 
 - ルート [README](../../README.md) — アーキテクチャ概要、設定リファレンス、Docker セットアップ

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -536,6 +536,15 @@ Five extension points introduced in v0.4.0 (see
 
 All five adapters are optional — absence = no-op default.
 
+### UserSessionStore / FederationTokenStore (TODO-F)
+
+Two new optional `AppOptions` fields introduced for federation + OIDC support:
+
+- `userSessionStore`: sid-keyed session metadata (auth_time, active RPs, family IDs, OIDC claims). Built-in adapters: `memory`, `redis`.
+- `federationTokenStore`: `(sid, federationName)`-keyed upstream IdP tokens. Built-in adapters: `memory`, `redis` (with mandatory AES-256-GCM encryption of refresh_token; `allow-plaintext` is opt-in and emits a warning).
+
+Both stores are consumed by upcoming TODO-F-3 (cascading revocation), F-4 (id_token + /userinfo), F-5 (logout), and F-6 (/oauth/federation/:name/token). This plan (F-1) only adds the plumbing. See [the TODO-F spec](../../.claude/superpowers/specs/2026-04-21-todo-f-federation-token-lifecycle-design.md) for the full interface + encryption contract.
+
 ## See Also
 
 - Root [README](../../README.md) — architecture overview, configuration reference, Docker setup

--- a/packages/core/src/__tests__/app-extensions.test.mts
+++ b/packages/core/src/__tests__/app-extensions.test.mts
@@ -17,9 +17,11 @@ import type { Router } from "express";
 import { describe, expect, it, vi } from "vitest";
 import { createApp } from "#/app.mjs";
 import type { AppConfig } from "#/config/application.schema.mjs";
+import { createInMemoryFederationTokenStore } from "#/federation-tokens/adapters/memory.mjs";
 import { createSymmetricKeyStore } from "#/keys/KeyStore.mjs";
 import type { MfaCoordinator, MfaProviderFactory, MfaTransactionStore } from "#/mfa/types.mjs";
 import type { GrantPolicyHookBase } from "#/policy/types.mjs";
+import { createInMemoryUserSessionStore } from "#/user-sessions/adapters/memory.mjs";
 
 const mockExpress = {
 	Router: () =>
@@ -224,6 +226,79 @@ describe("createApp — grantPolicy / jwt.issuer consistency guard (CP-20)", () 
 			createApp({
 				express: mockExpress,
 				config: configWithoutIssuer,
+				keyStore: createSymmetricKeyStore("test-secret"),
+				modules: [],
+			}),
+		).not.toThrow();
+	});
+});
+
+describe("createApp — TODO-F-1 federation store plumbing", () => {
+	const configWithFederations = {
+		...mockConfig,
+		federations: {
+			google: { enabled: true, clientId: "x", clientSecret: "y", callbackURL: "z" },
+		},
+	} as unknown as AppConfig;
+
+	const configWithoutFederations = {
+		...mockConfig,
+		federations: {},
+	} as unknown as AppConfig;
+
+	it("throws when federations configured without federationTokenStore", () => {
+		expect(() =>
+			createApp({
+				express: mockExpress,
+				config: configWithFederations,
+				keyStore: createSymmetricKeyStore("test-secret"),
+				modules: [],
+				userSessionStore: createInMemoryUserSessionStore(),
+			}),
+		).toThrow(/federationTokenStore/);
+	});
+
+	it("throws when federations configured without userSessionStore", () => {
+		expect(() =>
+			createApp({
+				express: mockExpress,
+				config: configWithFederations,
+				keyStore: createSymmetricKeyStore("test-secret"),
+				modules: [],
+				federationTokenStore: createInMemoryFederationTokenStore(),
+			}),
+		).toThrow(/userSessionStore/);
+	});
+
+	it("accepts federation config when both stores are wired", () => {
+		expect(() =>
+			createApp({
+				express: mockExpress,
+				config: configWithFederations,
+				keyStore: createSymmetricKeyStore("test-secret"),
+				modules: [],
+				userSessionStore: createInMemoryUserSessionStore(),
+				federationTokenStore: createInMemoryFederationTokenStore(),
+			}),
+		).not.toThrow();
+	});
+
+	it("accepts no stores when no federations are configured", () => {
+		expect(() =>
+			createApp({
+				express: mockExpress,
+				config: configWithoutFederations,
+				keyStore: createSymmetricKeyStore("test-secret"),
+				modules: [],
+			}),
+		).not.toThrow();
+	});
+
+	it("accepts no stores when federations config is entirely absent", () => {
+		expect(() =>
+			createApp({
+				express: mockExpress,
+				config: mockConfig,
 				keyStore: createSymmetricKeyStore("test-secret"),
 				modules: [],
 			}),

--- a/packages/core/src/__tests__/app-extensions.test.mts
+++ b/packages/core/src/__tests__/app-extensions.test.mts
@@ -354,4 +354,26 @@ describe("createApp — TODO-F-1 federation store plumbing", () => {
 			}),
 		).not.toThrow();
 	});
+
+	it('does NOT treat non-schema strings like "yes" as enabled (schema-alignment, Copilot round 3 #6)', () => {
+		// Schema coerces only "true"/"1" to true; "yes" is rejected at parse.
+		// The pre-parse check must NOT fire the stores-missing error on "yes"
+		// or it would mask the real schema validation error that the user
+		// needs to see.
+		const configWithYes = {
+			...mockConfig,
+			federations: {
+				google: { enabled: "yes", clientId: "x", clientSecret: "y", callbackURL: "z" },
+			},
+		} as unknown as AppConfig;
+		expect(() =>
+			createApp({
+				express: mockExpress,
+				config: configWithYes,
+				keyStore: createSymmetricKeyStore("test-secret"),
+				modules: [],
+				// Stores omitted — should NOT throw here; schema parse at init() will flag it.
+			}),
+		).not.toThrow();
+	});
 });

--- a/packages/core/src/__tests__/app-extensions.test.mts
+++ b/packages/core/src/__tests__/app-extensions.test.mts
@@ -304,4 +304,54 @@ describe("createApp — TODO-F-1 federation store plumbing", () => {
 			}),
 		).not.toThrow();
 	});
+
+	it('treats env-var string "true" as enabled and requires stores (pre-zod-coerce robustness)', () => {
+		const configWithEnvString = {
+			...mockConfig,
+			federations: {
+				google: { enabled: "true", clientId: "x", clientSecret: "y", callbackURL: "z" },
+			},
+		} as unknown as AppConfig;
+		expect(() =>
+			createApp({
+				express: mockExpress,
+				config: configWithEnvString,
+				keyStore: createSymmetricKeyStore("test-secret"),
+				modules: [],
+				// Both stores omitted — should throw.
+			}),
+		).toThrow(/federationTokenStore|userSessionStore/);
+	});
+
+	it('treats env-var string "1" as enabled', () => {
+		const configWithEnvOne = {
+			...mockConfig,
+			federations: { google: { enabled: "1", clientId: "x", clientSecret: "y", callbackURL: "z" } },
+		} as unknown as AppConfig;
+		expect(() =>
+			createApp({
+				express: mockExpress,
+				config: configWithEnvOne,
+				keyStore: createSymmetricKeyStore("test-secret"),
+				modules: [],
+			}),
+		).toThrow();
+	});
+
+	it('treats env-var string "false" as disabled (no stores required)', () => {
+		const configWithEnvFalse = {
+			...mockConfig,
+			federations: {
+				google: { enabled: "false", clientId: "x", clientSecret: "y", callbackURL: "z" },
+			},
+		} as unknown as AppConfig;
+		expect(() =>
+			createApp({
+				express: mockExpress,
+				config: configWithEnvFalse,
+				keyStore: createSymmetricKeyStore("test-secret"),
+				modules: [],
+			}),
+		).not.toThrow();
+	});
 });

--- a/packages/core/src/app.mts
+++ b/packages/core/src/app.mts
@@ -73,16 +73,22 @@ export function createApp(options: AppOptions): AppResult {
 
 	// Spec Section 10.1 — federations configured means stores are required.
 	// This runs BEFORE zod parsing, so `enabled` may still be a string from
-	// env-var overrides (HOCON substitutions emit `"true"`/`"1"`/etc.). Mirror
-	// `coerceBooleanFromEnv` semantics (Plan #3 schema) so the check does not
-	// miss federations that zod will later coerce to boolean true.
+	// env-var overrides (HOCON substitutions emit `"true"`/`"1"`). We MUST
+	// accept exactly the strings that Plan #3's `coerceBooleanFromEnv`
+	// zod-preprocess coerces to true, so this pre-parse check neither
+	// (a) lets a schema-enabled federation slip through unchecked nor
+	// (b) rejects a config that zod would later reject anyway (false
+	// positive, mask the real schema error).
+	//
+	// Matches schema behavior: only `"true"` and `"1"` coerce to true.
+	// Arbitrary strings like "yes"/"on" are rejected by the schema, so
+	// treating them as truthy here would fire the stores-missing error
+	// before the real validation message.
 	const isEnabledTruthy = (v: unknown): boolean => {
 		if (v === true) return true;
 		if (typeof v !== "string") return false;
 		const normalized = v.trim().toLowerCase();
-		return (
-			normalized === "true" || normalized === "1" || normalized === "yes" || normalized === "on"
-		);
+		return normalized === "true" || normalized === "1";
 	};
 	const federationsCfg = (config as { federations?: Record<string, { enabled?: unknown }> })
 		.federations;

--- a/packages/core/src/app.mts
+++ b/packages/core/src/app.mts
@@ -18,6 +18,7 @@ import type { z } from "zod";
 import type { AuditSinkBase } from "./audit/types.mjs";
 import type { CoreConfig } from "./config/application.schema.mjs";
 import { composeConfigSchema } from "./config/application.schema.mjs";
+import type { FederationTokenStoreBase } from "./federation-tokens/types.mjs";
 import { GrantRegistry } from "./grants/registry.mjs";
 import type { KeyStore } from "./keys/KeyStore.mjs";
 import type { MfaCoordinator, MfaProviderFactory, MfaTransactionStore } from "./mfa/types.mjs";
@@ -27,6 +28,7 @@ import type { RateLimiterBase } from "./ratelimit/types.mjs";
 import type { RefreshTokenStoreBase } from "./refresh/types.mjs";
 import * as healthcheck from "./routes/Healthcheck.mjs";
 import * as jwks from "./routes/Jwks.mjs";
+import type { UserSessionStoreBase } from "./user-sessions/types.mjs";
 
 type ExpressLike = {
 	Router: () => Router;
@@ -47,6 +49,8 @@ export interface AppOptions {
 	rateLimiter?: RateLimiterBase;
 	refreshTokenStore?: RefreshTokenStoreBase;
 	grantPolicy?: GrantPolicyHookBase;
+	userSessionStore?: UserSessionStoreBase;
+	federationTokenStore?: FederationTokenStoreBase;
 }
 
 export interface AppResult {
@@ -65,6 +69,28 @@ export function createApp(options: AppOptions): AppResult {
 		if (!options.mfaTransactionStore) {
 			throw new Error("createApp: mfaTransactionStore is required when mfaCoordinator is set");
 		}
+	}
+
+	// Spec Section 10.1 — federations configured means stores are required.
+	// We detect configured federations by any entry with enabled === true.
+	const federationsCfg = (config as { federations?: Record<string, { enabled?: unknown }> })
+		.federations;
+	const federationsConfigured =
+		typeof federationsCfg === "object" &&
+		federationsCfg !== null &&
+		Object.values(federationsCfg).some((f) => f != null && f.enabled === true);
+
+	if (federationsConfigured && !options.federationTokenStore) {
+		throw new Error(
+			"createApp: federations are configured but federationTokenStore was not provided. " +
+				"Register a FederationTokenStore adapter in AppOptions.",
+		);
+	}
+	if (federationsConfigured && !options.userSessionStore) {
+		throw new Error(
+			"createApp: federations are configured but userSessionStore was not provided. " +
+				"Register a UserSessionStore adapter in AppOptions.",
+		);
 	}
 
 	// CP-20: when grantPolicy is configured, config.oauth.jwt.issuer MUST be
@@ -109,6 +135,8 @@ export function createApp(options: AppOptions): AppResult {
 		rateLimiter: options.rateLimiter,
 		refreshTokenStore: options.refreshTokenStore,
 		grantPolicy: options.grantPolicy,
+		userSessionStore: options.userSessionStore,
+		federationTokenStore: options.federationTokenStore,
 	};
 
 	async function init(): Promise<void> {

--- a/packages/core/src/app.mts
+++ b/packages/core/src/app.mts
@@ -72,13 +72,24 @@ export function createApp(options: AppOptions): AppResult {
 	}
 
 	// Spec Section 10.1 — federations configured means stores are required.
-	// We detect configured federations by any entry with enabled === true.
+	// This runs BEFORE zod parsing, so `enabled` may still be a string from
+	// env-var overrides (HOCON substitutions emit `"true"`/`"1"`/etc.). Mirror
+	// `coerceBooleanFromEnv` semantics (Plan #3 schema) so the check does not
+	// miss federations that zod will later coerce to boolean true.
+	const isEnabledTruthy = (v: unknown): boolean => {
+		if (v === true) return true;
+		if (typeof v !== "string") return false;
+		const normalized = v.trim().toLowerCase();
+		return (
+			normalized === "true" || normalized === "1" || normalized === "yes" || normalized === "on"
+		);
+	};
 	const federationsCfg = (config as { federations?: Record<string, { enabled?: unknown }> })
 		.federations;
 	const federationsConfigured =
 		typeof federationsCfg === "object" &&
 		federationsCfg !== null &&
-		Object.values(federationsCfg).some((f) => f != null && f.enabled === true);
+		Object.values(federationsCfg).some((f) => f != null && isEnabledTruthy(f.enabled));
 
 	if (federationsConfigured && !options.federationTokenStore) {
 		throw new Error(

--- a/packages/core/src/federation-tokens/__tests__/crypto.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/crypto.test.mts
@@ -25,10 +25,13 @@ describe("encryptTokenField / decryptTokenField", () => {
 	it("tampering fails authentication", () => {
 		const ct = encryptTokenField(plaintext, key);
 		const parts = ct.split(".");
+		expect(parts).toHaveLength(4);
+		const [ver, iv, ct0, tag] = parts as [string, string, string, string];
 		// Flip one bit in the ciphertext section.
-		const ctBuf = Buffer.from(parts[2]!, "base64url");
-		ctBuf[0] = ctBuf[0]! ^ 0x01;
-		const tampered = [parts[0], parts[1], ctBuf.toString("base64url"), parts[3]].join(".");
+		const ctBuf = Buffer.from(ct0, "base64url");
+		const first = ctBuf[0] ?? 0;
+		ctBuf[0] = first ^ 0x01;
+		const tampered = [ver, iv, ctBuf.toString("base64url"), tag].join(".");
 		expect(() => decryptTokenField(tampered, key)).toThrow();
 	});
 

--- a/packages/core/src/federation-tokens/__tests__/crypto.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/crypto.test.mts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { describe, expect, it } from "vitest";
+import { decryptTokenField, encryptTokenField } from "../crypto.mjs";
+
+const key = Buffer.alloc(32, 1); // 32-byte key for AES-256
+const plaintext = "ya29.federation-refresh-token-example";
+
+describe("encryptTokenField / decryptTokenField", () => {
+	it("roundtrips a plaintext", () => {
+		const ct = encryptTokenField(plaintext, key);
+		expect(ct).not.toContain(plaintext);
+		expect(decryptTokenField(ct, key)).toBe(plaintext);
+	});
+
+	it("produces different ciphertext each call (random IV)", () => {
+		const a = encryptTokenField(plaintext, key);
+		const b = encryptTokenField(plaintext, key);
+		expect(a).not.toBe(b);
+	});
+
+	it("tampering fails authentication", () => {
+		const ct = encryptTokenField(plaintext, key);
+		const parts = ct.split(".");
+		// Flip one bit in the ciphertext section.
+		const ctBuf = Buffer.from(parts[2]!, "base64url");
+		ctBuf[0] = ctBuf[0]! ^ 0x01;
+		const tampered = [parts[0], parts[1], ctBuf.toString("base64url"), parts[3]].join(".");
+		expect(() => decryptTokenField(tampered, key)).toThrow();
+	});
+
+	it("rejects wrong key", () => {
+		const ct = encryptTokenField(plaintext, key);
+		const wrong = Buffer.alloc(32, 2);
+		expect(() => decryptTokenField(ct, wrong)).toThrow();
+	});
+
+	it("rejects non-32-byte keys", () => {
+		const short = Buffer.alloc(16);
+		expect(() => encryptTokenField(plaintext, short)).toThrow(/32 bytes/);
+	});
+});

--- a/packages/core/src/federation-tokens/__tests__/factory.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/factory.test.mts
@@ -23,7 +23,12 @@ describe("FederationTokenStoreFactory", () => {
 		await expect(
 			f.create({
 				type: "redis",
-				client: { get: async () => null, set: async () => "OK", del: async () => 0, keys: async () => [] },
+				client: {
+					get: async () => null,
+					set: async () => "OK",
+					del: async () => 0,
+					keys: async () => [],
+				},
 				// encryption omitted intentionally
 			}),
 		).rejects.toThrow(/encryption/i);
@@ -35,7 +40,12 @@ describe("FederationTokenStoreFactory", () => {
 		await expect(
 			f.create({
 				type: "redis",
-				client: { get: async () => null, set: async () => "OK", del: async () => 0, keys: async () => [] },
+				client: {
+					get: async () => null,
+					set: async () => "OK",
+					del: async () => 0,
+					keys: async () => [],
+				},
 				encryption: { mode: "required", key: Buffer.alloc(16) },
 			}),
 		).rejects.toThrow(/32 bytes/);
@@ -50,7 +60,12 @@ describe("FederationTokenStoreFactory", () => {
 			registerBuiltinFederationTokenStores(f);
 			const store = await f.create({
 				type: "redis",
-				client: { get: async () => null, set: async () => "OK", del: async () => 0, keys: async () => [] },
+				client: {
+					get: async () => null,
+					set: async () => "OK",
+					del: async () => 0,
+					keys: async () => [],
+				},
 				encryption: { mode: "allow-plaintext" },
 			});
 			expect(store.kind).toBe("redis");

--- a/packages/core/src/federation-tokens/__tests__/factory.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/factory.test.mts
@@ -27,7 +27,7 @@ describe("FederationTokenStoreFactory", () => {
 					get: async () => null,
 					set: async () => "OK",
 					del: async () => 0,
-					keys: async () => [],
+					scanIterator: async function* () {},
 				},
 				// encryption omitted intentionally
 			}),
@@ -44,7 +44,7 @@ describe("FederationTokenStoreFactory", () => {
 					get: async () => null,
 					set: async () => "OK",
 					del: async () => 0,
-					keys: async () => [],
+					scanIterator: async function* () {},
 				},
 				encryption: { mode: "required", key: Buffer.alloc(16) },
 			}),
@@ -64,7 +64,7 @@ describe("FederationTokenStoreFactory", () => {
 					get: async () => null,
 					set: async () => "OK",
 					del: async () => 0,
-					keys: async () => [],
+					scanIterator: async function* () {},
 				},
 				encryption: { mode: "allow-plaintext" },
 			});

--- a/packages/core/src/federation-tokens/__tests__/factory.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/factory.test.mts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	createFederationTokenStoreFactory,
+	registerBuiltinFederationTokenStores,
+} from "../factory.mjs";
+
+describe("FederationTokenStoreFactory", () => {
+	it("built-in memory is registered", async () => {
+		const f = createFederationTokenStoreFactory();
+		registerBuiltinFederationTokenStores(f);
+		const store = await f.create({ type: "memory" });
+		expect(store.kind).toBe("memory");
+	});
+
+	it("redis requires an encryption config", async () => {
+		const f = createFederationTokenStoreFactory();
+		registerBuiltinFederationTokenStores(f);
+		await expect(
+			f.create({
+				type: "redis",
+				client: { get: async () => null, set: async () => "OK", del: async () => 0, keys: async () => [] },
+				// encryption omitted intentionally
+			}),
+		).rejects.toThrow(/encryption/i);
+	});
+
+	it("redis with mode=required needs a 32-byte key", async () => {
+		const f = createFederationTokenStoreFactory();
+		registerBuiltinFederationTokenStores(f);
+		await expect(
+			f.create({
+				type: "redis",
+				client: { get: async () => null, set: async () => "OK", del: async () => 0, keys: async () => [] },
+				encryption: { mode: "required", key: Buffer.alloc(16) },
+			}),
+		).rejects.toThrow(/32 bytes/);
+	});
+
+	it("redis with mode=allow-plaintext logs warning but succeeds", async () => {
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (msg: string) => warnings.push(msg);
+		try {
+			const f = createFederationTokenStoreFactory();
+			registerBuiltinFederationTokenStores(f);
+			const store = await f.create({
+				type: "redis",
+				client: { get: async () => null, set: async () => "OK", del: async () => 0, keys: async () => [] },
+				encryption: { mode: "allow-plaintext" },
+			});
+			expect(store.kind).toBe("redis");
+			expect(warnings.some((w) => /plaintext/i.test(w))).toBe(true);
+		} finally {
+			console.warn = originalWarn;
+		}
+	});
+});

--- a/packages/core/src/federation-tokens/__tests__/factory.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/factory.test.mts
@@ -17,7 +17,7 @@ describe("FederationTokenStoreFactory", () => {
 		expect(store.kind).toBe("memory");
 	});
 
-	it("redis requires an encryption config", async () => {
+	it("redis defaults encryption.mode to 'required' when omitted; missing key throws", async () => {
 		const f = createFederationTokenStoreFactory();
 		registerBuiltinFederationTokenStores(f);
 		await expect(
@@ -29,9 +29,38 @@ describe("FederationTokenStoreFactory", () => {
 					del: async () => 0,
 					scanIterator: async function* () {},
 				},
-				// encryption omitted intentionally
+				// encryption omitted — should default to mode: "required".
 			}),
-		).rejects.toThrow(/encryption/i);
+		).rejects.toThrow(/32 bytes/);
+	});
+
+	it("redis rejects an incompatible client (missing scanIterator)", async () => {
+		const f = createFederationTokenStoreFactory();
+		registerBuiltinFederationTokenStores(f);
+		await expect(
+			f.create({
+				type: "redis",
+				client: {
+					get: async () => null,
+					set: async () => "OK",
+					del: async () => 0,
+					// scanIterator missing
+				},
+				encryption: { mode: "allow-plaintext" },
+			}),
+		).rejects.toThrow(/scanIterator/);
+	});
+
+	it("redis rejects a client missing multiple methods with a combined message", async () => {
+		const f = createFederationTokenStoreFactory();
+		registerBuiltinFederationTokenStores(f);
+		await expect(
+			f.create({
+				type: "redis",
+				client: { get: async () => null }, // missing set, del, scanIterator
+				encryption: { mode: "allow-plaintext" },
+			}),
+		).rejects.toThrow(/set.*del.*scanIterator/);
 	});
 
 	it("redis with mode=required needs a 32-byte key", async () => {

--- a/packages/core/src/federation-tokens/__tests__/memory.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/memory.test.mts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { describe, expect, it, beforeEach } from "vitest";
+import { createInMemoryFederationTokenStore } from "../adapters/memory.mjs";
+import type { FederationTokenStoreBase, FederationTokens } from "../types.mjs";
+
+describe("in-memory FederationTokenStore", () => {
+	let store: FederationTokenStoreBase;
+	const tokens: FederationTokens = {
+		accessToken: "at",
+		refreshToken: "rt",
+		idToken: "it",
+		expiresAt: new Date("2026-04-22"),
+	};
+
+	beforeEach(() => {
+		store = createInMemoryFederationTokenStore();
+	});
+
+	it("kind is 'memory'", () => {
+		expect(store.kind).toBe("memory");
+	});
+
+	it("attach + get returns same tokens (including refreshToken in clear)", async () => {
+		await store.attach("sid-1", "google", tokens);
+		expect(await store.get("sid-1", "google")).toEqual(tokens);
+	});
+
+	it("get returns null for missing (sid, name)", async () => {
+		expect(await store.get("sid-1", "google")).toBeNull();
+		await store.attach("sid-1", "google", tokens);
+		expect(await store.get("sid-1", "github")).toBeNull();
+	});
+
+	it("update replaces atomically", async () => {
+		await store.attach("sid-1", "google", tokens);
+		const next: FederationTokens = {
+			accessToken: "at-new",
+			refreshToken: "rt-new",
+			expiresAt: new Date("2026-04-23"),
+		};
+		await store.update("sid-1", "google", next);
+		expect(await store.get("sid-1", "google")).toEqual(next);
+	});
+
+	it("deleteBySession removes all federation entries for sid", async () => {
+		await store.attach("sid-1", "google", tokens);
+		await store.attach("sid-1", "github", tokens);
+		await store.attach("sid-2", "google", tokens);
+		await store.deleteBySession("sid-1");
+		expect(await store.get("sid-1", "google")).toBeNull();
+		expect(await store.get("sid-1", "github")).toBeNull();
+		expect(await store.get("sid-2", "google")).toEqual(tokens);
+	});
+
+	it("delete removes a single (sid, name) only", async () => {
+		await store.attach("sid-1", "google", tokens);
+		await store.attach("sid-1", "github", tokens);
+		await store.delete("sid-1", "google");
+		expect(await store.get("sid-1", "google")).toBeNull();
+		expect(await store.get("sid-1", "github")).toEqual(tokens);
+	});
+
+	it("deleteBySession / delete are idempotent", async () => {
+		await expect(store.deleteBySession("nope")).resolves.toBeUndefined();
+		await expect(store.delete("nope", "google")).resolves.toBeUndefined();
+	});
+});

--- a/packages/core/src/federation-tokens/__tests__/memory.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/memory.test.mts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  */
 
-import { describe, expect, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { createInMemoryFederationTokenStore } from "../adapters/memory.mjs";
 import type { FederationTokenStoreBase, FederationTokens } from "../types.mjs";
 

--- a/packages/core/src/federation-tokens/__tests__/redis.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/redis.test.mts
@@ -152,6 +152,35 @@ describe("redis FederationTokenStore (encryption = allow-plaintext)", () => {
 		expect(raw).toContain("rt-secret");
 		expect(await store.get("sid-1", "google")).toEqual(tokens);
 	});
+
+	it("get() self-heals corrupt JSON by deleting the key (Copilot round 3 #5)", async () => {
+		const store = createRedisFederationTokenStore({
+			client: redis,
+			encryption: { mode: "allow-plaintext" },
+		});
+		redis.data.set("ft:sid-1:google", "{not-json");
+		expect(await store.get("sid-1", "google")).toBeNull();
+		expect(redis.del).toHaveBeenCalledWith("ft:sid-1:google");
+		expect(redis.data.has("ft:sid-1:google")).toBe(false);
+	});
+
+	it("get() self-heals when decryption fails (wrong / rotated encryption key)", async () => {
+		const keyA = Buffer.alloc(32, 1);
+		const keyB = Buffer.alloc(32, 2);
+		// Encrypt with keyA, try to read with keyB.
+		const writer = createRedisFederationTokenStore({
+			client: redis,
+			encryption: { mode: "required", key: keyA },
+		});
+		await writer.attach("sid-1", "google", tokens);
+		const reader = createRedisFederationTokenStore({
+			client: redis,
+			encryption: { mode: "required", key: keyB },
+		});
+		expect(await reader.get("sid-1", "google")).toBeNull();
+		// The corrupt key is now gone so the next get also returns null naturally.
+		expect(redis.data.has("ft:sid-1:google")).toBe(false);
+	});
 });
 
 describe("redis FederationTokenStore TTL is independent of access_token expiry", () => {

--- a/packages/core/src/federation-tokens/__tests__/redis.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/redis.test.mts
@@ -9,11 +9,14 @@ import type { FederationTokens } from "../types.mjs";
 
 function createFakeRedis() {
 	const data = new Map<string, string>();
+	const ttls = new Map<string, number>();
 	return {
 		data,
+		ttls,
 		get: vi.fn(async (k: string) => data.get(k) ?? null),
-		set: vi.fn(async (k: string, v: string) => {
+		set: vi.fn(async (k: string, v: string, opts?: { PX?: number }) => {
 			data.set(k, v);
+			if (opts?.PX !== undefined) ttls.set(k, opts.PX);
 			return "OK";
 		}),
 		del: vi.fn(async (...keys: string[]) => {
@@ -25,7 +28,7 @@ function createFakeRedis() {
 			const prefix = pattern.endsWith("*") ? pattern.slice(0, -1) : pattern;
 			return [...data.keys()].filter((k) => k.startsWith(prefix));
 		}),
-	} satisfies RedisLikeClient & { data: Map<string, string> };
+	} satisfies RedisLikeClient & { data: Map<string, string>; ttls: Map<string, number> };
 }
 
 const encryptionKey = Buffer.alloc(32, 7);
@@ -105,5 +108,50 @@ describe("redis FederationTokenStore (encryption = allow-plaintext)", () => {
 		const raw = values[0] as string;
 		expect(raw).toContain("rt-secret");
 		expect(await store.get("sid-1", "google")).toEqual(tokens);
+	});
+});
+
+describe("redis FederationTokenStore TTL is independent of access_token expiry", () => {
+	let redis: ReturnType<typeof createFakeRedis>;
+	beforeEach(() => {
+		redis = createFakeRedis();
+	});
+
+	it("default TTL (24h) is used regardless of tokens.expiresAt", async () => {
+		const store = createRedisFederationTokenStore({
+			client: redis,
+			encryption: { mode: "allow-plaintext" },
+		});
+		// Access token expires in 1 hour, but the record must live long enough
+		// for the refresh_token to be usable after that.
+		const shortLivedAT: FederationTokens = {
+			accessToken: "at",
+			refreshToken: "rt",
+			expiresAt: new Date(Date.now() + 3600_000),
+		};
+		await store.attach("sid-1", "google", shortLivedAT);
+		const ttl = redis.ttls.get("ft:sid-1:google");
+		expect(ttl).toBe(86400 * 1000); // 24h in ms, NOT 1h
+	});
+
+	it("custom TTL option is honored", async () => {
+		const store = createRedisFederationTokenStore({
+			client: redis,
+			encryption: { mode: "allow-plaintext" },
+			ttl: 7200, // 2h
+		});
+		await store.attach("sid-1", "google", tokens);
+		expect(redis.ttls.get("ft:sid-1:google")).toBe(7200 * 1000);
+	});
+
+	it("access token expiresAt is preserved in the envelope for consumer refresh decisions", async () => {
+		const store = createRedisFederationTokenStore({
+			client: redis,
+			encryption: { mode: "allow-plaintext" },
+		});
+		const accessTokenExpiry = new Date(Date.now() + 1800_000); // 30min
+		await store.attach("sid-1", "google", { ...tokens, expiresAt: accessTokenExpiry });
+		const round = await store.get("sid-1", "google");
+		expect(round?.expiresAt.getTime()).toBe(accessTokenExpiry.getTime());
 	});
 });

--- a/packages/core/src/federation-tokens/__tests__/redis.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/redis.test.mts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  */
 
-import { describe, expect, it, beforeEach, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createRedisFederationTokenStore, type RedisLikeClient } from "../adapters/redis.mjs";
 import type { FederationTokens } from "../types.mjs";
 

--- a/packages/core/src/federation-tokens/__tests__/redis.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/redis.test.mts
@@ -24,9 +24,12 @@ function createFakeRedis() {
 			for (const k of keys) if (data.delete(k)) n += 1;
 			return n;
 		}),
-		keys: vi.fn(async (pattern: string) => {
-			const prefix = pattern.endsWith("*") ? pattern.slice(0, -1) : pattern;
-			return [...data.keys()].filter((k) => k.startsWith(prefix));
+		scanIterator: vi.fn((opts: { MATCH: string; COUNT?: number }) => {
+			const prefix = opts.MATCH.endsWith("*") ? opts.MATCH.slice(0, -1) : opts.MATCH;
+			const matched = [...data.keys()].filter((k) => k.startsWith(prefix));
+			return (async function* () {
+				for (const k of matched) yield k;
+			})();
 		}),
 	} satisfies RedisLikeClient & { data: Map<string, string>; ttls: Map<string, number> };
 }

--- a/packages/core/src/federation-tokens/__tests__/redis.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/redis.test.mts
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { createRedisFederationTokenStore, type RedisLikeClient } from "../adapters/redis.mjs";
+import type { FederationTokens } from "../types.mjs";
+
+function createFakeRedis() {
+	const data = new Map<string, string>();
+	return {
+		data,
+		get: vi.fn(async (k: string) => data.get(k) ?? null),
+		set: vi.fn(async (k: string, v: string) => {
+			data.set(k, v);
+			return "OK";
+		}),
+		del: vi.fn(async (...keys: string[]) => {
+			let n = 0;
+			for (const k of keys) if (data.delete(k)) n += 1;
+			return n;
+		}),
+		keys: vi.fn(async (pattern: string) => {
+			const prefix = pattern.endsWith("*") ? pattern.slice(0, -1) : pattern;
+			return [...data.keys()].filter((k) => k.startsWith(prefix));
+		}),
+	} satisfies RedisLikeClient & { data: Map<string, string> };
+}
+
+const encryptionKey = Buffer.alloc(32, 7);
+const tokens: FederationTokens = {
+	accessToken: "at",
+	refreshToken: "rt-secret",
+	idToken: "it",
+	expiresAt: new Date(Date.now() + 3600_000),
+};
+
+describe("redis FederationTokenStore (encryption = required)", () => {
+	let redis: ReturnType<typeof createFakeRedis>;
+	beforeEach(() => {
+		redis = createFakeRedis();
+	});
+
+	it("kind is 'redis'", () => {
+		const store = createRedisFederationTokenStore({
+			client: redis,
+			encryption: { mode: "required", key: encryptionKey },
+		});
+		expect(store.kind).toBe("redis");
+	});
+
+	it("attach encrypts refreshToken at rest", async () => {
+		const store = createRedisFederationTokenStore({
+			client: redis,
+			encryption: { mode: "required", key: encryptionKey },
+		});
+		await store.attach("sid-1", "google", tokens);
+		const raw = [...redis.data.values()][0]!;
+		expect(raw).not.toContain("rt-secret");
+		// round-trip
+		expect(await store.get("sid-1", "google")).toEqual(tokens);
+	});
+
+	it("deleteBySession removes all federations for sid", async () => {
+		const store = createRedisFederationTokenStore({
+			client: redis,
+			encryption: { mode: "required", key: encryptionKey },
+		});
+		await store.attach("sid-1", "google", tokens);
+		await store.attach("sid-1", "github", tokens);
+		await store.attach("sid-2", "google", tokens);
+		await store.deleteBySession("sid-1");
+		expect(await store.get("sid-1", "google")).toBeNull();
+		expect(await store.get("sid-1", "github")).toBeNull();
+		expect(await store.get("sid-2", "google")).toEqual(tokens);
+	});
+
+	it("missing encryption key throws at construction", () => {
+		expect(() =>
+			createRedisFederationTokenStore({
+				client: redis,
+				encryption: { mode: "required", key: Buffer.alloc(0) },
+			}),
+		).toThrow(/encryption key/i);
+	});
+});
+
+describe("redis FederationTokenStore (encryption = allow-plaintext)", () => {
+	let redis: ReturnType<typeof createFakeRedis>;
+	beforeEach(() => {
+		redis = createFakeRedis();
+	});
+
+	it("attach stores refreshToken in clear (opt-in)", async () => {
+		const store = createRedisFederationTokenStore({
+			client: redis,
+			encryption: { mode: "allow-plaintext" },
+		});
+		await store.attach("sid-1", "google", tokens);
+		const raw = [...redis.data.values()][0]!;
+		expect(raw).toContain("rt-secret");
+		expect(await store.get("sid-1", "google")).toEqual(tokens);
+	});
+});

--- a/packages/core/src/federation-tokens/__tests__/redis.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/redis.test.mts
@@ -56,7 +56,9 @@ describe("redis FederationTokenStore (encryption = required)", () => {
 			encryption: { mode: "required", key: encryptionKey },
 		});
 		await store.attach("sid-1", "google", tokens);
-		const raw = [...redis.data.values()][0]!;
+		const values = [...redis.data.values()];
+		expect(values).toHaveLength(1);
+		const raw = values[0] as string;
 		expect(raw).not.toContain("rt-secret");
 		// round-trip
 		expect(await store.get("sid-1", "google")).toEqual(tokens);
@@ -98,7 +100,9 @@ describe("redis FederationTokenStore (encryption = allow-plaintext)", () => {
 			encryption: { mode: "allow-plaintext" },
 		});
 		await store.attach("sid-1", "google", tokens);
-		const raw = [...redis.data.values()][0]!;
+		const values = [...redis.data.values()];
+		expect(values).toHaveLength(1);
+		const raw = values[0] as string;
 		expect(raw).toContain("rt-secret");
 		expect(await store.get("sid-1", "google")).toEqual(tokens);
 	});

--- a/packages/core/src/federation-tokens/__tests__/redis.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/redis.test.mts
@@ -92,6 +92,46 @@ describe("redis FederationTokenStore (encryption = required)", () => {
 			}),
 		).toThrow(/encryption key/i);
 	});
+
+	it("rejects ttl: 0 at construction", () => {
+		expect(() =>
+			createRedisFederationTokenStore({
+				client: redis,
+				encryption: { mode: "allow-plaintext" },
+				ttl: 0,
+			}),
+		).toThrow(/ttl must be a positive finite number/i);
+	});
+
+	it("rejects ttl: -1 at construction", () => {
+		expect(() =>
+			createRedisFederationTokenStore({
+				client: redis,
+				encryption: { mode: "allow-plaintext" },
+				ttl: -1,
+			}),
+		).toThrow(/ttl must be a positive finite number/i);
+	});
+
+	it("rejects ttl: NaN at construction", () => {
+		expect(() =>
+			createRedisFederationTokenStore({
+				client: redis,
+				encryption: { mode: "allow-plaintext" },
+				ttl: Number.NaN,
+			}),
+		).toThrow(/ttl must be a positive finite number/i);
+	});
+
+	it("rejects ttl: Infinity at construction", () => {
+		expect(() =>
+			createRedisFederationTokenStore({
+				client: redis,
+				encryption: { mode: "allow-plaintext" },
+				ttl: Number.POSITIVE_INFINITY,
+			}),
+		).toThrow(/ttl must be a positive finite number/i);
+	});
 });
 
 describe("redis FederationTokenStore (encryption = allow-plaintext)", () => {

--- a/packages/core/src/federation-tokens/adapters/memory.mts
+++ b/packages/core/src/federation-tokens/adapters/memory.mts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import type { FederationTokenStoreBase, FederationTokens } from "../types.mjs";
+
+const key = (sid: string, name: string) => `${sid}\u0000${name}`;
+
+export function createInMemoryFederationTokenStore(): FederationTokenStoreBase {
+	const store = new Map<string, FederationTokens>();
+
+	return {
+		kind: "memory",
+		async attach(sid, name, tokens) {
+			store.set(key(sid, name), { ...tokens });
+		},
+		async get(sid, name) {
+			return store.get(key(sid, name)) ?? null;
+		},
+		async update(sid, name, tokens) {
+			store.set(key(sid, name), { ...tokens });
+		},
+		async deleteBySession(sid) {
+			for (const k of [...store.keys()]) {
+				if (k.startsWith(`${sid}\u0000`)) store.delete(k);
+			}
+		},
+		async delete(sid, name) {
+			store.delete(key(sid, name));
+		},
+	};
+}

--- a/packages/core/src/federation-tokens/adapters/memory.mts
+++ b/packages/core/src/federation-tokens/adapters/memory.mts
@@ -21,19 +21,32 @@ const key = (sid: string, name: string) => `${sid}\u0000${name}`;
  * calls `deleteBySession(sid)` when a session ends. For process longevity
  * consider redis instead (production-grade TTL + cross-instance replication).
  */
+const cloneTokens = (t: FederationTokens): FederationTokens => ({
+	accessToken: t.accessToken,
+	refreshToken: t.refreshToken,
+	idToken: t.idToken,
+	// Copy Date so caller-held references can't mutate stored state.
+	expiresAt: new Date(t.expiresAt.getTime()),
+	tokenType: t.tokenType,
+	scope: t.scope,
+	// Shallow-copy rawParams; sufficient since consumers treat it as read-only.
+	rawParams: t.rawParams ? { ...t.rawParams } : undefined,
+});
+
 export function createInMemoryFederationTokenStore(): FederationTokenStoreBase {
 	const store = new Map<string, FederationTokens>();
 
 	return {
 		kind: "memory",
 		async attach(sid, name, tokens) {
-			store.set(key(sid, name), { ...tokens });
+			store.set(key(sid, name), cloneTokens(tokens));
 		},
 		async get(sid, name) {
-			return store.get(key(sid, name)) ?? null;
+			const t = store.get(key(sid, name));
+			return t ? cloneTokens(t) : null;
 		},
 		async update(sid, name, tokens) {
-			store.set(key(sid, name), { ...tokens });
+			store.set(key(sid, name), cloneTokens(tokens));
 		},
 		async deleteBySession(sid) {
 			for (const k of [...store.keys()]) {

--- a/packages/core/src/federation-tokens/adapters/memory.mts
+++ b/packages/core/src/federation-tokens/adapters/memory.mts
@@ -7,6 +7,20 @@ import type { FederationTokenStoreBase, FederationTokens } from "../types.mjs";
 
 const key = (sid: string, name: string) => `${sid}\u0000${name}`;
 
+/**
+ * In-memory FederationTokenStore adapter (dev/test only).
+ *
+ * Expiry semantics: this adapter does NOT auto-expire entries. Unlike
+ * UserSessionStore where the session's `expiresAt` bounds the record lifetime,
+ * federation `tokens.expiresAt` is the access_token's expiry, which is shorter
+ * than the refresh_token lifetime — deleting the record at access_token expiry
+ * would strand the refresh_token. Token lifecycle (refresh vs expiry decision)
+ * is the consumer's responsibility in F-6 flows.
+ *
+ * Cleanup of stale entries happens via UserSessionStore logout cascade, which
+ * calls `deleteBySession(sid)` when a session ends. For process longevity
+ * consider redis instead (production-grade TTL + cross-instance replication).
+ */
 export function createInMemoryFederationTokenStore(): FederationTokenStoreBase {
 	const store = new Map<string, FederationTokens>();
 

--- a/packages/core/src/federation-tokens/adapters/redis.mts
+++ b/packages/core/src/federation-tokens/adapters/redis.mts
@@ -19,7 +19,22 @@ export interface RedisFederationTokenStoreOptions {
 	client: RedisLikeClient;
 	encryption: EncryptionConfig;
 	keyPrefix?: string;
+	/**
+	 * Redis key TTL in seconds. This is the upper bound on how long a federation
+	 * token record persists; it MUST exceed the upstream federation refresh_token
+	 * lifetime so that refresh flows (F-6) can still retrieve the refresh_token
+	 * after the access_token has expired.
+	 *
+	 * Do NOT tie this TTL to `tokens.expiresAt` (the access_token expiry) —
+	 * access_token expiry is kept inside the envelope for F-6 to consult at
+	 * retrieval time, but the record itself lives until this store TTL elapses.
+	 *
+	 * Default: 86400 seconds (24 hours). Spec Section 5.2.
+	 */
+	ttl?: number;
 }
+
+const DEFAULT_TTL_SECONDS = 86400;
 
 interface Envelope {
 	accessToken: string;
@@ -38,6 +53,7 @@ export function createRedisFederationTokenStore(
 		throw new Error("FederationTokenStore redis: encryption key must be 32 bytes");
 	}
 	const prefix = opts.keyPrefix ?? "ft:";
+	const storeTtlMs = (opts.ttl ?? DEFAULT_TTL_SECONDS) * 1000;
 	const k = (sid: string, name: string) => `${prefix}${sid}:${name}`;
 	const sidPattern = (sid: string) => `${prefix}${sid}:*`;
 
@@ -74,13 +90,11 @@ export function createRedisFederationTokenStore(
 	});
 
 	const writeEnv = async (sid: string, name: string, env: Envelope) => {
-		const remaining = env.expiresAtMs - Date.now();
-		const px = remaining > 0 ? remaining : undefined;
-		await opts.client.set(
-			k(sid, name),
-			JSON.stringify(env),
-			px !== undefined ? { PX: px } : undefined,
-		);
+		// Redis TTL is the store lifetime (session upper bound), NOT the access
+		// token's expiresAt. The access token's expiry is preserved inside the
+		// envelope so F-6 consumers can decide to refresh; the record itself
+		// must outlive the access_token so the refresh_token remains available.
+		await opts.client.set(k(sid, name), JSON.stringify(env), { PX: storeTtlMs });
 	};
 
 	return {

--- a/packages/core/src/federation-tokens/adapters/redis.mts
+++ b/packages/core/src/federation-tokens/adapters/redis.mts
@@ -13,9 +13,7 @@ export interface RedisLikeClient {
 	keys(pattern: string): Promise<string[]>;
 }
 
-export type EncryptionConfig =
-	| { mode: "required"; key: Buffer }
-	| { mode: "allow-plaintext" };
+export type EncryptionConfig = { mode: "required"; key: Buffer } | { mode: "allow-plaintext" };
 
 export interface RedisFederationTokenStoreOptions {
 	client: RedisLikeClient;
@@ -78,7 +76,11 @@ export function createRedisFederationTokenStore(
 	const writeEnv = async (sid: string, name: string, env: Envelope) => {
 		const remaining = env.expiresAtMs - Date.now();
 		const px = remaining > 0 ? remaining : undefined;
-		await opts.client.set(k(sid, name), JSON.stringify(env), px !== undefined ? { PX: px } : undefined);
+		await opts.client.set(
+			k(sid, name),
+			JSON.stringify(env),
+			px !== undefined ? { PX: px } : undefined,
+		);
 	};
 
 	return {

--- a/packages/core/src/federation-tokens/adapters/redis.mts
+++ b/packages/core/src/federation-tokens/adapters/redis.mts
@@ -113,11 +113,18 @@ export function createRedisFederationTokenStore(
 			await writeEnv(sid, name, toEnvelope(tokens));
 		},
 		async get(sid, name) {
-			const v = await opts.client.get(k(sid, name));
+			const key = k(sid, name);
+			const v = await opts.client.get(key);
 			if (!v) return null;
 			try {
 				return fromEnvelope(JSON.parse(v) as Envelope);
 			} catch {
+				// Corrupt JSON or decrypt failure (e.g. rotated encryption key):
+				// self-heal by deleting the key, mirroring UserSessionStore redis
+				// adapter. Otherwise operators see repeated silent failures and
+				// key/crypto mismatches surface as "missing tokens" — hard to
+				// debug. Returning null after delete signals re_authentication.
+				await opts.client.del(key);
 				return null;
 			}
 		},

--- a/packages/core/src/federation-tokens/adapters/redis.mts
+++ b/packages/core/src/federation-tokens/adapters/redis.mts
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { decryptTokenField, encryptTokenField } from "../crypto.mjs";
+import type { FederationTokenStoreBase, FederationTokens } from "../types.mjs";
+
+export interface RedisLikeClient {
+	get(key: string): Promise<string | null>;
+	set(key: string, value: string, opts?: { PX?: number }): Promise<string | null>;
+	del(...keys: string[]): Promise<number>;
+	keys(pattern: string): Promise<string[]>;
+}
+
+export type EncryptionConfig =
+	| { mode: "required"; key: Buffer }
+	| { mode: "allow-plaintext" };
+
+export interface RedisFederationTokenStoreOptions {
+	client: RedisLikeClient;
+	encryption: EncryptionConfig;
+	keyPrefix?: string;
+}
+
+interface Envelope {
+	accessToken: string;
+	refreshToken?: string;
+	idToken?: string;
+	expiresAtMs: number;
+	tokenType?: string;
+	scope?: string;
+	rawParams?: Record<string, unknown>;
+}
+
+export function createRedisFederationTokenStore(
+	opts: RedisFederationTokenStoreOptions,
+): FederationTokenStoreBase {
+	if (opts.encryption.mode === "required" && opts.encryption.key.length !== 32) {
+		throw new Error("FederationTokenStore redis: encryption key must be 32 bytes");
+	}
+	const prefix = opts.keyPrefix ?? "ft:";
+	const k = (sid: string, name: string) => `${prefix}${sid}:${name}`;
+	const sidPattern = (sid: string) => `${prefix}${sid}:*`;
+
+	const encryptRequired = (v: string): string =>
+		opts.encryption.mode === "allow-plaintext" ? v : encryptTokenField(v, opts.encryption.key);
+
+	const encryptOptional = (v: string | undefined): string | undefined =>
+		v === undefined ? undefined : encryptRequired(v);
+
+	const decryptRequired = (v: string): string =>
+		opts.encryption.mode === "allow-plaintext" ? v : decryptTokenField(v, opts.encryption.key);
+
+	const decryptOptional = (v: string | undefined): string | undefined =>
+		v === undefined ? undefined : decryptRequired(v);
+
+	const toEnvelope = (t: FederationTokens): Envelope => ({
+		accessToken: encryptRequired(t.accessToken),
+		refreshToken: encryptOptional(t.refreshToken),
+		idToken: encryptOptional(t.idToken),
+		expiresAtMs: t.expiresAt.getTime(),
+		tokenType: t.tokenType,
+		scope: t.scope,
+		rawParams: t.rawParams as Record<string, unknown> | undefined,
+	});
+
+	const fromEnvelope = (e: Envelope): FederationTokens => ({
+		accessToken: decryptRequired(e.accessToken),
+		refreshToken: decryptOptional(e.refreshToken),
+		idToken: decryptOptional(e.idToken),
+		expiresAt: new Date(e.expiresAtMs),
+		tokenType: e.tokenType,
+		scope: e.scope,
+		rawParams: e.rawParams,
+	});
+
+	const writeEnv = async (sid: string, name: string, env: Envelope) => {
+		const remaining = env.expiresAtMs - Date.now();
+		const px = remaining > 0 ? remaining : undefined;
+		await opts.client.set(k(sid, name), JSON.stringify(env), px !== undefined ? { PX: px } : undefined);
+	};
+
+	return {
+		kind: "redis",
+		async attach(sid, name, tokens) {
+			await writeEnv(sid, name, toEnvelope(tokens));
+		},
+		async get(sid, name) {
+			const v = await opts.client.get(k(sid, name));
+			if (!v) return null;
+			try {
+				return fromEnvelope(JSON.parse(v) as Envelope);
+			} catch {
+				return null;
+			}
+		},
+		async update(sid, name, tokens) {
+			await writeEnv(sid, name, toEnvelope(tokens));
+		},
+		async deleteBySession(sid) {
+			const keys = await opts.client.keys(sidPattern(sid));
+			if (keys.length > 0) await opts.client.del(...keys);
+		},
+		async delete(sid, name) {
+			await opts.client.del(k(sid, name));
+		},
+	};
+}

--- a/packages/core/src/federation-tokens/adapters/redis.mts
+++ b/packages/core/src/federation-tokens/adapters/redis.mts
@@ -10,7 +10,13 @@ export interface RedisLikeClient {
 	get(key: string): Promise<string | null>;
 	set(key: string, value: string, opts?: { PX?: number }): Promise<string | null>;
 	del(...keys: string[]): Promise<number>;
-	keys(pattern: string): Promise<string[]>;
+	/**
+	 * Non-blocking alternative to Redis KEYS — matches redis v5 client's
+	 * `scanIterator({ MATCH, COUNT })`. Cursor-based, yields matching keys in
+	 * batches without blocking the server. Required for `deleteBySession` to
+	 * be safe in production.
+	 */
+	scanIterator(opts: { MATCH: string; COUNT?: number }): AsyncIterable<string>;
 }
 
 export type EncryptionConfig = { mode: "required"; key: Buffer } | { mode: "allow-plaintext" };
@@ -115,8 +121,17 @@ export function createRedisFederationTokenStore(
 			await writeEnv(sid, name, toEnvelope(tokens));
 		},
 		async deleteBySession(sid) {
-			const keys = await opts.client.keys(sidPattern(sid));
-			if (keys.length > 0) await opts.client.del(...keys);
+			// Use SCAN (non-blocking) instead of KEYS (O(N), blocking). Each
+			// batch of scanned keys is deleted before we await the next batch.
+			const keysBatch: string[] = [];
+			for await (const key of opts.client.scanIterator({ MATCH: sidPattern(sid), COUNT: 100 })) {
+				keysBatch.push(key);
+				if (keysBatch.length >= 100) {
+					await opts.client.del(...keysBatch);
+					keysBatch.length = 0;
+				}
+			}
+			if (keysBatch.length > 0) await opts.client.del(...keysBatch);
 		},
 		async delete(sid, name) {
 			await opts.client.del(k(sid, name));

--- a/packages/core/src/federation-tokens/adapters/redis.mts
+++ b/packages/core/src/federation-tokens/adapters/redis.mts
@@ -59,7 +59,11 @@ export function createRedisFederationTokenStore(
 		throw new Error("FederationTokenStore redis: encryption key must be 32 bytes");
 	}
 	const prefix = opts.keyPrefix ?? "ft:";
-	const storeTtlMs = (opts.ttl ?? DEFAULT_TTL_SECONDS) * 1000;
+	const ttlSeconds = opts.ttl ?? DEFAULT_TTL_SECONDS;
+	if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
+		throw new Error("FederationTokenStore redis: ttl must be a positive finite number of seconds");
+	}
+	const storeTtlMs = ttlSeconds * 1000;
 	const k = (sid: string, name: string) => `${prefix}${sid}:${name}`;
 	const sidPattern = (sid: string) => `${prefix}${sid}:*`;
 

--- a/packages/core/src/federation-tokens/crypto.mts
+++ b/packages/core/src/federation-tokens/crypto.mts
@@ -28,11 +28,17 @@ export function decryptTokenField(envelope: string, key: Buffer): string {
 	if (key.length !== KEY_LEN) throw new Error(`encryption key must be ${KEY_LEN} bytes`);
 	const parts = envelope.split(".");
 	if (parts.length !== 4) throw new Error("invalid envelope format");
-	const [ver, ivB64, ctB64, tagB64] = parts;
+	const ver = parts[0];
+	const ivB64 = parts[1];
+	const ctB64 = parts[2];
+	const tagB64 = parts[3];
+	if (ver === undefined || ivB64 === undefined || ctB64 === undefined || tagB64 === undefined) {
+		throw new Error("invalid envelope format");
+	}
 	if (ver !== VERSION) throw new Error(`unsupported envelope version: ${ver}`);
-	const iv = Buffer.from(ivB64!, "base64url");
-	const ct = Buffer.from(ctB64!, "base64url");
-	const tag = Buffer.from(tagB64!, "base64url");
+	const iv = Buffer.from(ivB64, "base64url");
+	const ct = Buffer.from(ctB64, "base64url");
+	const tag = Buffer.from(tagB64, "base64url");
 	const decipher = createDecipheriv(ALGO, key, iv);
 	decipher.setAuthTag(tag);
 	const pt = Buffer.concat([decipher.update(ct), decipher.final()]);

--- a/packages/core/src/federation-tokens/crypto.mts
+++ b/packages/core/src/federation-tokens/crypto.mts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGO = "aes-256-gcm";
+const IV_LEN = 12;
+const KEY_LEN = 32;
+const VERSION = "v1";
+
+/**
+ * Encrypts a string and returns `${version}.${iv}.${ct}.${tag}` where each
+ * component is base64url-encoded. Version is included so that future algorithm
+ * migrations can be detected on decrypt.
+ */
+export function encryptTokenField(plaintext: string, key: Buffer): string {
+	if (key.length !== KEY_LEN) throw new Error(`encryption key must be ${KEY_LEN} bytes`);
+	const iv = randomBytes(IV_LEN);
+	const cipher = createCipheriv(ALGO, key, iv);
+	const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+	const tag = cipher.getAuthTag();
+	return [VERSION, iv.toString("base64url"), ct.toString("base64url"), tag.toString("base64url")].join(".");
+}
+
+export function decryptTokenField(envelope: string, key: Buffer): string {
+	if (key.length !== KEY_LEN) throw new Error(`encryption key must be ${KEY_LEN} bytes`);
+	const parts = envelope.split(".");
+	if (parts.length !== 4) throw new Error("invalid envelope format");
+	const [ver, ivB64, ctB64, tagB64] = parts;
+	if (ver !== VERSION) throw new Error(`unsupported envelope version: ${ver}`);
+	const iv = Buffer.from(ivB64!, "base64url");
+	const ct = Buffer.from(ctB64!, "base64url");
+	const tag = Buffer.from(tagB64!, "base64url");
+	const decipher = createDecipheriv(ALGO, key, iv);
+	decipher.setAuthTag(tag);
+	const pt = Buffer.concat([decipher.update(ct), decipher.final()]);
+	return pt.toString("utf8");
+}

--- a/packages/core/src/federation-tokens/crypto.mts
+++ b/packages/core/src/federation-tokens/crypto.mts
@@ -21,7 +21,12 @@ export function encryptTokenField(plaintext: string, key: Buffer): string {
 	const cipher = createCipheriv(ALGO, key, iv);
 	const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
 	const tag = cipher.getAuthTag();
-	return [VERSION, iv.toString("base64url"), ct.toString("base64url"), tag.toString("base64url")].join(".");
+	return [
+		VERSION,
+		iv.toString("base64url"),
+		ct.toString("base64url"),
+		tag.toString("base64url"),
+	].join(".");
 }
 
 export function decryptTokenField(envelope: string, key: Buffer): string {

--- a/packages/core/src/federation-tokens/factory.mts
+++ b/packages/core/src/federation-tokens/factory.mts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { createAdapterFactory } from "../adapters/AdapterFactory.mjs";
+import { createInMemoryFederationTokenStore } from "./adapters/memory.mjs";
+import type { FederationTokenStoreBase, FederationTokenStoreFactory } from "./types.mjs";
+
+export function createFederationTokenStoreFactory(): FederationTokenStoreFactory {
+	return createAdapterFactory<FederationTokenStoreBase>("federationTokenStore");
+}
+
+export function registerBuiltinFederationTokenStores(factory: FederationTokenStoreFactory): void {
+	factory.register("memory", () => {
+		// eslint-disable-next-line no-console
+		console.warn(
+			"federationTokenStore: in-memory adapter is for dev/test only — do not use in production (tokens are lost on restart, no cross-instance replication).",
+		);
+		return createInMemoryFederationTokenStore();
+	});
+	factory.register("redis", async (config) => {
+		const cfg = config as {
+			client?: unknown;
+			encryption?: { mode?: "required" | "allow-plaintext"; key?: Buffer | string };
+			keyPrefix?: string;
+		};
+		if (!cfg.client) {
+			throw new Error("federationTokenStore.redis: 'client' option is required");
+		}
+		if (!cfg.encryption || !cfg.encryption.mode) {
+			throw new Error(
+				"federationTokenStore.redis: 'encryption.mode' is required ('required' or 'allow-plaintext')",
+			);
+		}
+		let encryption: import("./adapters/redis.mjs").EncryptionConfig;
+		if (cfg.encryption.mode === "required") {
+			const rawKey = cfg.encryption.key;
+			const keyBuf =
+				typeof rawKey === "string" ? Buffer.from(rawKey, "base64") : rawKey instanceof Buffer ? rawKey : Buffer.alloc(0);
+			if (keyBuf.length !== 32) {
+				throw new Error(
+					"federationTokenStore.redis: encryption.key must decode to 32 bytes (AES-256)",
+				);
+			}
+			encryption = { mode: "required", key: keyBuf };
+		} else {
+			// eslint-disable-next-line no-console
+			console.warn(
+				"federationTokenStore.redis: running with encryption.mode = allow-plaintext. Do not use in production.",
+			);
+			encryption = { mode: "allow-plaintext" };
+		}
+		const { createRedisFederationTokenStore } = await import("./adapters/redis.mjs");
+		return createRedisFederationTokenStore({
+			client: cfg.client as Parameters<typeof createRedisFederationTokenStore>[0]["client"],
+			encryption,
+			keyPrefix: cfg.keyPrefix,
+		});
+	});
+}
+
+export type { FederationTokenStoreFactory };

--- a/packages/core/src/federation-tokens/factory.mts
+++ b/packages/core/src/federation-tokens/factory.mts
@@ -28,7 +28,7 @@ export function registerBuiltinFederationTokenStores(factory: FederationTokenSto
 		if (!cfg.client) {
 			throw new Error("federationTokenStore.redis: 'client' option is required");
 		}
-		if (!cfg.encryption || !cfg.encryption.mode) {
+		if (!cfg.encryption?.mode) {
 			throw new Error(
 				"federationTokenStore.redis: 'encryption.mode' is required ('required' or 'allow-plaintext')",
 			);
@@ -37,7 +37,11 @@ export function registerBuiltinFederationTokenStores(factory: FederationTokenSto
 		if (cfg.encryption.mode === "required") {
 			const rawKey = cfg.encryption.key;
 			const keyBuf =
-				typeof rawKey === "string" ? Buffer.from(rawKey, "base64") : rawKey instanceof Buffer ? rawKey : Buffer.alloc(0);
+				typeof rawKey === "string"
+					? Buffer.from(rawKey, "base64")
+					: rawKey instanceof Buffer
+						? rawKey
+						: Buffer.alloc(0);
 			if (keyBuf.length !== 32) {
 				throw new Error(
 					"federationTokenStore.redis: encryption.key must decode to 32 bytes (AES-256)",

--- a/packages/core/src/federation-tokens/factory.mts
+++ b/packages/core/src/federation-tokens/factory.mts
@@ -24,6 +24,7 @@ export function registerBuiltinFederationTokenStores(factory: FederationTokenSto
 			client?: unknown;
 			encryption?: { mode?: "required" | "allow-plaintext"; key?: Buffer | string };
 			keyPrefix?: string;
+			ttl?: number;
 		};
 		if (!cfg.client) {
 			throw new Error("federationTokenStore.redis: 'client' option is required");
@@ -60,6 +61,7 @@ export function registerBuiltinFederationTokenStores(factory: FederationTokenSto
 			client: cfg.client as Parameters<typeof createRedisFederationTokenStore>[0]["client"],
 			encryption,
 			keyPrefix: cfg.keyPrefix,
+			ttl: cfg.ttl,
 		});
 	});
 }

--- a/packages/core/src/federation-tokens/factory.mts
+++ b/packages/core/src/federation-tokens/factory.mts
@@ -29,14 +29,27 @@ export function registerBuiltinFederationTokenStores(factory: FederationTokenSto
 		if (!cfg.client) {
 			throw new Error("federationTokenStore.redis: 'client' option is required");
 		}
-		if (!cfg.encryption?.mode) {
+		// Validate the client shape up-front so misconfiguration fails fast with
+		// a clear error, not later at deleteBySession runtime. The adapter uses
+		// get / set / del / scanIterator.
+		const clientObj = cfg.client as Record<string, unknown>;
+		const requiredMethods = ["get", "set", "del", "scanIterator"] as const;
+		const missing = requiredMethods.filter((m) => typeof clientObj[m] !== "function");
+		if (missing.length > 0) {
 			throw new Error(
-				"federationTokenStore.redis: 'encryption.mode' is required ('required' or 'allow-plaintext')",
+				`federationTokenStore.redis: client is missing required method(s): ${missing.join(", ")}. ` +
+					`Pass a 'redis' v5 client (or a mock that implements get/set/del/scanIterator).`,
 			);
 		}
+		// Default encryption.mode to "required" — the secure default, matching
+		// spec Section 5 (production MUST encrypt). Operators who want the
+		// plaintext dev mode must pass `encryption: { mode: "allow-plaintext" }`
+		// explicitly; implicit omission no longer means "reject config", it
+		// means "use the safe default".
+		const mode = cfg.encryption?.mode ?? "required";
 		let encryption: import("./adapters/redis.mjs").EncryptionConfig;
-		if (cfg.encryption.mode === "required") {
-			const rawKey = cfg.encryption.key;
+		if (mode === "required") {
+			const rawKey = cfg.encryption?.key;
 			const keyBuf =
 				typeof rawKey === "string"
 					? Buffer.from(rawKey, "base64")
@@ -45,7 +58,7 @@ export function registerBuiltinFederationTokenStores(factory: FederationTokenSto
 						: Buffer.alloc(0);
 			if (keyBuf.length !== 32) {
 				throw new Error(
-					"federationTokenStore.redis: encryption.key must decode to 32 bytes (AES-256)",
+					"federationTokenStore.redis: encryption.key must decode to 32 bytes (AES-256) when encryption.mode is 'required' (the default)",
 				);
 			}
 			encryption = { mode: "required", key: keyBuf };

--- a/packages/core/src/federation-tokens/factory.mts
+++ b/packages/core/src/federation-tokens/factory.mts
@@ -8,7 +8,7 @@ import { createInMemoryFederationTokenStore } from "./adapters/memory.mjs";
 import type { FederationTokenStoreBase, FederationTokenStoreFactory } from "./types.mjs";
 
 export function createFederationTokenStoreFactory(): FederationTokenStoreFactory {
-	return createAdapterFactory<FederationTokenStoreBase>("federationTokenStore");
+	return createAdapterFactory<FederationTokenStoreBase>("FederationTokenStore");
 }
 
 export function registerBuiltinFederationTokenStores(factory: FederationTokenStoreFactory): void {

--- a/packages/core/src/federation-tokens/types.mts
+++ b/packages/core/src/federation-tokens/types.mts
@@ -24,9 +24,13 @@ export interface FederationTokenStoreBase {
 	readonly kind: string;
 
 	/**
-	 * Persist tokens for a session + federation. Implementations MUST encrypt
-	 * refreshToken at rest. Plaintext persistence of refresh_token is a
-	 * REJECTED implementation. See spec Section 5.
+	 * Persist tokens for a session + federation. Production implementations
+	 * MUST encrypt refreshToken at rest. Plaintext persistence is supported
+	 * only as an explicit opt-in — the built-in redis adapter exposes this via
+	 * `encryption.mode = "allow-plaintext"` (with a startup warning), and the
+	 * built-in in-memory adapter is plaintext by design because the process
+	 * boundary already contains it. Both opt-outs are intended for
+	 * development / testing use only. See spec Section 5.
 	 */
 	attach(sid: string, federationName: string, tokens: FederationTokens): Promise<void>;
 

--- a/packages/core/src/federation-tokens/types.mts
+++ b/packages/core/src/federation-tokens/types.mts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import type { AdapterFactory } from "../adapters/AdapterFactory.mjs";
+
+export interface FederationTokens {
+	readonly accessToken: string;
+	readonly refreshToken?: string;
+	readonly idToken?: string;
+	readonly expiresAt: Date;
+	readonly tokenType?: string;
+	readonly scope?: string;
+	readonly rawParams?: Readonly<Record<string, unknown>>;
+}
+
+export interface FederationTokenStoreBase {
+	readonly kind: string;
+
+	/**
+	 * Persist tokens for a session + federation. Implementations MUST encrypt
+	 * refreshToken at rest. Plaintext persistence of refresh_token is a
+	 * REJECTED implementation. See spec Section 5.
+	 */
+	attach(sid: string, federationName: string, tokens: FederationTokens): Promise<void>;
+
+	get(sid: string, federationName: string): Promise<FederationTokens | null>;
+
+	/** Atomic replace. Called after a successful federation refresh. */
+	update(sid: string, federationName: string, tokens: FederationTokens): Promise<void>;
+
+	/** Delete all federation entries for a session. Idempotent. */
+	deleteBySession(sid: string): Promise<void>;
+
+	/** Delete a specific (sid, federationName) entry. Idempotent. */
+	delete(sid: string, federationName: string): Promise<void>;
+}
+
+export type FederationTokenStoreFactory = AdapterFactory<FederationTokenStoreBase>;

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -40,6 +40,16 @@ export {
 	composeConfigSchema,
 	fullSectionsSchema,
 } from "./config/application.schema.mjs";
+export {
+	createFederationTokenStoreFactory,
+	registerBuiltinFederationTokenStores,
+} from "./federation-tokens/factory.mjs";
+// FederationTokenStore — TODO-F-1
+export type {
+	FederationTokenStoreBase,
+	FederationTokenStoreFactory,
+	FederationTokens,
+} from "./federation-tokens/types.mjs";
 // Grant types and interfaces
 export { GrantRegistry } from "./grants/registry.mjs";
 // Token formatting utility (used by oauth package)
@@ -150,3 +160,17 @@ export { loadYamlMap } from "./repositories/loadYamlMap.mjs";
 export { createDefaultFactories } from "./repositories/RepositoryFactory.mjs";
 export type { Client, Code, CodeData, User } from "./repositories/types.mjs";
 export type { UserRepository } from "./repositories/UserRepository.mjs";
+export { extractUserClaims } from "./user-sessions/claims.mjs";
+export {
+	createUserSessionStoreFactory,
+	registerBuiltinUserSessionStores,
+} from "./user-sessions/factory.mjs";
+// UserSessionStore — TODO-F-1
+export type {
+	CreateUserSessionInput,
+	RegisteredRP,
+	UserSession,
+	UserSessionClaims,
+	UserSessionStoreBase,
+	UserSessionStoreFactory,
+} from "./user-sessions/types.mjs";

--- a/packages/core/src/modules/types.mts
+++ b/packages/core/src/modules/types.mts
@@ -18,12 +18,14 @@ import type { z } from "zod";
 
 import type { AuditSinkBase } from "../audit/types.mjs";
 import type { CoreConfig } from "../config/application.schema.mjs";
+import type { FederationTokenStoreBase } from "../federation-tokens/types.mjs";
 import type { GrantRegistry } from "../grants/registry.mjs";
 import type { KeyStore } from "../keys/KeyStore.mjs";
 import type { MfaCoordinator, MfaProviderFactory, MfaTransactionStore } from "../mfa/types.mjs";
 import type { GrantPolicyHookBase } from "../policy/types.mjs";
 import type { RateLimiterBase } from "../ratelimit/types.mjs";
 import type { RefreshTokenStoreBase } from "../refresh/types.mjs";
+import type { UserSessionStoreBase } from "../user-sessions/types.mjs";
 
 /**
  * Resolves a module specifier to a URL/path that can be passed to dynamic import().
@@ -50,6 +52,8 @@ export interface ModuleContext {
 	rateLimiter?: RateLimiterBase;
 	refreshTokenStore?: RefreshTokenStoreBase;
 	grantPolicy?: GrantPolicyHookBase;
+	userSessionStore?: UserSessionStoreBase;
+	federationTokenStore?: FederationTokenStoreBase;
 }
 
 /**

--- a/packages/core/src/user-sessions/__tests__/claims.test.mts
+++ b/packages/core/src/user-sessions/__tests__/claims.test.mts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { extractUserClaims } from "../claims.mjs";
+
+describe("extractUserClaims", () => {
+	it("maps standard OIDC fields when present", () => {
+		const user = {
+			id: "user-1",
+			username: "alice",
+			email: "alice@example.com",
+			emailVerified: true,
+			name: "Alice",
+			picture: "https://example.com/alice.png",
+			groups: ["admins"],
+		};
+		expect(extractUserClaims(user)).toEqual({
+			email: "alice@example.com",
+			emailVerified: true,
+			name: "Alice",
+			picture: "https://example.com/alice.png",
+			groups: ["admins"],
+		});
+	});
+
+	it("omits absent fields", () => {
+		const user = { id: "u", username: "u" };
+		expect(extractUserClaims(user)).toEqual({});
+	});
+
+	it("ignores fields of wrong type", () => {
+		const user = {
+			id: "u",
+			username: "u",
+			email: 42 as unknown as string,
+			groups: "admins" as unknown as string[],
+		};
+		expect(extractUserClaims(user)).toEqual({});
+	});
+});

--- a/packages/core/src/user-sessions/__tests__/factory.test.mts
+++ b/packages/core/src/user-sessions/__tests__/factory.test.mts
@@ -15,9 +15,10 @@ import {
 } from "../factory.mjs";
 
 describe("UserSessionStoreFactory", () => {
-	it("kind of the factory is 'userSessionStore'", () => {
+	it("registerBuiltinUserSessionStores registers the 'memory' type", () => {
 		const f = createUserSessionStoreFactory();
-		expect(f.kind).toBe("userSessionStore");
+		registerBuiltinUserSessionStores(f);
+		expect(f.registeredTypes()).toContain("memory");
 	});
 
 	it("built-in memory adapter is creatable", async () => {
@@ -27,9 +28,9 @@ describe("UserSessionStoreFactory", () => {
 		expect(store.kind).toBe("memory");
 	});
 
-	it("unknown type throws AdapterFactoryError", async () => {
+	it("unknown type throws AdapterFactoryError with UserSessionStore context", async () => {
 		const f = createUserSessionStoreFactory();
 		registerBuiltinUserSessionStores(f);
-		await expect(f.create({ type: "unknown" })).rejects.toThrow(/unknown/);
+		await expect(f.create({ type: "unknown" })).rejects.toThrow(/userSessionStore/);
 	});
 });

--- a/packages/core/src/user-sessions/__tests__/factory.test.mts
+++ b/packages/core/src/user-sessions/__tests__/factory.test.mts
@@ -28,7 +28,7 @@ describe("UserSessionStoreFactory", () => {
 	it("unknown type throws AdapterFactoryError with UserSessionStore context", async () => {
 		const f = createUserSessionStoreFactory();
 		registerBuiltinUserSessionStores(f);
-		await expect(f.create({ type: "unknown" })).rejects.toThrow(/userSessionStore/);
+		await expect(f.create({ type: "unknown" })).rejects.toThrow(/UserSessionStore/);
 	});
 
 	it("built-in redis adapter is registered and creates instance", async () => {

--- a/packages/core/src/user-sessions/__tests__/factory.test.mts
+++ b/packages/core/src/user-sessions/__tests__/factory.test.mts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	createUserSessionStoreFactory,
+	registerBuiltinUserSessionStores,
+} from "../factory.mjs";
+
+describe("UserSessionStoreFactory", () => {
+	it("kind of the factory is 'userSessionStore'", () => {
+		const f = createUserSessionStoreFactory();
+		expect(f.kind).toBe("userSessionStore");
+	});
+
+	it("built-in memory adapter is creatable", async () => {
+		const f = createUserSessionStoreFactory();
+		registerBuiltinUserSessionStores(f);
+		const store = await f.create({ type: "memory" });
+		expect(store.kind).toBe("memory");
+	});
+
+	it("unknown type throws AdapterFactoryError", async () => {
+		const f = createUserSessionStoreFactory();
+		registerBuiltinUserSessionStores(f);
+		await expect(f.create({ type: "unknown" })).rejects.toThrow(/unknown/);
+	});
+});

--- a/packages/core/src/user-sessions/__tests__/factory.test.mts
+++ b/packages/core/src/user-sessions/__tests__/factory.test.mts
@@ -9,10 +9,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import {
-	createUserSessionStoreFactory,
-	registerBuiltinUserSessionStores,
-} from "../factory.mjs";
+import { createUserSessionStoreFactory, registerBuiltinUserSessionStores } from "../factory.mjs";
 
 describe("UserSessionStoreFactory", () => {
 	it("registerBuiltinUserSessionStores registers the 'memory' type", () => {

--- a/packages/core/src/user-sessions/__tests__/factory.test.mts
+++ b/packages/core/src/user-sessions/__tests__/factory.test.mts
@@ -33,4 +33,21 @@ describe("UserSessionStoreFactory", () => {
 		registerBuiltinUserSessionStores(f);
 		await expect(f.create({ type: "unknown" })).rejects.toThrow(/userSessionStore/);
 	});
+
+	it("built-in redis adapter is registered and creates instance", async () => {
+		const f = createUserSessionStoreFactory();
+		registerBuiltinUserSessionStores(f);
+		// Provide an already-connected client to avoid dynamic import in tests.
+		const fakeClient = {
+			get: async () => null,
+			set: async () => "OK",
+			del: async () => 0,
+		};
+		const store = await f.create({
+			type: "redis",
+			client: fakeClient,
+			keyPrefix: "x:",
+		});
+		expect(store.kind).toBe("redis");
+	});
 });

--- a/packages/core/src/user-sessions/__tests__/memory.test.mts
+++ b/packages/core/src/user-sessions/__tests__/memory.test.mts
@@ -122,4 +122,30 @@ describe("in-memory UserSessionStore", () => {
 		// And the fresh record's expiresAt is in the future (not the stale past one).
 		expect(s?.expiresAt.getTime()).toBeGreaterThan(Date.now());
 	});
+
+	it("create clones claims.groups so caller cannot mutate stored state (Copilot round 3 #1)", async () => {
+		const groups = ["admins", "engineers"];
+		await store.create({ ...baseInput, claims: { email: "a@b.com", groups } });
+		groups.push("hijacked"); // mutate the array held by the caller
+		const s = await store.get("sid-1");
+		expect(s?.claims.groups).toEqual(["admins", "engineers"]);
+	});
+
+	it("get returns a cloned claims.groups that does not leak to the store (Copilot round 3 #2)", async () => {
+		await store.create({ ...baseInput, claims: { groups: ["admins"] } });
+		const first = await store.get("sid-1");
+		expect(first?.claims.groups).toEqual(["admins"]);
+		(first?.claims.groups as string[])?.push("hijacked"); // mutate the returned array
+		const second = await store.get("sid-1");
+		expect(second?.claims.groups).toEqual(["admins"]);
+	});
+
+	it("updateClaims clones incoming groups patch (defense-in-depth)", async () => {
+		await store.create(baseInput);
+		const incoming = ["a", "b"];
+		await store.updateClaims("sid-1", { groups: incoming });
+		incoming.push("hijacked");
+		const s = await store.get("sid-1");
+		expect(s?.claims.groups).toEqual(["a", "b"]);
+	});
 });

--- a/packages/core/src/user-sessions/__tests__/memory.test.mts
+++ b/packages/core/src/user-sessions/__tests__/memory.test.mts
@@ -109,13 +109,17 @@ describe("in-memory UserSessionStore", () => {
 	it("create succeeds when an expired entry exists for the same sid (GC before duplicate check)", async () => {
 		// Put an expired entry in the map first.
 		await store.create({ ...baseInput, expiresAt: new Date(Date.now() - 1000) });
-		// get() returns null (GC on read).
-		expect(await store.get("sid-1")).toBeNull();
-		// create() should ALSO see the entry as gone and succeed.
+		// DO NOT call store.get() here — it would GC the expired entry via
+		// readLive() and then the duplicate-check inside create() would trivially
+		// pass under any implementation (including the old `sessions.has()` check).
+		// We want the regression guarantee to rest on create() itself invoking
+		// readLive() before deciding whether a duplicate exists.
 		await expect(
 			store.create({ ...baseInput, expiresAt: new Date(Date.now() + 3600_000) }),
 		).resolves.toBeUndefined();
 		const s = await store.get("sid-1");
 		expect(s).not.toBeNull();
+		// And the fresh record's expiresAt is in the future (not the stale past one).
+		expect(s?.expiresAt.getTime()).toBeGreaterThan(Date.now());
 	});
 });

--- a/packages/core/src/user-sessions/__tests__/memory.test.mts
+++ b/packages/core/src/user-sessions/__tests__/memory.test.mts
@@ -105,4 +105,17 @@ describe("in-memory UserSessionStore", () => {
 		await store.create(baseInput);
 		await expect(store.create(baseInput)).rejects.toThrow(/already exists/);
 	});
+
+	it("create succeeds when an expired entry exists for the same sid (GC before duplicate check)", async () => {
+		// Put an expired entry in the map first.
+		await store.create({ ...baseInput, expiresAt: new Date(Date.now() - 1000) });
+		// get() returns null (GC on read).
+		expect(await store.get("sid-1")).toBeNull();
+		// create() should ALSO see the entry as gone and succeed.
+		await expect(
+			store.create({ ...baseInput, expiresAt: new Date(Date.now() + 3600_000) }),
+		).resolves.toBeUndefined();
+		const s = await store.get("sid-1");
+		expect(s).not.toBeNull();
+	});
 });

--- a/packages/core/src/user-sessions/__tests__/memory.test.mts
+++ b/packages/core/src/user-sessions/__tests__/memory.test.mts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  */
 
-import { describe, expect, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { createInMemoryUserSessionStore } from "../adapters/memory.mjs";
 import type { UserSessionStoreBase } from "../types.mjs";
 
@@ -92,7 +92,9 @@ describe("in-memory UserSessionStore", () => {
 	});
 
 	it("operations on missing sid are no-ops for idempotent ones", async () => {
-		await expect(store.registerRP("missing", { clientId: "rp", registeredAt: new Date() })).resolves.toBeUndefined();
+		await expect(
+			store.registerRP("missing", { clientId: "rp", registeredAt: new Date() }),
+		).resolves.toBeUndefined();
 		await expect(store.linkFamily("missing", "fam")).resolves.toBeUndefined();
 		await expect(store.updateClaims("missing", { email: "x" })).resolves.toBeUndefined();
 		await expect(store.removeFederation("missing", "google")).resolves.toBeUndefined();

--- a/packages/core/src/user-sessions/__tests__/memory.test.mts
+++ b/packages/core/src/user-sessions/__tests__/memory.test.mts
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { describe, expect, it, beforeEach } from "vitest";
+import { createInMemoryUserSessionStore } from "../adapters/memory.mjs";
+import type { UserSessionStoreBase } from "../types.mjs";
+
+describe("in-memory UserSessionStore", () => {
+	let store: UserSessionStoreBase;
+	beforeEach(() => {
+		store = createInMemoryUserSessionStore();
+	});
+
+	const baseInput = {
+		sid: "sid-1",
+		sub: "user-1",
+		authTime: new Date("2026-04-21T00:00:00Z"),
+		expiresAt: new Date("2026-04-22T00:00:00Z"),
+		claims: { email: "a@b.com" },
+	};
+
+	it("kind is 'memory'", () => {
+		expect(store.kind).toBe("memory");
+	});
+
+	it("create + get returns the session with defaulted arrays", async () => {
+		await store.create(baseInput);
+		const s = await store.get("sid-1");
+		expect(s).toMatchObject({
+			sid: "sid-1",
+			sub: "user-1",
+			federations: [],
+			activeRPs: [],
+			familyIds: [],
+			claims: { email: "a@b.com" },
+		});
+		expect(s?.createdAt).toBeInstanceOf(Date);
+	});
+
+	it("get returns null for unknown sid", async () => {
+		expect(await store.get("missing")).toBeNull();
+	});
+
+	it("get returns null for expired session (GC on read)", async () => {
+		await store.create({ ...baseInput, expiresAt: new Date(Date.now() - 1000) });
+		expect(await store.get("sid-1")).toBeNull();
+	});
+
+	it("registerRP appends then replaces duplicates by clientId", async () => {
+		await store.create(baseInput);
+		await store.registerRP("sid-1", { clientId: "rp-1", registeredAt: new Date() });
+		await store.registerRP("sid-1", {
+			clientId: "rp-1",
+			backchannelLogoutUri: "https://rp/bc",
+			registeredAt: new Date(),
+		});
+		const s = await store.get("sid-1");
+		expect(s?.activeRPs).toHaveLength(1);
+		expect(s?.activeRPs[0]?.backchannelLogoutUri).toBe("https://rp/bc");
+	});
+
+	it("linkFamily appends without duplicates", async () => {
+		await store.create(baseInput);
+		await store.linkFamily("sid-1", "fam-1");
+		await store.linkFamily("sid-1", "fam-1");
+		await store.linkFamily("sid-1", "fam-2");
+		const s = await store.get("sid-1");
+		expect(s?.familyIds).toEqual(["fam-1", "fam-2"]);
+	});
+
+	it("updateClaims merges, overwriting existing keys", async () => {
+		await store.create(baseInput);
+		await store.updateClaims("sid-1", { email: "b@c.com", name: "Alice" });
+		const s = await store.get("sid-1");
+		expect(s?.claims).toEqual({ email: "b@c.com", name: "Alice" });
+	});
+
+	it("removeFederation is idempotent", async () => {
+		await store.create({ ...baseInput, federations: ["google", "github"] });
+		await store.removeFederation("sid-1", "google");
+		await store.removeFederation("sid-1", "google");
+		const s = await store.get("sid-1");
+		expect(s?.federations).toEqual(["github"]);
+	});
+
+	it("delete removes the record (does NOT cascade)", async () => {
+		await store.create(baseInput);
+		await store.delete("sid-1");
+		expect(await store.get("sid-1")).toBeNull();
+	});
+
+	it("operations on missing sid are no-ops for idempotent ones", async () => {
+		await expect(store.registerRP("missing", { clientId: "rp", registeredAt: new Date() })).resolves.toBeUndefined();
+		await expect(store.linkFamily("missing", "fam")).resolves.toBeUndefined();
+		await expect(store.updateClaims("missing", { email: "x" })).resolves.toBeUndefined();
+		await expect(store.removeFederation("missing", "google")).resolves.toBeUndefined();
+		await expect(store.delete("missing")).resolves.toBeUndefined();
+	});
+
+	it("create throws on duplicate sid (caller must avoid re-use)", async () => {
+		await store.create(baseInput);
+		await expect(store.create(baseInput)).rejects.toThrow(/already exists/);
+	});
+});

--- a/packages/core/src/user-sessions/__tests__/redis.test.mts
+++ b/packages/core/src/user-sessions/__tests__/redis.test.mts
@@ -116,4 +116,20 @@ describe("redis UserSessionStore", () => {
 		const s = await store.get("sid-1");
 		expect(s?.federations).toEqual([]);
 	});
+
+	it("get() self-heals corrupt (non-JSON) payload by deleting the key", async () => {
+		// Match the fakeRedis envelope shape ({ value, px, addedAt }).
+		redis.data.set("us:corrupt", { value: "{not-json", addedAt: Date.now() });
+		expect(await store.get("corrupt")).toBeNull();
+		expect(redis.del).toHaveBeenCalledWith("us:corrupt");
+		// Subsequent create with the same sid must succeed (previously NX would
+		// fail with a misleading "already exists" error).
+		await expect(store.create({ ...base, sid: "corrupt" })).resolves.toBeUndefined();
+	});
+
+	it("create rejects expiresAt in the past with a clear message (not 'already exists')", async () => {
+		await expect(store.create({ ...base, expiresAt: new Date(Date.now() - 1000) })).rejects.toThrow(
+			/expiresAt is in the past/,
+		);
+	});
 });

--- a/packages/core/src/user-sessions/__tests__/redis.test.mts
+++ b/packages/core/src/user-sessions/__tests__/redis.test.mts
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { createRedisUserSessionStore } from "../adapters/redis.mjs";
+import type { UserSessionStoreBase } from "../types.mjs";
+
+// Minimal Redis client mock — matches the subset of the real client the adapter uses.
+function createFakeRedis() {
+	const data = new Map<string, { value: string; px?: number; addedAt: number }>();
+	return {
+		data,
+		get: vi.fn(async (k: string) => {
+			const entry = data.get(k);
+			if (!entry) return null;
+			if (entry.px && Date.now() - entry.addedAt > entry.px) {
+				data.delete(k);
+				return null;
+			}
+			return entry.value;
+		}),
+		set: vi.fn(async (k: string, v: string, opts?: { PX?: number; NX?: boolean }) => {
+			if (opts?.NX && data.has(k)) return null;
+			data.set(k, { value: v, px: opts?.PX, addedAt: Date.now() });
+			return "OK";
+		}),
+		del: vi.fn(async (k: string) => {
+			return data.delete(k) ? 1 : 0;
+		}),
+	};
+}
+
+describe("redis UserSessionStore", () => {
+	let redis: ReturnType<typeof createFakeRedis>;
+	let store: UserSessionStoreBase;
+	const base = {
+		sid: "sid-1",
+		sub: "u",
+		authTime: new Date("2026-04-21"),
+		expiresAt: new Date(Date.now() + 3600_000),
+		claims: { email: "a@b.com" },
+	};
+
+	beforeEach(() => {
+		redis = createFakeRedis();
+		store = createRedisUserSessionStore({
+			client: redis as unknown as Parameters<typeof createRedisUserSessionStore>[0]["client"],
+			keyPrefix: "us:",
+		});
+	});
+
+	it("kind is 'redis'", () => {
+		expect(store.kind).toBe("redis");
+	});
+
+	it("create writes to Redis with PX = expiresAt - now (±1s)", async () => {
+		await store.create(base);
+		expect(redis.set).toHaveBeenCalledWith(
+			"us:sid-1",
+			expect.any(String),
+			expect.objectContaining({ PX: expect.any(Number), NX: true }),
+		);
+		const [, , opts] = redis.set.mock.calls[0]!;
+		const expected = base.expiresAt.getTime() - Date.now();
+		expect(opts?.PX).toBeGreaterThan(expected - 2000);
+		expect(opts?.PX).toBeLessThanOrEqual(expected + 100);
+	});
+
+	it("create throws on duplicate sid (NX failure)", async () => {
+		await store.create(base);
+		await expect(store.create(base)).rejects.toThrow(/already exists/);
+	});
+
+	it("get returns null for missing sid", async () => {
+		expect(await store.get("missing")).toBeNull();
+	});
+
+	it("get roundtrips dates", async () => {
+		await store.create(base);
+		const s = await store.get("sid-1");
+		expect(s?.authTime).toEqual(base.authTime);
+		expect(s?.expiresAt).toEqual(base.expiresAt);
+		expect(s?.createdAt).toBeInstanceOf(Date);
+	});
+
+	it("registerRP mutates and re-writes with remaining TTL", async () => {
+		await store.create(base);
+		const before = redis.set.mock.calls.length;
+		await store.registerRP("sid-1", { clientId: "rp-1", registeredAt: new Date() });
+		expect(redis.set.mock.calls.length).toBeGreaterThan(before);
+		const s = await store.get("sid-1");
+		expect(s?.activeRPs).toHaveLength(1);
+	});
+
+	it("delete removes the key", async () => {
+		await store.create(base);
+		await store.delete("sid-1");
+		expect(redis.del).toHaveBeenCalledWith("us:sid-1");
+		expect(await store.get("sid-1")).toBeNull();
+	});
+
+	it("updateClaims merges", async () => {
+		await store.create(base);
+		await store.updateClaims("sid-1", { name: "Alice" });
+		const s = await store.get("sid-1");
+		expect(s?.claims).toEqual({ email: "a@b.com", name: "Alice" });
+	});
+
+	it("removeFederation is idempotent", async () => {
+		await store.create({ ...base, federations: ["google"] });
+		await store.removeFederation("sid-1", "google");
+		await store.removeFederation("sid-1", "google");
+		const s = await store.get("sid-1");
+		expect(s?.federations).toEqual([]);
+	});
+});

--- a/packages/core/src/user-sessions/__tests__/redis.test.mts
+++ b/packages/core/src/user-sessions/__tests__/redis.test.mts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  */
 
-import { describe, expect, it, beforeEach, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createRedisUserSessionStore } from "../adapters/redis.mjs";
 import type { UserSessionStoreBase } from "../types.mjs";
 
@@ -62,7 +62,8 @@ describe("redis UserSessionStore", () => {
 			expect.any(String),
 			expect.objectContaining({ PX: expect.any(Number), NX: true }),
 		);
-		const [, , opts] = redis.set.mock.calls[0]!;
+		expect(redis.set.mock.calls).toHaveLength(1);
+		const [, , opts] = redis.set.mock.calls[0] ?? [];
 		const expected = base.expiresAt.getTime() - Date.now();
 		expect(opts?.PX).toBeGreaterThan(expected - 2000);
 		expect(opts?.PX).toBeLessThanOrEqual(expected + 100);

--- a/packages/core/src/user-sessions/adapters/memory.mts
+++ b/packages/core/src/user-sessions/adapters/memory.mts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import type {
+	CreateUserSessionInput,
+	RegisteredRP,
+	UserSession,
+	UserSessionClaims,
+	UserSessionStoreBase,
+} from "../types.mjs";
+
+type Stored = Omit<UserSession, "claims"> & { claims: Record<string, unknown> };
+
+export function createInMemoryUserSessionStore(): UserSessionStoreBase {
+	const sessions = new Map<string, Stored>();
+
+	const readLive = (sid: string): Stored | null => {
+		const s = sessions.get(sid);
+		if (!s) return null;
+		if (s.expiresAt.getTime() <= Date.now()) {
+			sessions.delete(sid);
+			return null;
+		}
+		return s;
+	};
+
+	return {
+		kind: "memory",
+		async create(input: CreateUserSessionInput) {
+			if (sessions.has(input.sid)) {
+				throw new Error(`UserSession ${input.sid} already exists`);
+			}
+			sessions.set(input.sid, {
+				sid: input.sid,
+				sub: input.sub,
+				authTime: input.authTime,
+				createdAt: new Date(),
+				expiresAt: input.expiresAt,
+				federations: input.federations ?? [],
+				activeRPs: [],
+				familyIds: [],
+				claims: { ...input.claims },
+			});
+		},
+		async get(sid: string): Promise<UserSession | null> {
+			const s = readLive(sid);
+			if (!s) return null;
+			return { ...s, claims: { ...s.claims } as UserSessionClaims };
+		},
+		async registerRP(sid: string, rp: RegisteredRP) {
+			const s = readLive(sid);
+			if (!s) return;
+			s.activeRPs = [...s.activeRPs.filter((r) => r.clientId !== rp.clientId), rp];
+		},
+		async linkFamily(sid: string, familyId: string) {
+			const s = readLive(sid);
+			if (!s) return;
+			if (!s.familyIds.includes(familyId)) {
+				s.familyIds = [...s.familyIds, familyId];
+			}
+		},
+		async updateClaims(sid: string, claims: Partial<UserSessionClaims>) {
+			const s = readLive(sid);
+			if (!s) return;
+			s.claims = { ...s.claims, ...claims };
+		},
+		async removeFederation(sid: string, federationName: string) {
+			const s = readLive(sid);
+			if (!s) return;
+			s.federations = s.federations.filter((f) => f !== federationName);
+		},
+		async delete(sid: string) {
+			sessions.delete(sid);
+		},
+	};
+}

--- a/packages/core/src/user-sessions/adapters/memory.mts
+++ b/packages/core/src/user-sessions/adapters/memory.mts
@@ -39,7 +39,10 @@ export function createInMemoryUserSessionStore(): UserSessionStoreBase {
 	return {
 		kind: "memory",
 		async create(input: CreateUserSessionInput) {
-			if (sessions.has(input.sid)) {
+			// GC any expired entry first so duplicate-check semantics match
+			// `get()` (which GCs on read). Otherwise a stale expired record
+			// would cause create() to throw right after get() returned null.
+			if (readLive(input.sid) !== null) {
 				throw new Error(`UserSession ${input.sid} already exists`);
 			}
 			sessions.set(input.sid, {

--- a/packages/core/src/user-sessions/adapters/memory.mts
+++ b/packages/core/src/user-sessions/adapters/memory.mts
@@ -11,7 +11,17 @@ import type {
 	UserSessionStoreBase,
 } from "../types.mjs";
 
-type Stored = Omit<UserSession, "claims"> & { claims: Record<string, unknown> };
+type Stored = {
+	sid: string;
+	sub: string;
+	authTime: Date;
+	createdAt: Date;
+	expiresAt: Date;
+	federations: string[];
+	activeRPs: RegisteredRP[];
+	familyIds: string[];
+	claims: Record<string, unknown>;
+};
 
 export function createInMemoryUserSessionStore(): UserSessionStoreBase {
 	const sessions = new Map<string, Stored>();
@@ -38,7 +48,7 @@ export function createInMemoryUserSessionStore(): UserSessionStoreBase {
 				authTime: input.authTime,
 				createdAt: new Date(),
 				expiresAt: input.expiresAt,
-				federations: input.federations ?? [],
+				federations: [...(input.federations ?? [])],
 				activeRPs: [],
 				familyIds: [],
 				claims: { ...input.claims },

--- a/packages/core/src/user-sessions/adapters/memory.mts
+++ b/packages/core/src/user-sessions/adapters/memory.mts
@@ -23,6 +23,21 @@ type Stored = {
 	claims: Record<string, unknown>;
 };
 
+/**
+ * Deep-copy known array-valued standard claims so callers cannot mutate
+ * in-store state by holding onto the original array reference. `groups` is
+ * the only known array-valued claim in UserSessionClaims v1; extend this
+ * helper when new array-valued claims are added.
+ */
+const cloneClaims = (c: UserSessionClaims | Record<string, unknown>): Record<string, unknown> => {
+	const out: Record<string, unknown> = { ...c };
+	const groups = (c as { groups?: unknown }).groups;
+	if (Array.isArray(groups)) {
+		out.groups = [...groups];
+	}
+	return out;
+};
+
 export function createInMemoryUserSessionStore(): UserSessionStoreBase {
 	const sessions = new Map<string, Stored>();
 
@@ -55,7 +70,7 @@ export function createInMemoryUserSessionStore(): UserSessionStoreBase {
 				federations: [...(input.federations ?? [])],
 				activeRPs: [],
 				familyIds: [],
-				claims: { ...input.claims },
+				claims: cloneClaims(input.claims),
 			});
 		},
 		async get(sid: string): Promise<UserSession | null> {
@@ -79,7 +94,7 @@ export function createInMemoryUserSessionStore(): UserSessionStoreBase {
 					registeredAt: new Date(r.registeredAt.getTime()),
 				})),
 				familyIds: [...s.familyIds],
-				claims: { ...s.claims } as UserSessionClaims,
+				claims: cloneClaims(s.claims) as UserSessionClaims,
 			};
 		},
 		async registerRP(sid: string, rp: RegisteredRP) {
@@ -104,7 +119,9 @@ export function createInMemoryUserSessionStore(): UserSessionStoreBase {
 		async updateClaims(sid: string, claims: Partial<UserSessionClaims>) {
 			const s = readLive(sid);
 			if (!s) return;
-			s.claims = { ...s.claims, ...claims };
+			// Clone the incoming patch too — if the caller passes { groups: [...] }
+			// and later mutates that array, the store must not see the mutation.
+			s.claims = cloneClaims({ ...s.claims, ...claims });
 		},
 		async removeFederation(sid: string, federationName: string) {
 			const s = readLive(sid);

--- a/packages/core/src/user-sessions/adapters/memory.mts
+++ b/packages/core/src/user-sessions/adapters/memory.mts
@@ -48,9 +48,10 @@ export function createInMemoryUserSessionStore(): UserSessionStoreBase {
 			sessions.set(input.sid, {
 				sid: input.sid,
 				sub: input.sub,
-				authTime: input.authTime,
+				// Copy Dates so caller-held references cannot mutate stored state.
+				authTime: new Date(input.authTime.getTime()),
 				createdAt: new Date(),
-				expiresAt: input.expiresAt,
+				expiresAt: new Date(input.expiresAt.getTime()),
 				federations: [...(input.federations ?? [])],
 				activeRPs: [],
 				familyIds: [],
@@ -60,12 +61,38 @@ export function createInMemoryUserSessionStore(): UserSessionStoreBase {
 		async get(sid: string): Promise<UserSession | null> {
 			const s = readLive(sid);
 			if (!s) return null;
-			return { ...s, claims: { ...s.claims } as UserSessionClaims };
+			// Deep-copy every field that the public `readonly` types promise not to
+			// mutate: Dates, array references, and claim object. Without this, a
+			// caller doing `(await store.get()).federations.push(...)` (even with
+			// a `readonly` cast escape hatch) would mutate the in-store record.
+			return {
+				sid: s.sid,
+				sub: s.sub,
+				authTime: new Date(s.authTime.getTime()),
+				createdAt: new Date(s.createdAt.getTime()),
+				expiresAt: new Date(s.expiresAt.getTime()),
+				federations: [...s.federations],
+				activeRPs: s.activeRPs.map((r) => ({
+					clientId: r.clientId,
+					backchannelLogoutUri: r.backchannelLogoutUri,
+					frontchannelLogoutUri: r.frontchannelLogoutUri,
+					registeredAt: new Date(r.registeredAt.getTime()),
+				})),
+				familyIds: [...s.familyIds],
+				claims: { ...s.claims } as UserSessionClaims,
+			};
 		},
 		async registerRP(sid: string, rp: RegisteredRP) {
 			const s = readLive(sid);
 			if (!s) return;
-			s.activeRPs = [...s.activeRPs.filter((r) => r.clientId !== rp.clientId), rp];
+			// Copy the RP record so caller cannot mutate stored state via its reference.
+			const rpCopy: RegisteredRP = {
+				clientId: rp.clientId,
+				backchannelLogoutUri: rp.backchannelLogoutUri,
+				frontchannelLogoutUri: rp.frontchannelLogoutUri,
+				registeredAt: new Date(rp.registeredAt.getTime()),
+			};
+			s.activeRPs = [...s.activeRPs.filter((r) => r.clientId !== rp.clientId), rpCopy];
 		},
 		async linkFamily(sid: string, familyId: string) {
 			const s = readLive(sid);

--- a/packages/core/src/user-sessions/adapters/redis.mts
+++ b/packages/core/src/user-sessions/adapters/redis.mts
@@ -97,10 +97,16 @@ export function createRedisUserSessionStore(
 		}
 	};
 
-	const writeEnvelope = async (env: Envelope, nx = false): Promise<string | null> => {
+	type WriteResult = "ok" | "nx_failed" | "ttl_expired";
+
+	const writeEnvelope = async (env: Envelope, nx = false): Promise<WriteResult> => {
 		const remaining = env.expiresAtMs - Date.now();
-		if (remaining <= 0) return null;
-		return opts.client.set(k(env.sid), JSON.stringify(env), { PX: remaining, NX: nx });
+		if (remaining <= 0) return "ttl_expired";
+		const result = await opts.client.set(k(env.sid), JSON.stringify(env), {
+			PX: remaining,
+			NX: nx,
+		});
+		return result === null ? "nx_failed" : "ok";
 	};
 
 	return {
@@ -126,7 +132,17 @@ export function createRedisUserSessionStore(
 				claims: { ...input.claims },
 			};
 			const result = await writeEnvelope(toEnvelope(session), true);
-			if (result === null) throw new Error(`UserSession ${input.sid} already exists`);
+			if (result === "nx_failed") {
+				throw new Error(`UserSession ${input.sid} already exists`);
+			}
+			if (result === "ttl_expired") {
+				// Upstream expiresAt > now check (above) should prevent this, but a
+				// small racy window (clock skew, slow call) can still hit it. Surface
+				// a clear error rather than a misleading "already exists".
+				throw new Error(
+					`UserSession ${input.sid}: expiresAt elapsed before Redis SET could run (clock skew or delay)`,
+				);
+			}
 		},
 		async get(sid) {
 			const env = await loadEnvelope(sid);

--- a/packages/core/src/user-sessions/adapters/redis.mts
+++ b/packages/core/src/user-sessions/adapters/redis.mts
@@ -17,11 +17,7 @@ import type {
  */
 export interface RedisLikeClient {
 	get(key: string): Promise<string | null>;
-	set(
-		key: string,
-		value: string,
-		opts?: { PX?: number; NX?: boolean },
-	): Promise<string | null>;
+	set(key: string, value: string, opts?: { PX?: number; NX?: boolean }): Promise<string | null>;
 	del(key: string): Promise<number>;
 }
 
@@ -37,7 +33,12 @@ interface Envelope {
 	createdAtMs: number;
 	expiresAtMs: number;
 	federations: string[];
-	activeRPs: { clientId: string; backchannelLogoutUri?: string; frontchannelLogoutUri?: string; registeredAtMs: number }[];
+	activeRPs: {
+		clientId: string;
+		backchannelLogoutUri?: string;
+		frontchannelLogoutUri?: string;
+		registeredAtMs: number;
+	}[];
 	familyIds: string[];
 	claims: Record<string, unknown>;
 }
@@ -76,7 +77,9 @@ const fromEnvelope = (e: Envelope): UserSession => ({
 	claims: e.claims as UserSessionClaims,
 });
 
-export function createRedisUserSessionStore(opts: RedisUserSessionStoreOptions): UserSessionStoreBase {
+export function createRedisUserSessionStore(
+	opts: RedisUserSessionStoreOptions,
+): UserSessionStoreBase {
 	const prefix = opts.keyPrefix ?? "us:";
 	const k = (sid: string) => `${prefix}${sid}`;
 

--- a/packages/core/src/user-sessions/adapters/redis.mts
+++ b/packages/core/src/user-sessions/adapters/redis.mts
@@ -89,6 +89,10 @@ export function createRedisUserSessionStore(
 		try {
 			return JSON.parse(v) as Envelope;
 		} catch {
+			// Corrupt/non-JSON payload: self-heal by deleting the key so subsequent
+			// create(sid) doesn't fail NX with a misleading "already exists" error,
+			// and subsequent get(sid) stays consistently null.
+			await opts.client.del(k(sid));
 			return null;
 		}
 	};
@@ -102,6 +106,14 @@ export function createRedisUserSessionStore(
 	return {
 		kind: "redis",
 		async create(input: CreateUserSessionInput) {
+			// Validate expiresAt up-front so an already-expired input fails with a
+			// clear message rather than being misdiagnosed as a duplicate-sid error
+			// when writeEnvelope returns null for non-positive TTL.
+			if (input.expiresAt.getTime() <= Date.now()) {
+				throw new Error(
+					`UserSession ${input.sid}: expiresAt is in the past (TTL must be positive)`,
+				);
+			}
 			const session: UserSession = {
 				sid: input.sid,
 				sub: input.sub,

--- a/packages/core/src/user-sessions/adapters/redis.mts
+++ b/packages/core/src/user-sessions/adapters/redis.mts
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import type {
+	CreateUserSessionInput,
+	RegisteredRP,
+	UserSession,
+	UserSessionClaims,
+	UserSessionStoreBase,
+} from "../types.mjs";
+
+/**
+ * The subset of the `redis` v5 client used by this adapter. Matching a subset
+ * lets us mock the client in tests without importing the real package.
+ */
+export interface RedisLikeClient {
+	get(key: string): Promise<string | null>;
+	set(
+		key: string,
+		value: string,
+		opts?: { PX?: number; NX?: boolean },
+	): Promise<string | null>;
+	del(key: string): Promise<number>;
+}
+
+export interface RedisUserSessionStoreOptions {
+	client: RedisLikeClient;
+	keyPrefix?: string;
+}
+
+interface Envelope {
+	sid: string;
+	sub: string;
+	authTimeMs: number;
+	createdAtMs: number;
+	expiresAtMs: number;
+	federations: string[];
+	activeRPs: { clientId: string; backchannelLogoutUri?: string; frontchannelLogoutUri?: string; registeredAtMs: number }[];
+	familyIds: string[];
+	claims: Record<string, unknown>;
+}
+
+const toEnvelope = (s: UserSession): Envelope => ({
+	sid: s.sid,
+	sub: s.sub,
+	authTimeMs: s.authTime.getTime(),
+	createdAtMs: s.createdAt.getTime(),
+	expiresAtMs: s.expiresAt.getTime(),
+	federations: [...s.federations],
+	activeRPs: s.activeRPs.map((r) => ({
+		clientId: r.clientId,
+		backchannelLogoutUri: r.backchannelLogoutUri,
+		frontchannelLogoutUri: r.frontchannelLogoutUri,
+		registeredAtMs: r.registeredAt.getTime(),
+	})),
+	familyIds: [...s.familyIds],
+	claims: { ...s.claims },
+});
+
+const fromEnvelope = (e: Envelope): UserSession => ({
+	sid: e.sid,
+	sub: e.sub,
+	authTime: new Date(e.authTimeMs),
+	createdAt: new Date(e.createdAtMs),
+	expiresAt: new Date(e.expiresAtMs),
+	federations: e.federations,
+	activeRPs: e.activeRPs.map((r) => ({
+		clientId: r.clientId,
+		backchannelLogoutUri: r.backchannelLogoutUri,
+		frontchannelLogoutUri: r.frontchannelLogoutUri,
+		registeredAt: new Date(r.registeredAtMs),
+	})),
+	familyIds: e.familyIds,
+	claims: e.claims as UserSessionClaims,
+});
+
+export function createRedisUserSessionStore(opts: RedisUserSessionStoreOptions): UserSessionStoreBase {
+	const prefix = opts.keyPrefix ?? "us:";
+	const k = (sid: string) => `${prefix}${sid}`;
+
+	const loadEnvelope = async (sid: string): Promise<Envelope | null> => {
+		const v = await opts.client.get(k(sid));
+		if (!v) return null;
+		try {
+			return JSON.parse(v) as Envelope;
+		} catch {
+			return null;
+		}
+	};
+
+	const writeEnvelope = async (env: Envelope, nx = false): Promise<string | null> => {
+		const remaining = env.expiresAtMs - Date.now();
+		if (remaining <= 0) return null;
+		return opts.client.set(k(env.sid), JSON.stringify(env), { PX: remaining, NX: nx });
+	};
+
+	return {
+		kind: "redis",
+		async create(input: CreateUserSessionInput) {
+			const session: UserSession = {
+				sid: input.sid,
+				sub: input.sub,
+				authTime: input.authTime,
+				createdAt: new Date(),
+				expiresAt: input.expiresAt,
+				federations: input.federations ?? [],
+				activeRPs: [],
+				familyIds: [],
+				claims: { ...input.claims },
+			};
+			const result = await writeEnvelope(toEnvelope(session), true);
+			if (result === null) throw new Error(`UserSession ${input.sid} already exists`);
+		},
+		async get(sid) {
+			const env = await loadEnvelope(sid);
+			return env ? fromEnvelope(env) : null;
+		},
+		async registerRP(sid, rp: RegisteredRP) {
+			const env = await loadEnvelope(sid);
+			if (!env) return;
+			env.activeRPs = [
+				...env.activeRPs.filter((r) => r.clientId !== rp.clientId),
+				{
+					clientId: rp.clientId,
+					backchannelLogoutUri: rp.backchannelLogoutUri,
+					frontchannelLogoutUri: rp.frontchannelLogoutUri,
+					registeredAtMs: rp.registeredAt.getTime(),
+				},
+			];
+			await writeEnvelope(env);
+		},
+		async linkFamily(sid, familyId) {
+			const env = await loadEnvelope(sid);
+			if (!env) return;
+			if (!env.familyIds.includes(familyId)) env.familyIds = [...env.familyIds, familyId];
+			await writeEnvelope(env);
+		},
+		async updateClaims(sid, claims: Partial<UserSessionClaims>) {
+			const env = await loadEnvelope(sid);
+			if (!env) return;
+			env.claims = { ...env.claims, ...claims };
+			await writeEnvelope(env);
+		},
+		async removeFederation(sid, federationName) {
+			const env = await loadEnvelope(sid);
+			if (!env) return;
+			env.federations = env.federations.filter((f) => f !== federationName);
+			await writeEnvelope(env);
+		},
+		async delete(sid) {
+			await opts.client.del(k(sid));
+		},
+	};
+}

--- a/packages/core/src/user-sessions/claims.mts
+++ b/packages/core/src/user-sessions/claims.mts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { User } from "../repositories/types.mjs";
+import type { UserSessionClaims } from "./types.mjs";
+
+export function extractUserClaims(user: User): UserSessionClaims {
+	const c: Record<string, unknown> = {};
+	if (typeof user.email === "string") c.email = user.email;
+	if (typeof user.emailVerified === "boolean") c.emailVerified = user.emailVerified;
+	if (typeof user.name === "string") c.name = user.name;
+	if (typeof user.picture === "string") c.picture = user.picture;
+	if (Array.isArray(user.groups) && user.groups.every((g) => typeof g === "string")) {
+		c.groups = user.groups;
+	}
+	return c as UserSessionClaims;
+}

--- a/packages/core/src/user-sessions/factory.mts
+++ b/packages/core/src/user-sessions/factory.mts
@@ -12,14 +12,11 @@ import { createAdapterFactory } from "../adapters/AdapterFactory.mjs";
 import { createInMemoryUserSessionStore } from "./adapters/memory.mjs";
 import type { UserSessionStoreBase, UserSessionStoreFactory } from "./types.mjs";
 
-export function createUserSessionStoreFactory(): UserSessionStoreFactory & { kind: string } {
-	const factory = createAdapterFactory<UserSessionStoreBase>("userSessionStore");
-	return Object.assign(factory, { kind: "userSessionStore" });
+export function createUserSessionStoreFactory(): UserSessionStoreFactory {
+	return createAdapterFactory<UserSessionStoreBase>("userSessionStore");
 }
 
-export function registerBuiltinUserSessionStores(
-	factory: UserSessionStoreFactory,
-): void {
+export function registerBuiltinUserSessionStores(factory: UserSessionStoreFactory): void {
 	factory.register("memory", () => createInMemoryUserSessionStore());
 }
 

--- a/packages/core/src/user-sessions/factory.mts
+++ b/packages/core/src/user-sessions/factory.mts
@@ -13,7 +13,7 @@ import { createInMemoryUserSessionStore } from "./adapters/memory.mjs";
 import type { UserSessionStoreBase, UserSessionStoreFactory } from "./types.mjs";
 
 export function createUserSessionStoreFactory(): UserSessionStoreFactory {
-	return createAdapterFactory<UserSessionStoreBase>("userSessionStore");
+	return createAdapterFactory<UserSessionStoreBase>("UserSessionStore");
 }
 
 export function registerBuiltinUserSessionStores(factory: UserSessionStoreFactory): void {

--- a/packages/core/src/user-sessions/factory.mts
+++ b/packages/core/src/user-sessions/factory.mts
@@ -25,9 +25,10 @@ export function registerBuiltinUserSessionStores(factory: UserSessionStoreFactor
 				`userSessionStore.redis: 'client' option is required. Pass a connected 'redis' v5 client via AppOptions wiring.`,
 			);
 		}
-		const keyPrefix = typeof (config as { keyPrefix?: unknown }).keyPrefix === "string"
-			? ((config as { keyPrefix: string }).keyPrefix)
-			: undefined;
+		const keyPrefix =
+			typeof (config as { keyPrefix?: unknown }).keyPrefix === "string"
+				? (config as { keyPrefix: string }).keyPrefix
+				: undefined;
 		const { createRedisUserSessionStore } = await import("./adapters/redis.mjs");
 		return createRedisUserSessionStore({
 			client: client as Parameters<typeof createRedisUserSessionStore>[0]["client"],

--- a/packages/core/src/user-sessions/factory.mts
+++ b/packages/core/src/user-sessions/factory.mts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { createAdapterFactory } from "../adapters/AdapterFactory.mjs";
+import { createInMemoryUserSessionStore } from "./adapters/memory.mjs";
+import type { UserSessionStoreBase, UserSessionStoreFactory } from "./types.mjs";
+
+export function createUserSessionStoreFactory(): UserSessionStoreFactory & { kind: string } {
+	const factory = createAdapterFactory<UserSessionStoreBase>("userSessionStore");
+	return Object.assign(factory, { kind: "userSessionStore" });
+}
+
+export function registerBuiltinUserSessionStores(
+	factory: UserSessionStoreFactory,
+): void {
+	factory.register("memory", () => createInMemoryUserSessionStore());
+}
+
+export type { UserSessionStoreFactory };

--- a/packages/core/src/user-sessions/factory.mts
+++ b/packages/core/src/user-sessions/factory.mts
@@ -18,6 +18,22 @@ export function createUserSessionStoreFactory(): UserSessionStoreFactory {
 
 export function registerBuiltinUserSessionStores(factory: UserSessionStoreFactory): void {
 	factory.register("memory", () => createInMemoryUserSessionStore());
+	factory.register("redis", async (config) => {
+		const client = (config as { client?: unknown }).client;
+		if (!client) {
+			throw new Error(
+				`userSessionStore.redis: 'client' option is required. Pass a connected 'redis' v5 client via AppOptions wiring.`,
+			);
+		}
+		const keyPrefix = typeof (config as { keyPrefix?: unknown }).keyPrefix === "string"
+			? ((config as { keyPrefix: string }).keyPrefix)
+			: undefined;
+		const { createRedisUserSessionStore } = await import("./adapters/redis.mjs");
+		return createRedisUserSessionStore({
+			client: client as Parameters<typeof createRedisUserSessionStore>[0]["client"],
+			keyPrefix,
+		});
+	});
 }
 
 export type { UserSessionStoreFactory };

--- a/packages/core/src/user-sessions/types.mts
+++ b/packages/core/src/user-sessions/types.mts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import type { AdapterFactory } from "../adapters/AdapterFactory.mjs";
+
+/**
+ * OIDC-standard user claims durably attached to a session. Populated at login.
+ * Used as the authoritative source for /userinfo and id_token; independent of
+ * the browser session.
+ */
+export interface UserSessionClaims {
+	readonly email?: string;
+	readonly emailVerified?: boolean;
+	readonly name?: string;
+	readonly picture?: string;
+	readonly groups?: ReadonlyArray<string>;
+	readonly [customClaim: string]: unknown;
+}
+
+export interface RegisteredRP {
+	readonly clientId: string;
+	readonly backchannelLogoutUri?: string;
+	readonly frontchannelLogoutUri?: string;
+	readonly registeredAt: Date;
+}
+
+export interface UserSession {
+	readonly sid: string;
+	readonly sub: string;
+	readonly authTime: Date;
+	readonly createdAt: Date;
+	readonly expiresAt: Date;
+	readonly federations: ReadonlyArray<string>;
+	readonly activeRPs: ReadonlyArray<RegisteredRP>;
+	readonly familyIds: ReadonlyArray<string>;
+	readonly claims: UserSessionClaims;
+}
+
+/**
+ * Parameters for creating a new session. createdAt / activeRPs / familyIds
+ * are initialized by the store (not caller-supplied).
+ */
+export interface CreateUserSessionInput {
+	readonly sid: string;
+	readonly sub: string;
+	readonly authTime: Date;
+	readonly expiresAt: Date;
+	readonly federations?: ReadonlyArray<string>;
+	readonly claims: UserSessionClaims;
+}
+
+export interface UserSessionStoreBase {
+	readonly kind: string;
+	create(input: CreateUserSessionInput): Promise<void>;
+	get(sid: string): Promise<UserSession | null>;
+	registerRP(sid: string, rp: RegisteredRP): Promise<void>;
+	linkFamily(sid: string, familyId: string): Promise<void>;
+	updateClaims(sid: string, claims: Partial<UserSessionClaims>): Promise<void>;
+	removeFederation(sid: string, federationName: string): Promise<void>;
+	/**
+	 * Delete the session record. MUST NOT cascade to other stores — cascade is
+	 * orchestrated by the logout route handler (see spec Section 14.2).
+	 */
+	delete(sid: string): Promise<void>;
+}
+
+export type UserSessionStoreFactory = AdapterFactory<UserSessionStoreBase>;


### PR DESCRIPTION
## Summary

- Introduce two new foundation adapters for the TODO-F (federation + OIDC) workstream:
  - **`UserSessionStore`** — sid-keyed session metadata (sub, auth_time, active RPs, refresh-family IDs, OIDC claims). Durable source for `/userinfo` and `id_token` in upcoming plans.
  - **`FederationTokenStore`** — `(sid, federationName)`-keyed upstream IdP token persistence with required AES-256-GCM encryption of `refresh_token` at rest.
- Both stores are optional `AppOptions` with built-in `memory` + `redis` adapters following the TODO-C factory pattern.
- `createApp` now fails fast when `config.federations` is non-empty but either store is missing.
- **Plumbing only** — no routes or grants consume the stores yet. Consumers land in TODO-F-3 / F-4 / F-5 / F-6 plans.

## Scope

- Spec: [`.claude/superpowers/specs/2026-04-21-todo-f-federation-token-lifecycle-design.md`](../../.claude/superpowers/specs/2026-04-21-todo-f-federation-token-lifecycle-design.md) Section 2 (adapter interfaces) + Section 5 (encryption contract) + Section 10.1 (boot validation).
- Plan: [`.claude/superpowers/plans/2026-04-21-todo-f-1-session-federation-token-stores.md`](../../.claude/superpowers/plans/2026-04-21-todo-f-1-session-federation-token-stores.md)

## Key design points

- **Encryption contract:** redis `FederationTokenStore` requires `encryption.mode = "required"` (AES-256-GCM, 32-byte key) by default. `allow-plaintext` is opt-in and logs a warning at startup — dev/test only.
- **Token TTL independence (review fix):** redis record TTL is store-level (`ttl`, default 24h) rather than derived from `tokens.expiresAt`. Access-token expiry is preserved inside the envelope so F-6 refresh flows can still read the refresh_token after access-token expiry.
- **`UserSession.delete` responsibility boundary:** explicitly non-cascading. Logout cascade is orchestrated by the logout route handler (see spec Section 14.2), not the adapter interface.
- **`RedisLikeClient` interface:** adapters depend on a minimal subset of `redis` v5 (get/set/del/keys) rather than importing the real package, so core has no redis runtime dep and tests can use simple fakes.

## Breaking changes

None. All changes are additive:
- `AppOptions.userSessionStore?` / `AppOptions.federationTokenStore?` are optional.
- `ModuleContext.userSessionStore?` / `ModuleContext.federationTokenStore?` are optional.
- Boot-time validation only activates when `config.federations` has at least one `enabled: true` entry (pre-F-1 deployments without federations are unaffected).

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm exec biome check src/user-sessions/ src/federation-tokens/` — 0 errors
- [x] `pnpm vitest run` — 322 tests pass (37 test files)
- [x] `pnpm build` — succeeds across all packages + standalone template
- [x] Multi-agent review round 1 → 3 fixes applied (critical TTL bug + memory GC symmetry + docstring)
- [x] Multi-agent review round 2 → 1 test tautology fixed (memory GC regression guarantee verified via temp-revert)

## Next

- **F-2**: Federation capability (`SupportsClaimMapping` / `SupportsRefresh`) + Google/GitHub passport callback adapting to UserSessionStore + FederationTokenStore.
- **F-3**: access_token / refresh_token claim additions (`family_id`, `sid`) + `/introspect` cascading revocation + `CodeRepository` schema extension.
- **F-4**: `id_token` + `/userinfo` + `/.well-known/openid-configuration`.
- **F-5**: Logout (RP-initiated + federation-scoped + back/front-channel).
- **F-6**: `/oauth/federation/:name/token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
