### PR TITLE
feat(session)!: federation capabilities + Google/GitHub provider adapt (TODO-F-2)

### DIFF
--- a/packages/session/README.ja.md
+++ b/packages/session/README.ja.md
@@ -330,7 +330,7 @@ readonly onFederationCallback?: (params: {
 
 **組み込みの動作:** `sessionModule` が passport コンテキストをセットアップする際、`AppOptions` に `UserSessionStore` と `FederationTokenStore` の**両方**が設定されている場合にのみ、組み込みの `onFederationCallback` が自動的に注入される。組み込みフックの動作:
 
-1. フェデレーションプロファイルから `User` を検索または作成する（利用可能な場合は `SupportsClaimMapping` を使用）。
+1. `UserRepository.authenticateByToken(`${federationName}:${profile.id}`)` を使って `User` を検索する。フェデレーション初回ログイン時にユーザーを自動プロビジョニングするデプロイでは、`authenticateByToken` の実装内でその処理を行うこと。
 2. IdP トークンを `FederationTokenStore` に保存する。
 3. 成功時に `done(null, user)` を呼び出す。
 

--- a/packages/session/README.ja.md
+++ b/packages/session/README.ja.md
@@ -135,7 +135,7 @@ function createGithubProvider(config: {
 }): FederationProviderBase;
 ```
 
-GitHub OAuth 2.0 用の `FederationProviderBase` を生成する。`passport-github2`（オプションの peer dep）が必要なため、別途インストールすること。デフォルトのスコープは `["read:user", "user:email"]`。`externalId` のフォーマットは `"github:" + profile.id`。
+GitHub OAuth 2.0 用の `FederationProviderBase` を生成する。`passport-github2`（オプションの peer dep）が必要なため、別途インストールすること。デフォルトのスコープは `["read:user", "user:email"]`。`externalId` のフォーマットは `${federationName}:${profile.id}`（`federationName` はプロバイダーに設定した `name`。例: デフォルトは `"github"`、カスタムテナントの場合は `"github-enterprise"` など）。
 
 ---
 
@@ -351,7 +351,7 @@ readonly onFederationCallback?: (params: {
 
 - デフォルトスコープは `["read:user", "user:email"]`。
 - プロファイルオブジェクトに `email` フィールドが含まれない場合、GitHub `/user/emails` API を呼び出してプライマリの確認済みメールアドレスを取得することでプロファイルを補完する。
-- `externalId` フォーマット: `"github:" + profile.id`。
+- `externalId` フォーマット: `${federationName}:${profile.id}`（`federationName` は設定した `name`。例: デフォルトは `"github"`、カスタムテナントの場合は `"github-enterprise"`）。
 
 ---
 

--- a/packages/session/README.ja.md
+++ b/packages/session/README.ja.md
@@ -236,6 +236,125 @@ if (supportsLogout(provider)) {
 
 ---
 
+### `SupportsClaimMapping` (オプショナル capability)
+
+OAuth プロファイルから正規化されたクレームセットを生成できる provider 向けのオプショナル capability。
+
+```ts
+interface MappedClaims {
+  readonly email?: string;
+  readonly emailVerified?: boolean;
+  readonly name?: string;
+  readonly picture?: string;
+  readonly groups?: ReadonlyArray<string>;
+  readonly [key: string]: unknown;   // 非標準 IdP クレーム（例: Google の "hd"）
+}
+
+interface FederationProfile {
+  readonly id: string;                 // プロバイダー内部ユーザー ID
+  readonly raw: Readonly<Record<string, unknown>>;  // 生の passport プロファイルオブジェクト
+  readonly accessToken?: string;
+  readonly refreshToken?: string;
+  readonly idToken?: string;
+  readonly expiresIn?: number;
+}
+
+interface SupportsClaimMapping {
+  mapClaims(profile: FederationProfile): MappedClaims;
+}
+
+function supportsClaimMapping(
+  provider: FederationProviderBase | undefined | null,
+): provider is FederationProviderBase & SupportsClaimMapping;
+```
+
+`SupportsClaimMapping` を実装した provider は、生の passport プロファイルデータを OIDC 標準のクレーム名に変換する。組み込みの `"google"` / `"github"` はこの capability を実装している。カスタム provider は `mapClaims` メソッドを追加することで対応できる:
+
+```ts
+import { supportsClaimMapping } from "@o3co/auth-provider-session";
+
+if (supportsClaimMapping(provider)) {
+  const claims = provider.mapClaims(profile);
+  // claims.email, claims.name, claims.picture …
+}
+```
+
+---
+
+### `SupportsRefresh` (オプショナル capability)
+
+リフレッシュトークンを使って新しいアクセストークンを取得できる provider 向けのオプショナル capability。
+
+```ts
+interface RefreshedTokens {
+  readonly accessToken: string;
+  readonly refreshToken?: string;
+  readonly idToken?: string;
+  readonly expiresAt: Date;
+}
+
+interface SupportsRefresh {
+  refreshFederationToken(refreshToken: string): Promise<RefreshedTokens>;
+}
+
+function supportsRefresh(
+  provider: FederationProviderBase | undefined | null,
+): provider is FederationProviderBase & SupportsRefresh;
+```
+
+`SupportsRefresh` を実装した provider は、ユーザー操作なしにフェデレーショントークンを維持できる。`FederationTokenStore`（`AppOptions` で設定）が初回トークンを保存し、リフレッシュフローが自動的に取得・更新する。
+
+```ts
+import { supportsRefresh } from "@o3co/auth-provider-session";
+
+if (supportsRefresh(provider)) {
+  const refreshed = await provider.refreshFederationToken(storedRefreshToken);
+  // refreshed.accessToken, refreshed.expiresAt …
+}
+```
+
+---
+
+### `onFederationCallback` フック
+
+`SetupPassportContext` にはオプショナルな `onFederationCallback` フックがある:
+
+```ts
+readonly onFederationCallback?: (params: {
+  readonly federationName: string;
+  readonly profile: FederationProfile;
+  readonly req: import("express").Request;
+  readonly done: (err: Error | null, user: User | false) => void;
+}) => Promise<void>;
+```
+
+**組み込みの動作:** `sessionModule` が passport コンテキストをセットアップする際、`AppOptions` に `UserSessionStore` と `FederationTokenStore` の**両方**が設定されている場合にのみ、組み込みの `onFederationCallback` が自動的に注入される。組み込みフックの動作:
+
+1. フェデレーションプロファイルから `User` を検索または作成する（利用可能な場合は `SupportsClaimMapping` を使用）。
+2. IdP トークンを `FederationTokenStore` に保存する。
+3. 成功時に `done(null, user)` を呼び出す。
+
+いずれかのストアが未設定の場合、モジュールはレガシーの `verifyUser(externalId)` パスにフォールバックする。これはトークン永続化が不要なデプロイには十分。
+
+カスタム provider はこのフックを実装する必要はない。`SetupPassportContext.onFederationCallback` 経由で受け取り、`setupPassportStrategy` 内から呼び出す。このフック抽象化により、provider コードはストア依存から解放される。
+
+---
+
+### 組み込みプロバイダーのメモ
+
+**Google プロバイダー（`createGoogleProvider`）**
+
+- デフォルトで `openid profile email` スコープをリクエストする（`openid` スコープを追加することで、Google がアクセストークンと共に ID トークンを返すようになった）。
+- `passReqToCallback: true` を使用し、`onFederationCallback` フックがセッションデータを含む Express リクエストオブジェクトにアクセスできるようにする。
+
+**GitHub プロバイダー（`createGithubProvider`）**
+
+- デフォルトスコープは `["read:user", "user:email"]`。
+- プロファイルオブジェクトに `email` フィールドが含まれない場合、GitHub `/user/emails` API を呼び出してプライマリの確認済みメールアドレスを取得することでプロファイルを補完する。
+- `externalId` フォーマット: `"github:" + profile.id`。
+
+---
+
 ### `FederationProviderFactory` (type)
 
 ```typescript

--- a/packages/session/README.md
+++ b/packages/session/README.md
@@ -135,7 +135,7 @@ function createGithubProvider(config: {
 }): FederationProviderBase;
 ```
 
-Creates a `FederationProviderBase` for GitHub OAuth 2.0. Uses `passport-github2` (optional peer dep — must be installed separately). The default scope is `["read:user", "user:email"]`. The `externalId` format is `"github:" + profile.id`.
+Creates a `FederationProviderBase` for GitHub OAuth 2.0. Uses `passport-github2` (optional peer dep — must be installed separately). The default scope is `["read:user", "user:email"]`. The `externalId` format is `${federationName}:${profile.id}` where `federationName` is the configured `name` on the provider (e.g. `"github"` by default, or `"github-enterprise"` if you customize).
 
 ---
 
@@ -351,7 +351,7 @@ Custom providers never need to implement this hook — they receive it via `Setu
 
 - Default scope is `["read:user", "user:email"]`.
 - When the primary profile object omits an `email` field, the provider enriches the profile by calling the GitHub `/user/emails` API to retrieve the primary verified email.
-- `externalId` format: `"github:" + profile.id`.
+- `externalId` format: `${federationName}:${profile.id}` where `federationName` equals the configured `name` (e.g. `"github"` by default, or `"github-enterprise"` for a custom tenant).
 
 ---
 

--- a/packages/session/README.md
+++ b/packages/session/README.md
@@ -236,6 +236,125 @@ if (supportsLogout(provider)) {
 
 ---
 
+### `SupportsClaimMapping` (optional capability)
+
+Optional capability for providers that can produce a normalized claim set from an OAuth profile.
+
+```ts
+interface MappedClaims {
+  readonly email?: string;
+  readonly emailVerified?: boolean;
+  readonly name?: string;
+  readonly picture?: string;
+  readonly groups?: ReadonlyArray<string>;
+  readonly [key: string]: unknown;   // non-standard IdP claims (e.g. Google's "hd")
+}
+
+interface FederationProfile {
+  readonly id: string;                 // provider-internal user id
+  readonly raw: Readonly<Record<string, unknown>>;  // raw passport profile object
+  readonly accessToken?: string;
+  readonly refreshToken?: string;
+  readonly idToken?: string;
+  readonly expiresIn?: number;
+}
+
+interface SupportsClaimMapping {
+  mapClaims(profile: FederationProfile): MappedClaims;
+}
+
+function supportsClaimMapping(
+  provider: FederationProviderBase | undefined | null,
+): provider is FederationProviderBase & SupportsClaimMapping;
+```
+
+Providers that implement `SupportsClaimMapping` translate raw passport profile data into OIDC-standard claim names. The built-in `"google"` and `"github"` providers implement this capability. Custom providers can add it by exposing a `mapClaims` method:
+
+```ts
+import { supportsClaimMapping } from "@o3co/auth-provider-session";
+
+if (supportsClaimMapping(provider)) {
+  const claims = provider.mapClaims(profile);
+  // claims.email, claims.name, claims.picture …
+}
+```
+
+---
+
+### `SupportsRefresh` (optional capability)
+
+Optional capability for providers that can exchange a refresh token for a fresh access token.
+
+```ts
+interface RefreshedTokens {
+  readonly accessToken: string;
+  readonly refreshToken?: string;
+  readonly idToken?: string;
+  readonly expiresAt: Date;
+}
+
+interface SupportsRefresh {
+  refreshFederationToken(refreshToken: string): Promise<RefreshedTokens>;
+}
+
+function supportsRefresh(
+  provider: FederationProviderBase | undefined | null,
+): provider is FederationProviderBase & SupportsRefresh;
+```
+
+Providers implementing `SupportsRefresh` can keep federation tokens alive without user interaction. The `FederationTokenStore` (wired via `AppOptions`) stores the initial tokens; the refresh flow retrieves and updates them automatically.
+
+```ts
+import { supportsRefresh } from "@o3co/auth-provider-session";
+
+if (supportsRefresh(provider)) {
+  const refreshed = await provider.refreshFederationToken(storedRefreshToken);
+  // refreshed.accessToken, refreshed.expiresAt …
+}
+```
+
+---
+
+### `onFederationCallback` hook
+
+`SetupPassportContext` carries an optional `onFederationCallback` hook:
+
+```ts
+readonly onFederationCallback?: (params: {
+  readonly federationName: string;
+  readonly profile: FederationProfile;
+  readonly req: import("express").Request;
+  readonly done: (err: Error | null, user: User | false) => void;
+}) => Promise<void>;
+```
+
+**Built-in behaviour:** When `sessionModule` wires the passport context, it injects a built-in `onFederationCallback` implementation automatically — but only when **both** `UserSessionStore` and `FederationTokenStore` are configured in `AppOptions`. The built-in hook:
+
+1. Looks up or creates a `User` from the federation profile (`SupportsClaimMapping` is used when available).
+2. Saves the IdP tokens to `FederationTokenStore`.
+3. Calls `done(null, user)` on success.
+
+When either store is absent the module falls back to the legacy `verifyUser(externalId)` path, which is sufficient for deployments that do not need token persistence.
+
+Custom providers never need to implement this hook — they receive it via `SetupPassportContext.onFederationCallback` and call it from inside `setupPassportStrategy`. The hook abstraction keeps provider code free of store dependencies.
+
+---
+
+### Built-in provider notes
+
+**Google provider (`createGoogleProvider`)**
+
+- Requests `openid profile email` scope by default (the `openid` scope was added to ensure Google returns an ID token alongside the access token).
+- Uses `passReqToCallback: true` so the `onFederationCallback` hook can access the Express request object for session data.
+
+**GitHub provider (`createGithubProvider`)**
+
+- Default scope is `["read:user", "user:email"]`.
+- When the primary profile object omits an `email` field, the provider enriches the profile by calling the GitHub `/user/emails` API to retrieve the primary verified email.
+- `externalId` format: `"github:" + profile.id`.
+
+---
+
 ### `FederationProviderFactory` (type)
 
 ```typescript

--- a/packages/session/README.md
+++ b/packages/session/README.md
@@ -330,7 +330,7 @@ readonly onFederationCallback?: (params: {
 
 **Built-in behaviour:** When `sessionModule` wires the passport context, it injects a built-in `onFederationCallback` implementation automatically — but only when **both** `UserSessionStore` and `FederationTokenStore` are configured in `AppOptions`. The built-in hook:
 
-1. Looks up or creates a `User` from the federation profile (`SupportsClaimMapping` is used when available).
+1. Looks up a `User` via `UserRepository.authenticateByToken(`${federationName}:${profile.id}`)`. If your deployment auto-provisions users on first federation login, implement that inside your `authenticateByToken`.
 2. Saves the IdP tokens to `FederationTokenStore`.
 3. Calls `done(null, user)` on success.
 

--- a/packages/session/src/__tests__/module.test.mts
+++ b/packages/session/src/__tests__/module.test.mts
@@ -17,9 +17,11 @@
 import {
 	type AppConfig,
 	createSymmetricKeyStore,
+	type FederationTokenStoreBase,
 	GrantRegistry,
 	type ModuleContext,
 	type UserRepository,
+	type UserSessionStoreBase,
 } from "@o3co/auth-provider-core";
 import type { Router } from "express";
 import { describe, expect, it, vi } from "vitest";
@@ -313,6 +315,62 @@ describe("sessionModule", () => {
 		});
 
 		await expect(module.init(ctx)).rejects.toThrow(/provider builder returned name/i);
+	});
+
+	it("forwards userSessionStore, federationTokenStore, and sessionTtlMs to createPassport", async () => {
+		// Arrange: stub stores and a _createPassport spy to capture call arguments.
+		const userSessionStore: UserSessionStoreBase = {
+			create: vi.fn(),
+			get: vi.fn(),
+			delete: vi.fn(),
+			list: vi.fn(),
+		} as unknown as UserSessionStoreBase;
+		const federationTokenStore: FederationTokenStoreBase = {
+			attach: vi.fn(),
+			get: vi.fn(),
+			delete: vi.fn(),
+		} as unknown as FederationTokenStoreBase;
+
+		let capturedOptions: Record<string, unknown> | undefined;
+		// Return a passport stub with all methods used by route factories so init() can proceed.
+		const passportStub = {
+			serializeUser: vi.fn(),
+			deserializeUser: vi.fn(),
+			use: vi.fn(),
+			initialize: vi.fn().mockReturnValue(vi.fn()),
+			session: vi.fn().mockReturnValue(vi.fn()),
+			authenticate: vi.fn().mockReturnValue(vi.fn()),
+		};
+		const createPassportSpy = vi.fn().mockImplementation(async (opts: Record<string, unknown>) => {
+			capturedOptions = opts;
+			return passportStub;
+		});
+
+		const routerMock = { use: vi.fn().mockReturnThis() } as unknown as Router;
+		const ctx = makeContext({
+			router: routerMock,
+			userSessionStore,
+			federationTokenStore,
+		});
+
+		const module = _sessionModuleImpl({
+			userRepository: {
+				authenticate: vi.fn(),
+				authenticateByToken: vi.fn(),
+			} as unknown as UserRepository,
+			sessionTtlMs: 3600_000,
+			_createPassport:
+				createPassportSpy as unknown as typeof import("#/passport.mjs").createPassport,
+		});
+
+		await module.init(ctx);
+
+		expect(createPassportSpy).toHaveBeenCalledTimes(1);
+		expect(capturedOptions).toMatchObject({
+			userSessionStore,
+			federationTokenStore,
+			sessionTtlMs: 3600_000,
+		});
 	});
 
 	it("injects name and context fields into builder config", async () => {

--- a/packages/session/src/__tests__/passport-onFederationCallback.test.mts
+++ b/packages/session/src/__tests__/passport-onFederationCallback.test.mts
@@ -52,11 +52,16 @@ function makeUserSessionStore(): UserSessionStoreBase & { _saved: unknown[]; _de
 	} as UserSessionStoreBase & { _saved: unknown[]; _deleted: string[] };
 }
 
-function makeFederationTokenStore(): FederationTokenStoreBase & { _attached: unknown[] } {
+function makeFederationTokenStore(): FederationTokenStoreBase & {
+	_attached: unknown[];
+	_deletedPairs: Array<{ sid: string; federationName: string }>;
+} {
 	const attached: unknown[] = [];
+	const deletedPairs: Array<{ sid: string; federationName: string }> = [];
 	return {
 		kind: "memory",
 		_attached: attached,
+		_deletedPairs: deletedPairs,
 		async attach(sid, name, tokens) {
 			attached.push({ sid, name, tokens });
 		},
@@ -65,8 +70,13 @@ function makeFederationTokenStore(): FederationTokenStoreBase & { _attached: unk
 		},
 		async update() {},
 		async deleteBySession() {},
-		async delete() {},
-	} as FederationTokenStoreBase & { _attached: unknown[] };
+		async delete(sid: string, federationName: string) {
+			deletedPairs.push({ sid, federationName });
+		},
+	} as FederationTokenStoreBase & {
+		_attached: unknown[];
+		_deletedPairs: Array<{ sid: string; federationName: string }>;
+	};
 }
 
 type DoneRecord = { err: Error | null; user: unknown; reqSid: unknown };
@@ -341,6 +351,82 @@ describe("_createPassportImpl onFederationCallback wiring", () => {
 		expect(doneResults).toHaveLength(1);
 		expect(doneResults[0]?.err).toBe(boom);
 		expect(doneResults[0]?.user).toBe(false);
+	});
+
+	it("rolls back both FederationTokenStore and UserSession when session.save throws after attach", async () => {
+		const doneResults: DoneRecord[] = [];
+		const us = makeUserSessionStore();
+		const ft = makeFederationTokenStore();
+		const saveError = new Error("session save failure");
+		const provider = makeProvider(
+			"google",
+			{ id: "gid-save-fail", accessToken: "at" },
+			doneResults,
+		);
+		// Override the req.session provided by makeProvider to have a save() that throws.
+		// We do this by injecting a custom provider that passes a session with a failing save().
+		const reqStub = {
+			session: {
+				save(cb: (err: unknown) => void) {
+					cb(saveError);
+				},
+			} as Record<string, unknown>,
+		} as unknown as import("express").Request;
+		const providerWithFailingSave: typeof provider = {
+			...provider,
+			async setupPassportStrategy(_passport, ctx) {
+				if (!ctx.onFederationCallback) throw new Error("onFederationCallback hook missing");
+				await ctx.onFederationCallback({
+					federationName: "google",
+					profile: {
+						id: "gid-save-fail",
+						raw: {},
+						accessToken: "at",
+					},
+					req: reqStub,
+					done: (err, user) => {
+						doneResults.push({
+							err,
+							user,
+							reqSid: (reqStub.session as Record<string, unknown>).sid,
+						});
+					},
+				});
+			},
+		};
+		const userRepo = {
+			authenticate: async () => null,
+			authenticateByToken: vi.fn().mockResolvedValue(fakeUser),
+		};
+
+		await _createPassportImpl({
+			pathResolver: (s) => s,
+			userRepository: userRepo as unknown as Parameters<
+				typeof _createPassportImpl
+			>[0]["userRepository"],
+			federationProviders: new Map([["google", providerWithFailingSave]]),
+			userSessionStore: us,
+			federationTokenStore: ft,
+			_passportOverride: makePassportStub(),
+		});
+
+		// UserSession was created
+		expect(us._saved).toHaveLength(1);
+		const saved = us._saved[0] as { sid: string };
+
+		// done was called with the save error
+		expect(doneResults).toHaveLength(1);
+		expect(doneResults[0]?.err).toBe(saveError);
+		expect(doneResults[0]?.user).toBe(false);
+
+		// FederationTokenStore entry was deleted (attach succeeded before save failed)
+		expect(ft._deletedPairs).toHaveLength(1);
+		expect(ft._deletedPairs[0]?.sid).toBe(saved.sid);
+		expect(ft._deletedPairs[0]?.federationName).toBe("google");
+
+		// UserSession was also rolled back
+		expect(us._deleted).toHaveLength(1);
+		expect(us._deleted[0]).toBe(saved.sid);
 	});
 
 	it("rolls back UserSession (delete) when federationTokenStore.attach throws post-create", async () => {

--- a/packages/session/src/__tests__/passport-onFederationCallback.test.mts
+++ b/packages/session/src/__tests__/passport-onFederationCallback.test.mts
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { FederationTokenStoreBase, UserSessionStoreBase } from "@o3co/auth-provider-core";
+import { describe, expect, it, vi } from "vitest";
+import type { FederationProviderBase, SupportsClaimMapping } from "#/federations/types.mjs";
+import { _createPassportImpl } from "#/passport.mjs";
+
+const fakeUser = { id: "u-1", username: "u", email: "existing@x.com" };
+
+function makePassportStub() {
+	return {
+		use: vi.fn(),
+		serializeUser: vi.fn(),
+		deserializeUser: vi.fn(),
+	} as unknown as import("passport").PassportStatic;
+}
+
+function makeUserSessionStore(): UserSessionStoreBase & { _saved: unknown[] } {
+	const saved: unknown[] = [];
+	return {
+		kind: "memory",
+		_saved: saved,
+		async create(input) {
+			saved.push(input);
+		},
+		async get() {
+			return null;
+		},
+		async registerRP() {},
+		async linkFamily() {},
+		async updateClaims() {},
+		async removeFederation() {},
+		async delete() {},
+	} as UserSessionStoreBase & { _saved: unknown[] };
+}
+
+function makeFederationTokenStore(): FederationTokenStoreBase & { _attached: unknown[] } {
+	const attached: unknown[] = [];
+	return {
+		kind: "memory",
+		_attached: attached,
+		async attach(sid, name, tokens) {
+			attached.push({ sid, name, tokens });
+		},
+		async get() {
+			return null;
+		},
+		async update() {},
+		async deleteBySession() {},
+		async delete() {},
+	} as FederationTokenStoreBase & { _attached: unknown[] };
+}
+
+type DoneRecord = { err: Error | null; user: unknown; reqSid: unknown };
+
+function makeProvider(
+	federationName: string,
+	profileOverride: {
+		id: string;
+		raw?: Record<string, unknown>;
+		accessToken?: string;
+		refreshToken?: string;
+		idToken?: string;
+		expiresIn?: number;
+	},
+	doneResults: DoneRecord[],
+	mapClaimsImpl?: (profile: {
+		id: string;
+		raw: Record<string, unknown>;
+	}) => Record<string, unknown>,
+): FederationProviderBase & SupportsClaimMapping {
+	const reqStub = {
+		session: {} as Record<string, unknown>,
+	} as unknown as import("express").Request;
+	return {
+		name: federationName,
+		scope: ["openid"],
+		validateRedirect: () => ({ ok: true as const, value: undefined }),
+		resolveCallbackRedirect: () => ({ ok: true as const, value: "/" }),
+		async setupPassportStrategy(_passport, ctx) {
+			if (!ctx.onFederationCallback) throw new Error("onFederationCallback hook missing");
+			await ctx.onFederationCallback({
+				federationName,
+				profile: {
+					id: profileOverride.id,
+					raw: profileOverride.raw ?? {},
+					accessToken: profileOverride.accessToken,
+					refreshToken: profileOverride.refreshToken,
+					idToken: profileOverride.idToken,
+					expiresIn: profileOverride.expiresIn,
+				},
+				req: reqStub,
+				done: (err, user) => {
+					doneResults.push({
+						err,
+						user,
+						reqSid: (reqStub.session as Record<string, unknown>).sid,
+					});
+				},
+			});
+		},
+		mapClaims: mapClaimsImpl
+			? (profile) => mapClaimsImpl(profile as { id: string; raw: Record<string, unknown> })
+			: () => ({}),
+	};
+}
+
+describe("_createPassportImpl onFederationCallback wiring", () => {
+	it("creates UserSession, attaches federation tokens, sets req.session.sid on success", async () => {
+		const doneResults: DoneRecord[] = [];
+		const us = makeUserSessionStore();
+		const ft = makeFederationTokenStore();
+		const provider = makeProvider(
+			"google",
+			{
+				id: "gid-1",
+				raw: { displayName: "Alice" },
+				accessToken: "at",
+				refreshToken: "rt",
+				idToken: "it",
+				expiresIn: 3600,
+			},
+			doneResults,
+			() => ({ name: "Alice", email: "fed@x.com" }),
+		);
+		const userRepo = {
+			authenticate: async () => null,
+			authenticateByToken: vi.fn().mockResolvedValue(fakeUser),
+		};
+
+		await _createPassportImpl({
+			pathResolver: (s) => s,
+			userRepository: userRepo as unknown as Parameters<
+				typeof _createPassportImpl
+			>[0]["userRepository"],
+			federationProviders: new Map([["google", provider]]),
+			userSessionStore: us,
+			federationTokenStore: ft,
+			sessionTtlMs: 86400_000,
+			_passportOverride: makePassportStub(),
+		});
+
+		// UserSession was created
+		expect(us._saved).toHaveLength(1);
+		const saved = us._saved[0] as {
+			sid: string;
+			sub: string;
+			claims: Record<string, unknown>;
+			federations: string[];
+		};
+		expect(saved.sub).toBe("u-1");
+		expect(saved.federations).toEqual(["google"]);
+		// federation claims override user claims (spread order: user first, then mapped)
+		expect(saved.claims).toMatchObject({ email: "fed@x.com", name: "Alice" });
+
+		// FederationTokens were attached
+		expect(ft._attached).toHaveLength(1);
+		const at = ft._attached[0] as {
+			sid: string;
+			name: string;
+			tokens: {
+				accessToken: string;
+				refreshToken: string | undefined;
+				idToken: string | undefined;
+			};
+		};
+		expect(at.sid).toBe(saved.sid);
+		expect(at.name).toBe("google");
+		expect(at.tokens.accessToken).toBe("at");
+		expect(at.tokens.refreshToken).toBe("rt");
+		expect(at.tokens.idToken).toBe("it");
+
+		// done was called with (null, user)
+		expect(doneResults).toHaveLength(1);
+		expect(doneResults[0]?.err).toBeNull();
+		expect((doneResults[0]?.user as { id: string })?.id).toBe("u-1");
+
+		// req.session.sid was set to the same sid
+		expect(doneResults[0]?.reqSid).toBe(saved.sid);
+	});
+
+	it("calls done(null, false) and creates no session when verifyUser returns null", async () => {
+		const doneResults: DoneRecord[] = [];
+		const us = makeUserSessionStore();
+		const ft = makeFederationTokenStore();
+		const provider = makeProvider("google", { id: "gid-unknown" }, doneResults);
+		const userRepo = {
+			authenticate: async () => null,
+			authenticateByToken: vi.fn().mockResolvedValue(null),
+		};
+
+		await _createPassportImpl({
+			pathResolver: (s) => s,
+			userRepository: userRepo as unknown as Parameters<
+				typeof _createPassportImpl
+			>[0]["userRepository"],
+			federationProviders: new Map([["google", provider]]),
+			userSessionStore: us,
+			federationTokenStore: ft,
+			sessionTtlMs: 86400_000,
+			_passportOverride: makePassportStub(),
+		});
+
+		expect(doneResults).toHaveLength(1);
+		expect(doneResults[0]?.err).toBeNull();
+		expect(doneResults[0]?.user).toBe(false);
+		expect(us._saved).toHaveLength(0);
+		expect(ft._attached).toHaveLength(0);
+	});
+
+	it("skips FederationTokenStore.attach when profile has no accessToken", async () => {
+		const doneResults: DoneRecord[] = [];
+		const us = makeUserSessionStore();
+		const ft = makeFederationTokenStore();
+		// No accessToken in profile
+		const provider = makeProvider("google", { id: "gid-1" }, doneResults);
+		const userRepo = {
+			authenticate: async () => null,
+			authenticateByToken: vi.fn().mockResolvedValue(fakeUser),
+		};
+
+		await _createPassportImpl({
+			pathResolver: (s) => s,
+			userRepository: userRepo as unknown as Parameters<
+				typeof _createPassportImpl
+			>[0]["userRepository"],
+			federationProviders: new Map([["google", provider]]),
+			userSessionStore: us,
+			federationTokenStore: ft,
+			_passportOverride: makePassportStub(),
+		});
+
+		expect(us._saved).toHaveLength(1);
+		expect(ft._attached).toHaveLength(0);
+	});
+
+	it("leaves onFederationCallback undefined when userSessionStore is absent", async () => {
+		let receivedCtx: unknown;
+		const provider: FederationProviderBase = {
+			name: "google",
+			scope: ["openid"],
+			validateRedirect: () => ({ ok: true as const, value: undefined }),
+			resolveCallbackRedirect: () => ({ ok: true as const, value: "/" }),
+			async setupPassportStrategy(_passport, ctx) {
+				receivedCtx = ctx;
+			},
+		};
+		const ft = makeFederationTokenStore();
+		const userRepo = {
+			authenticate: async () => null,
+			authenticateByToken: vi.fn().mockResolvedValue(null),
+		};
+
+		await _createPassportImpl({
+			pathResolver: (s) => s,
+			userRepository: userRepo as unknown as Parameters<
+				typeof _createPassportImpl
+			>[0]["userRepository"],
+			federationProviders: new Map([["google", provider]]),
+			federationTokenStore: ft,
+			_passportOverride: makePassportStub(),
+		});
+
+		expect(
+			(receivedCtx as { onFederationCallback?: unknown })?.onFederationCallback,
+		).toBeUndefined();
+	});
+
+	it("leaves onFederationCallback undefined when federationTokenStore is absent", async () => {
+		let receivedCtx: unknown;
+		const provider: FederationProviderBase = {
+			name: "google",
+			scope: ["openid"],
+			validateRedirect: () => ({ ok: true as const, value: undefined }),
+			resolveCallbackRedirect: () => ({ ok: true as const, value: "/" }),
+			async setupPassportStrategy(_passport, ctx) {
+				receivedCtx = ctx;
+			},
+		};
+		const us = makeUserSessionStore();
+		const userRepo = {
+			authenticate: async () => null,
+			authenticateByToken: vi.fn().mockResolvedValue(null),
+		};
+
+		await _createPassportImpl({
+			pathResolver: (s) => s,
+			userRepository: userRepo as unknown as Parameters<
+				typeof _createPassportImpl
+			>[0]["userRepository"],
+			federationProviders: new Map([["google", provider]]),
+			userSessionStore: us,
+			_passportOverride: makePassportStub(),
+		});
+
+		expect(
+			(receivedCtx as { onFederationCallback?: unknown })?.onFederationCallback,
+		).toBeUndefined();
+	});
+
+	it("calls done(err, false) when an internal error is thrown", async () => {
+		const doneResults: DoneRecord[] = [];
+		const us = makeUserSessionStore();
+		const ft = makeFederationTokenStore();
+		const provider = makeProvider("google", { id: "gid-1", accessToken: "at" }, doneResults);
+		const boom = new Error("db failure");
+		const userRepo = {
+			authenticate: async () => null,
+			authenticateByToken: vi.fn().mockRejectedValue(boom),
+		};
+
+		await _createPassportImpl({
+			pathResolver: (s) => s,
+			userRepository: userRepo as unknown as Parameters<
+				typeof _createPassportImpl
+			>[0]["userRepository"],
+			federationProviders: new Map([["google", provider]]),
+			userSessionStore: us,
+			federationTokenStore: ft,
+			_passportOverride: makePassportStub(),
+		});
+
+		expect(doneResults).toHaveLength(1);
+		expect(doneResults[0]?.err).toBe(boom);
+		expect(doneResults[0]?.user).toBe(false);
+	});
+});

--- a/packages/session/src/__tests__/passport-onFederationCallback.test.mts
+++ b/packages/session/src/__tests__/passport-onFederationCallback.test.mts
@@ -236,6 +236,36 @@ describe("_createPassportImpl onFederationCallback wiring", () => {
 		expect(ft._attached).toHaveLength(0);
 	});
 
+	it("rejects empty profile.id without calling authenticateByToken or touching stores", async () => {
+		const doneResults: DoneRecord[] = [];
+		const us = makeUserSessionStore();
+		const ft = makeFederationTokenStore();
+		const provider = makeProvider("google", { id: "" }, doneResults);
+		const authenticateByToken = vi.fn().mockResolvedValue(fakeUser);
+		const userRepo = {
+			authenticate: async () => null,
+			authenticateByToken,
+		};
+
+		await _createPassportImpl({
+			pathResolver: (s) => s,
+			userRepository: userRepo as unknown as Parameters<
+				typeof _createPassportImpl
+			>[0]["userRepository"],
+			federationProviders: new Map([["google", provider]]),
+			userSessionStore: us,
+			federationTokenStore: ft,
+			_passportOverride: makePassportStub(),
+		});
+
+		expect(doneResults).toHaveLength(1);
+		expect(doneResults[0]?.err).toBeNull();
+		expect(doneResults[0]?.user).toBe(false);
+		expect(authenticateByToken).not.toHaveBeenCalled();
+		expect(us._saved).toHaveLength(0);
+		expect(ft._attached).toHaveLength(0);
+	});
+
 	it("skips FederationTokenStore.attach when profile has no accessToken", async () => {
 		const doneResults: DoneRecord[] = [];
 		const us = makeUserSessionStore();

--- a/packages/session/src/__tests__/passport-onFederationCallback.test.mts
+++ b/packages/session/src/__tests__/passport-onFederationCallback.test.mts
@@ -29,11 +29,13 @@ function makePassportStub() {
 	} as unknown as import("passport").PassportStatic;
 }
 
-function makeUserSessionStore(): UserSessionStoreBase & { _saved: unknown[] } {
+function makeUserSessionStore(): UserSessionStoreBase & { _saved: unknown[]; _deleted: string[] } {
 	const saved: unknown[] = [];
+	const deleted: string[] = [];
 	return {
 		kind: "memory",
 		_saved: saved,
+		_deleted: deleted,
 		async create(input) {
 			saved.push(input);
 		},
@@ -44,8 +46,10 @@ function makeUserSessionStore(): UserSessionStoreBase & { _saved: unknown[] } {
 		async linkFamily() {},
 		async updateClaims() {},
 		async removeFederation() {},
-		async delete() {},
-	} as UserSessionStoreBase & { _saved: unknown[] };
+		async delete(sid: string) {
+			deleted.push(sid);
+		},
+	} as UserSessionStoreBase & { _saved: unknown[]; _deleted: string[] };
 }
 
 function makeFederationTokenStore(): FederationTokenStoreBase & { _attached: unknown[] } {
@@ -337,5 +341,54 @@ describe("_createPassportImpl onFederationCallback wiring", () => {
 		expect(doneResults).toHaveLength(1);
 		expect(doneResults[0]?.err).toBe(boom);
 		expect(doneResults[0]?.user).toBe(false);
+	});
+
+	it("rolls back UserSession (delete) when federationTokenStore.attach throws post-create", async () => {
+		const doneResults: DoneRecord[] = [];
+		const us = makeUserSessionStore();
+		const attachError = new Error("attach failure");
+		const ft: FederationTokenStoreBase & { _attached: unknown[] } = {
+			kind: "memory",
+			_attached: [],
+			async attach() {
+				throw attachError;
+			},
+			async get() {
+				return null;
+			},
+			async update() {},
+			async deleteBySession() {},
+			async delete() {},
+		} as FederationTokenStoreBase & { _attached: unknown[] };
+
+		const provider = makeProvider("google", { id: "gid-rollback", accessToken: "at" }, doneResults);
+		const userRepo = {
+			authenticate: async () => null,
+			authenticateByToken: vi.fn().mockResolvedValue(fakeUser),
+		};
+
+		await _createPassportImpl({
+			pathResolver: (s) => s,
+			userRepository: userRepo as unknown as Parameters<
+				typeof _createPassportImpl
+			>[0]["userRepository"],
+			federationProviders: new Map([["google", provider]]),
+			userSessionStore: us,
+			federationTokenStore: ft,
+			_passportOverride: makePassportStub(),
+		});
+
+		// UserSession was created
+		expect(us._saved).toHaveLength(1);
+		const saved = us._saved[0] as { sid: string };
+
+		// done was called with the attach error
+		expect(doneResults).toHaveLength(1);
+		expect(doneResults[0]?.err).toBe(attachError);
+		expect(doneResults[0]?.user).toBe(false);
+
+		// UserSession was rolled back (delete called with the generated sid)
+		expect(us._deleted).toHaveLength(1);
+		expect(us._deleted[0]).toBe(saved.sid);
 	});
 });

--- a/packages/session/src/federations/__tests__/github.test.mts
+++ b/packages/session/src/federations/__tests__/github.test.mts
@@ -270,5 +270,13 @@ describe("GitHub provider capabilities", () => {
 			expect(result.url.href).toContain("https://rp/done");
 			expect(result.url.searchParams.get("state")).toBe("abc");
 		});
+
+		it("throws a descriptive error when postLogoutRedirectUri is an invalid URL", async () => {
+			const p = createGithubProvider(base);
+			if (!supportsLogout(p)) throw new Error("expected logout capability");
+			await expect(p.endSession({ postLogoutRedirectUri: "not a valid url" })).rejects.toThrow(
+				/invalid postLogoutRedirectUri/i,
+			);
+		});
 	});
 });

--- a/packages/session/src/federations/__tests__/github.test.mts
+++ b/packages/session/src/federations/__tests__/github.test.mts
@@ -118,7 +118,7 @@ describe("setupPassportStrategy", () => {
 		expect(mockPassport.use).toHaveBeenCalledWith("github", expect.any(Object));
 	});
 
-	it("verify callback builds externalId as 'github:' + profile.id", async () => {
+	it("verify callback builds externalId as config.name + ':' + profile.id (default name='github')", async () => {
 		const mockPassport = { use: vi.fn() } as unknown as PassportStatic;
 		const verifyUser = vi.fn(async () => null);
 		const provider = createGithubProvider(baseConfig);
@@ -131,7 +131,35 @@ describe("setupPassportStrategy", () => {
 		const done = vi.fn();
 		const reqStub = { session: {} } as unknown as import("express").Request;
 		await verifyCallback(reqStub, "at", "rt", {}, { id: "99999" }, done);
-		expect(verifyUser).toHaveBeenCalledWith("github:99999");
+		expect(verifyUser).toHaveBeenCalledWith(`${baseConfig.name}:99999`);
+	});
+
+	it("verify callback uses config.name in externalId for multi-tenant (github-enterprise)", async () => {
+		const mockPassport = { use: vi.fn() } as unknown as PassportStatic;
+		const verifyUser = vi.fn(async () => null);
+		const multiTenantConfig = { ...baseConfig, name: "github-enterprise" };
+		const provider = createGithubProvider(multiTenantConfig);
+		await provider.setupPassportStrategy(mockPassport, { verifyUser });
+		const strategyInstance = (mockPassport.use as ReturnType<typeof vi.fn>).mock.calls[0][1];
+		const verifyCallback = strategyInstance._verify ?? strategyInstance.verify;
+		const done = vi.fn();
+		const reqStub = { session: {} } as unknown as import("express").Request;
+		await verifyCallback(reqStub, "at", "rt", {}, { id: "99999" }, done);
+		expect(verifyUser).toHaveBeenCalledWith("github-enterprise:99999");
+	});
+
+	it("verify callback calls done(null, false) when profile.id is empty", async () => {
+		const mockPassport = { use: vi.fn() } as unknown as PassportStatic;
+		const verifyUser = vi.fn(async () => null);
+		const provider = createGithubProvider(baseConfig);
+		await provider.setupPassportStrategy(mockPassport, { verifyUser });
+		const strategyInstance = (mockPassport.use as ReturnType<typeof vi.fn>).mock.calls[0][1];
+		const verifyCallback = strategyInstance._verify ?? strategyInstance.verify;
+		const done = vi.fn();
+		const reqStub = { session: {} } as unknown as import("express").Request;
+		await verifyCallback(reqStub, "at", "rt", {}, { id: "" }, done);
+		expect(done).toHaveBeenCalledWith(null, false);
+		expect(verifyUser).not.toHaveBeenCalled();
 	});
 
 	it("uses config.name as the passport strategy identifier for multi-tenant", async () => {

--- a/packages/session/src/federations/__tests__/github.test.mts
+++ b/packages/session/src/federations/__tests__/github.test.mts
@@ -127,9 +127,10 @@ describe("setupPassportStrategy", () => {
 		const strategyInstance = (mockPassport.use as ReturnType<typeof vi.fn>).mock.calls[0][1];
 		const verifyCallback = strategyInstance._verify ?? strategyInstance.verify;
 		// Invoke it with a mock profile — passReqToCallback:true means req is the first arg
+		// arity-6: req, accessToken, refreshToken, params, profile, done
 		const done = vi.fn();
 		const reqStub = { session: {} } as unknown as import("express").Request;
-		await verifyCallback(reqStub, "at", "rt", { id: "99999" }, done);
+		await verifyCallback(reqStub, "at", "rt", {}, { id: "99999" }, done);
 		expect(verifyUser).toHaveBeenCalledWith("github:99999");
 	});
 

--- a/packages/session/src/federations/__tests__/github.test.mts
+++ b/packages/session/src/federations/__tests__/github.test.mts
@@ -17,6 +17,8 @@
 import type { PassportStatic } from "passport";
 import { describe, expect, it, vi } from "vitest";
 import { createGithubProvider } from "#/federations/github.mjs";
+import type { FederationProfile } from "#/federations/types.mjs";
+import { supportsClaimMapping, supportsLogout, supportsRefresh } from "#/federations/types.mjs";
 
 const baseConfig = {
 	name: "github",
@@ -177,5 +179,66 @@ describe("createGithubProvider validation", () => {
 
 	it("throws when callbackURL is missing", () => {
 		expect(() => createGithubProvider({ ...baseConfig, callbackURL: "" })).toThrow(/callbackURL/i);
+	});
+});
+
+describe("GitHub provider capabilities", () => {
+	const base = {
+		name: "github",
+		clientId: "cid",
+		clientSecret: "csec",
+		callbackURL: "https://example.com/cb",
+	};
+
+	it("implements mapClaims and endSession; does NOT implement refresh", () => {
+		const p = createGithubProvider(base);
+		expect(supportsClaimMapping(p)).toBe(true);
+		expect(supportsLogout(p)).toBe(true);
+		expect(supportsRefresh(p)).toBe(false);
+	});
+
+	describe("mapClaims", () => {
+		it("maps profile fields (without fetching /user/emails)", async () => {
+			const p = createGithubProvider(base);
+			if (!supportsClaimMapping(p)) throw new Error("expected claim mapping");
+			const profile: FederationProfile = {
+				id: "gh-42",
+				raw: {
+					username: "alice",
+					displayName: "Alice Dev",
+					emails: [{ value: "primary@x.com" }],
+					photos: [{ value: "https://avatars.githubusercontent.com/u/42" }],
+				},
+			};
+			expect(p.mapClaims(profile)).toEqual({
+				email: "primary@x.com",
+				name: "Alice Dev",
+				picture: "https://avatars.githubusercontent.com/u/42",
+			});
+		});
+
+		it("omits email when passport profile exposes none (caller must fetchGithubPrimaryEmail separately)", () => {
+			const p = createGithubProvider(base);
+			if (!supportsClaimMapping(p)) throw new Error("expected claim mapping");
+			const profile: FederationProfile = {
+				id: "gh",
+				raw: { displayName: "Anon" },
+			};
+			expect(p.mapClaims(profile)).toEqual({ name: "Anon" });
+		});
+	});
+
+	describe("endSession", () => {
+		it("returns a no-op-ish GET URL pointing at the post_logout_redirect_uri directly (GitHub has no end-session endpoint)", async () => {
+			const p = createGithubProvider(base);
+			if (!supportsLogout(p)) throw new Error("expected logout capability");
+			const result = await p.endSession({
+				postLogoutRedirectUri: "https://rp/done",
+				state: "abc",
+			});
+			expect(result.method).toBe("GET");
+			expect(result.url.href).toContain("https://rp/done");
+			expect(result.url.searchParams.get("state")).toBe("abc");
+		});
 	});
 });

--- a/packages/session/src/federations/__tests__/github.test.mts
+++ b/packages/session/src/federations/__tests__/github.test.mts
@@ -126,9 +126,10 @@ describe("setupPassportStrategy", () => {
 		// Extract the verify callback passed to the GithubStrategy constructor
 		const strategyInstance = (mockPassport.use as ReturnType<typeof vi.fn>).mock.calls[0][1];
 		const verifyCallback = strategyInstance._verify ?? strategyInstance.verify;
-		// Invoke it with a mock profile
+		// Invoke it with a mock profile — passReqToCallback:true means req is the first arg
 		const done = vi.fn();
-		await verifyCallback("at", "rt", { id: "99999" }, done);
+		const reqStub = { session: {} } as unknown as import("express").Request;
+		await verifyCallback(reqStub, "at", "rt", { id: "99999" }, done);
 		expect(verifyUser).toHaveBeenCalledWith("github:99999");
 	});
 

--- a/packages/session/src/federations/__tests__/google.test.mts
+++ b/packages/session/src/federations/__tests__/google.test.mts
@@ -354,6 +354,19 @@ describe("Google provider capabilities", () => {
 			if (!supportsRefresh(p)) throw new Error("expected refresh capability");
 			await expect(p.refreshFederationToken("rt")).rejects.toThrow(/temporarily_unavailable/);
 		});
+
+		it("throws temporarily_unavailable when the fetch is aborted (timeout simulation)", async () => {
+			const abortError = Object.assign(new Error("The operation was aborted."), {
+				name: "AbortError",
+			});
+			const fetchMock = vi.fn().mockRejectedValue(abortError);
+			const p = createGoogleProvider({
+				...capConfig,
+				_fetch: fetchMock as unknown as typeof fetch,
+			});
+			if (!supportsRefresh(p)) throw new Error("expected refresh capability");
+			await expect(p.refreshFederationToken("rt")).rejects.toThrow(/temporarily_unavailable/);
+		});
 	});
 
 	describe("endSession", () => {
@@ -395,6 +408,23 @@ describe("Google provider capabilities", () => {
 			expect(url.searchParams.get("id_token_hint")).toBe("idt");
 			expect(url.searchParams.get("post_logout_redirect_uri")).toBe("https://rp/done");
 			expect(url.searchParams.get("state")).toBe("s2");
+		});
+
+		it("throws a descriptive error when endSessionEndpoint is an invalid URL", async () => {
+			const p = createGoogleProvider({
+				...capConfig,
+				endSessionEndpoint: "not-a-valid-url",
+			});
+			if (!supportsLogout(p)) throw new Error("expected logout capability");
+			await expect(p.endSession({})).rejects.toThrow(/invalid endSessionEndpoint/i);
+		});
+
+		it("throws a descriptive error when postLogoutRedirectUri is an invalid URL (no endSessionEndpoint)", async () => {
+			const p = createGoogleProvider(capConfig);
+			if (!supportsLogout(p)) throw new Error("expected logout capability");
+			await expect(p.endSession({ postLogoutRedirectUri: "not a valid url" })).rejects.toThrow(
+				/invalid postLogoutRedirectUri/i,
+			);
 		});
 	});
 });

--- a/packages/session/src/federations/__tests__/google.test.mts
+++ b/packages/session/src/federations/__tests__/google.test.mts
@@ -17,6 +17,8 @@
 import type { PassportStatic } from "passport";
 import { describe, expect, it, vi } from "vitest";
 import { createGoogleProvider } from "#/federations/google.mjs";
+import type { FederationProfile } from "#/federations/types.mjs";
+import { supportsClaimMapping, supportsLogout, supportsRefresh } from "#/federations/types.mjs";
 
 const baseConfig = {
 	name: "google",
@@ -166,5 +168,130 @@ describe("createGoogleProvider validation", () => {
 
 	it("throws when callbackURL is missing", () => {
 		expect(() => createGoogleProvider({ ...baseConfig, callbackURL: "" })).toThrow(/callbackURL/i);
+	});
+});
+
+describe("Google provider capabilities", () => {
+	const capConfig = {
+		name: "google",
+		clientId: "cid",
+		clientSecret: "csec",
+		callbackURL: "https://example.com/cb",
+	};
+
+	it("implements all three capabilities", () => {
+		const p = createGoogleProvider(capConfig);
+		expect(supportsClaimMapping(p)).toBe(true);
+		expect(supportsRefresh(p)).toBe(true);
+		expect(supportsLogout(p)).toBe(true);
+	});
+
+	describe("mapClaims", () => {
+		const p = createGoogleProvider(capConfig);
+		it("extracts email + name + picture from google profile", () => {
+			if (!supportsClaimMapping(p)) throw new Error("expected claim mapping");
+			const profile: FederationProfile = {
+				id: "gid-123",
+				raw: {
+					emails: [{ value: "alice@example.com", verified: true }],
+					displayName: "Alice",
+					photos: [{ value: "https://lh.com/p.png" }],
+					_json: { email: "alice@example.com", email_verified: true, hd: "example.com" },
+				},
+			};
+			expect(p.mapClaims(profile)).toEqual({
+				email: "alice@example.com",
+				emailVerified: true,
+				name: "Alice",
+				picture: "https://lh.com/p.png",
+				hd: "example.com",
+			});
+		});
+
+		it("returns empty claims when fields are absent", () => {
+			if (!supportsClaimMapping(p)) throw new Error("expected claim mapping");
+			const profile: FederationProfile = { id: "gid", raw: {} };
+			expect(p.mapClaims(profile)).toEqual({});
+		});
+	});
+
+	describe("refreshFederationToken", () => {
+		it("exchanges refresh_token for a new access_token via Google token endpoint", async () => {
+			const fetchMock = vi.fn().mockResolvedValue({
+				ok: true,
+				status: 200,
+				async json() {
+					return {
+						access_token: "new-at",
+						expires_in: 3600,
+						token_type: "Bearer",
+						id_token: "new-id",
+					};
+				},
+			});
+			const p = createGoogleProvider({
+				...capConfig,
+				_fetch: fetchMock as unknown as typeof fetch,
+			});
+			if (!supportsRefresh(p)) throw new Error("expected refresh capability");
+			const result = await p.refreshFederationToken("old-rt");
+			expect(result.accessToken).toBe("new-at");
+			expect(result.idToken).toBe("new-id");
+			expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now() + 3500_000);
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			const firstCall = fetchMock.mock.calls[0];
+			if (!firstCall) throw new Error("expected fetch to be called");
+			const [url, init] = firstCall;
+			expect(url).toBe("https://oauth2.googleapis.com/token");
+			expect((init as RequestInit).method).toBe("POST");
+			expect((init as RequestInit).body).toContain("refresh_token=old-rt");
+			expect((init as RequestInit).body).toContain("grant_type=refresh_token");
+		});
+
+		it("throws invalid_grant-shaped Error when Google rejects the refresh_token", async () => {
+			const fetchMock = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 400,
+				async json() {
+					return { error: "invalid_grant", error_description: "Token revoked" };
+				},
+			});
+			const p = createGoogleProvider({
+				...capConfig,
+				_fetch: fetchMock as unknown as typeof fetch,
+			});
+			if (!supportsRefresh(p)) throw new Error("expected refresh capability");
+			await expect(p.refreshFederationToken("rt")).rejects.toThrow(/invalid_grant/);
+		});
+
+		it("throws transient-shaped Error on 5xx (caller returns 503 in F-6)", async () => {
+			const fetchMock = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 503,
+				async json() {
+					return {};
+				},
+			});
+			const p = createGoogleProvider({
+				...capConfig,
+				_fetch: fetchMock as unknown as typeof fetch,
+			});
+			if (!supportsRefresh(p)) throw new Error("expected refresh capability");
+			await expect(p.refreshFederationToken("rt")).rejects.toThrow(/temporarily_unavailable/);
+		});
+	});
+
+	describe("endSession", () => {
+		it("returns Google revoke URL", async () => {
+			const p = createGoogleProvider(capConfig);
+			if (!supportsLogout(p)) throw new Error("expected logout capability");
+			const { url, method } = await p.endSession({
+				idTokenHint: "idt",
+				postLogoutRedirectUri: "https://rp/logout-done",
+			});
+			expect(method).toBe("GET");
+			expect(url.hostname).toBe("accounts.google.com");
+			expect(url.pathname).toContain("logout");
+		});
 	});
 });

--- a/packages/session/src/federations/__tests__/google.test.mts
+++ b/packages/session/src/federations/__tests__/google.test.mts
@@ -122,10 +122,56 @@ describe("setupPassportStrategy", () => {
 		const strategyInstance = (mockPassport.use as ReturnType<typeof vi.fn>).mock.calls[0][1];
 		const verifyCallback = strategyInstance._verify ?? strategyInstance.verify;
 		// Invoke it with a mock profile — passReqToCallback:true means req is the first arg
+		// arity-6: req, accessToken, refreshToken, params, profile, done
 		const done = vi.fn();
 		const reqStub = { session: {} } as unknown as import("express").Request;
-		await verifyCallback(reqStub, "at", "rt", { id: "12345" }, done);
+		await verifyCallback(reqStub, "at", "rt", {}, { id: "12345" }, done);
 		expect(verifyUser).toHaveBeenCalledWith("google:12345");
+	});
+
+	it("verify callback passes id_token and expires_in from params to FederationProfile", async () => {
+		const mockPassport = { use: vi.fn() } as unknown as PassportStatic;
+		const onFederationCallback = vi.fn(
+			async ({ done }: { done: (err: Error | null, user: unknown) => void }) => {
+				done(null, { id: "u1" });
+			},
+		);
+		const verifyUser = vi.fn(async () => null);
+		const provider = createGoogleProvider(baseConfig);
+		await provider.setupPassportStrategy(mockPassport, { verifyUser, onFederationCallback });
+		const strategyInstance = (mockPassport.use as ReturnType<typeof vi.fn>).mock.calls[0][1];
+		const verifyCallback = strategyInstance._verify ?? strategyInstance.verify;
+		const done = vi.fn();
+		const reqStub = { session: {} } as unknown as import("express").Request;
+		// arity-6: params carries id_token and expires_in
+		await verifyCallback(
+			reqStub,
+			"access-token",
+			"refresh-token",
+			{ id_token: "google-id-token", expires_in: 7200 },
+			{ id: "gid-123" },
+			done,
+		);
+		expect(onFederationCallback).toHaveBeenCalledTimes(1);
+		const callArg = (onFederationCallback as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+			profile: import("#/federations/types.mjs").FederationProfile;
+		};
+		expect(callArg.profile.idToken).toBe("google-id-token");
+		expect(callArg.profile.expiresIn).toBe(7200);
+		expect(callArg.profile.accessToken).toBe("access-token");
+		expect(callArg.profile.refreshToken).toBe("refresh-token");
+	});
+
+	it("strategy has authorizationParams that always includes access_type=offline", async () => {
+		const mockPassport = { use: vi.fn() } as unknown as PassportStatic;
+		const provider = createGoogleProvider(baseConfig);
+		await provider.setupPassportStrategy(mockPassport, { verifyUser: async () => null });
+		const strategyInstance = (mockPassport.use as ReturnType<typeof vi.fn>).mock
+			.calls[0][1] as unknown as {
+			authorizationParams(opts: Record<string, unknown>): Record<string, unknown>;
+		};
+		const params = strategyInstance.authorizationParams({});
+		expect(params).toMatchObject({ access_type: "offline" });
 	});
 
 	it("uses config.name as the passport strategy identifier for multi-tenant", async () => {
@@ -283,16 +329,44 @@ describe("Google provider capabilities", () => {
 	});
 
 	describe("endSession", () => {
-		it("returns Google revoke URL", async () => {
+		it("without endSessionEndpoint configured: redirects to postLogoutRedirectUri directly", async () => {
 			const p = createGoogleProvider(capConfig);
 			if (!supportsLogout(p)) throw new Error("expected logout capability");
 			const { url, method } = await p.endSession({
-				idTokenHint: "idt",
 				postLogoutRedirectUri: "https://rp/logout-done",
+				state: "s1",
 			});
 			expect(method).toBe("GET");
+			expect(url.href).toContain("https://rp/logout-done");
+			expect(url.searchParams.get("state")).toBe("s1");
+		});
+
+		it("without endSessionEndpoint and no postLogoutRedirectUri: falls back to accounts.google.com/Logout", async () => {
+			const p = createGoogleProvider(capConfig);
+			if (!supportsLogout(p)) throw new Error("expected logout capability");
+			const { url, method } = await p.endSession({});
+			expect(method).toBe("GET");
 			expect(url.hostname).toBe("accounts.google.com");
-			expect(url.pathname).toContain("logout");
+			expect(url.pathname.endsWith("/Logout")).toBe(true);
+		});
+
+		it("with endSessionEndpoint configured: uses it and attaches all params", async () => {
+			const p = createGoogleProvider({
+				...capConfig,
+				endSessionEndpoint: "https://custom-logout.example.com/end",
+			});
+			if (!supportsLogout(p)) throw new Error("expected logout capability");
+			const { url, method } = await p.endSession({
+				idTokenHint: "idt",
+				postLogoutRedirectUri: "https://rp/done",
+				state: "s2",
+			});
+			expect(method).toBe("GET");
+			expect(url.origin).toBe("https://custom-logout.example.com");
+			expect(url.pathname).toBe("/end");
+			expect(url.searchParams.get("id_token_hint")).toBe("idt");
+			expect(url.searchParams.get("post_logout_redirect_uri")).toBe("https://rp/done");
+			expect(url.searchParams.get("state")).toBe("s2");
 		});
 	});
 });

--- a/packages/session/src/federations/__tests__/google.test.mts
+++ b/packages/session/src/federations/__tests__/google.test.mts
@@ -113,7 +113,7 @@ describe("setupPassportStrategy", () => {
 		expect(mockPassport.use).toHaveBeenCalledWith("google", expect.any(Object));
 	});
 
-	it("verify callback builds externalId as 'google:' + profile.id", async () => {
+	it("verify callback builds externalId as config.name + ':' + profile.id (default name='google')", async () => {
 		const mockPassport = { use: vi.fn() } as unknown as PassportStatic;
 		const verifyUser = vi.fn(async () => null);
 		const provider = createGoogleProvider(baseConfig);
@@ -126,7 +126,35 @@ describe("setupPassportStrategy", () => {
 		const done = vi.fn();
 		const reqStub = { session: {} } as unknown as import("express").Request;
 		await verifyCallback(reqStub, "at", "rt", {}, { id: "12345" }, done);
-		expect(verifyUser).toHaveBeenCalledWith("google:12345");
+		expect(verifyUser).toHaveBeenCalledWith(`${baseConfig.name}:12345`);
+	});
+
+	it("verify callback uses config.name in externalId for multi-tenant (google-work)", async () => {
+		const mockPassport = { use: vi.fn() } as unknown as PassportStatic;
+		const verifyUser = vi.fn(async () => null);
+		const multiTenantConfig = { ...baseConfig, name: "google-work" };
+		const provider = createGoogleProvider(multiTenantConfig);
+		await provider.setupPassportStrategy(mockPassport, { verifyUser });
+		const strategyInstance = (mockPassport.use as ReturnType<typeof vi.fn>).mock.calls[0][1];
+		const verifyCallback = strategyInstance._verify ?? strategyInstance.verify;
+		const done = vi.fn();
+		const reqStub = { session: {} } as unknown as import("express").Request;
+		await verifyCallback(reqStub, "at", "rt", {}, { id: "12345" }, done);
+		expect(verifyUser).toHaveBeenCalledWith("google-work:12345");
+	});
+
+	it("verify callback calls done(null, false) when profile.id is empty", async () => {
+		const mockPassport = { use: vi.fn() } as unknown as PassportStatic;
+		const verifyUser = vi.fn(async () => null);
+		const provider = createGoogleProvider(baseConfig);
+		await provider.setupPassportStrategy(mockPassport, { verifyUser });
+		const strategyInstance = (mockPassport.use as ReturnType<typeof vi.fn>).mock.calls[0][1];
+		const verifyCallback = strategyInstance._verify ?? strategyInstance.verify;
+		const done = vi.fn();
+		const reqStub = { session: {} } as unknown as import("express").Request;
+		await verifyCallback(reqStub, "at", "rt", {}, { id: "" }, done);
+		expect(done).toHaveBeenCalledWith(null, false);
+		expect(verifyUser).not.toHaveBeenCalled();
 	});
 
 	it("verify callback passes id_token and expires_in from params to FederationProfile", async () => {

--- a/packages/session/src/federations/__tests__/google.test.mts
+++ b/packages/session/src/federations/__tests__/google.test.mts
@@ -121,9 +121,10 @@ describe("setupPassportStrategy", () => {
 		// Extract the verify callback passed to the GoogleStrategy constructor
 		const strategyInstance = (mockPassport.use as ReturnType<typeof vi.fn>).mock.calls[0][1];
 		const verifyCallback = strategyInstance._verify ?? strategyInstance.verify;
-		// Invoke it with a mock profile
+		// Invoke it with a mock profile — passReqToCallback:true means req is the first arg
 		const done = vi.fn();
-		await verifyCallback("at", "rt", { id: "12345" }, done);
+		const reqStub = { session: {} } as unknown as import("express").Request;
+		await verifyCallback(reqStub, "at", "rt", { id: "12345" }, done);
 		expect(verifyUser).toHaveBeenCalledWith("google:12345");
 	});
 

--- a/packages/session/src/federations/__tests__/helpers.test.mts
+++ b/packages/session/src/federations/__tests__/helpers.test.mts
@@ -76,4 +76,31 @@ describe("fetchGithubPrimaryEmail", () => {
 		expect(capturedInit?.headers?.["User-Agent"]).toMatch(/auth[.-]?provider/i);
 		expect(capturedInit?.headers?.Accept).toBe("application/vnd.github+json");
 	});
+
+	it("passes an AbortSignal in the fetch init (timeout wiring)", async () => {
+		let capturedInit: { signal?: unknown } | undefined;
+		const fetchImpl = (async (_url: string, init?: unknown) => {
+			capturedInit = init as { signal?: unknown };
+			return {
+				status: 200,
+				ok: true,
+				async json() {
+					return [];
+				},
+			};
+		}) as unknown as typeof fetch;
+		await fetchGithubPrimaryEmail("any-token", fetchImpl);
+		expect(capturedInit?.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("returns null when the fetch is aborted (abort treated as unavailable)", async () => {
+		const abortError = Object.assign(new Error("The operation was aborted."), {
+			name: "AbortError",
+		});
+		const fetchImpl = (async () => {
+			throw abortError;
+		}) as unknown as typeof fetch;
+		const result = await fetchGithubPrimaryEmail("token", fetchImpl);
+		expect(result).toBeNull();
+	});
 });

--- a/packages/session/src/federations/__tests__/helpers.test.mts
+++ b/packages/session/src/federations/__tests__/helpers.test.mts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { fetchGithubPrimaryEmail } from "../helpers.mjs";
+
+describe("fetchGithubPrimaryEmail", () => {
+	const makeFetch = (response: unknown, status = 200) =>
+		(async (_url: string, _init?: unknown) => ({
+			status,
+			ok: status >= 200 && status < 300,
+			async json() {
+				return response;
+			},
+		})) as unknown as typeof fetch;
+
+	it("returns the primary verified email when present", async () => {
+		const body = [
+			{ email: "a@x.com", primary: false, verified: true },
+			{ email: "primary@x.com", primary: true, verified: true },
+			{ email: "b@x.com", primary: false, verified: false },
+		];
+		const email = await fetchGithubPrimaryEmail("token", makeFetch(body));
+		expect(email).toEqual({ email: "primary@x.com", verified: true });
+	});
+
+	it("falls back to the first verified email when no primary exists", async () => {
+		const body = [
+			{ email: "unverified@x.com", primary: false, verified: false },
+			{ email: "ok@x.com", primary: false, verified: true },
+		];
+		const email = await fetchGithubPrimaryEmail("token", makeFetch(body));
+		expect(email).toEqual({ email: "ok@x.com", verified: true });
+	});
+
+	it("returns null when no verified email exists", async () => {
+		const body = [
+			{ email: "a@x.com", primary: true, verified: false },
+			{ email: "b@x.com", primary: false, verified: false },
+		];
+		expect(await fetchGithubPrimaryEmail("token", makeFetch(body))).toBeNull();
+	});
+
+	it("returns null on 4xx/5xx without throwing", async () => {
+		expect(await fetchGithubPrimaryEmail("token", makeFetch({ message: "nope" }, 401))).toBeNull();
+		expect(await fetchGithubPrimaryEmail("token", makeFetch({}, 502))).toBeNull();
+	});
+
+	it("sends Authorization + User-Agent headers", async () => {
+		let capturedInit: { headers?: Record<string, string> } | undefined;
+		const fetchImpl = (async (_url: string, init?: unknown) => {
+			capturedInit = init as { headers?: Record<string, string> };
+			return {
+				status: 200,
+				ok: true,
+				async json() {
+					return [];
+				},
+			};
+		}) as unknown as typeof fetch;
+		await fetchGithubPrimaryEmail("token-123", fetchImpl);
+		expect(capturedInit?.headers?.Authorization).toBe("Bearer token-123");
+		expect(capturedInit?.headers?.["User-Agent"]).toMatch(/auth[.-]?provider/i);
+		expect(capturedInit?.headers?.Accept).toBe("application/vnd.github+json");
+	});
+});

--- a/packages/session/src/federations/github.mts
+++ b/packages/session/src/federations/github.mts
@@ -15,8 +15,17 @@
  */
 
 import type { PassportStatic } from "passport";
-import { resolveCallbackRedirect, validateRedirect } from "./helpers.mjs";
-import type { FederationProviderBase, SetupPassportContext } from "./types.mjs";
+import { fetchGithubPrimaryEmail, resolveCallbackRedirect, validateRedirect } from "./helpers.mjs";
+import type {
+	EndSessionRequest,
+	EndSessionResult,
+	FederationProfile,
+	FederationProviderBase,
+	MappedClaims,
+	SetupPassportContext,
+	SupportsClaimMapping,
+	SupportsLogout,
+} from "./types.mjs";
 
 export interface GithubProviderConfig {
 	/** Passport strategy identifier — use a unique name per tenant for multi-tenant setups. */
@@ -30,9 +39,13 @@ export interface GithubProviderConfig {
 	authCallbackUrl?: string;
 	/** Fallback URL for the client app (used when no redirectTo is present). Optional. */
 	clientUrl?: string;
+	/** Test-only: inject fetch impl used by fetchGithubPrimaryEmail. */
+	_fetch?: typeof fetch;
 }
 
-export function createGithubProvider(config: GithubProviderConfig): FederationProviderBase {
+type GithubProvider = FederationProviderBase & SupportsClaimMapping & SupportsLogout;
+
+export function createGithubProvider(config: GithubProviderConfig): GithubProvider {
 	if (!config.clientId || !config.clientSecret || !config.callbackURL) {
 		throw new Error(
 			`GitHub federation "${config.name}" requires clientId, clientSecret, and callbackURL`,
@@ -40,6 +53,7 @@ export function createGithubProvider(config: GithubProviderConfig): FederationPr
 	}
 
 	const scope = ["read:user", "user:email"] as const;
+	const fetchImpl: typeof fetch = config._fetch ?? fetch;
 
 	return {
 		name: config.name,
@@ -55,11 +69,13 @@ export function createGithubProvider(config: GithubProviderConfig): FederationPr
 
 		async setupPassportStrategy(
 			passport: PassportStatic,
-			{ verifyUser, pathResolver }: SetupPassportContext,
+			ctx: SetupPassportContext,
 		): Promise<void> {
 			let GithubStrategy: typeof import("passport-github2").Strategy;
 			try {
-				const modSpec = pathResolver ? pathResolver("passport-github2") : "passport-github2";
+				const modSpec = ctx.pathResolver
+					? ctx.pathResolver("passport-github2")
+					: "passport-github2";
 				({ Strategy: GithubStrategy } = (await import(
 					modSpec
 				)) as typeof import("passport-github2"));
@@ -79,13 +95,44 @@ export function createGithubProvider(config: GithubProviderConfig): FederationPr
 						scope: [...scope],
 					},
 					async (
-						_at: string,
-						_rt: string,
-						profile: { id: string },
+						accessToken: string,
+						refreshToken: string | undefined,
+						profileRaw: { id: string } & Record<string, unknown>,
 						done: (err: Error | null, user?: unknown) => void,
 					) => {
+						let enrichedRaw: Record<string, unknown> = {
+							...(profileRaw as Record<string, unknown>),
+						};
+						if (!hasEmail(enrichedRaw)) {
+							const fetched = await fetchGithubPrimaryEmail(accessToken, fetchImpl);
+							if (fetched) {
+								enrichedRaw = {
+									...enrichedRaw,
+									emails: [{ value: fetched.email, verified: fetched.verified }],
+								};
+							}
+						}
+						const profile: FederationProfile = {
+							id:
+								typeof enrichedRaw.id === "string" ? enrichedRaw.id : String(enrichedRaw.id ?? ""),
+							raw: enrichedRaw,
+							accessToken,
+							refreshToken,
+						};
+						if (ctx.onFederationCallback) {
+							try {
+								await ctx.onFederationCallback({
+									federationName: config.name,
+									profile,
+									done: done as (err: Error | null, user: unknown) => void,
+								});
+							} catch (err) {
+								done(err as Error);
+							}
+							return;
+						}
 						try {
-							const user = await verifyUser(`github:${profile.id}`);
+							const user = await ctx.verifyUser(`github:${profile.id}`);
 							return done(null, user ?? false);
 						} catch (err) {
 							return done(err as Error);
@@ -94,5 +141,36 @@ export function createGithubProvider(config: GithubProviderConfig): FederationPr
 				),
 			);
 		},
+
+		mapClaims(profile: FederationProfile): MappedClaims {
+			const raw = profile.raw as Record<string, unknown>;
+			const emails = Array.isArray(raw.emails)
+				? (raw.emails as Array<{ value?: unknown; verified?: unknown }>)
+				: [];
+			const photos = Array.isArray(raw.photos) ? (raw.photos as Array<{ value?: unknown }>) : [];
+			const claims: Record<string, unknown> = {};
+			if (typeof emails[0]?.value === "string") claims.email = emails[0].value;
+			if (typeof emails[0]?.verified === "boolean") claims.emailVerified = emails[0].verified;
+			if (typeof raw.displayName === "string") claims.name = raw.displayName;
+			if (typeof photos[0]?.value === "string") claims.picture = photos[0].value;
+			return claims as MappedClaims;
+		},
+
+		async endSession(req: EndSessionRequest): Promise<EndSessionResult> {
+			// GitHub has no RP-Initiated Logout endpoint. Return a redirect directly to
+			// the post_logout_redirect_uri with round-tripped state. If no redirect is
+			// given, fall back to GitHub's top-level logout page.
+			const base = req.postLogoutRedirectUri ?? "https://github.com/logout";
+			const url = new URL(base);
+			if (req.state) url.searchParams.set("state", req.state);
+			return { url, method: "GET" };
+		},
 	};
+}
+
+function hasEmail(raw: Record<string, unknown>): boolean {
+	return (
+		Array.isArray(raw.emails) &&
+		raw.emails.some((e) => typeof (e as { value?: unknown }).value === "string")
+	);
 }

--- a/packages/session/src/federations/github.mts
+++ b/packages/session/src/federations/github.mts
@@ -85,6 +85,58 @@ export function createGithubProvider(config: GithubProviderConfig): GithubProvid
 					{ cause: err },
 				);
 			}
+			// passport-oauth2 runtime dispatches on callback arity: 6-arg receives `params`
+			// (raw token-endpoint response including expires_in). @types/passport-github2 only
+			// declares the 5-arg overload, so we cast the verify function to bypass the
+			// TypeScript restriction while preserving the correct runtime behavior.
+			const verify6 = async (
+				req: import("express").Request,
+				accessToken: string,
+				refreshToken: string | undefined,
+				params: Record<string, unknown> | undefined,
+				profileRaw: { id: string } & Record<string, unknown>,
+				done: (err: Error | null, user?: unknown) => void,
+			): Promise<void> => {
+				let enrichedRaw: Record<string, unknown> = {
+					...(profileRaw as Record<string, unknown>),
+				};
+				if (!hasEmail(enrichedRaw)) {
+					const fetched = await fetchGithubPrimaryEmail(accessToken, fetchImpl);
+					if (fetched) {
+						enrichedRaw = {
+							...enrichedRaw,
+							emails: [{ value: fetched.email, verified: fetched.verified }],
+						};
+					}
+				}
+				const profile: FederationProfile = {
+					id: typeof enrichedRaw.id === "string" ? enrichedRaw.id : String(enrichedRaw.id ?? ""),
+					raw: enrichedRaw,
+					accessToken,
+					refreshToken,
+					idToken: typeof params?.id_token === "string" ? params.id_token : undefined,
+					expiresIn: typeof params?.expires_in === "number" ? params.expires_in : undefined,
+				};
+				if (ctx.onFederationCallback) {
+					try {
+						await ctx.onFederationCallback({
+							federationName: config.name,
+							profile,
+							req,
+							done: done as (err: Error | null, user: unknown) => void,
+						});
+					} catch (err) {
+						done(err as Error);
+					}
+					return;
+				}
+				try {
+					const user = await ctx.verifyUser(`github:${profile.id}`);
+					return done(null, user ?? false);
+				} catch (err) {
+					return done(err as Error);
+				}
+			};
 			passport.use(
 				config.name,
 				new GithubStrategy(
@@ -95,52 +147,13 @@ export function createGithubProvider(config: GithubProviderConfig): GithubProvid
 						scope: [...scope],
 						passReqToCallback: true,
 					},
-					async (
-						req: import("express").Request,
+					verify6 as unknown as (
+						req: unknown,
 						accessToken: string,
-						refreshToken: string | undefined,
-						profileRaw: { id: string } & Record<string, unknown>,
+						refreshToken: string,
+						profile: unknown,
 						done: (err: Error | null, user?: unknown) => void,
-					) => {
-						let enrichedRaw: Record<string, unknown> = {
-							...(profileRaw as Record<string, unknown>),
-						};
-						if (!hasEmail(enrichedRaw)) {
-							const fetched = await fetchGithubPrimaryEmail(accessToken, fetchImpl);
-							if (fetched) {
-								enrichedRaw = {
-									...enrichedRaw,
-									emails: [{ value: fetched.email, verified: fetched.verified }],
-								};
-							}
-						}
-						const profile: FederationProfile = {
-							id:
-								typeof enrichedRaw.id === "string" ? enrichedRaw.id : String(enrichedRaw.id ?? ""),
-							raw: enrichedRaw,
-							accessToken,
-							refreshToken,
-						};
-						if (ctx.onFederationCallback) {
-							try {
-								await ctx.onFederationCallback({
-									federationName: config.name,
-									profile,
-									req,
-									done: done as (err: Error | null, user: unknown) => void,
-								});
-							} catch (err) {
-								done(err as Error);
-							}
-							return;
-						}
-						try {
-							const user = await ctx.verifyUser(`github:${profile.id}`);
-							return done(null, user ?? false);
-						} catch (err) {
-							return done(err as Error);
-						}
-					},
+					) => void,
 				),
 			);
 		},
@@ -174,6 +187,9 @@ export function createGithubProvider(config: GithubProviderConfig): GithubProvid
 function hasEmail(raw: Record<string, unknown>): boolean {
 	return (
 		Array.isArray(raw.emails) &&
-		raw.emails.some((e) => typeof (e as { value?: unknown }).value === "string")
+		raw.emails.some(
+			(e) =>
+				typeof e === "object" && e !== null && typeof (e as { value?: unknown }).value === "string",
+		)
 	);
 }

--- a/packages/session/src/federations/github.mts
+++ b/packages/session/src/federations/github.mts
@@ -93,8 +93,10 @@ export function createGithubProvider(config: GithubProviderConfig): GithubProvid
 						clientSecret: config.clientSecret,
 						callbackURL: config.callbackURL,
 						scope: [...scope],
+						passReqToCallback: true,
 					},
 					async (
+						req: import("express").Request,
 						accessToken: string,
 						refreshToken: string | undefined,
 						profileRaw: { id: string } & Record<string, unknown>,
@@ -124,6 +126,7 @@ export function createGithubProvider(config: GithubProviderConfig): GithubProvid
 								await ctx.onFederationCallback({
 									federationName: config.name,
 									profile,
+									req,
 									done: done as (err: Error | null, user: unknown) => void,
 								});
 							} catch (err) {

--- a/packages/session/src/federations/github.mts
+++ b/packages/session/src/federations/github.mts
@@ -180,7 +180,14 @@ export function createGithubProvider(config: GithubProviderConfig): GithubProvid
 			// the post_logout_redirect_uri with round-tripped state. If no redirect is
 			// given, fall back to GitHub's top-level logout page.
 			const base = req.postLogoutRedirectUri ?? "https://github.com/logout";
-			const url = new URL(base);
+			let url: URL;
+			try {
+				url = new URL(base);
+			} catch {
+				throw new Error(
+					`GitHub federation "${config.name}" received an invalid postLogoutRedirectUri: ${base}`,
+				);
+			}
 			if (req.state) url.searchParams.set("state", req.state);
 			return { url, method: "GET" };
 		},

--- a/packages/session/src/federations/github.mts
+++ b/packages/session/src/federations/github.mts
@@ -131,7 +131,10 @@ export function createGithubProvider(config: GithubProviderConfig): GithubProvid
 					return;
 				}
 				try {
-					const user = await ctx.verifyUser(`github:${profile.id}`);
+					if (!profile.id) {
+						return done(null, false);
+					}
+					const user = await ctx.verifyUser(`${config.name}:${profile.id}`);
 					return done(null, user ?? false);
 				} catch (err) {
 					return done(err as Error);

--- a/packages/session/src/federations/google.mts
+++ b/packages/session/src/federations/google.mts
@@ -95,15 +95,16 @@ export const createGoogleProvider = (config: GoogleProviderConfig): GoogleProvid
 						clientID: config.clientId,
 						clientSecret: config.clientSecret,
 						callbackURL: config.callbackURL,
-						passReqToCallback: false,
+						passReqToCallback: true,
 					},
-					async (accessToken, refreshToken, profileRaw, done) => {
+					async (req, accessToken, refreshToken, profileRaw, done) => {
 						const profile = toFederationProfile(profileRaw, accessToken, refreshToken);
 						if (ctx.onFederationCallback) {
 							try {
 								await ctx.onFederationCallback({
 									federationName: config.name,
 									profile,
+									req: req as import("express").Request,
 									done: done as (err: Error | null, user: unknown) => void,
 								});
 							} catch (err) {

--- a/packages/session/src/federations/google.mts
+++ b/packages/session/src/federations/google.mts
@@ -126,7 +126,10 @@ export const createGoogleProvider = (config: GoogleProviderConfig): GoogleProvid
 						return;
 					}
 					try {
-						const user = await ctx.verifyUser(`google:${profile.id}`);
+						if (!profile.id) {
+							return done(null, false);
+						}
+						const user = await ctx.verifyUser(`${config.name}:${profile.id}`);
 						return done(null, user ?? false);
 					} catch (err) {
 						return done(err as Error);

--- a/packages/session/src/federations/google.mts
+++ b/packages/session/src/federations/google.mts
@@ -15,7 +15,18 @@
  */
 
 import { resolveCallbackRedirect, validateRedirect } from "./helpers.mjs";
-import type { FederationProviderBase, SetupPassportContext } from "./types.mjs";
+import type {
+	EndSessionRequest,
+	EndSessionResult,
+	FederationProfile,
+	FederationProviderBase,
+	MappedClaims,
+	RefreshedTokens,
+	SetupPassportContext,
+	SupportsClaimMapping,
+	SupportsLogout,
+	SupportsRefresh,
+} from "./types.mjs";
 
 export interface GoogleProviderConfig {
 	/** Passport strategy identifier — use a unique name per tenant for multi-tenant setups. */
@@ -29,18 +40,35 @@ export interface GoogleProviderConfig {
 	authCallbackUrl?: string;
 	/** Fallback URL for the client app (used when no redirectTo is present). Optional. */
 	clientUrl?: string;
+	/** Override Google's OAuth token endpoint (default: https://oauth2.googleapis.com/token). */
+	tokenEndpoint?: string;
+	/** Override Google's end-session endpoint (default: https://accounts.google.com/o/oauth2/v2/auth/logout). */
+	endSessionEndpoint?: string;
+	/** Test-only: inject a fetch impl for refreshFederationToken. Not documented publicly. */
+	_fetch?: typeof fetch;
 }
 
-export const createGoogleProvider = (config: GoogleProviderConfig): FederationProviderBase => {
+type GoogleProvider = FederationProviderBase &
+	SupportsClaimMapping &
+	SupportsRefresh &
+	SupportsLogout;
+
+const DEFAULT_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+const DEFAULT_END_SESSION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth/logout";
+
+export const createGoogleProvider = (config: GoogleProviderConfig): GoogleProvider => {
 	if (!config.clientId || !config.clientSecret || !config.callbackURL) {
 		throw new Error(
 			`Google federation "${config.name}" requires clientId, clientSecret, and callbackURL`,
 		);
 	}
+	const tokenEndpoint = config.tokenEndpoint ?? DEFAULT_TOKEN_ENDPOINT;
+	const endSessionEndpoint = config.endSessionEndpoint ?? DEFAULT_END_SESSION_ENDPOINT;
+	const fetchImpl: typeof fetch = config._fetch ?? fetch;
 
 	return {
 		name: config.name,
-		scope: ["profile", "email"],
+		scope: ["openid", "profile", "email"],
 
 		validateRedirect(url: string) {
 			return validateRedirect(url, config);
@@ -53,9 +81,9 @@ export const createGoogleProvider = (config: GoogleProviderConfig): FederationPr
 			return resolveCallbackRedirect(session, config);
 		},
 
-		async setupPassportStrategy(passport, { verifyUser, pathResolver }: SetupPassportContext) {
-			const modSpec = pathResolver
-				? pathResolver("passport-google-oauth20")
+		async setupPassportStrategy(passport, ctx: SetupPassportContext) {
+			const modSpec = ctx.pathResolver
+				? ctx.pathResolver("passport-google-oauth20")
 				: "passport-google-oauth20";
 			const { Strategy: GoogleStrategy } = (await import(
 				modSpec
@@ -67,10 +95,25 @@ export const createGoogleProvider = (config: GoogleProviderConfig): FederationPr
 						clientID: config.clientId,
 						clientSecret: config.clientSecret,
 						callbackURL: config.callbackURL,
+						passReqToCallback: false,
 					},
-					async (_at, _rt, profile, done) => {
+					async (accessToken, refreshToken, profileRaw, done) => {
+						const profile = toFederationProfile(profileRaw, accessToken, refreshToken);
+						if (ctx.onFederationCallback) {
+							try {
+								await ctx.onFederationCallback({
+									federationName: config.name,
+									profile,
+									done: done as (err: Error | null, user: unknown) => void,
+								});
+							} catch (err) {
+								done(err as Error);
+							}
+							return;
+						}
+						// Legacy fallback (federation-tokens not wired): emulate prior behavior.
 						try {
-							const user = await verifyUser(`google:${profile.id}`);
+							const user = await ctx.verifyUser(`google:${profile.id}`);
 							return done(null, user ?? false);
 						} catch (err) {
 							return done(err as Error);
@@ -79,5 +122,96 @@ export const createGoogleProvider = (config: GoogleProviderConfig): FederationPr
 				),
 			);
 		},
+
+		mapClaims(profile: FederationProfile): MappedClaims {
+			const raw = profile.raw as Record<string, unknown>;
+			const json = (raw._json ?? {}) as Record<string, unknown>;
+			const emails = Array.isArray(raw.emails)
+				? (raw.emails as Array<{ value?: unknown; verified?: unknown }>)
+				: [];
+			const photos = Array.isArray(raw.photos) ? (raw.photos as Array<{ value?: unknown }>) : [];
+			const claims: Record<string, unknown> = {};
+			if (typeof json.email === "string") claims.email = json.email;
+			else if (emails[0]?.value && typeof emails[0].value === "string")
+				claims.email = emails[0].value;
+			if (typeof json.email_verified === "boolean") claims.emailVerified = json.email_verified;
+			else if (typeof emails[0]?.verified === "boolean") claims.emailVerified = emails[0].verified;
+			if (typeof raw.displayName === "string") claims.name = raw.displayName;
+			if (typeof photos[0]?.value === "string") claims.picture = photos[0].value;
+			if (typeof json.hd === "string") claims.hd = json.hd;
+			return claims as MappedClaims;
+		},
+
+		async refreshFederationToken(refreshToken: string): Promise<RefreshedTokens> {
+			const body = new URLSearchParams({
+				grant_type: "refresh_token",
+				refresh_token: refreshToken,
+				client_id: config.clientId,
+				client_secret: config.clientSecret,
+			});
+			const res = await fetchImpl(tokenEndpoint, {
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				body: body.toString(),
+			});
+			if (!res.ok) {
+				let detail = "";
+				try {
+					const err = (await res.json()) as { error?: string; error_description?: string };
+					detail = `${err.error ?? ""} ${err.error_description ?? ""}`.trim();
+				} catch {
+					// ignore JSON parse error
+				}
+				if (res.status >= 500) {
+					throw new Error(
+						`temporarily_unavailable: google refresh failed (${res.status}) ${detail}`,
+					);
+				}
+				if (detail.includes("invalid_grant")) {
+					throw new Error(`invalid_grant: google refresh rejected ${detail}`);
+				}
+				throw new Error(`refresh_failed: google refresh failed (${res.status}) ${detail}`);
+			}
+			const json = (await res.json()) as {
+				access_token?: unknown;
+				refresh_token?: unknown;
+				id_token?: unknown;
+				expires_in?: unknown;
+			};
+			if (typeof json.access_token !== "string") {
+				throw new Error("refresh_failed: google refresh returned no access_token");
+			}
+			const expiresIn = typeof json.expires_in === "number" ? json.expires_in : 3600;
+			return {
+				accessToken: json.access_token,
+				refreshToken: typeof json.refresh_token === "string" ? json.refresh_token : undefined,
+				idToken: typeof json.id_token === "string" ? json.id_token : undefined,
+				expiresAt: new Date(Date.now() + expiresIn * 1000),
+			};
+		},
+
+		async endSession(req: EndSessionRequest): Promise<EndSessionResult> {
+			const url = new URL(endSessionEndpoint);
+			if (req.idTokenHint) url.searchParams.set("id_token_hint", req.idTokenHint);
+			if (req.postLogoutRedirectUri)
+				url.searchParams.set("post_logout_redirect_uri", req.postLogoutRedirectUri);
+			if (req.state) url.searchParams.set("state", req.state);
+			return { url, method: "GET" };
+		},
 	};
 };
+
+function toFederationProfile(
+	raw: unknown,
+	accessToken: string | undefined,
+	refreshToken: string | undefined,
+): FederationProfile {
+	const rawObj = (raw ?? {}) as Record<string, unknown>;
+	const id = typeof rawObj.id === "string" ? rawObj.id : "";
+	return {
+		id,
+		raw: rawObj,
+		accessToken,
+		refreshToken,
+	};
+}

--- a/packages/session/src/federations/google.mts
+++ b/packages/session/src/federations/google.mts
@@ -182,11 +182,27 @@ export const createGoogleProvider = (config: GoogleProviderConfig): GoogleProvid
 				client_id: config.clientId,
 				client_secret: config.clientSecret,
 			});
-			const res = await fetchImpl(tokenEndpoint, {
-				method: "POST",
-				headers: { "Content-Type": "application/x-www-form-urlencoded" },
-				body: body.toString(),
-			});
+			const refreshTimeoutMs = 30_000;
+			const controller = new AbortController();
+			const timer = setTimeout(() => controller.abort(), refreshTimeoutMs);
+			let res: Response;
+			try {
+				res = await fetchImpl(tokenEndpoint, {
+					method: "POST",
+					headers: { "Content-Type": "application/x-www-form-urlencoded" },
+					body: body.toString(),
+					signal: controller.signal,
+				});
+			} catch (err) {
+				if (err instanceof Error && err.name === "AbortError") {
+					throw new Error(
+						`temporarily_unavailable: google refresh timed out after ${refreshTimeoutMs}ms`,
+					);
+				}
+				throw err;
+			} finally {
+				clearTimeout(timer);
+			}
 			if (!res.ok) {
 				let detail = "";
 				try {
@@ -229,7 +245,14 @@ export const createGoogleProvider = (config: GoogleProviderConfig): GoogleProvid
 			// Absent that, we redirect directly to the RP's postLogoutRedirectUri with state,
 			// mirroring the GitHub provider. The application is responsible for its own session cleanup.
 			if (config.endSessionEndpoint) {
-				const url = new URL(config.endSessionEndpoint);
+				let url: URL;
+				try {
+					url = new URL(config.endSessionEndpoint);
+				} catch {
+					throw new Error(
+						`Google federation "${config.name}" has an invalid endSessionEndpoint: ${config.endSessionEndpoint}`,
+					);
+				}
 				if (req.idTokenHint) url.searchParams.set("id_token_hint", req.idTokenHint);
 				if (req.postLogoutRedirectUri)
 					url.searchParams.set("post_logout_redirect_uri", req.postLogoutRedirectUri);
@@ -237,7 +260,14 @@ export const createGoogleProvider = (config: GoogleProviderConfig): GoogleProvid
 				return { url, method: "GET" };
 			}
 			const base = req.postLogoutRedirectUri ?? "https://accounts.google.com/Logout";
-			const url = new URL(base);
+			let url: URL;
+			try {
+				url = new URL(base);
+			} catch {
+				throw new Error(
+					`Google federation "${config.name}" received an invalid postLogoutRedirectUri: ${base}`,
+				);
+			}
 			if (req.state) url.searchParams.set("state", req.state);
 			return { url, method: "GET" };
 		},

--- a/packages/session/src/federations/google.mts
+++ b/packages/session/src/federations/google.mts
@@ -42,7 +42,7 @@ export interface GoogleProviderConfig {
 	clientUrl?: string;
 	/** Override Google's OAuth token endpoint (default: https://oauth2.googleapis.com/token). */
 	tokenEndpoint?: string;
-	/** Override Google's end-session endpoint (default: https://accounts.google.com/o/oauth2/v2/auth/logout). */
+	/** Override Google's end-session endpoint. When omitted Google does not publish an OIDC end_session_endpoint; the provider redirects directly to postLogoutRedirectUri instead. */
 	endSessionEndpoint?: string;
 	/** Test-only: inject a fetch impl for refreshFederationToken. Not documented publicly. */
 	_fetch?: typeof fetch;
@@ -54,7 +54,6 @@ type GoogleProvider = FederationProviderBase &
 	SupportsLogout;
 
 const DEFAULT_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
-const DEFAULT_END_SESSION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth/logout";
 
 export const createGoogleProvider = (config: GoogleProviderConfig): GoogleProvider => {
 	if (!config.clientId || !config.clientSecret || !config.callbackURL) {
@@ -63,7 +62,6 @@ export const createGoogleProvider = (config: GoogleProviderConfig): GoogleProvid
 		);
 	}
 	const tokenEndpoint = config.tokenEndpoint ?? DEFAULT_TOKEN_ENDPOINT;
-	const endSessionEndpoint = config.endSessionEndpoint ?? DEFAULT_END_SESSION_ENDPOINT;
 	const fetchImpl: typeof fetch = config._fetch ?? fetch;
 
 	return {
@@ -88,40 +86,71 @@ export const createGoogleProvider = (config: GoogleProviderConfig): GoogleProvid
 			const { Strategy: GoogleStrategy } = (await import(
 				modSpec
 			)) as typeof import("passport-google-oauth20");
-			passport.use(
-				config.name,
-				new GoogleStrategy(
-					{
-						clientID: config.clientId,
-						clientSecret: config.clientSecret,
-						callbackURL: config.callbackURL,
-						passReqToCallback: true,
-					},
-					async (req, accessToken, refreshToken, profileRaw, done) => {
-						const profile = toFederationProfile(profileRaw, accessToken, refreshToken);
-						if (ctx.onFederationCallback) {
-							try {
-								await ctx.onFederationCallback({
-									federationName: config.name,
-									profile,
-									req: req as import("express").Request,
-									done: done as (err: Error | null, user: unknown) => void,
-								});
-							} catch (err) {
-								done(err as Error);
-							}
-							return;
-						}
-						// Legacy fallback (federation-tokens not wired): emulate prior behavior.
+			const strategy = new GoogleStrategy(
+				{
+					clientID: config.clientId,
+					clientSecret: config.clientSecret,
+					callbackURL: config.callbackURL,
+					passReqToCallback: true,
+				},
+				// 6-arg verify form: passport-oauth2 dispatches on arity and passes the
+				// raw token-endpoint response `params` only when the callback declares 6
+				// parameters. We need `params.id_token` + `params.expires_in` for the
+				// FederationProfile.
+				async (
+					req: import("express").Request,
+					accessToken: string,
+					refreshToken: string,
+					params: import("passport-google-oauth20").GoogleCallbackParameters,
+					profileRaw: import("passport-google-oauth20").Profile,
+					done: import("passport-google-oauth20").VerifyCallback,
+				) => {
+					const p = params as unknown as Record<string, unknown>;
+					const profile = toFederationProfile(profileRaw as unknown as Record<string, unknown>, {
+						accessToken,
+						refreshToken,
+						idToken: typeof p?.id_token === "string" ? p.id_token : undefined,
+						expiresIn: typeof p?.expires_in === "number" ? p.expires_in : undefined,
+					});
+					if (ctx.onFederationCallback) {
 						try {
-							const user = await ctx.verifyUser(`google:${profile.id}`);
-							return done(null, user ?? false);
+							await ctx.onFederationCallback({
+								federationName: config.name,
+								profile,
+								req,
+								done: done as (err: Error | null, user: unknown) => void,
+							});
 						} catch (err) {
-							return done(err as Error);
+							done(err as Error);
 						}
-					},
-				),
+						return;
+					}
+					try {
+						const user = await ctx.verifyUser(`google:${profile.id}`);
+						return done(null, user ?? false);
+					} catch (err) {
+						return done(err as Error);
+					}
+				},
 			);
+			// Override authorizationParams to always include access_type=offline so Google
+			// returns a refresh_token on the first authorization. This cannot be set via the
+			// constructor options because passport-google-oauth20 only reads accessType from
+			// the per-request options passed to passport.authenticate(); overriding the method
+			// here avoids exposing per-strategy configuration to the route layer.
+			const baseAuthorizationParams = (
+				strategy as unknown as {
+					authorizationParams(opts: Record<string, unknown>): Record<string, unknown>;
+				}
+			).authorizationParams.bind(strategy);
+			(
+				strategy as unknown as {
+					authorizationParams(opts: Record<string, unknown>): Record<string, unknown>;
+				}
+			).authorizationParams = (opts: Record<string, unknown>) => {
+				return { ...baseAuthorizationParams(opts), access_type: "offline" };
+			};
+			passport.use(config.name, strategy);
 		},
 
 		mapClaims(profile: FederationProfile): MappedClaims {
@@ -192,10 +221,20 @@ export const createGoogleProvider = (config: GoogleProviderConfig): GoogleProvid
 		},
 
 		async endSession(req: EndSessionRequest): Promise<EndSessionResult> {
-			const url = new URL(endSessionEndpoint);
-			if (req.idTokenHint) url.searchParams.set("id_token_hint", req.idTokenHint);
-			if (req.postLogoutRedirectUri)
-				url.searchParams.set("post_logout_redirect_uri", req.postLogoutRedirectUri);
+			// Google does not publish an OIDC end_session_endpoint in its discovery document;
+			// operators MUST pass `endSessionEndpoint` explicitly if they want an upstream logout.
+			// Absent that, we redirect directly to the RP's postLogoutRedirectUri with state,
+			// mirroring the GitHub provider. The application is responsible for its own session cleanup.
+			if (config.endSessionEndpoint) {
+				const url = new URL(config.endSessionEndpoint);
+				if (req.idTokenHint) url.searchParams.set("id_token_hint", req.idTokenHint);
+				if (req.postLogoutRedirectUri)
+					url.searchParams.set("post_logout_redirect_uri", req.postLogoutRedirectUri);
+				if (req.state) url.searchParams.set("state", req.state);
+				return { url, method: "GET" };
+			}
+			const base = req.postLogoutRedirectUri ?? "https://accounts.google.com/Logout";
+			const url = new URL(base);
 			if (req.state) url.searchParams.set("state", req.state);
 			return { url, method: "GET" };
 		},
@@ -204,15 +243,18 @@ export const createGoogleProvider = (config: GoogleProviderConfig): GoogleProvid
 
 function toFederationProfile(
 	raw: unknown,
-	accessToken: string | undefined,
-	refreshToken: string | undefined,
+	tokens: {
+		accessToken: string | undefined;
+		refreshToken: string | undefined;
+		idToken?: string;
+		expiresIn?: number;
+	},
 ): FederationProfile {
 	const rawObj = (raw ?? {}) as Record<string, unknown>;
 	const id = typeof rawObj.id === "string" ? rawObj.id : "";
 	return {
 		id,
 		raw: rawObj,
-		accessToken,
-		refreshToken,
+		...tokens,
 	};
 }

--- a/packages/session/src/federations/helpers.mts
+++ b/packages/session/src/federations/helpers.mts
@@ -128,3 +128,48 @@ export function resolveCallbackRedirect(
 
 	return { ok: true, value: clientUrl };
 }
+
+export interface GithubEmailResult {
+	readonly email: string;
+	readonly verified: boolean;
+}
+
+/**
+ * Fetches the authenticated user's email list from the GitHub REST API and
+ * returns the primary verified email (or first verified if no primary is set).
+ * Used by the GitHub federation provider's claim mapping — the passport profile
+ * does not carry email for most users because they keep it private.
+ *
+ * Non-2xx responses resolve to null (consumer treats as "no email available"),
+ * never throw, so a transient GitHub API failure does not kill federation login.
+ *
+ * Requires `user:email` scope, which the built-in GitHub provider already requests.
+ */
+export async function fetchGithubPrimaryEmail(
+	accessToken: string,
+	fetchImpl: typeof fetch = fetch,
+): Promise<GithubEmailResult | null> {
+	try {
+		const res = await fetchImpl("https://api.github.com/user/emails", {
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				"User-Agent": "o3co-auth-provider",
+				Accept: "application/vnd.github+json",
+			},
+		});
+		if (!res.ok) return null;
+		const rows = (await res.json()) as Array<{
+			email?: unknown;
+			primary?: unknown;
+			verified?: unknown;
+		}>;
+		if (!Array.isArray(rows)) return null;
+		const verified = rows.filter((r) => r.verified === true && typeof r.email === "string");
+		const primary = verified.find((r) => r.primary === true);
+		const chosen = primary ?? verified[0];
+		if (!chosen || typeof chosen.email !== "string") return null;
+		return { email: chosen.email, verified: true };
+	} catch {
+		return null;
+	}
+}

--- a/packages/session/src/federations/helpers.mts
+++ b/packages/session/src/federations/helpers.mts
@@ -149,6 +149,9 @@ export async function fetchGithubPrimaryEmail(
 	accessToken: string,
 	fetchImpl: typeof fetch = fetch,
 ): Promise<GithubEmailResult | null> {
+	const timeoutMs = 10_000;
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
 	try {
 		const res = await fetchImpl("https://api.github.com/user/emails", {
 			headers: {
@@ -156,6 +159,7 @@ export async function fetchGithubPrimaryEmail(
 				"User-Agent": "o3co-auth-provider",
 				Accept: "application/vnd.github+json",
 			},
+			signal: controller.signal,
 		});
 		if (!res.ok) return null;
 		const rows = (await res.json()) as Array<{
@@ -170,6 +174,9 @@ export async function fetchGithubPrimaryEmail(
 		if (!chosen || typeof chosen.email !== "string") return null;
 		return { email: chosen.email, verified: true };
 	} catch {
+		// Abort (timeout) and any other transient error treated as "no email available".
 		return null;
+	} finally {
+		clearTimeout(timer);
 	}
 }

--- a/packages/session/src/federations/types.mts
+++ b/packages/session/src/federations/types.mts
@@ -22,13 +22,25 @@ export type FederationResult<T> =
 	| { ok: false; status: number; error: string; errorDescription: string };
 
 export interface SetupPassportContext {
-	verifyUser: (externalId: string) => Promise<User | null>;
+	readonly verifyUser: (externalId: string) => Promise<User | null>;
 	/**
 	 * Optional module resolver used for dynamic imports of passport strategies.
 	 * Deployments with non-standard module layouts (Yarn PnP, custom require hooks)
 	 * can pass a resolver; standard Node/npm deployments omit it.
 	 */
-	pathResolver?: (spec: string) => string;
+	readonly pathResolver?: (spec: string) => string;
+	/**
+	 * Optional hook called by federation provider passport strategies after
+	 * successful OAuth code exchange. Built-in implementations (in session
+	 * module) orchestrate UserSessionStore + FederationTokenStore; custom
+	 * deployments can wire their own. When absent, providers fall back to
+	 * the legacy single-parameter `verifyUser(externalId)` flow.
+	 */
+	readonly onFederationCallback?: (params: {
+		federationName: string;
+		profile: FederationProfile;
+		done: (err: Error | null, user: User | false) => void;
+	}) => Promise<void>;
 }
 
 /**
@@ -95,4 +107,60 @@ export function supportsLogout(
 ): provider is FederationProviderBase & SupportsLogout {
 	if (provider == null) return false;
 	return typeof (provider as { endSession?: unknown }).endSession === "function";
+}
+
+/**
+ * OIDC-standard claims mapped from a federation profile. `[key: string]: unknown`
+ * allows providers to add non-standard claims (e.g. Google's `hd` hosted domain).
+ */
+export interface MappedClaims {
+	readonly email?: string;
+	readonly emailVerified?: boolean;
+	readonly name?: string;
+	readonly picture?: string;
+	readonly groups?: ReadonlyArray<string>;
+	readonly [key: string]: unknown;
+}
+
+/**
+ * Snapshot of a successful federation callback: provider-internal id + the raw
+ * passport profile payload + the tokens the IdP returned. Consumed by the
+ * `onFederationCallback` hook (see {@link SetupPassportContext}).
+ */
+export interface FederationProfile {
+	readonly id: string;
+	readonly raw: Readonly<Record<string, unknown>>;
+	readonly accessToken?: string;
+	readonly refreshToken?: string;
+	readonly idToken?: string;
+	readonly expiresIn?: number;
+}
+
+export interface SupportsClaimMapping {
+	mapClaims(profile: FederationProfile): MappedClaims;
+}
+
+export function supportsClaimMapping(
+	p: FederationProviderBase | undefined | null,
+): p is FederationProviderBase & SupportsClaimMapping {
+	if (p == null) return false;
+	return typeof (p as { mapClaims?: unknown }).mapClaims === "function";
+}
+
+export interface RefreshedTokens {
+	readonly accessToken: string;
+	readonly refreshToken?: string;
+	readonly idToken?: string;
+	readonly expiresAt: Date;
+}
+
+export interface SupportsRefresh {
+	refreshFederationToken(refreshToken: string): Promise<RefreshedTokens>;
+}
+
+export function supportsRefresh(
+	p: FederationProviderBase | undefined | null,
+): p is FederationProviderBase & SupportsRefresh {
+	if (p == null) return false;
+	return typeof (p as { refreshFederationToken?: unknown }).refreshFederationToken === "function";
 }

--- a/packages/session/src/federations/types.mts
+++ b/packages/session/src/federations/types.mts
@@ -37,9 +37,10 @@ export interface SetupPassportContext {
 	 * the legacy single-parameter `verifyUser(externalId)` flow.
 	 */
 	readonly onFederationCallback?: (params: {
-		federationName: string;
-		profile: FederationProfile;
-		done: (err: Error | null, user: User | false) => void;
+		readonly federationName: string;
+		readonly profile: FederationProfile;
+		readonly req: import("express").Request;
+		readonly done: (err: Error | null, user: User | false) => void;
 	}) => Promise<void>;
 }
 

--- a/packages/session/src/index.mts
+++ b/packages/session/src/index.mts
@@ -25,12 +25,21 @@ export { createGoogleProvider } from "./federations/google.mjs";
 export type {
 	EndSessionRequest,
 	EndSessionResult,
+	FederationProfile,
 	FederationProviderBase,
 	FederationResult,
+	MappedClaims,
+	RefreshedTokens,
 	SetupPassportContext,
+	SupportsClaimMapping,
 	SupportsLogout,
+	SupportsRefresh,
 } from "./federations/types.mjs";
-export { supportsLogout } from "./federations/types.mjs";
+export {
+	supportsClaimMapping,
+	supportsLogout,
+	supportsRefresh,
+} from "./federations/types.mjs";
 export { sessionModule } from "./module.mjs";
 export { createPassport } from "./passport.mjs";
 export type { SessionStoreFactory } from "./store/factory.mjs";

--- a/packages/session/src/module.mts
+++ b/packages/session/src/module.mts
@@ -49,11 +49,15 @@ const sessionConfigSchema = fullSectionsSchema.pick({
 export type SessionModuleOptions = {
 	userRepository: UserRepository;
 	express?: ExpressLike;
+	/** Session TTL in milliseconds for new UserSessions (federation + local login). Default 24h. */
+	sessionTtlMs?: number;
 };
 
 type SessionModuleInternalOptions = SessionModuleOptions & {
 	/** For testing only — inject a pre-configured factory to skip registration. */
 	_federationFactory?: FederationProviderFactory;
+	/** For testing only — replace createPassport to capture call arguments. */
+	_createPassport?: typeof createPassport;
 };
 
 /**
@@ -160,11 +164,18 @@ export const _sessionModuleImpl = (params: SessionModuleInternalOptions): Module
 			federationProviders.set(name, provider);
 		}
 
-		// Initialize passport with pathResolver
-		const passport = await createPassport({
+		// Initialize passport with pathResolver and optional store bindings.
+		// userSessionStore / federationTokenStore are optional on ModuleContext (F-1);
+		// if absent, createPassport receives undefined and the built-in
+		// onFederationCallback won't activate — correct fallback for unconfigured stores.
+		const _cp = params._createPassport ?? createPassport;
+		const passport = await _cp({
 			pathResolver: context.pathResolver,
 			userRepository: params.userRepository,
 			federationProviders,
+			userSessionStore: context.userSessionStore,
+			federationTokenStore: context.federationTokenStore,
+			sessionTtlMs: params.sessionTtlMs,
 		});
 
 		// Mount session routes

--- a/packages/session/src/module.mts
+++ b/packages/session/src/module.mts
@@ -49,7 +49,7 @@ const sessionConfigSchema = fullSectionsSchema.pick({
 export type SessionModuleOptions = {
 	userRepository: UserRepository;
 	express?: ExpressLike;
-	/** Session TTL in milliseconds for new UserSessions (federation + local login). Default 24h. */
+	/** Session TTL in milliseconds for new federation-created UserSessions. Default 24h. */
 	sessionTtlMs?: number;
 };
 

--- a/packages/session/src/passport.mts
+++ b/packages/session/src/passport.mts
@@ -153,8 +153,23 @@ export const _createPassportImpl = async ({
 								expiresAt: new Date(Date.now() + (params.profile.expiresIn ?? 3600) * 1000),
 							});
 						}
-						const session = params.req.session as unknown as Record<string, unknown> | undefined;
-						if (session) session.sid = sid;
+						const session = params.req.session as unknown as
+							| (Record<string, unknown> & {
+									save?: (cb: (err: unknown) => void) => void;
+							  })
+							| undefined;
+						if (session) {
+							session.sid = sid;
+							if (typeof session.save === "function") {
+								await new Promise<void>((resolve, reject) => {
+									// session.save is guaranteed by the typeof check above; call it.
+									(session.save as (cb: (err: unknown) => void) => void)((err) => {
+										if (err) reject(err as Error);
+										else resolve();
+									});
+								});
+							}
+						}
 						params.done(null, user);
 					} catch (err) {
 						params.done(err as Error, false);

--- a/packages/session/src/passport.mts
+++ b/packages/session/src/passport.mts
@@ -128,6 +128,14 @@ export const _createPassportImpl = async ({
 						const provider = federationProviders.get(params.federationName);
 						const mapped =
 							provider && supportsClaimMapping(provider) ? provider.mapClaims(params.profile) : {};
+						// Reject empty profile.id — otherwise authenticateByToken("name:") could
+						// accidentally match a different externalId scheme or create records
+						// under a malformed key. Symmetric with the legacy-fallback guard in
+						// google.mts / github.mts.
+						if (!params.profile.id) {
+							params.done(null, false);
+							return;
+						}
 						const user = await userRepository.authenticateByToken(
 							`${params.federationName}:${params.profile.id}`,
 						);

--- a/packages/session/src/passport.mts
+++ b/packages/session/src/passport.mts
@@ -145,32 +145,45 @@ export const _createPassportImpl = async ({
 							federations: [params.federationName],
 							claims,
 						});
-						if (params.profile.accessToken) {
-							await federationTokenStore.attach(sid, params.federationName, {
-								accessToken: params.profile.accessToken,
-								refreshToken: params.profile.refreshToken,
-								idToken: params.profile.idToken,
-								expiresAt: new Date(Date.now() + (params.profile.expiresIn ?? 3600) * 1000),
-							});
-						}
-						const session = params.req.session as unknown as
-							| (Record<string, unknown> & {
-									save?: (cb: (err: unknown) => void) => void;
-							  })
-							| undefined;
-						if (session) {
-							session.sid = sid;
-							if (typeof session.save === "function") {
-								await new Promise<void>((resolve, reject) => {
-									// session.save is guaranteed by the typeof check above; call it.
-									(session.save as (cb: (err: unknown) => void) => void)((err) => {
-										if (err) reject(err as Error);
-										else resolve();
-									});
+						// Post-create operations: any failure here orphans the UserSession,
+						// so we roll back with a best-effort delete before calling done(err).
+						try {
+							if (params.profile.accessToken) {
+								await federationTokenStore.attach(sid, params.federationName, {
+									accessToken: params.profile.accessToken,
+									refreshToken: params.profile.refreshToken,
+									idToken: params.profile.idToken,
+									expiresAt: new Date(Date.now() + (params.profile.expiresIn ?? 3600) * 1000),
 								});
 							}
+							const session = params.req.session as unknown as
+								| (Record<string, unknown> & {
+										save?: (cb: (err: unknown) => void) => void;
+								  })
+								| undefined;
+							if (session) {
+								session.sid = sid;
+								if (typeof session.save === "function") {
+									await new Promise<void>((resolve, reject) => {
+										// session.save is guaranteed by the typeof check above; call it.
+										(session.save as (cb: (err: unknown) => void) => void)((err) => {
+											if (err) reject(err as Error);
+											else resolve();
+										});
+									});
+								}
+							}
+							params.done(null, user);
+						} catch (postCreateErr) {
+							// Best-effort rollback: delete the orphan UserSession. If delete itself
+							// throws, swallow it — the original error is what matters for the caller.
+							try {
+								await userSessionStore.delete(sid);
+							} catch {
+								// ignore
+							}
+							params.done(postCreateErr as Error, false);
 						}
-						params.done(null, user);
 					} catch (err) {
 						params.done(err as Error, false);
 					}

--- a/packages/session/src/passport.mts
+++ b/packages/session/src/passport.mts
@@ -14,9 +14,21 @@
  * limitations under the License.
  */
 
-import type { PathResolver, UserRepository } from "@o3co/auth-provider-core";
+import { randomUUID } from "node:crypto";
+import {
+	extractUserClaims,
+	type FederationTokenStoreBase,
+	type PathResolver,
+	type UserRepository,
+	type UserSessionStoreBase,
+} from "@o3co/auth-provider-core";
 import type { PassportStatic } from "passport";
-import type { FederationProviderBase, SetupPassportContext } from "./federations/types.mjs";
+import {
+	type FederationProfile,
+	type FederationProviderBase,
+	type SetupPassportContext,
+	supportsClaimMapping,
+} from "./federations/types.mjs";
 
 declare global {
 	namespace Express {
@@ -28,7 +40,13 @@ export type CreatePassportOptions = {
 	pathResolver: PathResolver;
 	userRepository: UserRepository;
 	federationProviders: ReadonlyMap<string, FederationProviderBase>;
+	userSessionStore?: UserSessionStoreBase;
+	federationTokenStore?: FederationTokenStoreBase;
+	/** Session TTL in milliseconds. Default: 24h. */
+	sessionTtlMs?: number;
 };
+
+const DEFAULT_SESSION_TTL_MS = 86400_000;
 
 /**
  * Internal implementation — accepts an optional passport override for testing.
@@ -38,6 +56,9 @@ export const _createPassportImpl = async ({
 	pathResolver,
 	userRepository,
 	federationProviders,
+	userSessionStore,
+	federationTokenStore,
+	sessionTtlMs = DEFAULT_SESSION_TTL_MS,
 	_passportOverride,
 }: CreatePassportOptions & {
 	/** For testing only — inject a passport stub to skip dynamic import. */
@@ -91,12 +112,62 @@ export const _createPassportImpl = async ({
 		),
 	);
 
+	// Build the built-in onFederationCallback only when BOTH stores are wired.
+	// When either store is absent the hook is left undefined so providers fall
+	// back to their legacy single-call verifyUser path.
+	const onFederationCallback =
+		userSessionStore && federationTokenStore
+			? async (params: {
+					federationName: string;
+					profile: FederationProfile;
+					req: import("express").Request;
+					done: (err: Error | null, user: unknown) => void;
+				}) => {
+					try {
+						const provider = federationProviders.get(params.federationName);
+						const mapped =
+							provider && supportsClaimMapping(provider) ? provider.mapClaims(params.profile) : {};
+						const user = await userRepository.authenticateByToken(
+							`${params.federationName}:${params.profile.id}`,
+						);
+						if (!user) {
+							params.done(null, false);
+							return;
+						}
+						const sid = randomUUID();
+						const claims = { ...extractUserClaims(user), ...mapped };
+						await userSessionStore.create({
+							sid,
+							sub: user.id,
+							authTime: new Date(),
+							expiresAt: new Date(Date.now() + sessionTtlMs),
+							federations: [params.federationName],
+							claims,
+						});
+						if (params.profile.accessToken) {
+							await federationTokenStore.attach(sid, params.federationName, {
+								accessToken: params.profile.accessToken,
+								refreshToken: params.profile.refreshToken,
+								idToken: params.profile.idToken,
+								expiresAt: new Date(Date.now() + (params.profile.expiresIn ?? 3600) * 1000),
+							});
+						}
+						const session = params.req.session as Record<string, unknown> | undefined;
+						if (session) session.sid = sid;
+						params.done(null, user as Record<string, unknown>);
+					} catch (err) {
+						params.done(err as Error, false);
+					}
+				}
+			: undefined;
+
 	// Build the setup context once: verifyUser delegates to userRepository so federation
 	// providers don't depend on the repo directly; pathResolver is forwarded for
 	// non-standard module layouts (Yarn PnP, custom require hooks).
 	const ctx: SetupPassportContext = {
 		verifyUser: (externalId: string) => userRepository.authenticateByToken(externalId),
 		pathResolver,
+		onFederationCallback,
 	};
 
 	// Register each enabled federation provider's passport strategy.

--- a/packages/session/src/passport.mts
+++ b/packages/session/src/passport.mts
@@ -147,6 +147,7 @@ export const _createPassportImpl = async ({
 						});
 						// Post-create operations: any failure here orphans the UserSession,
 						// so we roll back with a best-effort delete before calling done(err).
+						let attachedToFederation = false;
 						try {
 							if (params.profile.accessToken) {
 								await federationTokenStore.attach(sid, params.federationName, {
@@ -155,6 +156,7 @@ export const _createPassportImpl = async ({
 									idToken: params.profile.idToken,
 									expiresAt: new Date(Date.now() + (params.profile.expiresIn ?? 3600) * 1000),
 								});
+								attachedToFederation = true;
 							}
 							const session = params.req.session as unknown as
 								| (Record<string, unknown> & {
@@ -175,8 +177,15 @@ export const _createPassportImpl = async ({
 							}
 							params.done(null, user);
 						} catch (postCreateErr) {
-							// Best-effort rollback: delete the orphan UserSession. If delete itself
-							// throws, swallow it — the original error is what matters for the caller.
+							// Best-effort rollback: delete in REVERSE order of creation.
+							// Token first (only if attach succeeded), then UserSession.
+							if (attachedToFederation) {
+								try {
+									await federationTokenStore.delete(sid, params.federationName);
+								} catch {
+									// ignore
+								}
+							}
 							try {
 								await userSessionStore.delete(sid);
 							} catch {

--- a/packages/session/src/passport.mts
+++ b/packages/session/src/passport.mts
@@ -19,6 +19,7 @@ import {
 	extractUserClaims,
 	type FederationTokenStoreBase,
 	type PathResolver,
+	type User,
 	type UserRepository,
 	type UserSessionStoreBase,
 } from "@o3co/auth-provider-core";
@@ -118,10 +119,10 @@ export const _createPassportImpl = async ({
 	const onFederationCallback =
 		userSessionStore && federationTokenStore
 			? async (params: {
-					federationName: string;
-					profile: FederationProfile;
-					req: import("express").Request;
-					done: (err: Error | null, user: unknown) => void;
+					readonly federationName: string;
+					readonly profile: FederationProfile;
+					readonly req: import("express").Request;
+					readonly done: (err: Error | null, user: User | false) => void;
 				}) => {
 					try {
 						const provider = federationProviders.get(params.federationName);
@@ -152,9 +153,9 @@ export const _createPassportImpl = async ({
 								expiresAt: new Date(Date.now() + (params.profile.expiresIn ?? 3600) * 1000),
 							});
 						}
-						const session = params.req.session as Record<string, unknown> | undefined;
+						const session = params.req.session as unknown as Record<string, unknown> | undefined;
 						if (session) session.sid = sid;
-						params.done(null, user as Record<string, unknown>);
+						params.done(null, user);
 					} catch (err) {
 						params.done(err as Error, false);
 					}

--- a/packages/session/src/routes/Federation.mts
+++ b/packages/session/src/routes/Federation.mts
@@ -25,6 +25,8 @@ declare module "express-session" {
 		oauth_csrf_state?: string;
 		isAuthenticated?: boolean;
 		user?: Record<string, unknown>;
+		/** UserSession ID — set by the built-in onFederationCallback hook and preserved across session regeneration. */
+		sid?: string;
 	}
 }
 
@@ -121,7 +123,7 @@ export const createRouter = (
 				const user = req.user;
 				const { redirectTo } = req.session;
 				// Capture sid before regeneration — it was set by the built-in onFederationCallback.
-				const sid = (req.session as unknown as { sid?: string }).sid;
+				const sid = req.session.sid;
 
 				req.session.regenerate((err: Error | null) => {
 					if (err) return res.status(500).json({ message: "Error regenerating session" });
@@ -129,7 +131,7 @@ export const createRouter = (
 					req.session.isAuthenticated = true;
 					req.session.user = user as Record<string, unknown> | undefined;
 					// Restore sid on the new session so F-3's access_token claim has a source.
-					if (sid) (req.session as unknown as { sid: string }).sid = sid;
+					if (sid) req.session.sid = sid;
 
 					const redirectResult = provider.resolveCallbackRedirect({ redirectTo });
 					if (!redirectResult.ok) {

--- a/packages/session/src/routes/Federation.mts
+++ b/packages/session/src/routes/Federation.mts
@@ -120,12 +120,16 @@ export const createRouter = (
 
 				const user = req.user;
 				const { redirectTo } = req.session;
+				// Capture sid before regeneration — it was set by the built-in onFederationCallback.
+				const sid = (req.session as unknown as { sid?: string }).sid;
 
 				req.session.regenerate((err: Error | null) => {
 					if (err) return res.status(500).json({ message: "Error regenerating session" });
 
 					req.session.isAuthenticated = true;
 					req.session.user = user as Record<string, unknown> | undefined;
+					// Restore sid on the new session so F-3's access_token claim has a source.
+					if (sid) (req.session as unknown as { sid: string }).sid = sid;
 
 					const redirectResult = provider.resolveCallbackRedirect({ redirectTo });
 					if (!redirectResult.ok) {


### PR DESCRIPTION
## Summary

- Adds `SupportsClaimMapping` / `SupportsRefresh` capability types on top of `FederationProviderBase` (TODO-A pattern), plus `SetupPassportContext.onFederationCallback` hook.
- Google and GitHub providers implement `mapClaims`, `endSession`, plus Google implements `refreshFederationToken`. 6-arg passport callback captures `params.id_token` + `params.expires_in`. Google now requests `access_type=offline` for refresh_token issuance.
- Built-in `onFederationCallback` in `_createPassportImpl` populates `UserSessionStore` + `FederationTokenStore` when both are wired via `AppOptions`. Route handler restores `sid` after `req.session.regenerate()` so subsequent requests can read it.
- Breaking: Google `scope` changes `["profile","email"]` → `["openid","profile","email"]` (required for `id_token` used by F-5 logout). Google default `endSessionEndpoint` removed (was HTTP 400); provider now redirects directly to `postLogoutRedirectUri` unless operator configures `endSessionEndpoint`.

## Test plan

- [ ] CI green (tsc + biome + vitest + build for `packages/session`)
- [ ] `packages/core` still at 339/339 (no regression from F-1 baseline)
- [ ] `packages/session` now 104 passing (+27 from F-1 baseline of 77)
- [ ] Multi-agent review round 1: 7 must-fix items resolved in commit 15a53ac (Claude I1-I4 + M2/M3; Codex P2#1-#2)
- [ ] Copilot review round
- [ ] Squash merge

Depends on TODO-F-1 (PR #74, merged as `bc399b0`). Plan: `.claude/superpowers/plans/2026-04-21-todo-f-2-federation-capability-and-provider-adapt.md`. Spec: `.claude/superpowers/specs/2026-04-21-todo-f-federation-token-lifecycle-design.md` (Sections 4, 4.1, 6.1).

Next: F-3 (access_token claims + /introspect cascade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)