### PR TITLE
feat(oauth)!: access_token family_id+sid claims + /introspect cascade (TODO-F-3)

### DIFF
--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -544,6 +544,13 @@ Federation + OIDC 対応のために `AppOptions` に追加された 2 つのオ
 
 両 store は TODO-F-3 (cascading revoke)、F-4 (id_token + /userinfo)、F-5 (logout)、F-6 (/oauth/federation/:name/token) で消費される。本 F-1 では plumbing のみを追加する。詳細な interface + encryption contract は [TODO-F spec](../../.claude/superpowers/specs/2026-04-21-todo-f-federation-token-lifecycle-design.md) を参照。
 
+**F-3 での consumer 有効化。** `CodeData` にログインパスが書き込む 2 つのオプションフィールドが追加された:
+
+- `nonce?` — 認可リクエストから転送される OIDC nonce。アクセストークンおよびリフレッシュトークンに伝播される。
+- `sid?` — ログインハンドラーが書き込むセッション ID（`UserSession.id`）。発行したトークンをセッションに紐付けるために使用される。
+
+`CodeRepository.createCode` のパラメーターと `InMemoryCodeRepository` は同一の呼び出しで `nonce`、`sid`、`grantedScope` を受け付ける。consumer（`authorization_code` grant）は、`session.granted_scopes` の代わりに、`/oauth/authorize` 時に `GrantPolicyHook` が設定した `codeData.grantedScope` をトークン発行のスコープとして使用する。
+
 ## 関連
 
 - ルート [README](../../README.md) — アーキテクチャ概要、設定リファレンス、Docker セットアップ

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -546,7 +546,7 @@ Federation + OIDC 対応のために `AppOptions` に追加された 2 つのオ
 
 **F-3 での consumer 有効化。** `CodeData` にログインパスが書き込む 2 つのオプションフィールドが追加された:
 
-- `nonce?` — 認可リクエストから転送される OIDC nonce。アクセストークンおよびリフレッシュトークンに伝播される。
+- `nonce?` — 認可リクエストから転送される OIDC nonce。コードレコードに保存され、後続の `id_token` / `/userinfo` 向け処理で参照できるように保持される。
 - `sid?` — ログインハンドラーが書き込むセッション ID（`UserSession.id`）。発行したトークンをセッションに紐付けるために使用される。
 
 `CodeRepository.createCode` のパラメーターと `InMemoryCodeRepository` は同一の呼び出しで `nonce`、`sid`、`grantedScope` を受け付ける。consumer（`authorization_code` grant）は、`session.granted_scopes` の代わりに、`/oauth/authorize` 時に `GrantPolicyHook` が設定した `codeData.grantedScope` をトークン発行のスコープとして使用する。

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -547,7 +547,7 @@ Federation + OIDC 対応のために `AppOptions` に追加された 2 つのオ
 **F-3 での consumer 有効化。** `CodeData` にログインパスが書き込む 2 つのオプションフィールドが追加された:
 
 - `nonce?` — 認可リクエストから転送される OIDC nonce。コードレコードに保存され、後続の `id_token` / `/userinfo` 向け処理で参照できるように保持される。
-- `sid?` — ログインハンドラーが書き込むセッション ID（`UserSession.id`）。発行したトークンをセッションに紐付けるために使用される。
+- `sid?` — ログインハンドラーが書き込むセッション ID（`UserSession.sid`）。発行したトークンをセッションに紐付けるために使用される。
 
 `CodeRepository.createCode` のパラメーターと `InMemoryCodeRepository` は同一の呼び出しで `nonce`、`sid`、`grantedScope` を受け付ける。consumer（`authorization_code` grant）は、`session.granted_scopes` の代わりに、`/oauth/authorize` 時に `GrantPolicyHook` が設定した `codeData.grantedScope` をトークン発行のスコープとして使用する。
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -545,6 +545,13 @@ Two new optional `AppOptions` fields introduced for federation + OIDC support:
 
 Both stores are consumed by upcoming TODO-F-3 (cascading revocation), F-4 (id_token + /userinfo), F-5 (logout), and F-6 (/oauth/federation/:name/token). This plan (F-1) only adds the plumbing. See [the TODO-F spec](../../.claude/superpowers/specs/2026-04-21-todo-f-federation-token-lifecycle-design.md) for the full interface + encryption contract.
 
+**F-3 consumers activated.** `CodeData` now carries two optional fields wired by the login paths:
+
+- `nonce?` — OIDC nonce forwarded from the authorization request, propagated into access tokens and refresh tokens.
+- `sid?` — Session ID (`UserSession.id`) written by the login handler and used to bind minted tokens to the session.
+
+The `CodeRepository.createCode` params and `InMemoryCodeRepository` accept `nonce`, `sid`, and `grantedScope` in the same call. Consumers (the `authorization_code` grant) read `codeData.grantedScope` (set by `GrantPolicyHook` at `/oauth/authorize`) as the authoritative scope for token minting instead of `session.granted_scopes`.
+
 ## See Also
 
 - Root [README](../../README.md) — architecture overview, configuration reference, Docker setup

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -547,7 +547,7 @@ Both stores are consumed by upcoming TODO-F-3 (cascading revocation), F-4 (id_to
 
 **F-3 consumers activated.** `CodeData` now carries two optional fields wired by the login paths:
 
-- `nonce?` — OIDC nonce forwarded from the authorization request, propagated into access tokens and refresh tokens.
+- `nonce?` — OIDC nonce forwarded from the authorization request, persisted on the code record for later `id_token`/`userinfo` use.
 - `sid?` — Session ID (`UserSession.id`) written by the login handler and used to bind minted tokens to the session.
 
 The `CodeRepository.createCode` params and `InMemoryCodeRepository` accept `nonce`, `sid`, and `grantedScope` in the same call. Consumers (the `authorization_code` grant) read `codeData.grantedScope` (set by `GrantPolicyHook` at `/oauth/authorize`) as the authoritative scope for token minting instead of `session.granted_scopes`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -548,7 +548,7 @@ Both stores are consumed by upcoming TODO-F-3 (cascading revocation), F-4 (id_to
 **F-3 consumers activated.** `CodeData` now carries two optional fields wired by the login paths:
 
 - `nonce?` — OIDC nonce forwarded from the authorization request, persisted on the code record for later `id_token`/`userinfo` use.
-- `sid?` — Session ID (`UserSession.id`) written by the login handler and used to bind minted tokens to the session.
+- `sid?` — Session ID (`UserSession.sid`) written by the login handler and used to bind minted tokens to the session.
 
 The `CodeRepository.createCode` params and `InMemoryCodeRepository` accept `nonce`, `sid`, and `grantedScope` in the same call. Consumers (the `authorization_code` grant) read `codeData.grantedScope` (set by `GrantPolicyHook` at `/oauth/authorize`) as the authoritative scope for token minting instead of `session.granted_scopes`.
 

--- a/packages/core/src/grants/types.mts
+++ b/packages/core/src/grants/types.mts
@@ -20,6 +20,7 @@ import type { KeyStore } from "../keys/KeyStore.mjs";
 import type { PathResolver } from "../modules/types.mjs";
 import type { GrantPolicyHookBase } from "../policy/types.mjs";
 import type { RefreshTokenStoreBase } from "../refresh/types.mjs";
+import type { UserSessionStoreBase } from "../user-sessions/types.mjs";
 
 export interface SessionData {
 	user?: Record<string, unknown>;
@@ -74,6 +75,7 @@ export interface GrantDependencies {
 	pathResolver?: PathResolver;
 	refreshTokenStore?: RefreshTokenStoreBase;
 	grantPolicy?: GrantPolicyHookBase;
+	userSessionStore?: UserSessionStoreBase;
 }
 
 /**

--- a/packages/core/src/repositories/CodeRepository.mts
+++ b/packages/core/src/repositories/CodeRepository.mts
@@ -24,6 +24,9 @@ export interface CodeRepository {
 		expiresIn?: number;
 		grantedScope?: readonly string[];
 		grantedAudience?: readonly string[];
+		// NEW (TODO-F-3): OIDC authorize → token round-trip state.
+		nonce?: string;
+		sid?: string;
 	}): Promise<Code>;
 	getByCode(code: string): Promise<Code | null>;
 	consumeByCode(code: string): Promise<Code | null>;

--- a/packages/core/src/repositories/InMemoryCodeRepository.mts
+++ b/packages/core/src/repositories/InMemoryCodeRepository.mts
@@ -23,6 +23,9 @@ interface StoredCode extends Code {
 	redirect_uri?: string;
 	grantedScope?: readonly string[];
 	grantedAudience?: readonly string[];
+	// NEW (TODO-F-3): OIDC authorize → token round-trip state.
+	nonce?: string;
+	sid?: string;
 }
 
 export class InMemoryCodeRepository implements CodeRepository {
@@ -48,6 +51,9 @@ export class InMemoryCodeRepository implements CodeRepository {
 		expiresIn?: number;
 		grantedScope?: readonly string[];
 		grantedAudience?: readonly string[];
+		// NEW (TODO-F-3): OIDC authorize → token round-trip state.
+		nonce?: string;
+		sid?: string;
 	}): Promise<Code> {
 		const code = crypto.randomBytes(32).toString("base64url");
 		const expiresIn = params.expiresIn ?? this.defaultExpiresIn;
@@ -60,6 +66,8 @@ export class InMemoryCodeRepository implements CodeRepository {
 			expiresAt: Date.now() + expiresIn * 1000,
 			grantedScope: params.grantedScope,
 			grantedAudience: params.grantedAudience,
+			nonce: params.nonce,
+			sid: params.sid,
 		};
 		this.codes.set(code, stored);
 		return {
@@ -70,6 +78,8 @@ export class InMemoryCodeRepository implements CodeRepository {
 			expiresIn,
 			grantedScope: params.grantedScope,
 			grantedAudience: params.grantedAudience,
+			nonce: params.nonce,
+			sid: params.sid,
 		};
 	}
 
@@ -88,6 +98,8 @@ export class InMemoryCodeRepository implements CodeRepository {
 			expiresIn: stored.expiresIn,
 			grantedScope: stored.grantedScope,
 			grantedAudience: stored.grantedAudience,
+			nonce: stored.nonce,
+			sid: stored.sid,
 		};
 	}
 
@@ -104,6 +116,8 @@ export class InMemoryCodeRepository implements CodeRepository {
 			expiresIn: stored.expiresIn,
 			grantedScope: stored.grantedScope,
 			grantedAudience: stored.grantedAudience,
+			nonce: stored.nonce,
+			sid: stored.sid,
 		};
 	}
 

--- a/packages/core/src/repositories/__tests__/InMemoryCodeRepository.test.mts
+++ b/packages/core/src/repositories/__tests__/InMemoryCodeRepository.test.mts
@@ -144,4 +144,44 @@ describe("InMemoryCodeRepository", () => {
 			expect(found).toBeNull();
 		});
 	});
+
+	describe("TODO-F-3 extended fields (nonce / sid)", () => {
+		it("roundtrips nonce + sid + grantedScope via createCode → getByCode", async () => {
+			repo = new InMemoryCodeRepository();
+			const { code } = await repo.createCode({
+				code_challenge: "cc",
+				code_challenge_method: "S256",
+				redirect_uri: "https://rp/cb",
+				nonce: "n-abc",
+				sid: "sid-123",
+				grantedScope: ["openid", "profile"],
+				expiresIn: 60,
+			});
+			const r = await repo.getByCode(code);
+			expect(r?.nonce).toBe("n-abc");
+			expect(r?.sid).toBe("sid-123");
+			expect(r?.grantedScope).toEqual(["openid", "profile"]);
+		});
+
+		it("consumeByCode returns the fields exactly once then removes them", async () => {
+			repo = new InMemoryCodeRepository();
+			const { code } = await repo.createCode({
+				sid: "sid-1",
+				nonce: "n-1",
+			});
+			const first = await repo.consumeByCode(code);
+			expect(first?.sid).toBe("sid-1");
+			expect(first?.nonce).toBe("n-1");
+			const second = await repo.consumeByCode(code);
+			expect(second).toBeNull();
+		});
+
+		it("createCode without nonce/sid leaves them undefined (backward compat)", async () => {
+			repo = new InMemoryCodeRepository();
+			const { code } = await repo.createCode({ redirect_uri: "https://rp/cb" });
+			const r = await repo.getByCode(code);
+			expect(r?.nonce).toBeUndefined();
+			expect(r?.sid).toBeUndefined();
+		});
+	});
 });

--- a/packages/core/src/repositories/types.mts
+++ b/packages/core/src/repositories/types.mts
@@ -31,6 +31,10 @@ export interface CodeData {
 	code_challenge?: string;
 	code_challenge_method?: string;
 	redirect_uri?: string;
+	// NEW (TODO-F-3): OIDC authorize → token round-trip state.
+	// These fields are persisted at /authorize and read at /token.
+	nonce?: string;
+	sid?: string;
 }
 
 export interface Code extends CodeData {

--- a/packages/oauth/README.ja.md
+++ b/packages/oauth/README.ja.md
@@ -111,6 +111,13 @@ const app = createApp(express, {
 await app.init();
 ```
 
+## TODO-F-3 の変更点
+
+- **`/oauth/introspect` によるカスケード失効。** アクセストークンに `family_id` クレームが含まれ、`AppOptions.refreshTokenStore` が設定されている場合、イントロスペクトエンドポイントはアクティブレスポンスを返す前に `RefreshTokenStore.isFamilyRevoked(familyId)` を呼び出す。ファミリーが失効済み、またはストアに到達できない場合は `{ active: false }` を返す（フェイルクローズ、RFC 7009 §2.1 SHOULD 準拠）。`family_id` クレームを持たない F-3 以前発行のトークンはこのチェックをスキップし、署名のみで検証される。
+- **`family_id` + `sid` データクレーム。** `authorization_code` および `refresh_token` グラントで発行される `access_token` と `refresh_token` の両方に、`family_id`（カスケード失効用トークンファミリー）と `sid`（セッション ID、コードレコードに含まれる場合）が JWT クレームとして付与される。
+- **`authorization_code` グラント — `sid` の必要条件。** グラントは `CodeData` レコードから `sid` を読み取る。発行トークンに `sid` クレームを含めるには、F-2/F-3 のログインワイアリング（ローカルログインまたはフェデレーションコールバックがコードに `sid` を書き込む処理）が必要。
+- **`refresh_token` グラント — セッション検証。** `AppOptions.userSessionStore` が設定されており、かつリフレッシュトークンに `sid` クレームが含まれる場合、グラントは `userSessionStore.get(sid)` を呼び出してセッションがまだアクティブかを検証する。セッションが存在しない場合は `400 invalid_grant`、ストアエラーの場合は `503 temporarily_unavailable` を返す。
+
 ## 関連
 
 - [`@o3co/auth-provider-session`](../session/README.ja.md) — セッションログイン / フェデレーションルート

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -111,6 +111,13 @@ const app = createApp(express, {
 await app.init();
 ```
 
+## TODO-F-3 changes
+
+- **`/oauth/introspect` cascading revoke.** When the access token carries a `family_id` claim and `AppOptions.refreshTokenStore` is wired, the introspect endpoint calls `RefreshTokenStore.isFamilyRevoked(familyId)` before returning an active response. If the family is revoked or the store is unreachable, the response is `{ active: false }` (fail-closed, per RFC 7009 §2.1 SHOULD). Tokens minted before F-3 that lack a `family_id` claim bypass this check and are validated by signature only.
+- **`family_id` + `sid` data claims.** Both `access_token` and `refresh_token` minted by the `authorization_code` and `refresh_token` grants carry `family_id` (token family for cascading revoke) and `sid` (session ID, when the code record contains it) as JWT claims.
+- **`authorization_code` grant — `sid` requirement.** The grant reads `sid` from the `CodeData` record. Deployments must have the F-2/F-3 login wiring in place (local login or federation callback writing `sid` onto the code) for the `sid` claim to be present in issued tokens.
+- **`refresh_token` grant — session validation.** When `AppOptions.userSessionStore` is wired and the refresh token carries a `sid` claim, the grant calls `userSessionStore.get(sid)` to verify the session is still active. A missing session returns `400 invalid_grant`; a store error returns `503 temporarily_unavailable`.
+
 ## See Also
 
 - [`@o3co/auth-provider-session`](../session/README.md) — session login / federation routes

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -125,7 +125,7 @@ describe("createAuthorizationGrant", () => {
 		});
 
 		it("returns 200 with access and refresh tokens on valid code exchange (no PKCE)", async () => {
-			const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc" }));
+			const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" }));
 			const handler = createAuthorizationGrant(deps);
 			const ctx: GrantContext = {
 				body: { code: "abc", client_id: "client1" },
@@ -171,7 +171,7 @@ describe("createAuthorizationGrant", () => {
 				async revokeFamily() {},
 			};
 			const deps = {
-				...makeDeps(vi.fn().mockResolvedValue({ code: "abc" })),
+				...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" })),
 				refreshTokenStore,
 			};
 			const handler = createAuthorizationGrant(deps);
@@ -218,7 +218,7 @@ describe("createAuthorizationGrant", () => {
 				async revokeFamily() {},
 			};
 			const deps = {
-				...makeDeps(vi.fn().mockResolvedValue({ code: "abc" })),
+				...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" })),
 				refreshTokenStore: throwingStore,
 			};
 			const handler = createAuthorizationGrant(deps);
@@ -241,7 +241,7 @@ describe("createAuthorizationGrant", () => {
 		});
 
 		it("skips initial-register when no refreshTokenStore is configured (CP-2 graceful)", async () => {
-			const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc" }));
+			const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" }));
 			const handler = createAuthorizationGrant(deps);
 			const { result } = await handler.handle({
 				body: { code: "abc", client_id: "client1" },
@@ -258,7 +258,7 @@ describe("createAuthorizationGrant", () => {
 		});
 
 		it("issues an initial rt+jwt carrying a new family_id (C-3)", async () => {
-			const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc" }));
+			const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" }));
 			const handler = createAuthorizationGrant(deps);
 			const ctx: GrantContext = {
 				body: { code: "abc", client_id: "client1" },
@@ -288,7 +288,7 @@ describe("createAuthorizationGrant", () => {
 
 		it("omits scope from token response when granted scopes is empty (CP-12)", async () => {
 			// Code has neither grantedScope nor session.granted_scopes.
-			const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc" }));
+			const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" }));
 			const handler = createAuthorizationGrant(deps);
 			const ctx: GrantContext = {
 				body: { code: "abc", client_id: "client1" },
@@ -315,7 +315,11 @@ describe("createAuthorizationGrant", () => {
 		it("omits scope when Code.grantedScope is explicitly empty (CP-12)", async () => {
 			// Even if persisted as [], code exchange must not emit `scope: ""`.
 			const deps = makeDeps(
-				vi.fn().mockResolvedValue({ code: "abc", grantedScope: [] as readonly string[] }),
+				vi.fn().mockResolvedValue({
+					code: "abc",
+					sid: "test-sid-1",
+					grantedScope: [] as readonly string[],
+				}),
 			);
 			const handler = createAuthorizationGrant(deps);
 			const { result } = await handler.handle({
@@ -408,6 +412,7 @@ describe("createAuthorizationGrant", () => {
 			const deps = makeDeps(
 				vi.fn().mockResolvedValue({
 					code: "abc",
+					sid: "test-sid-1",
 					code_challenge: challenge,
 					code_challenge_method: "S256",
 				}),
@@ -430,6 +435,7 @@ describe("createAuthorizationGrant", () => {
 			const deps = makeDeps(
 				vi.fn().mockResolvedValue({
 					code: "abc",
+					sid: "test-sid-1",
 					code_challenge: verifier,
 					code_challenge_method: "plain",
 				}),
@@ -507,6 +513,7 @@ describe("createAuthorizationGrant", () => {
 					codeRepository: {
 						consumeByCode: vi.fn().mockResolvedValue({
 							code: "abc",
+							sid: "test-sid-1",
 							code_challenge: challenge,
 							code_challenge_method: "S256",
 						}),
@@ -585,6 +592,7 @@ describe("createAuthorizationGrant", () => {
 				const deps = makeDeps(
 					vi.fn().mockResolvedValue({
 						code: "abc",
+						sid: "test-sid-1",
 						redirect_uri: "https://example.com/callback",
 					}),
 				);
@@ -609,6 +617,7 @@ describe("createAuthorizationGrant", () => {
 				const deps = makeDeps(
 					vi.fn().mockResolvedValue({
 						code: "abc",
+						sid: "test-sid-1",
 					}),
 				);
 				const handler = createAuthorizationGrant(deps);
@@ -663,7 +672,10 @@ describe("createAuthorizationGrant", () => {
 						allowedScopes: [],
 					}),
 				};
-				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc" }), clientRepo);
+				const deps = makeDeps(
+					vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" }),
+					clientRepo,
+				);
 				const handler = createAuthorizationGrant(deps);
 				const ctx: GrantContext = {
 					body: { code: "abc", client_id: "client1", client_secret: "correct-secret" },
@@ -687,7 +699,10 @@ describe("createAuthorizationGrant", () => {
 					}),
 					authenticate: vi.fn().mockResolvedValue(null),
 				};
-				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc" }), clientRepo);
+				const deps = makeDeps(
+					vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" }),
+					clientRepo,
+				);
 				const handler = createAuthorizationGrant(deps);
 				const ctx: GrantContext = {
 					body: { code: "abc", client_id: "client1" }, // no client_secret
@@ -790,6 +805,7 @@ describe("createAuthorizationGrant", () => {
 					codeRepository: {
 						consumeByCode: vi.fn().mockResolvedValue({
 							code: "abc",
+							sid: "test-sid-1",
 							// no code_challenge_method
 						}),
 						createCode: vi.fn(),
@@ -809,6 +825,131 @@ describe("createAuthorizationGrant", () => {
 				const { result } = await handler.handle(ctx);
 
 				expect(result.status).toBe(200);
+			});
+		});
+
+		describe("TODO-F-3: family_id + sid claims, RP registration", () => {
+			it("happy path: access_token and refresh_token both carry family_id and sid claims (F-3-1)", async () => {
+				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "session-abc" }));
+				const handler = createAuthorizationGrant(deps);
+				const { result } = await handler.handle({
+					body: { code: "abc", client_id: "client1" },
+					session: {
+						code: "abc",
+						code_client_id: "client1",
+						granted_scopes: ["read"],
+						user: { id: "u1" },
+					},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+				});
+
+				expect(result.status).toBe(200);
+				if (!("tokens" in result)) throw new Error("expected tokens");
+
+				const decodedAt = decodeJwt(result.tokens.access_token) as Record<string, unknown>;
+				expect(typeof decodedAt.family_id).toBe("string");
+				expect(decodedAt.family_id as string).toMatch(
+					/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+				);
+				expect(decodedAt.sid).toBe("session-abc");
+
+				const refreshToken = result.tokens.refresh_token;
+				if (typeof refreshToken !== "string") throw new Error("expected refresh_token string");
+				const decodedRt = decodeJwt(refreshToken) as Record<string, unknown>;
+				expect(decodedRt.family_id).toBe(decodedAt.family_id);
+				expect(decodedRt.sid).toBe("session-abc");
+			});
+
+			it("returns 400 invalid_grant when code record has no sid (F-3-2)", async () => {
+				// Code was issued before Task 2 login wiring — sid missing.
+				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc" /* no sid */ }));
+				const handler = createAuthorizationGrant(deps);
+				const { result } = await handler.handle({
+					body: { code: "abc", client_id: "client1" },
+					session: {
+						code: "abc",
+						code_client_id: "client1",
+						user: { id: "u1" },
+					},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+				});
+
+				expect(result.status).toBe(400);
+				if (!("error" in result)) throw new Error("expected error");
+				expect(result.error).toBe("invalid_grant");
+				expect((result as { errorDescription?: string }).errorDescription).toMatch(/sid/);
+			});
+
+			it("calls linkFamily and registerRP when userSessionStore is wired (F-3-3)", async () => {
+				const linkFamilySpy = vi.fn(async (_sid: string, _fam: string) => {});
+				const registerRPSpy = vi.fn(async (_sid: string, _rp: unknown) => {});
+				const userSessionStore = {
+					kind: "spy",
+					linkFamily: linkFamilySpy,
+					registerRP: registerRPSpy,
+					async create() {},
+					async get() {
+						return null;
+					},
+					async updateClaims() {},
+					async removeFederation() {},
+					async delete() {},
+				};
+				const deps = {
+					...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "session-xyz" })),
+					userSessionStore,
+				};
+				const handler = createAuthorizationGrant(deps);
+				const { result } = await handler.handle({
+					body: { code: "abc", client_id: "client1" },
+					session: {
+						code: "abc",
+						code_client_id: "client1",
+						granted_scopes: ["read"],
+						user: { id: "u1" },
+					},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+				});
+
+				expect(result.status).toBe(200);
+				expect(linkFamilySpy).toHaveBeenCalledTimes(1);
+				const [sidArg, familyIdArg] = linkFamilySpy.mock.calls[0] as [string, string];
+				expect(sidArg).toBe("session-xyz");
+				expect(familyIdArg).toMatch(
+					/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+				);
+				expect(registerRPSpy).toHaveBeenCalledTimes(1);
+				const [rpSid, rpData] = registerRPSpy.mock.calls[0] as [string, Record<string, unknown>];
+				expect(rpSid).toBe("session-xyz");
+				expect(rpData.clientId).toBe("client1");
+				expect(rpData.registeredAt).toBeInstanceOf(Date);
+			});
+
+			it("backward compat: issues tokens without userSessionStore (F-3-4)", async () => {
+				// No userSessionStore in deps — grant must succeed without linkFamily/registerRP.
+				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "session-abc" }));
+				const handler = createAuthorizationGrant(deps);
+				const { result } = await handler.handle({
+					body: { code: "abc", client_id: "client1" },
+					session: {
+						code: "abc",
+						code_client_id: "client1",
+						granted_scopes: ["read"],
+						user: { id: "u1" },
+					},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+				});
+
+				expect(result.status).toBe(200);
+				if (!("tokens" in result)) throw new Error("expected tokens");
+				// Tokens must still carry family_id and sid even without a session store.
+				const decoded = decodeJwt(result.tokens.access_token) as Record<string, unknown>;
+				expect(typeof decoded.family_id).toBe("string");
+				expect(decoded.sid).toBe("session-abc");
 			});
 		});
 	});

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -861,9 +861,25 @@ describe("createAuthorizationGrant", () => {
 				expect(decodedRt.sid).toBe("session-abc");
 			});
 
-			it("returns 400 invalid_grant when code record has no sid (F-3-2)", async () => {
+			it("returns 400 invalid_grant when code record has no sid and userSessionStore IS wired (F-3-2)", async () => {
 				// Code was issued before Task 2 login wiring — sid missing.
-				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc" /* no sid */ }));
+				// When the store is wired, sid is required so the store can link/register.
+				const userSessionStore = {
+					kind: "spy",
+					linkFamily: vi.fn(),
+					registerRP: vi.fn(),
+					create: vi.fn(),
+					async get() {
+						return null;
+					},
+					updateClaims: vi.fn(),
+					removeFederation: vi.fn(),
+					delete: vi.fn(),
+				};
+				const deps = {
+					...makeDeps(vi.fn().mockResolvedValue({ code: "abc" /* no sid */ })),
+					userSessionStore,
+				};
 				const handler = createAuthorizationGrant(deps);
 				const { result } = await handler.handle({
 					body: { code: "abc", client_id: "client1" },
@@ -882,6 +898,31 @@ describe("createAuthorizationGrant", () => {
 				expect((result as { errorDescription?: string }).errorDescription).toMatch(/sid/);
 			});
 
+			it("backward compat — no userSessionStore + no sid → grant succeeds without sid claim (F-3-2-compat)", async () => {
+				// Deployments that have not wired userSessionStore do not write sid at login
+				// time and must continue to work. No store → sid not required.
+				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc" /* no sid */ }));
+				const handler = createAuthorizationGrant(deps);
+				const { result } = await handler.handle({
+					body: { code: "abc", client_id: "client1" },
+					session: {
+						code: "abc",
+						code_client_id: "client1",
+						granted_scopes: ["read"],
+						user: { id: "u1" },
+					},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+				});
+
+				expect(result.status).toBe(200);
+				if (!("tokens" in result)) throw new Error("expected tokens");
+				const decoded = decodeJwt(result.tokens.access_token) as Record<string, unknown>;
+				// family_id is always present; sid must NOT appear when it was never set
+				expect(typeof decoded.family_id).toBe("string");
+				expect(Object.hasOwn(decoded, "sid")).toBe(false);
+			});
+
 			it("calls linkFamily and registerRP when userSessionStore is wired (F-3-3)", async () => {
 				const linkFamilySpy = vi.fn(async (_sid: string, _fam: string) => {});
 				const registerRPSpy = vi.fn(async (_sid: string, _rp: unknown) => {});
@@ -891,7 +932,18 @@ describe("createAuthorizationGrant", () => {
 					registerRP: registerRPSpy,
 					async create() {},
 					async get() {
-						return null;
+						// Return a minimal session so the existence check passes
+						return {
+							sid: "session-xyz",
+							sub: "u1",
+							authTime: new Date(),
+							createdAt: new Date(),
+							expiresAt: new Date(Date.now() + 3600_000),
+							federations: [],
+							activeRPs: [],
+							familyIds: [],
+							claims: {},
+						};
 					},
 					async updateClaims() {},
 					async removeFederation() {},
@@ -950,6 +1002,132 @@ describe("createAuthorizationGrant", () => {
 				const decoded = decodeJwt(result.tokens.access_token) as Record<string, unknown>;
 				expect(typeof decoded.family_id).toBe("string");
 				expect(decoded.sid).toBe("session-abc");
+			});
+
+			it("returns 400 invalid_grant session_invalid when session was deleted between /authorize and /token (F-3-I1)", async () => {
+				// Session deleted after /authorize was issued — get(sid) returns null.
+				const userSessionStore = {
+					kind: "spy",
+					linkFamily: vi.fn(),
+					registerRP: vi.fn(),
+					async create() {},
+					async get() {
+						return null; // session gone
+					},
+					async updateClaims() {},
+					async removeFederation() {},
+					async delete() {},
+				};
+				const deps = {
+					...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "session-gone" })),
+					userSessionStore,
+				};
+				const handler = createAuthorizationGrant(deps);
+				const { result } = await handler.handle({
+					body: { code: "abc", client_id: "client1" },
+					session: {
+						code: "abc",
+						code_client_id: "client1",
+						granted_scopes: ["read"],
+						user: { id: "u1" },
+					},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+				});
+
+				expect(result.status).toBe(400);
+				if (!("error" in result)) throw new Error("expected error");
+				expect(result.error).toBe("invalid_grant");
+				expect((result as { errorDescription?: string }).errorDescription).toMatch(/session/i);
+			});
+
+			it("returns 503 temporarily_unavailable when userSessionStore.get throws (F-3-I1-503)", async () => {
+				// Store is wired but unavailable when get() is called.
+				const userSessionStore = {
+					kind: "broken",
+					linkFamily: vi.fn(),
+					registerRP: vi.fn(),
+					async create() {},
+					async get() {
+						throw new Error("store down");
+					},
+					async updateClaims() {},
+					async removeFederation() {},
+					async delete() {},
+				};
+				const deps = {
+					...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "session-abc" })),
+					userSessionStore,
+				};
+				const handler = createAuthorizationGrant(deps);
+				const { result } = await handler.handle({
+					body: { code: "abc", client_id: "client1" },
+					session: {
+						code: "abc",
+						code_client_id: "client1",
+						granted_scopes: ["read"],
+						user: { id: "u1" },
+					},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+				});
+
+				expect(result.status).toBe(503);
+				if (!("error" in result)) throw new Error("expected error");
+				expect(result.error).toBe("temporarily_unavailable");
+			});
+
+			it("returns 503 temporarily_unavailable when clientRepository.findById throws (F-3-I2)", async () => {
+				// findById is now inside the try/catch — a throw must produce a controlled 503.
+				const throwingClientRepo: ClientRepository = {
+					findById: vi.fn().mockRejectedValue(new Error("db down")),
+					authenticate: vi.fn().mockResolvedValue(null),
+				};
+				const userSessionStore = {
+					kind: "spy",
+					linkFamily: vi.fn(),
+					registerRP: vi.fn(),
+					async create() {},
+					async get() {
+						return {
+							sid: "session-abc",
+							sub: "u1",
+							authTime: new Date(),
+							createdAt: new Date(),
+							expiresAt: new Date(Date.now() + 3600_000),
+							federations: [] as ReadonlyArray<string>,
+							activeRPs: [] as ReadonlyArray<{ clientId: string; registeredAt: Date }>,
+							familyIds: [] as ReadonlyArray<string>,
+							claims: {},
+						};
+					},
+					async updateClaims() {},
+					async removeFederation() {},
+					async delete() {},
+				};
+				const deps = {
+					...makeDeps(
+						vi.fn().mockResolvedValue({ code: "abc", sid: "session-abc" }),
+						throwingClientRepo,
+					),
+					userSessionStore,
+				};
+				const handler = createAuthorizationGrant(deps);
+				const { result } = await handler.handle({
+					body: { code: "abc", client_id: "client1" },
+					session: {
+						code: "abc",
+						code_client_id: "client1",
+						granted_scopes: ["read"],
+						user: { id: "u1" },
+					},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+				});
+
+				expect(result.status).toBe(503);
+				if (!("error" in result)) throw new Error("expected error");
+				expect(result.error).toBe("temporarily_unavailable");
 			});
 		});
 	});

--- a/packages/oauth/src/__tests__/hooks.test.mts
+++ b/packages/oauth/src/__tests__/hooks.test.mts
@@ -551,6 +551,7 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 				code: "code-xyz",
 				redirect_uri: "https://example.test/cb",
 				grantedScope: ["read"],
+				sid: "test-sid-1",
 			};
 			const codeRepo: CodeRepository = {
 				createCode: async () => persistedCode,

--- a/packages/oauth/src/__tests__/introspectCascade.test.mts
+++ b/packages/oauth/src/__tests__/introspectCascade.test.mts
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSecretKey } from "node:crypto";
+import {
+	type AppConfig,
+	type ClientRepository,
+	type CodeRepository,
+	createSymmetricKeyStore,
+	GrantRegistry,
+	type RefreshTokenStoreBase,
+} from "@o3co/auth-provider-core";
+import express from "express";
+import { SignJWT } from "jose";
+import type { PassportStatic } from "passport";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import { createOAuthRouter } from "#/routes.mjs";
+
+const SECRET = "test-secret-at-least-32-chars!!";
+const keyStore = createSymmetricKeyStore(SECRET);
+const secretKey = createSecretKey(Buffer.from(SECRET));
+
+const mockConfig = {
+	oauth: {
+		jwt: { issuer: "https://auth.example" },
+		accessToken: { expiresIn: 3600 },
+		refreshToken: { expiresIn: 86400 },
+	},
+	endpoints: {
+		login: { url: "/login" },
+	},
+} as unknown as AppConfig;
+
+const mockPassport = {
+	authenticate: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+} as unknown as PassportStatic;
+
+const mockClientRepository: ClientRepository = {
+	findById: async () => null,
+	authenticate: async () => null,
+};
+
+const mockCodeRepository: CodeRepository = {
+	createCode: async () => ({ code: "test-code" }),
+	getByCode: async () => null,
+	consumeByCode: async () => null,
+	removeByCode: async () => {},
+};
+
+async function makeAccessToken(overrides: Record<string, unknown> = {}): Promise<string> {
+	return new SignJWT({ sub: "u1", scope: "read", ...overrides })
+		.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "at+jwt" })
+		.setExpirationTime("1h")
+		.sign(secretKey);
+}
+
+async function buildApp(refreshTokenStore?: RefreshTokenStoreBase) {
+	const app = express();
+	app.set("trust proxy", 1);
+	app.use(express.json());
+	app.use(express.urlencoded({ extended: false }));
+
+	const { router } = await createOAuthRouter(express, {
+		passport: mockPassport,
+		registry: new GrantRegistry(),
+		config: mockConfig,
+		clientRepository: mockClientRepository,
+		codeRepository: mockCodeRepository,
+		keyStore,
+		refreshTokenStore,
+	});
+
+	app.use("/oauth", router);
+	return app;
+}
+
+// Use the Bearer self-introspection path: Bearer token == body token.
+// RFC 7662 §2.1 allows the resource server (or the client itself) to send
+// the same token as the Bearer credential — the introspect handler validates
+// that the body.token matches the Authorization header token, then proceeds.
+async function introspect(app: ReturnType<typeof express>, token: string) {
+	return request(app)
+		.post("/oauth/introspect")
+		.set("Authorization", `Bearer ${token}`)
+		.send({ token });
+}
+
+describe("/introspect — family revoke cascade (TODO-F-3 task 5)", () => {
+	it("returns active:true when family_id present and isFamilyRevoked returns false", async () => {
+		const familyId = "fam-abc";
+		const token = await makeAccessToken({ family_id: familyId });
+
+		const refreshTokenStore: RefreshTokenStoreBase = {
+			kind: "test",
+			rotate: vi.fn(),
+			revokeFamily: vi.fn(),
+			isFamilyRevoked: vi.fn().mockResolvedValue(false),
+		};
+
+		const app = await buildApp(refreshTokenStore);
+		const res = await introspect(app, token);
+
+		expect(res.status).toBe(200);
+		expect(res.body.active).toBe(true);
+		expect(refreshTokenStore.isFamilyRevoked).toHaveBeenCalledWith(familyId);
+	});
+
+	it("returns active:false when family_id present and isFamilyRevoked returns true", async () => {
+		const familyId = "fam-revoked";
+		const token = await makeAccessToken({ family_id: familyId });
+
+		const refreshTokenStore: RefreshTokenStoreBase = {
+			kind: "test",
+			rotate: vi.fn(),
+			revokeFamily: vi.fn(),
+			isFamilyRevoked: vi.fn().mockResolvedValue(true),
+		};
+
+		const app = await buildApp(refreshTokenStore);
+		const res = await introspect(app, token);
+
+		expect(res.status).toBe(200);
+		expect(res.body.active).toBe(false);
+	});
+
+	it("returns active:false (fail-closed) when isFamilyRevoked throws", async () => {
+		const familyId = "fam-error";
+		const token = await makeAccessToken({ family_id: familyId });
+
+		const refreshTokenStore: RefreshTokenStoreBase = {
+			kind: "test",
+			rotate: vi.fn(),
+			revokeFamily: vi.fn(),
+			isFamilyRevoked: vi.fn().mockRejectedValue(new Error("store unavailable")),
+		};
+
+		const app = await buildApp(refreshTokenStore);
+		const res = await introspect(app, token);
+
+		expect(res.status).toBe(200);
+		expect(res.body.active).toBe(false);
+	});
+
+	it("returns active:true and does NOT consult store for legacy token without family_id", async () => {
+		const token = await makeAccessToken(); // no family_id claim
+
+		const refreshTokenStore: RefreshTokenStoreBase = {
+			kind: "test",
+			rotate: vi.fn(),
+			revokeFamily: vi.fn(),
+			// Throws if called — ensures no consultation for legacy tokens
+			isFamilyRevoked: vi.fn().mockImplementation(() => {
+				throw new Error("isFamilyRevoked must not be called for legacy tokens");
+			}),
+		};
+
+		const app = await buildApp(refreshTokenStore);
+		const res = await introspect(app, token);
+
+		expect(res.status).toBe(200);
+		expect(res.body.active).toBe(true);
+		expect(refreshTokenStore.isFamilyRevoked).not.toHaveBeenCalled();
+	});
+});

--- a/packages/oauth/src/__tests__/introspectCascade.test.mts
+++ b/packages/oauth/src/__tests__/introspectCascade.test.mts
@@ -17,17 +17,22 @@
 import { createSecretKey } from "node:crypto";
 import {
 	type AppConfig,
+	type AuditEvent,
+	type AuditSinkBase,
 	type ClientRepository,
 	type CodeRepository,
 	createSymmetricKeyStore,
 	GrantRegistry,
+	type ModuleContext,
 	type RefreshTokenStoreBase,
 } from "@o3co/auth-provider-core";
+import type { Router } from "express";
 import express from "express";
 import { SignJWT } from "jose";
 import type { PassportStatic } from "passport";
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
+import { oauthModule } from "#/module.mjs";
 import { createOAuthRouter } from "#/routes.mjs";
 
 const SECRET = "test-secret-at-least-32-chars!!";
@@ -39,6 +44,7 @@ const mockConfig = {
 		jwt: { issuer: "https://auth.example" },
 		accessToken: { expiresIn: 3600 },
 		refreshToken: { expiresIn: 86400 },
+		grants: {},
 	},
 	endpoints: {
 		login: { url: "/login" },
@@ -68,7 +74,7 @@ async function makeAccessToken(overrides: Record<string, unknown> = {}): Promise
 		.sign(secretKey);
 }
 
-async function buildApp(refreshTokenStore?: RefreshTokenStoreBase) {
+async function buildApp(refreshTokenStore?: RefreshTokenStoreBase, auditSink?: AuditSinkBase) {
 	const app = express();
 	app.set("trust proxy", 1);
 	app.use(express.json());
@@ -82,6 +88,7 @@ async function buildApp(refreshTokenStore?: RefreshTokenStoreBase) {
 		codeRepository: mockCodeRepository,
 		keyStore,
 		refreshTokenStore,
+		auditSink,
 	});
 
 	app.use("/oauth", router);
@@ -155,6 +162,63 @@ describe("/introspect — family revoke cascade (TODO-F-3 task 5)", () => {
 		expect(res.body.active).toBe(false);
 	});
 
+	it("emits introspect.store_unavailable audit event when isFamilyRevoked throws", async () => {
+		const familyId = "fam-error-audit";
+		const token = await makeAccessToken({ family_id: familyId });
+
+		const refreshTokenStore: RefreshTokenStoreBase = {
+			kind: "test",
+			rotate: vi.fn(),
+			revokeFamily: vi.fn(),
+			isFamilyRevoked: vi.fn().mockRejectedValue(new Error("backend down")),
+		};
+		const events: AuditEvent[] = [];
+		const auditSink: AuditSinkBase = {
+			kind: "spy",
+			async record(event) {
+				events.push(event);
+			},
+		};
+
+		const app = await buildApp(refreshTokenStore, auditSink);
+		const res = await introspect(app, token);
+
+		expect(res.status).toBe(200);
+		expect(res.body.active).toBe(false);
+		const storeEvent = events.find((e) => e.type === "introspect.store_unavailable");
+		expect(storeEvent).toBeDefined();
+		expect((storeEvent?.details as Record<string, unknown>)?.family_id).toBe(familyId);
+		expect((storeEvent?.details as Record<string, unknown>)?.error).toContain("backend down");
+	});
+
+	it("emits introspect.family_revoked audit event when family is revoked", async () => {
+		const familyId = "fam-revoked-audit";
+		const token = await makeAccessToken({ family_id: familyId });
+
+		const refreshTokenStore: RefreshTokenStoreBase = {
+			kind: "test",
+			rotate: vi.fn(),
+			revokeFamily: vi.fn(),
+			isFamilyRevoked: vi.fn().mockResolvedValue(true),
+		};
+		const events: AuditEvent[] = [];
+		const auditSink: AuditSinkBase = {
+			kind: "spy",
+			async record(event) {
+				events.push(event);
+			},
+		};
+
+		const app = await buildApp(refreshTokenStore, auditSink);
+		const res = await introspect(app, token);
+
+		expect(res.status).toBe(200);
+		expect(res.body.active).toBe(false);
+		const revokedEvent = events.find((e) => e.type === "introspect.family_revoked");
+		expect(revokedEvent).toBeDefined();
+		expect((revokedEvent?.details as Record<string, unknown>)?.family_id).toBe(familyId);
+	});
+
 	it("returns active:true and does NOT consult store for legacy token without family_id", async () => {
 		const token = await makeAccessToken(); // no family_id claim
 
@@ -174,5 +238,76 @@ describe("/introspect — family revoke cascade (TODO-F-3 task 5)", () => {
 		expect(res.status).toBe(200);
 		expect(res.body.active).toBe(true);
 		expect(refreshTokenStore.isFamilyRevoked).not.toHaveBeenCalled();
+	});
+
+	it("rejects empty-string family_id and does NOT consult store", async () => {
+		// family_id: "" should be treated as missing (M1 guard)
+		const token = await makeAccessToken({ family_id: "" });
+
+		const refreshTokenStore: RefreshTokenStoreBase = {
+			kind: "test",
+			rotate: vi.fn(),
+			revokeFamily: vi.fn(),
+			isFamilyRevoked: vi.fn().mockImplementation(() => {
+				throw new Error("isFamilyRevoked must not be called for empty family_id");
+			}),
+		};
+
+		const app = await buildApp(refreshTokenStore);
+		const res = await introspect(app, token);
+
+		expect(res.status).toBe(200);
+		expect(res.body.active).toBe(true);
+		expect(refreshTokenStore.isFamilyRevoked).not.toHaveBeenCalled();
+	});
+});
+
+describe("oauthModule.init — refreshTokenStore composition (C1)", () => {
+	it("threads refreshTokenStore through to /introspect so family revocation returns active:false", async () => {
+		// This test proves C1 is fixed at the module layer: oauthModule.init must
+		// pass context.refreshTokenStore into createOAuthRouter. A revoked family
+		// must yield active:false even when the app is wired via oauthModule.
+		const app = express();
+		app.set("trust proxy", 1);
+		app.use(express.json());
+		app.use(express.urlencoded({ extended: false }));
+
+		const familyId = "fam-module-revoked";
+		const token = await makeAccessToken({ family_id: familyId });
+
+		const refreshTokenStore: RefreshTokenStoreBase = {
+			kind: "test",
+			rotate: vi.fn(),
+			revokeFamily: vi.fn(),
+			isFamilyRevoked: vi.fn().mockResolvedValue(true),
+		};
+
+		const rootRouter = express.Router() as Router;
+		const ctx: ModuleContext = {
+			pathResolver: (s: string) => s,
+			config: mockConfig,
+			keyStore,
+			grantRegistry: new GrantRegistry(),
+			router: rootRouter,
+			refreshTokenStore,
+		};
+
+		const module = oauthModule({
+			clientRepository: mockClientRepository,
+			codeRepository: mockCodeRepository,
+			express,
+		});
+
+		await module.init(ctx);
+		app.use(rootRouter);
+
+		const res = await introspect(app, token);
+
+		// If C1 is fixed, the store was consulted and the family is revoked → inactive.
+		// If C1 were broken (store not threaded), isFamilyRevoked would not be called
+		// and the token would appear active:true.
+		expect(res.status).toBe(200);
+		expect(res.body.active).toBe(false);
+		expect(refreshTokenStore.isFamilyRevoked).toHaveBeenCalledWith(familyId);
 	});
 });

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -25,8 +25,84 @@ import {
 	type RefreshTokenStoreBase,
 } from "@o3co/auth-provider-core";
 import type { Router } from "express";
+import express from "express";
+import type { PassportStatic } from "passport";
+import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
 import { oauthAuthorizationModule } from "#/oauthAuthorization.mjs";
+import { createOAuthRouter } from "#/routes.mjs";
+
+// ---------------------------------------------------------------------------
+// Helpers shared by the authorize-captures-nonce-sid suite
+// ---------------------------------------------------------------------------
+
+const authorizeConfig = {
+	oauth: {
+		jwt: { issuer: "https://auth.example" },
+		accessToken: { expiresIn: 3600 },
+		refreshToken: { expiresIn: 86400 },
+	},
+	endpoints: {
+		login: { url: "/login" },
+	},
+} as unknown as AppConfig;
+
+const authorizePassport = {
+	authenticate: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+} as unknown as PassportStatic;
+
+const authorizeClientRepo: ClientRepository = {
+	findById: async () => ({
+		clientId: "client-1",
+		allowedRedirectUris: ["https://example.test/cb"],
+		allowedScopes: ["openid", "profile"],
+	}),
+	authenticate: async () => null,
+};
+
+/**
+ * Build a minimal express app wired to createOAuthRouter.
+ * The session middleware injects the provided session fields into req.session.
+ */
+async function buildAuthorizeApp(opts: {
+	sessionFields: Record<string, unknown>;
+	captureCode: (params: Parameters<CodeRepository["createCode"]>[0]) => void;
+}) {
+	const app = express();
+	app.use(express.json());
+	app.use(express.urlencoded({ extended: false }));
+
+	// Inline session substitute — minimal surface needed by the /authorize route.
+	app.use((req, _res, next) => {
+		(req as unknown as { session: Record<string, unknown> }).session = {
+			isAuthenticated: true,
+			user: { id: "user-1" },
+			...opts.sessionFields,
+		};
+		next();
+	});
+
+	const codeRepo: CodeRepository = {
+		createCode: async (params) => {
+			opts.captureCode(params);
+			return { code: "auth-code" };
+		},
+		getByCode: async () => null,
+		consumeByCode: async () => null,
+		removeByCode: async () => {},
+	};
+
+	const { router } = await createOAuthRouter(express, {
+		passport: authorizePassport,
+		registry: new GrantRegistry(),
+		config: authorizeConfig,
+		clientRepository: authorizeClientRepo,
+		codeRepository: codeRepo,
+		keyStore: createSymmetricKeyStore("test-secret-at-least-32-chars!!"),
+	});
+	app.use("/oauth", router);
+	return app;
+}
 
 const mockClientRepository: ClientRepository = {
 	findById: vi.fn().mockResolvedValue(null),
@@ -188,5 +264,52 @@ describe("oauthAuthorizationModule", () => {
 		});
 
 		expect(result.status).toBe(400);
+	});
+});
+
+describe("authorize persists OIDC round-trip state on code record (TODO-F-3)", () => {
+	it("captures nonce + sid on createCode when both are present", async () => {
+		let captured: Parameters<CodeRepository["createCode"]>[0] | undefined;
+
+		const app = await buildAuthorizeApp({
+			sessionFields: { sid: "sid-abc" },
+			captureCode: (p) => {
+				captured = p;
+			},
+		});
+
+		await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "client-1",
+			redirect_uri: "https://example.test/cb",
+			nonce: "nonce-xyz",
+		});
+
+		expect(captured).toBeDefined();
+		expect(captured?.nonce).toBe("nonce-xyz");
+		expect(captured?.sid).toBe("sid-abc");
+	});
+
+	it("omits nonce on createCode when query.nonce is not provided", async () => {
+		let captured: Parameters<CodeRepository["createCode"]>[0] | undefined;
+
+		const app = await buildAuthorizeApp({
+			sessionFields: { sid: "sid-1" },
+			captureCode: (p) => {
+				captured = p;
+			},
+		});
+
+		await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "client-1",
+			redirect_uri: "https://example.test/cb",
+			// no nonce
+		});
+
+		expect(captured).toBeDefined();
+		expect(captured?.nonce).toBeUndefined();
+		// sid is still captured even without nonce
+		expect(captured?.sid).toBe("sid-1");
 	});
 });

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -23,6 +23,7 @@ import {
 	GrantRegistry,
 	type ModuleContext,
 	type RefreshTokenStoreBase,
+	type UserSessionStoreBase,
 } from "@o3co/auth-provider-core";
 import type { Router } from "express";
 import express from "express";
@@ -220,6 +221,67 @@ describe("oauthAuthorizationModule", () => {
 		});
 
 		expect(rotateSpy).toHaveBeenCalled();
+	});
+
+	it("forwards context.userSessionStore to authorization and refresh_token grants (Fix C1/P1)", async () => {
+		// Construct module with a spy userSessionStore. Drive the authorization grant
+		// through a valid code exchange; assert get() was consulted (store is threaded).
+		const getSpy = vi.fn().mockResolvedValue({
+			sid: "sid-wired",
+			sub: "u1",
+			authTime: new Date(),
+			createdAt: new Date(),
+			expiresAt: new Date(Date.now() + 3600_000),
+			federations: [],
+			activeRPs: [],
+			familyIds: [],
+			claims: {},
+		});
+		const userSessionStore: UserSessionStoreBase = {
+			kind: "spy",
+			get: getSpy,
+			create: vi.fn(),
+			registerRP: vi.fn(),
+			linkFamily: vi.fn(),
+			updateClaims: vi.fn(),
+			removeFederation: vi.fn(),
+			delete: vi.fn(),
+		};
+		const keyStore = createSymmetricKeyStore("test-secret-at-least-32-chars!!");
+		const ctx = makeContext({ userSessionStore, keyStore });
+
+		const consumeByCode = vi.fn().mockResolvedValue({ code: "auth-code", sid: "sid-wired" });
+		const module = oauthAuthorizationModule({
+			codeRepository: {
+				consumeByCode,
+				createCode: vi.fn(),
+				getByCode: vi.fn(),
+				removeByCode: vi.fn(),
+			} as unknown as CodeRepository,
+			clientRepository: mockClientRepository,
+		});
+
+		await module.init(ctx);
+
+		const handler = ctx.grantRegistry.get("authorization");
+		expect(handler).toBeDefined();
+		if (!handler) return;
+
+		const { result } = await handler.handle({
+			body: { code: "auth-code", client_id: "client1" },
+			session: {
+				code: "auth-code",
+				code_client_id: "client1",
+				granted_scopes: ["read"],
+				user: { id: "u1" },
+			},
+			issuer: "localhost",
+			metadata: {},
+		});
+
+		// The grant must succeed and have consulted the store via get(sid)
+		expect(result.status).toBe(200);
+		expect(getSpy).toHaveBeenCalledWith("sid-wired");
 	});
 
 	it("forwards context.grantPolicy to authorization and refresh_token grants", async () => {

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -21,6 +21,7 @@ import {
 	type GrantPolicyHookBase,
 	type RefreshTokenRotateOutcome,
 	type RefreshTokenStoreBase,
+	type UserSessionStoreBase,
 } from "@o3co/auth-provider-core";
 import { SignJWT } from "jose";
 import { describe, expect, it } from "vitest";
@@ -579,6 +580,129 @@ describe("createRefreshTokenGrant", () => {
 			if (!("tokens" in result)) expect.fail("expected tokens");
 			// Response MUST NOT include scope: "". decodeJwt scope field is also absent.
 			expect(result.tokens.scope).toBeUndefined();
+		});
+	});
+
+	describe("sid claim propagation and userSessionStore integration (TODO-F-3 task 4)", () => {
+		function decodeTokenPayload(token: string): Record<string, unknown> {
+			const parts = token.split(".");
+			return JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString("utf-8")) as Record<
+				string,
+				unknown
+			>;
+		}
+
+		function createStubUserSessionStore(
+			get: (sid: string) => Promise<import("@o3co/auth-provider-core").UserSession | null>,
+		): UserSessionStoreBase {
+			return {
+				kind: "stub",
+				get,
+				async create() {},
+				async registerRP() {},
+				async linkFamily() {},
+				async updateClaims() {},
+				async removeFederation() {},
+				async delete() {},
+			};
+		}
+
+		it("preserves family_id and sid on both minted tokens (F-3-4-1)", async () => {
+			const token = await makeRefreshToken({ family_id: "fam-1", sid: "sid-1" });
+			const store = createStubUserSessionStore(async (_sid) => ({
+				sid: "sid-1",
+				sub: "u1",
+				authTime: new Date(),
+				createdAt: new Date(),
+				expiresAt: new Date(Date.now() + 3600_000),
+				federations: [],
+				activeRPs: [],
+				familyIds: [],
+				claims: {},
+			}));
+			const deps: GrantDependencies = { ...mockDeps, userSessionStore: store };
+			const handler = createRefreshTokenGrant(deps);
+
+			const { result } = await handler.handle({
+				body: { refresh_token: token },
+				session: {},
+				issuer: "localhost",
+				metadata: {},
+			});
+
+			expect(result.status).toBe(200);
+			if (!("tokens" in result)) expect.fail("Expected tokens in result");
+
+			const atPayload = decodeTokenPayload(result.tokens.access_token as string);
+			expect(atPayload.family_id).toBe("fam-1");
+			expect(atPayload.sid).toBe("sid-1");
+
+			const rtPayload = decodeTokenPayload(result.tokens.refresh_token as string);
+			expect(rtPayload.family_id).toBe("fam-1");
+			expect(rtPayload.sid).toBe("sid-1");
+		});
+
+		it("returns 400 invalid_grant when userSessionStore.get returns null (F-3-4-2)", async () => {
+			const token = await makeRefreshToken({ sid: "sid-dead" });
+			const store = createStubUserSessionStore(async (_sid) => null);
+			const deps: GrantDependencies = { ...mockDeps, userSessionStore: store };
+			const handler = createRefreshTokenGrant(deps);
+
+			const { result } = await handler.handle({
+				body: { refresh_token: token },
+				session: {},
+				issuer: "localhost",
+				metadata: {},
+			});
+
+			expect(result.status).toBe(400);
+			if (!("error" in result)) expect.fail("Expected error in result");
+			expect(result.error).toBe("invalid_grant");
+			expect(result.errorDescription).toMatch(/session/i);
+		});
+
+		it("returns 503 temporarily_unavailable when userSessionStore.get throws (F-3-4-3)", async () => {
+			const token = await makeRefreshToken({ sid: "sid-boom" });
+			const store = createStubUserSessionStore(async (_sid) => {
+				throw new Error("redis down");
+			});
+			const deps: GrantDependencies = { ...mockDeps, userSessionStore: store };
+			const handler = createRefreshTokenGrant(deps);
+
+			const { result } = await handler.handle({
+				body: { refresh_token: token },
+				session: {},
+				issuer: "localhost",
+				metadata: {},
+			});
+
+			expect(result.status).toBe(503);
+			if (!("error" in result)) expect.fail("Expected error in result");
+			expect(result.error).toBe("temporarily_unavailable");
+		});
+
+		it("succeeds without sid on minted tokens when legacy token has no sid claim (F-3-4-4)", async () => {
+			// Token minted before F-3: only family_id, no sid
+			const token = await makeRefreshToken({ family_id: "fam-legacy" });
+			const handler = createRefreshTokenGrant(mockDeps);
+
+			const { result } = await handler.handle({
+				body: { refresh_token: token },
+				session: {},
+				issuer: "localhost",
+				metadata: {},
+			});
+
+			expect(result.status).toBe(200);
+			if (!("tokens" in result)) expect.fail("Expected tokens in result");
+
+			const atPayload = decodeTokenPayload(result.tokens.access_token as string);
+			expect(atPayload.family_id).toBe("fam-legacy");
+			expect(Object.hasOwn(atPayload, "sid")).toBe(false);
+
+			const rtPayload = decodeTokenPayload(result.tokens.refresh_token as string);
+			expect(rtPayload.family_id).toBe("fam-legacy");
+			expect(Object.hasOwn(rtPayload, "sid")).toBe(false);
 		});
 	});
 });

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -213,6 +213,23 @@ export const createAuthorizationGrant = (
 				}
 			}
 
+			// TODO-F-3: sid is required on the code record — it is written at /authorize
+			// time by the login/federation callback wiring (Task 2). A missing sid means
+			// the operator has not yet deployed the F-2 login wiring; fail with a clear
+			// error so the misconfiguration is surfaced immediately rather than silently
+			// producing tokens without a session link.
+			const sid = codeData.sid;
+			if (!sid) {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_grant",
+						errorDescription:
+							"code record is missing session identifier (sid) — ensure login wiring records sid at authorize time",
+					},
+				};
+			}
+
 			const rawUserId = (session.user as Record<string, unknown> | undefined)?.id;
 			const userId = typeof rawUserId === "string" ? rawUserId : undefined;
 
@@ -234,8 +251,11 @@ export const createAuthorizationGrant = (
 			// consumers can't distinguish from "scope claim omitted").
 			const scopeClaim = grantedScopes && grantedScopes.length > 0 ? grantedScopes.join(" ") : null;
 
+			// TODO-F-3: both access_token and refresh_token carry family_id + sid so
+			// introspect (Task 5) and refresh (Task 4) can propagate them without
+			// re-reading the session store on every request.
 			const accessToken = await generateToken(
-				{},
+				{ family_id: familyId, sid },
 				{
 					expiresIn: config.oauth.accessToken.expiresIn,
 					keyStore,
@@ -248,7 +268,7 @@ export const createAuthorizationGrant = (
 				},
 			);
 			const refreshToken = await generateToken(
-				{ family_id: familyId },
+				{ family_id: familyId, sid },
 				{
 					expiresIn: config.oauth.refreshToken.expiresIn,
 					keyStore,
@@ -288,6 +308,33 @@ export const createAuthorizationGrant = (
 							},
 						};
 					}
+				}
+			}
+
+			// TODO-F-3: link the new token family to the user session and register
+			// the RP for back/front-channel logout. Both calls are fail-closed: if the
+			// session store is unavailable, return 503 rather than issuing tokens that
+			// are invisible to logout orchestration.
+			if (deps.userSessionStore) {
+				const clientRecord = await clientRepository.findById(client_id ?? "");
+				try {
+					await deps.userSessionStore.linkFamily(sid, familyId);
+					await deps.userSessionStore.registerRP(sid, {
+						clientId: client_id ?? "",
+						backchannelLogoutUri: (clientRecord as Record<string, unknown> | null)
+							?.backchannelLogoutUri as string | undefined,
+						frontchannelLogoutUri: (clientRecord as Record<string, unknown> | null)
+							?.frontchannelLogoutUri as string | undefined,
+						registeredAt: new Date(),
+					});
+				} catch {
+					return {
+						result: {
+							status: 503,
+							error: "temporarily_unavailable",
+							errorDescription: "session store unavailable",
+						},
+					};
 				}
 			}
 

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -316,11 +316,11 @@ export const createAuthorizationGrant = (
 			// session store is unavailable, return 503 rather than issuing tokens that
 			// are invisible to logout orchestration.
 			if (deps.userSessionStore) {
-				const clientRecord = await clientRepository.findById(client_id ?? "");
+				const clientRecord = await clientRepository.findById(client_id);
 				try {
 					await deps.userSessionStore.linkFamily(sid, familyId);
 					await deps.userSessionStore.registerRP(sid, {
-						clientId: client_id ?? "",
+						clientId: client_id,
 						backchannelLogoutUri: (clientRecord as Record<string, unknown> | null)
 							?.backchannelLogoutUri as string | undefined,
 						frontchannelLogoutUri: (clientRecord as Record<string, unknown> | null)

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -213,13 +213,15 @@ export const createAuthorizationGrant = (
 				}
 			}
 
-			// TODO-F-3: sid is required on the code record — it is written at /authorize
-			// time by the login/federation callback wiring (Task 2). A missing sid means
-			// the operator has not yet deployed the F-2 login wiring; fail with a clear
-			// error so the misconfiguration is surfaced immediately rather than silently
-			// producing tokens without a session link.
+			// TODO-F-3: sid from the code record — written at /authorize time by the
+			// login/federation callback wiring (Task 2).
+			// Only enforce sid presence when userSessionStore is wired. Deployments
+			// that opt out of session tracking (userSessionStore not configured) have
+			// no store to write sid at login time, so requiring it here would be a
+			// backward-compat regression. When the store IS wired, sid is mandatory
+			// so subsequent linkFamily / registerRP can execute.
 			const sid = codeData.sid;
-			if (!sid) {
+			if (deps.userSessionStore && !sid) {
 				return {
 					result: {
 						status: 400,
@@ -251,11 +253,12 @@ export const createAuthorizationGrant = (
 			// consumers can't distinguish from "scope claim omitted").
 			const scopeClaim = grantedScopes && grantedScopes.length > 0 ? grantedScopes.join(" ") : null;
 
-			// TODO-F-3: both access_token and refresh_token carry family_id + sid so
-			// introspect (Task 5) and refresh (Task 4) can propagate them without
-			// re-reading the session store on every request.
+			// TODO-F-3: both access_token and refresh_token carry family_id and, when
+			// sid is present, the sid claim so introspect (Task 5) and refresh (Task 4)
+			// can propagate them without re-reading the session store on every request.
+			// sid is omitted when no userSessionStore is wired (backward-compat path).
 			const accessToken = await generateToken(
-				{ family_id: familyId, sid },
+				{ family_id: familyId, ...(sid ? { sid } : {}) },
 				{
 					expiresIn: config.oauth.accessToken.expiresIn,
 					keyStore,
@@ -268,7 +271,7 @@ export const createAuthorizationGrant = (
 				},
 			);
 			const refreshToken = await generateToken(
-				{ family_id: familyId, sid },
+				{ family_id: familyId, ...(sid ? { sid } : {}) },
 				{
 					expiresIn: config.oauth.refreshToken.expiresIn,
 					keyStore,
@@ -312,12 +315,42 @@ export const createAuthorizationGrant = (
 			}
 
 			// TODO-F-3: link the new token family to the user session and register
-			// the RP for back/front-channel logout. Both calls are fail-closed: if the
-			// session store is unavailable, return 503 rather than issuing tokens that
+			// the RP for back/front-channel logout. All calls are fail-closed: if the
+			// session store is unavailable or the session was deleted between /authorize
+			// and /token, we return a controlled error rather than issuing tokens that
 			// are invisible to logout orchestration.
-			if (deps.userSessionStore) {
-				const clientRecord = await clientRepository.findById(client_id);
+			// sid is guaranteed non-null here when deps.userSessionStore is set because
+			// the earlier guard (deps.userSessionStore && !sid) already rejected that case.
+			if (deps.userSessionStore && sid) {
+				// Fix I1: validate session still exists (mirrors refresh_token grant pattern).
+				// A session deleted between /authorize and /token exchange must not produce
+				// tokens — they would be orphaned from logout orchestration.
+				let session: Awaited<ReturnType<typeof deps.userSessionStore.get>>;
 				try {
+					session = await deps.userSessionStore.get(sid);
+				} catch {
+					return {
+						result: {
+							status: 503,
+							error: "temporarily_unavailable",
+							errorDescription: "session store unavailable",
+						},
+					};
+				}
+				if (!session) {
+					return {
+						result: {
+							status: 400,
+							error: "invalid_grant",
+							errorDescription: "session_invalid",
+						},
+					};
+				}
+				// Fix I2: clientRepository.findById is fallible — move inside try/catch
+				// so a throw here returns a controlled 503 instead of propagating to the
+				// express default handler as an unhandled HTML 500.
+				try {
+					const clientRecord = await clientRepository.findById(client_id);
 					await deps.userSessionStore.linkFamily(sid, familyId);
 					await deps.userSessionStore.registerRP(sid, {
 						clientId: client_id,

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -361,11 +361,16 @@ export const createAuthorizationGrant = (
 						registeredAt: new Date(),
 					});
 				} catch {
+					// Fail-closed for any downstream dependency throw in this block —
+					// clientRepository.findById, userSessionStore.linkFamily, or
+					// userSessionStore.registerRP. The errorDescription is intentionally
+					// generic because the try spans both client lookup and session-store
+					// mutations; a more specific message would misattribute failures.
 					return {
 						result: {
 							status: 503,
 							error: "temporarily_unavailable",
-							errorDescription: "session store unavailable",
+							errorDescription: "session linking unavailable",
 						},
 					};
 				}

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -216,7 +216,8 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			const tokenPayloadClaims = tokenPayload as Record<string, unknown>;
 			const familyId =
 				typeof tokenPayloadClaims.family_id === "string" ? tokenPayloadClaims.family_id : null;
-			const sid = typeof tokenPayloadClaims.sid === "string" ? tokenPayloadClaims.sid : undefined;
+			const sidRaw = tokenPayloadClaims.sid;
+			const sid = typeof sidRaw === "string" && sidRaw.length > 0 ? sidRaw : undefined;
 			const previousJti =
 				typeof tokenPayloadClaims.jti === "string" ? tokenPayloadClaims.jti : null;
 			const newFamilyId = familyId ?? randomUUID();

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -214,8 +214,9 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			}
 
 			const tokenPayloadClaims = tokenPayload as Record<string, unknown>;
+			const familyIdRaw = tokenPayloadClaims.family_id;
 			const familyId =
-				typeof tokenPayloadClaims.family_id === "string" ? tokenPayloadClaims.family_id : null;
+				typeof familyIdRaw === "string" && familyIdRaw.length > 0 ? familyIdRaw : null;
 			const sidRaw = tokenPayloadClaims.sid;
 			const sid = typeof sidRaw === "string" && sidRaw.length > 0 ? sidRaw : undefined;
 			const previousJti =

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -213,18 +213,45 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				}
 			}
 
+			const tokenPayloadClaims = tokenPayload as Record<string, unknown>;
 			const familyId =
-				((tokenPayload as Record<string, unknown>).family_id as string | undefined) ?? null;
+				typeof tokenPayloadClaims.family_id === "string" ? tokenPayloadClaims.family_id : null;
+			const sid = typeof tokenPayloadClaims.sid === "string" ? tokenPayloadClaims.sid : undefined;
 			const previousJti =
-				((tokenPayload as Record<string, unknown>).jti as string | undefined) ?? null;
+				typeof tokenPayloadClaims.jti === "string" ? tokenPayloadClaims.jti : null;
 			const newFamilyId = familyId ?? randomUUID();
+
+			// Fail-closed session check — only when both sid + store are present.
+			if (sid && deps.userSessionStore) {
+				let session: Awaited<ReturnType<typeof deps.userSessionStore.get>>;
+				try {
+					session = await deps.userSessionStore.get(sid);
+				} catch {
+					return {
+						result: {
+							status: 503,
+							error: "temporarily_unavailable",
+							errorDescription: "session store unavailable",
+						},
+					};
+				}
+				if (!session) {
+					return {
+						result: {
+							status: 400,
+							error: "invalid_grant",
+							errorDescription: "session_invalid",
+						},
+					};
+				}
+			}
 
 			// CP-15: empty string (e.g. requested=" ") normalizes to null so the
 			// token response omits scope rather than emitting `scope: ""`.
 			const scopeClaim = finalScope && finalScope.length > 0 ? finalScope : null;
 
 			const newAccessToken = await generateToken(
-				{},
+				{ family_id: newFamilyId, ...(sid ? { sid } : {}) },
 				{
 					expiresIn: config.oauth.accessToken.expiresIn,
 					keyStore,
@@ -238,7 +265,7 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			);
 
 			const newRefreshToken = await generateToken(
-				{ family_id: newFamilyId },
+				{ family_id: newFamilyId, ...(sid ? { sid } : {}) },
 				{
 					expiresIn: config.oauth.refreshToken.expiresIn,
 					keyStore,

--- a/packages/oauth/src/module.mts
+++ b/packages/oauth/src/module.mts
@@ -104,6 +104,7 @@ export const oauthModule = (params: {
 			rateLimiter: context.rateLimiter,
 			auditSink: context.auditSink,
 			grantPolicy: context.grantPolicy,
+			refreshTokenStore: context.refreshTokenStore,
 		});
 
 		context.router.use("/oauth", oauthRouter);

--- a/packages/oauth/src/oauthAuthorization.mts
+++ b/packages/oauth/src/oauthAuthorization.mts
@@ -39,6 +39,7 @@ export const oauthAuthorizationModule = (params: {
 				codeRepository: params.codeRepository,
 				clientRepository: params.clientRepository,
 				refreshTokenStore: context.refreshTokenStore,
+				userSessionStore: context.userSessionStore,
 				grantPolicy: context.grantPolicy,
 			});
 			context.grantRegistry.register("authorization", handler);
@@ -49,6 +50,7 @@ export const oauthAuthorizationModule = (params: {
 				config,
 				keyStore: context.keyStore,
 				refreshTokenStore: context.refreshTokenStore,
+				userSessionStore: context.userSessionStore,
 				grantPolicy: context.grantPolicy,
 			});
 			context.grantRegistry.register("refresh_token", handler);

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -26,6 +26,7 @@ import {
 	type KeyStore,
 	type PublicClient,
 	type RateLimiterBase,
+	type RefreshTokenStoreBase,
 } from "@o3co/auth-provider-core";
 import type { Request, RequestHandler, Response, Router } from "express";
 import { decodeProtectedHeader, jwtVerify } from "jose";
@@ -62,6 +63,7 @@ export const createOAuthRouter = async (
 		rateLimiter,
 		auditSink,
 		grantPolicy,
+		refreshTokenStore,
 	}: {
 		passport: PassportStatic;
 		registry: GrantRegistry;
@@ -72,6 +74,7 @@ export const createOAuthRouter = async (
 		rateLimiter?: RateLimiterBase;
 		auditSink?: AuditSinkBase;
 		grantPolicy?: GrantPolicyHookBase;
+		refreshTokenStore?: RefreshTokenStoreBase;
 	},
 ): Promise<{ router: Router; registry: GrantRegistry }> => {
 	const router = express.Router();
@@ -237,6 +240,29 @@ export const createOAuthRouter = async (
 						header.kid ?? keyStore.getSigningKidFallback(),
 					);
 					const { payload } = await jwtVerify(token, key);
+
+					// TODO-F-3: cascading revoke (RFC 7009 §2.1 SHOULD). When a refresh_token
+					// family has been revoked, all access_tokens minted under the same
+					// authorization grant must introspect as inactive. family_id claim is
+					// optional — legacy tokens without it still succeed (no cascade available).
+					const familyId =
+						typeof (payload as Record<string, unknown>).family_id === "string"
+							? ((payload as Record<string, unknown>).family_id as string)
+							: null;
+					if (familyId !== null && refreshTokenStore) {
+						let revoked: boolean;
+						try {
+							revoked = await refreshTokenStore.isFamilyRevoked(familyId);
+						} catch {
+							// Fail-closed: when we cannot determine family state, prefer inactive
+							// per RFC 7009 §2.2 intent ("serve inactive if state cannot be determined").
+							return res.status(200).json({ active: false });
+						}
+						if (revoked) {
+							return res.status(200).json({ active: false });
+						}
+					}
+
 					const { exp, iat, iss, aud, sub } = payload;
 					const claims = payload as Record<string, unknown>;
 					const azp = typeof claims.azp === "string" ? claims.azp : undefined;

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -42,7 +42,7 @@ declare module "express-session" {
 		code_redirect_uri?: string;
 		granted_scopes?: string[];
 		isAuthenticated?: boolean;
-		/** UserSession ID — set by the federation callback hook and preserved across session regeneration. */
+		/** UserSession ID — set by the federation callback hook or local login (`POST /session/login`) and preserved across session regeneration. */
 		sid?: string;
 	}
 }

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -245,20 +245,40 @@ export const createOAuthRouter = async (
 					// family has been revoked, all access_tokens minted under the same
 					// authorization grant must introspect as inactive. family_id claim is
 					// optional — legacy tokens without it still succeed (no cascade available).
+					const rawFamilyId = (payload as Record<string, unknown>).family_id;
 					const familyId =
-						typeof (payload as Record<string, unknown>).family_id === "string"
-							? ((payload as Record<string, unknown>).family_id as string)
-							: null;
+						typeof rawFamilyId === "string" && rawFamilyId.length > 0 ? rawFamilyId : null;
 					if (familyId !== null && refreshTokenStore) {
 						let revoked: boolean;
 						try {
 							revoked = await refreshTokenStore.isFamilyRevoked(familyId);
-						} catch {
-							// Fail-closed: when we cannot determine family state, prefer inactive
-							// per RFC 7009 §2.2 intent ("serve inactive if state cannot be determined").
+						} catch (cause) {
+							// Fail-closed: RFC 7662 §2.2 defines `active: false` for revoked/invalid tokens.
+							// When we cannot determine family revocation state, prefer inactive over active
+							// (and over a 5xx) — introspect's response shape has no "temporarily_unavailable"
+							// equivalent, so inactive keeps resource servers on the safe side of the scope gate.
+							// Note: Tasks 3/4 use 503 temporarily_unavailable for store failures, but RFC 7662
+							// has no such slot for introspect responses — inactive is the only safe fallback.
+							emitAuditEvent(auditSink, {
+								timestamp: new Date(),
+								type: "introspect.store_unavailable",
+								ip: req.ip,
+								userAgent: req.get("user-agent"),
+								details: {
+									family_id: familyId,
+									error: cause instanceof Error ? cause.message : String(cause),
+								},
+							});
 							return res.status(200).json({ active: false });
 						}
 						if (revoked) {
+							emitAuditEvent(auditSink, {
+								timestamp: new Date(),
+								type: "introspect.family_revoked",
+								ip: req.ip,
+								userAgent: req.get("user-agent"),
+								details: { family_id: familyId },
+							});
 							return res.status(200).json({ active: false });
 						}
 					}

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -41,6 +41,8 @@ declare module "express-session" {
 		code_redirect_uri?: string;
 		granted_scopes?: string[];
 		isAuthenticated?: boolean;
+		/** UserSession ID — set by the federation callback hook and preserved across session regeneration. */
+		sid?: string;
 	}
 }
 
@@ -481,6 +483,9 @@ export const createOAuthRouter = async (
 						redirect_uri,
 						grantedScope: scopeForPersist,
 						grantedAudience: audienceForPersist,
+						// NEW (TODO-F-3): OIDC round-trip state on the code record.
+						nonce: typeof req.query.nonce === "string" ? req.query.nonce : undefined,
+						sid: typeof req.session?.sid === "string" ? req.session.sid : undefined,
 					});
 				} catch {
 					return redirectError(

--- a/packages/session/README.ja.md
+++ b/packages/session/README.ja.md
@@ -499,6 +499,10 @@ for (const [name, section] of Object.entries(config.federations)) {
 }
 ```
 
+## TODO-F-3 の変更点
+
+- **ローカルログインのセッショントラッキング。** `AppOptions.userSessionStore` が設定されている場合、`POST /session/login` は `userSessionStore.create()` で `UserSession` レコードを作成し、生成された `sid` を `req.session.sid` に書き込む。これは F-2 で確立したフェデレーションコールバックのセッション作成パスと対称であり、ローカルログイン後に発行されるトークンに有効な `sid` クレームが付与されることを保証する。
+
 ## 関連
 
 - [`@o3co/auth-provider-oauth`](../oauth/README.ja.md) — OAuth 2.0 トークン・認可ルート

--- a/packages/session/README.md
+++ b/packages/session/README.md
@@ -499,6 +499,10 @@ for (const [name, section] of Object.entries(config.federations)) {
 }
 ```
 
+## TODO-F-3 changes
+
+- **Local login session tracking.** `POST /session/login` now creates a `UserSession` record via `userSessionStore.create()` and writes the resulting `sid` into `req.session.sid` when `AppOptions.userSessionStore` is wired. This mirrors the federation-callback session-creation path established in F-2 and ensures that tokens issued after a local login carry a valid `sid` claim.
+
 ## See Also
 
 - [`@o3co/auth-provider-oauth`](../oauth/README.md) — OAuth 2.0 token and authorization routes

--- a/packages/session/src/__tests__/module.test.mts
+++ b/packages/session/src/__tests__/module.test.mts
@@ -373,6 +373,61 @@ describe("sessionModule", () => {
 		});
 	});
 
+	it("forwards userSessionStore and sessionTtlMs to sessionRoutes.createRouter", async () => {
+		// C1: module.mts must thread context.userSessionStore and params.sessionTtlMs to
+		// sessionRoutes.createRouter so the local login handler can create UserSession records.
+		const userSessionStore: UserSessionStoreBase = {
+			create: vi.fn(),
+			get: vi.fn(),
+			delete: vi.fn(),
+			list: vi.fn(),
+		} as unknown as UserSessionStoreBase;
+
+		let capturedRouterOptions: Record<string, unknown> | undefined;
+		// Stub router so init() can proceed without a real express app.
+		const routerStub = { use: vi.fn().mockReturnThis() } as unknown as import("express").Router;
+		const createSessionRouterSpy = vi
+			.fn()
+			.mockImplementation((_, opts: Record<string, unknown>) => {
+				capturedRouterOptions = opts;
+				return routerStub;
+			});
+
+		// Provide a full passport stub so route mounting works.
+		const passportStub = {
+			serializeUser: vi.fn(),
+			deserializeUser: vi.fn(),
+			use: vi.fn(),
+			initialize: vi.fn().mockReturnValue(vi.fn()),
+			session: vi.fn().mockReturnValue(vi.fn()),
+			authenticate: vi.fn().mockReturnValue(vi.fn()),
+		};
+		const createPassportSpy = vi.fn().mockResolvedValue(passportStub);
+
+		const routerMock = { use: vi.fn().mockReturnThis() } as unknown as import("express").Router;
+		const ctx = makeContext({ router: routerMock, userSessionStore });
+
+		const module = _sessionModuleImpl({
+			userRepository: {
+				authenticate: vi.fn(),
+				authenticateByToken: vi.fn(),
+			} as unknown as UserRepository,
+			sessionTtlMs: 7200_000,
+			_createPassport:
+				createPassportSpy as unknown as typeof import("#/passport.mjs").createPassport,
+			_createSessionRouter:
+				createSessionRouterSpy as unknown as typeof import("#/routes/Session.mjs").createRouter,
+		});
+
+		await module.init(ctx);
+
+		expect(createSessionRouterSpy).toHaveBeenCalledTimes(1);
+		expect(capturedRouterOptions).toMatchObject({
+			userSessionStore,
+			sessionTtlMs: 7200_000,
+		});
+	});
+
 	it("injects name and context fields into builder config", async () => {
 		const factory = {
 			create: vi.fn().mockResolvedValue({

--- a/packages/session/src/module.mts
+++ b/packages/session/src/module.mts
@@ -58,6 +58,8 @@ type SessionModuleInternalOptions = SessionModuleOptions & {
 	_federationFactory?: FederationProviderFactory;
 	/** For testing only — replace createPassport to capture call arguments. */
 	_createPassport?: typeof createPassport;
+	/** For testing only — replace sessionRoutes.createRouter to capture call arguments. */
+	_createSessionRouter?: typeof sessionRoutes.createRouter;
 };
 
 /**
@@ -179,11 +181,14 @@ export const _sessionModuleImpl = (params: SessionModuleInternalOptions): Module
 		});
 
 		// Mount session routes
+		const _csr = params._createSessionRouter ?? sessionRoutes.createRouter;
 		context.router.use(
 			"/session",
-			sessionRoutes.createRouter(express, {
+			_csr(express, {
 				passport,
 				config,
+				userSessionStore: context.userSessionStore,
+				sessionTtlMs: params.sessionTtlMs,
 			}),
 		);
 

--- a/packages/session/src/routes/Session.mts
+++ b/packages/session/src/routes/Session.mts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import type { AppConfig } from "@o3co/auth-provider-core";
+import { randomUUID } from "node:crypto";
+import {
+	type AppConfig,
+	extractUserClaims,
+	type User,
+	type UserSessionStoreBase,
+} from "@o3co/auth-provider-core";
 import type { NextFunction, Request, RequestHandler, Response, Router } from "express";
 import rateLimit from "express-rate-limit";
 import type { PassportStatic } from "passport";
@@ -27,13 +33,26 @@ declare module "express-session" {
 	}
 }
 
+const DEFAULT_SESSION_TTL_MS = 86400_000;
+
 export const createRouter = (
 	express: {
 		Router: () => Router;
 		json: () => RequestHandler;
 		urlencoded: (opts: { extended: boolean }) => RequestHandler;
 	},
-	{ passport, config }: { passport: PassportStatic; config: AppConfig },
+	{
+		passport,
+		config,
+		userSessionStore,
+		sessionTtlMs = DEFAULT_SESSION_TTL_MS,
+	}: {
+		passport: PassportStatic;
+		config: AppConfig;
+		userSessionStore?: UserSessionStoreBase;
+		/** Session TTL in milliseconds. Default: 24h. */
+		sessionTtlMs?: number;
+	},
 ): Router => {
 	const router = express.Router();
 
@@ -112,9 +131,28 @@ export const createRouter = (
 			passport.authenticate("local", {
 				session: true,
 			}),
-			(req: Request, res: Response) => {
+			async (req: Request, res: Response) => {
 				const user = req.user;
 				const redirectTo = req.body.redirect_to as string | undefined;
+
+				// Generate sid and create UserSession before regenerating the browser session,
+				// so we can restore the sid on the new session afterwards.
+				let sid: string | undefined;
+				if (userSessionStore && user) {
+					const userObj = user as User;
+					const claims = extractUserClaims(userObj);
+					const now = new Date();
+					sid = randomUUID();
+					await userSessionStore.create({
+						sid,
+						sub: userObj.id,
+						authTime: now,
+						expiresAt: new Date(now.getTime() + sessionTtlMs),
+						federations: [],
+						claims,
+					});
+				}
+
 				req.session.regenerate((err: Error | null) => {
 					if (err) {
 						return res.status(500).json({ message: "Error regenerating session" });
@@ -123,6 +161,10 @@ export const createRouter = (
 					req.session.user = user as Record<string, unknown> | undefined;
 					if (redirectTo) {
 						req.session.redirectTo = redirectTo;
+					}
+					// Restore sid on the new session so downstream (token/introspect) can read it.
+					if (sid) {
+						req.session.sid = sid;
 					}
 					return res.status(200).json({ message: "Logged in successfully" });
 				});

--- a/packages/session/src/routes/Session.mts
+++ b/packages/session/src/routes/Session.mts
@@ -30,6 +30,8 @@ declare module "express-session" {
 		isAuthenticated?: boolean;
 		user?: Record<string, unknown>;
 		redirectTo?: string;
+		/** UserSession ID — set by local login and preserved across session regeneration. */
+		sid?: string;
 	}
 }
 
@@ -155,6 +157,14 @@ export const createRouter = (
 
 				req.session.regenerate((err: Error | null) => {
 					if (err) {
+						// Best-effort rollback: UserSession was created but session regeneration failed.
+						// Delete the orphan record so it doesn't leak. Ignore cleanup errors — the
+						// primary error is already being returned to the caller.
+						if (sid && userSessionStore) {
+							userSessionStore.delete(sid).catch(() => {
+								/* best-effort cleanup */
+							});
+						}
 						return res.status(500).json({ message: "Error regenerating session" });
 					}
 					req.session.isAuthenticated = true;

--- a/packages/session/src/routes/Session.mts
+++ b/packages/session/src/routes/Session.mts
@@ -145,14 +145,24 @@ export const createRouter = (
 					const claims = extractUserClaims(userObj);
 					const now = new Date();
 					sid = randomUUID();
-					await userSessionStore.create({
-						sid,
-						sub: userObj.id,
-						authTime: now,
-						expiresAt: new Date(now.getTime() + sessionTtlMs),
-						federations: [],
-						claims,
-					});
+					try {
+						await userSessionStore.create({
+							sid,
+							sub: userObj.id,
+							authTime: now,
+							expiresAt: new Date(now.getTime() + sessionTtlMs),
+							federations: [],
+							claims,
+						});
+					} catch {
+						// Fail-closed: store unavailable — return controlled 503 JSON rather
+						// than an unhandled rejection hitting Express's default HTML error
+						// handler. Matches the /token grant fail-closed pattern (CP-16/CP-17).
+						return res.status(503).json({
+							message: "Session store temporarily unavailable",
+							error: "temporarily_unavailable",
+						});
+					}
 				}
 
 				req.session.regenerate((err: Error | null) => {

--- a/packages/session/src/routes/__tests__/Session.test.mts
+++ b/packages/session/src/routes/__tests__/Session.test.mts
@@ -203,5 +203,37 @@ describe("Session routes — POST /session/login", () => {
 			expect(res.status).toBe(200);
 			expect(res.body).toMatchObject({ message: "Logged in successfully" });
 		});
+
+		it("returns 503 temporarily_unavailable when userSessionStore.create throws (fail-closed)", async () => {
+			const throwingStore: UserSessionStoreBase = {
+				kind: "memory",
+				async create() {
+					throw new Error("redis down");
+				},
+				async get() {
+					return null;
+				},
+				async registerRP() {},
+				async linkFamily() {},
+				async updateClaims() {},
+				async removeFederation() {},
+				async delete() {},
+			};
+			const { app } = buildApp({
+				userSessionStore: throwingStore,
+				sessionTtlMs: 3600_000,
+				user: { id: "u-503", username: "carol" },
+			});
+
+			const res = await request(app)
+				.post("/session/login")
+				.send("username=carol&password=secret")
+				.set("Content-Type", "application/x-www-form-urlencoded");
+
+			expect(res.status).toBe(503);
+			expect(res.body).toMatchObject({
+				error: "temporarily_unavailable",
+			});
+		});
 	});
 });

--- a/packages/session/src/routes/__tests__/Session.test.mts
+++ b/packages/session/src/routes/__tests__/Session.test.mts
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { AppConfig, UserSessionStoreBase } from "@o3co/auth-provider-core";
+import express from "express";
+import type { PassportStatic } from "passport";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import { createRouter } from "#/routes/Session.mjs";
+
+/** Minimal AppConfig stub */
+const stubConfig: AppConfig = {
+	cors: { allowedOrigins: [] },
+	rateLimit: {
+		login: { windowMs: 60_000, limit: 100 },
+	},
+	session: { domain: null },
+} as unknown as AppConfig;
+
+/** In-memory UserSessionStore fake that exposes created sessions for assertions */
+function makeUserSessionStore(): UserSessionStoreBase & { sessions: unknown[] } {
+	const sessions: unknown[] = [];
+	return {
+		kind: "memory",
+		sessions,
+		async create(input) {
+			sessions.push(structuredClone(input));
+		},
+		async get() {
+			return null;
+		},
+		async registerRP() {},
+		async linkFamily() {},
+		async updateClaims() {},
+		async removeFederation() {},
+		async delete() {},
+	} as UserSessionStoreBase & { sessions: unknown[] };
+}
+
+/**
+ * Build a test express app with the Session router mounted at "/session".
+ *
+ * The passport stub short-circuits authenticate("local", …) by immediately
+ * calling next() after setting req.user — simulating a successful local login.
+ */
+function buildApp(
+	opts: {
+		userSessionStore?: UserSessionStoreBase;
+		sessionTtlMs?: number;
+		user?: Record<string, unknown>;
+	} = {},
+) {
+	const {
+		userSessionStore,
+		sessionTtlMs,
+		user = { id: "u-1", username: "alice", email: "alice@example.com" },
+	} = opts;
+
+	// Passport stub: authenticate("local", …) immediately calls next() + sets req.user
+	const passportStub: PassportStatic = {
+		authenticate: vi.fn(
+			(_strategy: string, _options: unknown) =>
+				(req: express.Request, _res: express.Response, next: express.NextFunction) => {
+					(req as unknown as { user: unknown }).user = user;
+					next();
+				},
+		),
+	} as unknown as PassportStatic;
+
+	const app = express();
+
+	// Minimal express-session stub so req.session.regenerate / req.session.sid work
+	app.use((req, _res, next) => {
+		const sessionData: Record<string, unknown> = {};
+		(req as unknown as { session: Record<string, unknown> }).session = {
+			...sessionData,
+			regenerate(cb: (err: null) => void) {
+				// After regenerate, session data is reset — mirror real express-session behaviour.
+				// We re-attach a fresh object but keep a reference so we can inspect sid after the call.
+				const fresh: Record<string, unknown> = {
+					regenerate: this.regenerate,
+					save: this.save,
+				};
+				Object.assign(req as unknown as { session: Record<string, unknown> }, { session: fresh });
+				cb(null);
+			},
+			save(cb: (err: null) => void) {
+				cb(null);
+			},
+		};
+		next();
+	});
+
+	const router = createRouter(express, {
+		passport: passportStub,
+		config: stubConfig,
+		...(userSessionStore !== undefined ? { userSessionStore } : {}),
+		...(sessionTtlMs !== undefined ? { sessionTtlMs } : {}),
+	});
+
+	app.use("/session", router);
+	return { app, passportStub };
+}
+
+describe("Session routes — POST /session/login", () => {
+	describe("UserSession creation on successful local login", () => {
+		it("creates a UserSession record and sets req.session.sid when userSessionStore is wired", async () => {
+			const store = makeUserSessionStore();
+
+			// Intercept the response to capture req.session.sid via a custom middleware
+			// placed after the router — we do this by inspecting the store instead.
+			const { app } = buildApp({
+				userSessionStore: store,
+				sessionTtlMs: 3600_000,
+				user: { id: "u-local-1", username: "alice", email: "alice@example.com", name: "Alice" },
+			});
+
+			// Also intercept to capture sid set on session post-response
+			// We'll verify via the store record that has the sid, then rely on the
+			// store.sessions array.
+			const res = await request(app)
+				.post("/session/login")
+				.send("username=alice&password=secret")
+				.set("Content-Type", "application/x-www-form-urlencoded");
+
+			expect(res.status).toBe(200);
+			expect(res.body).toMatchObject({ message: "Logged in successfully" });
+
+			// UserSession was created in the store
+			expect(store.sessions).toHaveLength(1);
+			const saved = store.sessions[0] as {
+				sid: string;
+				sub: string;
+				federations: unknown;
+				claims: Record<string, unknown>;
+				authTime: unknown;
+				expiresAt: unknown;
+			};
+
+			// sid is a non-empty UUID-shaped string
+			expect(typeof saved.sid).toBe("string");
+			expect(saved.sid.length).toBeGreaterThan(0);
+
+			// sub matches user.id
+			expect(saved.sub).toBe("u-local-1");
+
+			// federations defaults to [] (not required by CreateUserSessionInput — store initialises it)
+			// The implementation passes federations: [] explicitly; assert it's empty.
+			expect(saved.federations ?? []).toEqual([]);
+
+			// claims extracted from user
+			expect(saved.claims).toMatchObject({
+				email: "alice@example.com",
+				name: "Alice",
+			});
+
+			// authTime and expiresAt are Date instances (or ISO strings from structuredClone)
+			expect(saved.authTime).toBeTruthy();
+			expect(saved.expiresAt).toBeTruthy();
+		});
+
+		it("does not crash and does not create a UserSession when userSessionStore is not wired (backward compat)", async () => {
+			// No userSessionStore
+			const { app } = buildApp({
+				user: { id: "u-no-store", username: "bob" },
+			});
+
+			const res = await request(app)
+				.post("/session/login")
+				.send("username=bob&password=secret")
+				.set("Content-Type", "application/x-www-form-urlencoded");
+
+			// Login still succeeds — backward compat
+			expect(res.status).toBe(200);
+			expect(res.body).toMatchObject({ message: "Logged in successfully" });
+		});
+	});
+});

--- a/packages/session/src/routes/__tests__/Session.test.mts
+++ b/packages/session/src/routes/__tests__/Session.test.mts
@@ -55,6 +55,9 @@ function makeUserSessionStore(): UserSessionStoreBase & { sessions: unknown[] } 
  *
  * The passport stub short-circuits authenticate("local", …) by immediately
  * calling next() after setting req.user — simulating a successful local login.
+ *
+ * Returns `capturedSession`: a ref populated by a post-router middleware so
+ * tests can assert on `req.session` fields (e.g. `sid`) after a response.
  */
 function buildApp(
 	opts: {
@@ -111,8 +114,20 @@ function buildApp(
 		...(sessionTtlMs !== undefined ? { sessionTtlMs } : {}),
 	});
 
+	// Pre-router middleware: register a res.on('finish') listener before the route
+	// handler runs. When the route sends its response, finish fires and we snapshot
+	// req.session (which has already been mutated by the regenerate callback).
+	const capturedSession: { current: Record<string, unknown> | null } = { current: null };
+	app.use("/session", (req, res, next) => {
+		res.on("finish", () => {
+			capturedSession.current = (req as unknown as { session: Record<string, unknown> }).session;
+		});
+		next();
+	});
+
 	app.use("/session", router);
-	return { app, passportStub };
+
+	return { app, passportStub, capturedSession };
 }
 
 describe("Session routes — POST /session/login", () => {
@@ -120,17 +135,12 @@ describe("Session routes — POST /session/login", () => {
 		it("creates a UserSession record and sets req.session.sid when userSessionStore is wired", async () => {
 			const store = makeUserSessionStore();
 
-			// Intercept the response to capture req.session.sid via a custom middleware
-			// placed after the router — we do this by inspecting the store instead.
-			const { app } = buildApp({
+			const { app, capturedSession } = buildApp({
 				userSessionStore: store,
 				sessionTtlMs: 3600_000,
 				user: { id: "u-local-1", username: "alice", email: "alice@example.com", name: "Alice" },
 			});
 
-			// Also intercept to capture sid set on session post-response
-			// We'll verify via the store record that has the sid, then rely on the
-			// store.sessions array.
 			const res = await request(app)
 				.post("/session/login")
 				.send("username=alice&password=secret")
@@ -144,7 +154,7 @@ describe("Session routes — POST /session/login", () => {
 			const saved = store.sessions[0] as {
 				sid: string;
 				sub: string;
-				federations: unknown;
+				federations: unknown[];
 				claims: Record<string, unknown>;
 				authTime: unknown;
 				expiresAt: unknown;
@@ -157,9 +167,9 @@ describe("Session routes — POST /session/login", () => {
 			// sub matches user.id
 			expect(saved.sub).toBe("u-local-1");
 
-			// federations defaults to [] (not required by CreateUserSessionInput — store initialises it)
-			// The implementation passes federations: [] explicitly; assert it's empty.
-			expect(saved.federations ?? []).toEqual([]);
+			// federations is explicitly set to [] — assert directly (no ?? fallback)
+			// so a regression where the field is omitted would be caught.
+			expect(saved.federations).toEqual([]);
 
 			// claims extracted from user
 			expect(saved.claims).toMatchObject({
@@ -170,6 +180,12 @@ describe("Session routes — POST /session/login", () => {
 			// authTime and expiresAt are Date instances (or ISO strings from structuredClone)
 			expect(saved.authTime).toBeTruthy();
 			expect(saved.expiresAt).toBeTruthy();
+
+			// I2: req.session.sid must equal the store's sid after regenerate completes.
+			// capturedSession.current is populated by the res.on('finish') listener
+			// registered before the router, guaranteeing it reflects post-regenerate state.
+			expect(capturedSession.current).not.toBeNull();
+			expect(capturedSession.current?.sid).toBe(saved.sid);
 		});
 
 		it("does not crash and does not create a UserSession when userSessionStore is not wired (backward compat)", async () => {


### PR DESCRIPTION
## Summary

Implements TODO-F-3 from the auth-provider extensibility overhaul:

- **access/refresh token claims**: Both tokens now carry `family_id` + `sid` as data claims (sid only when `userSessionStore` is wired).
- **CodeData extension**: `nonce?` + `sid?` added to `CodeData`. `grantedScope` reused for scope persistence (no new `scopes` field).
- **`/authorize`**: persists nonce + sid on the code record via `CodeRepository.createCode`.
- **`authorization_code` grant**: reads sid from the code record, generates `familyId = randomUUID()`, mints both tokens with `{ family_id, sid }` claims. When `userSessionStore` is wired: validates session via `get(sid)` (400 `invalid_grant session_invalid` on missing, 503 `temporarily_unavailable` on throw), then calls `linkFamily` + `registerRP` with fail-closed 503.
- **`refresh_token` grant**: extracts + preserves sid, validates UserSession existence when wired (mirrors authorization_code pattern).
- **`/introspect`**: cascades family revoke via `RefreshTokenStore.isFamilyRevoked` (RFC 7009 §2.1 SHOULD). Fail-closed `{active:false}` per RFC 7662 §2.2. Emits `introspect.store_unavailable` / `introspect.family_revoked` audit events.
- **Local login (`POST /session/login`)**: creates UserSession record + sets `req.session.sid` when `userSessionStore` is wired. Rolls back on regenerate failure.
- **Module wiring**: threads `userSessionStore` through `sessionModule`, `oauthModule`, and `oauthAuthorizationModule` to their downstream route/grant handlers (caught by multi-agent-review as Critical issues in 3 separate rounds).

## Breaking changes

None at the public type level. Behaviorally:

- When `userSessionStore` IS wired: authorization_code grant requires `sid` on the code record. Deployments with `userSessionStore` configured but without F-2/F-3 login wiring will receive 400 `invalid_grant`. Authorization codes are short-lived (≤60s) so any in-flight codes at deploy time have a brief failure window.
- When `userSessionStore` is NOT wired: fully backward-compatible. Tokens mint without sid; introspect cascade becomes a no-op.

## Spec coverage

All items in `.claude/superpowers/specs/2026-04-21-todo-f-federation-token-lifecycle-design.md` Sections 3/7/8.1/9 implemented. F-4 (id_token + /userinfo + discovery), F-5 (logout 3 routes), F-6 (/oauth/federation/:name/token) remain future work.

## Test plan

- [x] `packages/core`: 342/342 passing (tsc 0, biome 0)
- [x] `packages/oauth`: 121/121 passing (tsc 0, biome 0)
- [x] `packages/session`: 120/120 passing + 1 skipped (tsc 0, biome 0)
- [x] Full workspace `pnpm -r test`: 871 tests passing across 7 packages
- [x] Full workspace `pnpm -r build`: clean
- [x] multi-agent-review (Claude code-reviewer + Codex) converged on 2 Critical + 2 Important findings; all resolved in `b03c124`
- [x] Manual review checklist:
  - [x] Fail-closed semantics consistent (503 on /token store throws, 200 `{active:false}` on /introspect store throws)
  - [x] audit events emitted on cascade revoke paths
  - [x] module composition roots thread the stores to handlers
  - [x] backward compat: unwired store → no crash, no sid claim, no session check

🤖 Generated with [Claude Code](https://claude.com/claude-code)