### PR TITLE
feat(oauth)!: OIDC Core 1.0 - id_token + /userinfo + /.well-known/openid-configuration (TODO-F-4)

### DIFF
--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -606,13 +606,14 @@ function filterClaimsByScope(
 
 #### `/.well-known/openid-configuration`
 
-OIDC Discovery 1.0 メタデータエンドポイント。`createApp` が `/health`・`/.well-known/jwks.json` と同様に無条件で登録する。以下を含む JSON ドキュメントを返す:
+OIDC Discovery 1.0 メタデータエンドポイント。OAuth モジュール（`@o3co/auth-provider-oauth`）が `config.oauth.jwt.issuer` が設定されている場合にのみ登録する。登録された場合、以下を含む JSON ドキュメントを返す:
 
-- `issuer`、`authorization_endpoint`、`token_endpoint`、`userinfo_endpoint`、`jwks_uri`、`introspection_endpoint`
+- `issuer`、`authorization_endpoint`、`token_endpoint`、`userinfo_endpoint`、`introspection_endpoint`
+- `jwks_uri` — 非対称な署名アルゴリズムが 1 つ以上設定されている場合のみ広告する（HS256 のみの構成では JWKS ルートが 404 を返すため省略）
 - `response_types_supported: ["code"]`
 - `subject_types_supported: ["public"]`
 - `id_token_signing_alg_values_supported` — 設定された `KeyStore.algorithm` から導出
-- `scopes_supported: ["openid", "profile", "email"]`
+- `scopes_supported: ["openid", "profile", "email", "groups"]`
 - `token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"]`
 - `code_challenge_methods_supported: ["S256"]`
 

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -551,6 +551,73 @@ Federation + OIDC 対応のために `AppOptions` に追加された 2 つのオ
 
 `CodeRepository.createCode` のパラメーターと `InMemoryCodeRepository` は同一の呼び出しで `nonce`、`sid`、`grantedScope` を受け付ける。consumer（`authorization_code` grant）は、`session.granted_scopes` の代わりに、`/oauth/authorize` 時に `GrantPolicyHook` が設定した `codeData.grantedScope` をトークン発行のスコープとして使用する。
 
+### OIDC id_token + クレームフィルター (TODO-F-4)
+
+`authorization_code` グラントと `/oauth/userinfo` エンドポイントが使用する低レベルヘルパー。
+
+#### `generateIdToken`
+
+```typescript
+interface GenerateIdTokenOptions {
+  readonly sub: string;
+  readonly aud: string;
+  readonly azp?: string;
+  readonly authTime: Date;
+  readonly nonce?: string;
+  readonly sid: string;
+  readonly scopes: ReadonlyArray<string>;
+  readonly userClaims: UserSessionClaims;
+  readonly keyStore: KeyStore;
+  readonly issuer: string;
+  readonly expiresIn?: number; // デフォルト 3600 秒
+}
+
+function generateIdToken(opts: GenerateIdTokenOptions): Promise<Token>;
+```
+
+OIDC id_token JWT（OIDC Core §2）に署名して返す。クレーム構成:
+
+- `iss`、`sub`、`aud`、`exp`、`iat`、`jti` — 標準 JWT クレーム
+- `auth_time` — `opts.authTime` をエポック秒に変換した値
+- `sid` — バックチャネルログアウト用セッション識別子（TODO-F-5）
+- `azp` — authorized party、指定された場合のみ付与
+- `nonce` — 認可リクエストから転送し、そのまま反映
+- `filterClaimsByScope` によるスコープフィルター済みユーザークレーム
+
+ヘッダーは `typ: "id+jwt"` を使用する（イントロスペクション向けのヒント）。
+
+#### `filterClaimsByScope`
+
+```typescript
+function filterClaimsByScope(
+  claims: UserSessionClaims,
+  scopes: ReadonlyArray<string>,
+): Record<string, unknown>;
+```
+
+`UserSessionClaims` を、付与されたスコープが許可するクレームのサブセットにマッピングする。厳格なホワイトリスト制 — 下表のマッピングのみを出力し、それ以外のフィールド（例: Google の `hd` など）は一切転送しない。
+
+| スコープ | 出力されるクレーム |
+| --- | --- |
+| `openid` | *(クレームなし — id_token 発行の可否を制御; `sub` は `generateIdToken` が付与)* |
+| `profile` | `name`、`picture` |
+| `email` | `email`、`email_verified` |
+| `groups` | `groups` |
+
+#### `/.well-known/openid-configuration`
+
+OIDC Discovery 1.0 メタデータエンドポイント。`createApp` が `/health`・`/.well-known/jwks.json` と同様に無条件で登録する。以下を含む JSON ドキュメントを返す:
+
+- `issuer`、`authorization_endpoint`、`token_endpoint`、`userinfo_endpoint`、`jwks_uri`、`introspection_endpoint`
+- `response_types_supported: ["code"]`
+- `subject_types_supported: ["public"]`
+- `id_token_signing_alg_values_supported` — 設定された `KeyStore.algorithm` から導出
+- `scopes_supported: ["openid", "profile", "email"]`
+- `token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"]`
+- `code_challenge_methods_supported: ["S256"]`
+
+追加エンドポイントが必要なフィールド（`revocation_endpoint`、`end_session_endpoint`、back/front-channel logout）は F-4 では省略し、TODO-F-5 で追加予定。
+
 ## 関連
 
 - ルート [README](../../README.md) — アーキテクチャ概要、設定リファレンス、Docker セットアップ

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -607,13 +607,14 @@ Maps `UserSessionClaims` to the JWT-shaped claim subset that the granted scopes 
 
 #### `/.well-known/openid-configuration`
 
-OIDC Discovery 1.0 metadata endpoint. Registered unconditionally by `createApp` alongside `/health` and `/.well-known/jwks.json`. Returns a JSON document advertising:
+OIDC Discovery 1.0 metadata endpoint. Registered by the OAuth module (`@o3co/auth-provider-oauth`) when `config.oauth.jwt.issuer` is configured. When registered, it returns a JSON document advertising:
 
-- `issuer`, `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, `jwks_uri`, `introspection_endpoint`
+- `issuer`, `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, `introspection_endpoint`
+- `jwks_uri` — only advertised when at least one asymmetric signing alg is configured (omitted for HS256-only deployments since the JWKS route returns 404 for symmetric keys)
 - `response_types_supported: ["code"]`
 - `subject_types_supported: ["public"]`
 - `id_token_signing_alg_values_supported` — derived from the configured `KeyStore.algorithm`
-- `scopes_supported: ["openid", "profile", "email"]`
+- `scopes_supported: ["openid", "profile", "email", "groups"]`
 - `token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"]`
 - `code_challenge_methods_supported: ["S256"]`
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -552,6 +552,73 @@ Both stores are consumed by upcoming TODO-F-3 (cascading revocation), F-4 (id_to
 
 The `CodeRepository.createCode` params and `InMemoryCodeRepository` accept `nonce`, `sid`, and `grantedScope` in the same call. Consumers (the `authorization_code` grant) read `codeData.grantedScope` (set by `GrantPolicyHook` at `/oauth/authorize`) as the authoritative scope for token minting instead of `session.granted_scopes`.
 
+### OIDC id_token + claim filter (TODO-F-4)
+
+Two low-level helpers used by the `authorization_code` grant and the `/oauth/userinfo` endpoint.
+
+#### `generateIdToken`
+
+```typescript
+interface GenerateIdTokenOptions {
+  readonly sub: string;
+  readonly aud: string;
+  readonly azp?: string;
+  readonly authTime: Date;
+  readonly nonce?: string;
+  readonly sid: string;
+  readonly scopes: ReadonlyArray<string>;
+  readonly userClaims: UserSessionClaims;
+  readonly keyStore: KeyStore;
+  readonly issuer: string;
+  readonly expiresIn?: number; // default 3600 s
+}
+
+function generateIdToken(opts: GenerateIdTokenOptions): Promise<Token>;
+```
+
+Signs and returns an OIDC id_token JWT (OIDC Core §2). Claim composition:
+
+- `iss`, `sub`, `aud`, `exp`, `iat`, `jti` — standard JWT claims
+- `auth_time` — seconds since epoch, from `opts.authTime`
+- `sid` — session identifier for back-channel logout (TODO-F-5)
+- `azp` — authorized party, included when provided
+- `nonce` — reflected verbatim from the authorization request when provided
+- scope-filtered user claims via `filterClaimsByScope`
+
+Header uses `typ: "id+jwt"` as an introspection convenience hint.
+
+#### `filterClaimsByScope`
+
+```typescript
+function filterClaimsByScope(
+  claims: UserSessionClaims,
+  scopes: ReadonlyArray<string>,
+): Record<string, unknown>;
+```
+
+Maps `UserSessionClaims` to the JWT-shaped claim subset that the granted scopes authorize. Strict whitelist — only the mappings in the table below are emitted; any other `UserSessionClaims` fields (e.g. provider-specific fields like `hd`) are never forwarded.
+
+| Scope | Emitted claims |
+| --- | --- |
+| `openid` | *(no claims — governs id_token issuance; `sub` is added by `generateIdToken`)* |
+| `profile` | `name`, `picture` |
+| `email` | `email`, `email_verified` |
+| `groups` | `groups` |
+
+#### `/.well-known/openid-configuration`
+
+OIDC Discovery 1.0 metadata endpoint. Registered unconditionally by `createApp` alongside `/health` and `/.well-known/jwks.json`. Returns a JSON document advertising:
+
+- `issuer`, `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, `jwks_uri`, `introspection_endpoint`
+- `response_types_supported: ["code"]`
+- `subject_types_supported: ["public"]`
+- `id_token_signing_alg_values_supported` — derived from the configured `KeyStore.algorithm`
+- `scopes_supported: ["openid", "profile", "email"]`
+- `token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"]`
+- `code_challenge_methods_supported: ["S256"]`
+
+Fields that require additional endpoints (`revocation_endpoint`, `end_session_endpoint`, back/front-channel logout) are omitted in F-4 and will be added in TODO-F-5.
+
 ## See Also
 
 - Root [README](../../README.md) — architecture overview, configuration reference, Docker setup

--- a/packages/core/src/app.mts
+++ b/packages/core/src/app.mts
@@ -147,9 +147,7 @@ export function createApp(options: AppOptions): AppResult {
 		// Advertise only the algorithm the configured KeyStore actually signs
 		// with. Hardcoding the full union would mislead clients to fetch JWKS
 		// expecting a key that is not there (OIDC Core §10.1 + RFC 8414 §2).
-		router.use(
-			oidcConfig.createRouter(express, { issuer, signingAlgs: [keyStore.algorithm] }),
-		);
+		router.use(oidcConfig.createRouter(express, { issuer, signingAlgs: [keyStore.algorithm] }));
 	}
 
 	const context: ModuleContext = {

--- a/packages/core/src/app.mts
+++ b/packages/core/src/app.mts
@@ -28,6 +28,7 @@ import type { RateLimiterBase } from "./ratelimit/types.mjs";
 import type { RefreshTokenStoreBase } from "./refresh/types.mjs";
 import * as healthcheck from "./routes/Healthcheck.mjs";
 import * as jwks from "./routes/Jwks.mjs";
+import * as oidcConfig from "./routes/OpenidConfiguration.mjs";
 import type { UserSessionStoreBase } from "./user-sessions/types.mjs";
 
 type ExpressLike = {
@@ -138,6 +139,16 @@ export function createApp(options: AppOptions): AppResult {
 
 	// Wire core infrastructure routes (pure — no external deps)
 	router.use(healthcheck.createRouter(express)).use(jwks.createRouter(express, keyStore));
+
+	// Mount OIDC discovery only when issuer is configured (without an issuer
+	// URL the discovery document would be invalid and misleading).
+	const issuer = (config as { oauth?: { jwt?: { issuer?: unknown } } }).oauth?.jwt?.issuer;
+	if (typeof issuer === "string" && issuer.length > 0) {
+		// Hardcode the algs KeyStore currently supports. Keep in sync with
+		// KeyStore.mts factory options. Task 7+ can read this from the KeyStore.
+		const signingAlgs = ["RS256", "ES256", "EdDSA", "HS256"];
+		router.use(oidcConfig.createRouter(express, { issuer, signingAlgs }));
+	}
 
 	const context: ModuleContext = {
 		pathResolver,

--- a/packages/core/src/app.mts
+++ b/packages/core/src/app.mts
@@ -144,10 +144,12 @@ export function createApp(options: AppOptions): AppResult {
 	// URL the discovery document would be invalid and misleading).
 	const issuer = (config as { oauth?: { jwt?: { issuer?: unknown } } }).oauth?.jwt?.issuer;
 	if (typeof issuer === "string" && issuer.length > 0) {
-		// Hardcode the algs KeyStore currently supports. Keep in sync with
-		// KeyStore.mts factory options. Task 7+ can read this from the KeyStore.
-		const signingAlgs = ["RS256", "ES256", "EdDSA", "HS256"];
-		router.use(oidcConfig.createRouter(express, { issuer, signingAlgs }));
+		// Advertise only the algorithm the configured KeyStore actually signs
+		// with. Hardcoding the full union would mislead clients to fetch JWKS
+		// expecting a key that is not there (OIDC Core §10.1 + RFC 8414 §2).
+		router.use(
+			oidcConfig.createRouter(express, { issuer, signingAlgs: [keyStore.algorithm] }),
+		);
 	}
 
 	const context: ModuleContext = {

--- a/packages/core/src/app.mts
+++ b/packages/core/src/app.mts
@@ -28,7 +28,6 @@ import type { RateLimiterBase } from "./ratelimit/types.mjs";
 import type { RefreshTokenStoreBase } from "./refresh/types.mjs";
 import * as healthcheck from "./routes/Healthcheck.mjs";
 import * as jwks from "./routes/Jwks.mjs";
-import * as oidcConfig from "./routes/OpenidConfiguration.mjs";
 import type { UserSessionStoreBase } from "./user-sessions/types.mjs";
 
 type ExpressLike = {
@@ -140,15 +139,8 @@ export function createApp(options: AppOptions): AppResult {
 	// Wire core infrastructure routes (pure — no external deps)
 	router.use(healthcheck.createRouter(express)).use(jwks.createRouter(express, keyStore));
 
-	// Mount OIDC discovery only when issuer is configured (without an issuer
-	// URL the discovery document would be invalid and misleading).
-	const issuer = (config as { oauth?: { jwt?: { issuer?: unknown } } }).oauth?.jwt?.issuer;
-	if (typeof issuer === "string" && issuer.length > 0) {
-		// Advertise only the algorithm the configured KeyStore actually signs
-		// with. Hardcoding the full union would mislead clients to fetch JWKS
-		// expecting a key that is not there (OIDC Core §10.1 + RFC 8414 §2).
-		router.use(oidcConfig.createRouter(express, { issuer, signingAlgs: [keyStore.algorithm] }));
-	}
+	// OIDC discovery is mounted by the oauth module (when the OAuth endpoints
+	// it advertises actually exist). See packages/oauth/src/module.mts.
 
 	const context: ModuleContext = {
 		pathResolver,

--- a/packages/core/src/grants/__tests__/claimFilter.test.mts
+++ b/packages/core/src/grants/__tests__/claimFilter.test.mts
@@ -1,4 +1,19 @@
-// packages/core/src/grants/__tests__/claimFilter.test.mts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { describe, expect, it } from "vitest";
 import { filterClaimsByScope } from "../claimFilter.mjs";
 

--- a/packages/core/src/grants/__tests__/claimFilter.test.mts
+++ b/packages/core/src/grants/__tests__/claimFilter.test.mts
@@ -54,4 +54,15 @@ describe("filterClaimsByScope", () => {
 	it("provider-specific claims are never emitted (strict whitelist)", () => {
 		expect(filterClaimsByScope({ hd: "example.com" }, ["openid", "profile", "email"])).toEqual({});
 	});
+
+	it("filters non-string elements from groups array (security)", () => {
+		// UserSessionClaims has an index signature, so upstream code may put
+		// arbitrary values in. Ensure only strings leak through.
+		const mixed = {
+			groups: ["admins", 42, { nested: "obj" }, null, "editors"] as unknown[],
+		};
+		expect(filterClaimsByScope(mixed, ["openid", "groups"])).toEqual({
+			groups: ["admins", "editors"],
+		});
+	});
 });

--- a/packages/core/src/grants/__tests__/claimFilter.test.mts
+++ b/packages/core/src/grants/__tests__/claimFilter.test.mts
@@ -1,0 +1,57 @@
+// packages/core/src/grants/__tests__/claimFilter.test.mts
+import { describe, expect, it } from "vitest";
+import { filterClaimsByScope } from "../claimFilter.mjs";
+
+describe("filterClaimsByScope", () => {
+	const all = {
+		email: "a@b.com",
+		emailVerified: true,
+		name: "Alice",
+		picture: "https://p/p.png",
+		groups: ["admins"],
+		hd: "example.com", // provider-specific, not in any standard scope
+	};
+
+	it("openid scope alone returns empty claim set (sub is added by the caller)", () => {
+		expect(filterClaimsByScope(all, ["openid"])).toEqual({});
+	});
+
+	it("profile scope emits name + picture", () => {
+		expect(filterClaimsByScope(all, ["openid", "profile"])).toEqual({
+			name: "Alice",
+			picture: "https://p/p.png",
+		});
+	});
+
+	it("email scope emits email + email_verified", () => {
+		expect(filterClaimsByScope(all, ["openid", "email"])).toEqual({
+			email: "a@b.com",
+			email_verified: true,
+		});
+	});
+
+	it("groups scope emits groups (non-standard, opt-in)", () => {
+		expect(filterClaimsByScope(all, ["openid", "groups"])).toEqual({
+			groups: ["admins"],
+		});
+	});
+
+	it("combined scopes compose", () => {
+		expect(filterClaimsByScope(all, ["openid", "profile", "email"])).toEqual({
+			name: "Alice",
+			picture: "https://p/p.png",
+			email: "a@b.com",
+			email_verified: true,
+		});
+	});
+
+	it("absent claims are omitted (not emitted as undefined)", () => {
+		expect(filterClaimsByScope({ email: "only@x.com" }, ["openid", "profile", "email"])).toEqual({
+			email: "only@x.com",
+		});
+	});
+
+	it("provider-specific claims are never emitted (strict whitelist)", () => {
+		expect(filterClaimsByScope({ hd: "example.com" }, ["openid", "profile", "email"])).toEqual({});
+	});
+});

--- a/packages/core/src/grants/__tests__/idToken.test.mts
+++ b/packages/core/src/grants/__tests__/idToken.test.mts
@@ -1,0 +1,104 @@
+// packages/core/src/grants/__tests__/idToken.test.mts
+import { describe, expect, it } from "vitest";
+import { createSymmetricKeyStore } from "#/keys/KeyStore.mjs";
+import { decodeJwt, decodeProtectedHeader } from "jose";
+import { generateIdToken } from "../idToken.mjs";
+
+describe("generateIdToken", () => {
+	const keyStore = createSymmetricKeyStore("test-secret-32-chars-xxxxxxxxxxxx");
+
+	it("emits typ: id+jwt header", async () => {
+		const { token } = await generateIdToken({
+			sub: "u-1",
+			aud: "client-1",
+			authTime: new Date("2026-04-21T00:00:00Z"),
+			sid: "sid-1",
+			scopes: ["openid"],
+			userClaims: {},
+			keyStore,
+			issuer: "https://auth.example.com",
+		});
+		expect(decodeProtectedHeader(token).typ).toBe("id+jwt");
+	});
+
+	it("carries the required OIDC claims (iss, sub, aud, exp, iat, auth_time, sid)", async () => {
+		const { token } = await generateIdToken({
+			sub: "u-1",
+			aud: "client-1",
+			authTime: new Date("2026-04-21T00:00:00Z"),
+			sid: "sid-1",
+			scopes: ["openid"],
+			userClaims: {},
+			keyStore,
+			issuer: "https://auth.example.com",
+		});
+		const payload = decodeJwt(token);
+		expect(payload.iss).toBe("https://auth.example.com");
+		expect(payload.sub).toBe("u-1");
+		expect(payload.aud).toBe("client-1");
+		expect(typeof payload.exp).toBe("number");
+		expect(typeof payload.iat).toBe("number");
+		expect(payload.auth_time).toBe(Math.floor(new Date("2026-04-21T00:00:00Z").getTime() / 1000));
+		expect(payload.sid).toBe("sid-1");
+	});
+
+	it("includes nonce when provided", async () => {
+		const { token } = await generateIdToken({
+			sub: "u", aud: "c", authTime: new Date(), sid: "s", scopes: ["openid"],
+			userClaims: {}, keyStore, issuer: "https://auth.example.com",
+			nonce: "client-nonce-123",
+		});
+		expect(decodeJwt(token).nonce).toBe("client-nonce-123");
+	});
+
+	it("omits nonce when absent", async () => {
+		const { token } = await generateIdToken({
+			sub: "u", aud: "c", authTime: new Date(), sid: "s", scopes: ["openid"],
+			userClaims: {}, keyStore, issuer: "https://auth.example.com",
+		});
+		expect(decodeJwt(token).nonce).toBeUndefined();
+	});
+
+	it("filters userClaims by scope (profile → name/picture)", async () => {
+		const { token } = await generateIdToken({
+			sub: "u", aud: "c", authTime: new Date(), sid: "s",
+			scopes: ["openid", "profile"],
+			userClaims: { name: "Alice", picture: "https://p", email: "hidden@x.com" },
+			keyStore, issuer: "iss",
+		});
+		const p = decodeJwt(token);
+		expect(p.name).toBe("Alice");
+		expect(p.picture).toBe("https://p");
+		expect(p.email).toBeUndefined();
+	});
+
+	it("adds azp claim when provided (distinct from aud, per OIDC 1.0 §2)", async () => {
+		const { token } = await generateIdToken({
+			sub: "u", aud: "c", authTime: new Date(), sid: "s", scopes: ["openid"],
+			userClaims: {}, keyStore, issuer: "iss",
+			azp: "c",
+		});
+		expect(decodeJwt(token).azp).toBe("c");
+	});
+
+	it("defaults expiresIn to 3600 seconds", async () => {
+		const { token, expiresIn } = await generateIdToken({
+			sub: "u", aud: "c", authTime: new Date(), sid: "s", scopes: ["openid"],
+			userClaims: {}, keyStore, issuer: "iss",
+		});
+		expect(expiresIn).toBe(3600);
+		const p = decodeJwt(token);
+		expect((p.exp as number) - (p.iat as number)).toBe(3600);
+	});
+
+	it("respects custom expiresIn", async () => {
+		const { token, expiresIn } = await generateIdToken({
+			sub: "u", aud: "c", authTime: new Date(), sid: "s", scopes: ["openid"],
+			userClaims: {}, keyStore, issuer: "iss",
+			expiresIn: 600,
+		});
+		expect(expiresIn).toBe(600);
+		const p = decodeJwt(token);
+		expect((p.exp as number) - (p.iat as number)).toBe(600);
+	});
+});

--- a/packages/core/src/grants/__tests__/idToken.test.mts
+++ b/packages/core/src/grants/__tests__/idToken.test.mts
@@ -1,4 +1,18 @@
-// packages/core/src/grants/__tests__/idToken.test.mts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { decodeJwt, decodeProtectedHeader } from "jose";
 import { describe, expect, it } from "vitest";

--- a/packages/core/src/grants/__tests__/idToken.test.mts
+++ b/packages/core/src/grants/__tests__/idToken.test.mts
@@ -1,7 +1,8 @@
 // packages/core/src/grants/__tests__/idToken.test.mts
+
+import { decodeJwt, decodeProtectedHeader } from "jose";
 import { describe, expect, it } from "vitest";
 import { createSymmetricKeyStore } from "#/keys/KeyStore.mjs";
-import { decodeJwt, decodeProtectedHeader } from "jose";
 import { generateIdToken } from "../idToken.mjs";
 
 describe("generateIdToken", () => {
@@ -44,8 +45,14 @@ describe("generateIdToken", () => {
 
 	it("includes nonce when provided", async () => {
 		const { token } = await generateIdToken({
-			sub: "u", aud: "c", authTime: new Date(), sid: "s", scopes: ["openid"],
-			userClaims: {}, keyStore, issuer: "https://auth.example.com",
+			sub: "u",
+			aud: "c",
+			authTime: new Date(),
+			sid: "s",
+			scopes: ["openid"],
+			userClaims: {},
+			keyStore,
+			issuer: "https://auth.example.com",
 			nonce: "client-nonce-123",
 		});
 		expect(decodeJwt(token).nonce).toBe("client-nonce-123");
@@ -53,18 +60,28 @@ describe("generateIdToken", () => {
 
 	it("omits nonce when absent", async () => {
 		const { token } = await generateIdToken({
-			sub: "u", aud: "c", authTime: new Date(), sid: "s", scopes: ["openid"],
-			userClaims: {}, keyStore, issuer: "https://auth.example.com",
+			sub: "u",
+			aud: "c",
+			authTime: new Date(),
+			sid: "s",
+			scopes: ["openid"],
+			userClaims: {},
+			keyStore,
+			issuer: "https://auth.example.com",
 		});
 		expect(decodeJwt(token).nonce).toBeUndefined();
 	});
 
 	it("filters userClaims by scope (profile → name/picture)", async () => {
 		const { token } = await generateIdToken({
-			sub: "u", aud: "c", authTime: new Date(), sid: "s",
+			sub: "u",
+			aud: "c",
+			authTime: new Date(),
+			sid: "s",
 			scopes: ["openid", "profile"],
 			userClaims: { name: "Alice", picture: "https://p", email: "hidden@x.com" },
-			keyStore, issuer: "iss",
+			keyStore,
+			issuer: "iss",
 		});
 		const p = decodeJwt(token);
 		expect(p.name).toBe("Alice");
@@ -74,8 +91,14 @@ describe("generateIdToken", () => {
 
 	it("adds azp claim when provided (distinct from aud, per OIDC 1.0 §2)", async () => {
 		const { token } = await generateIdToken({
-			sub: "u", aud: "c", authTime: new Date(), sid: "s", scopes: ["openid"],
-			userClaims: {}, keyStore, issuer: "iss",
+			sub: "u",
+			aud: "c",
+			authTime: new Date(),
+			sid: "s",
+			scopes: ["openid"],
+			userClaims: {},
+			keyStore,
+			issuer: "iss",
 			azp: "c",
 		});
 		expect(decodeJwt(token).azp).toBe("c");
@@ -83,8 +106,14 @@ describe("generateIdToken", () => {
 
 	it("defaults expiresIn to 3600 seconds", async () => {
 		const { token, expiresIn } = await generateIdToken({
-			sub: "u", aud: "c", authTime: new Date(), sid: "s", scopes: ["openid"],
-			userClaims: {}, keyStore, issuer: "iss",
+			sub: "u",
+			aud: "c",
+			authTime: new Date(),
+			sid: "s",
+			scopes: ["openid"],
+			userClaims: {},
+			keyStore,
+			issuer: "iss",
 		});
 		expect(expiresIn).toBe(3600);
 		const p = decodeJwt(token);
@@ -93,8 +122,14 @@ describe("generateIdToken", () => {
 
 	it("respects custom expiresIn", async () => {
 		const { token, expiresIn } = await generateIdToken({
-			sub: "u", aud: "c", authTime: new Date(), sid: "s", scopes: ["openid"],
-			userClaims: {}, keyStore, issuer: "iss",
+			sub: "u",
+			aud: "c",
+			authTime: new Date(),
+			sid: "s",
+			scopes: ["openid"],
+			userClaims: {},
+			keyStore,
+			issuer: "iss",
 			expiresIn: 600,
 		});
 		expect(expiresIn).toBe(600);

--- a/packages/core/src/grants/__tests__/token.test.mts
+++ b/packages/core/src/grants/__tests__/token.test.mts
@@ -235,3 +235,19 @@ describe("generateTokenResponse", () => {
 		expect(response.refresh_token).toBe(refreshToken.token);
 	});
 });
+
+describe("generateTokenResponse with id_token", () => {
+	it("includes id_token in the response when provided", () => {
+		const resp = generateTokenResponse({
+			accessToken: { token: "at", expiresIn: 3600 },
+			refreshToken: { token: "rt" },
+			idToken: { token: "it" },
+		});
+		expect(resp.id_token).toBe("it");
+	});
+
+	it("omits id_token when not provided (backward compat)", () => {
+		const resp = generateTokenResponse({ accessToken: { token: "at", expiresIn: 3600 } });
+		expect(resp.id_token).toBeUndefined();
+	});
+});

--- a/packages/core/src/grants/claimFilter.mts
+++ b/packages/core/src/grants/claimFilter.mts
@@ -35,7 +35,12 @@ export function filterClaimsByScope(
 		if (typeof claims.emailVerified === "boolean") out.email_verified = claims.emailVerified;
 	}
 	if (scopeSet.has("groups")) {
-		if (Array.isArray(claims.groups)) out.groups = claims.groups;
+		// UserSessionClaims has an index signature allowing unknown custom fields;
+		// filter to string members only so non-string elements (objects, numbers,
+		// etc.) cannot leak into JWT/userinfo responses.
+		if (Array.isArray(claims.groups)) {
+			out.groups = claims.groups.filter((g): g is string => typeof g === "string");
+		}
 	}
 	return out;
 }

--- a/packages/core/src/grants/claimFilter.mts
+++ b/packages/core/src/grants/claimFilter.mts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import type { UserSessionClaims } from "../user-sessions/types.mjs";
+
+/**
+ * OIDC-standard claim filter. Maps {@link UserSessionClaims} to the JWT-shaped
+ * claim subset that the requested scopes authorize.
+ *
+ * Scope → claim mapping (strict whitelist):
+ *   - profile  → name, picture
+ *   - email    → email, email_verified (note the OIDC snake_case name)
+ *   - groups   → groups (non-standard, opt-in per spec Section 6.4)
+ *
+ * `openid` scope itself yields no claim here — it governs whether id_token is
+ * issued at all; `sub` is added by the caller (`generateIdToken`).
+ *
+ * Provider-specific claims (e.g. Google `hd`) are NEVER emitted — consumers
+ * that need them must opt in via a custom scope mapping (out of scope for v1).
+ */
+export function filterClaimsByScope(
+	claims: UserSessionClaims,
+	scopes: ReadonlyArray<string>,
+): Record<string, unknown> {
+	const scopeSet = new Set(scopes);
+	const out: Record<string, unknown> = {};
+	if (scopeSet.has("profile")) {
+		if (typeof claims.name === "string") out.name = claims.name;
+		if (typeof claims.picture === "string") out.picture = claims.picture;
+	}
+	if (scopeSet.has("email")) {
+		if (typeof claims.email === "string") out.email = claims.email;
+		if (typeof claims.emailVerified === "boolean") out.email_verified = claims.emailVerified;
+	}
+	if (scopeSet.has("groups")) {
+		if (Array.isArray(claims.groups)) out.groups = claims.groups;
+	}
+	return out;
+}

--- a/packages/core/src/grants/idToken.mts
+++ b/packages/core/src/grants/idToken.mts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { randomUUID } from "node:crypto";
+import type { JWTPayload, KeyStore } from "../keys/KeyStore.mjs";
+import type { UserSessionClaims } from "../user-sessions/types.mjs";
+import type { Token } from "./token.mjs";
+import { filterClaimsByScope } from "./claimFilter.mjs";
+
+export interface GenerateIdTokenOptions {
+	readonly sub: string;
+	readonly aud: string;
+	readonly azp?: string;
+	readonly authTime: Date;
+	readonly nonce?: string;
+	readonly sid: string;
+	readonly scopes: ReadonlyArray<string>;
+	readonly userClaims: UserSessionClaims;
+	readonly keyStore: KeyStore;
+	readonly issuer: string;
+	readonly expiresIn?: number; // default 3600 seconds
+}
+
+/**
+ * Generates a signed id_token JWT (OIDC 1.0 Core §2).
+ *
+ * Claim composition:
+ *   - iss = issuer
+ *   - sub (required)
+ *   - aud (required)
+ *   - azp (optional, added when provided)
+ *   - exp / iat (seconds since epoch)
+ *   - auth_time (seconds since epoch, from `authTime`)
+ *   - sid (session identifier for back-channel logout)
+ *   - nonce (when provided by the authorize request)
+ *   - scope-filtered user claims via {@link filterClaimsByScope}
+ *
+ * Header: `typ: "id+jwt"` (RFC 9068 is at+jwt; id_token is in the OIDC family but
+ * we use typ for introspection convenience — the header is a hint, not spec-mandated).
+ */
+export async function generateIdToken(opts: GenerateIdTokenOptions): Promise<Token> {
+	const now = Math.floor(Date.now() / 1000);
+	const expiresIn = opts.expiresIn ?? 3600;
+	const claims: JWTPayload = {
+		iss: opts.issuer,
+		sub: opts.sub,
+		aud: opts.aud,
+		exp: now + expiresIn,
+		iat: now,
+		jti: randomUUID(),
+		auth_time: Math.floor(opts.authTime.getTime() / 1000),
+		sid: opts.sid,
+		...(opts.azp ? { azp: opts.azp } : {}),
+		...(opts.nonce ? { nonce: opts.nonce } : {}),
+		...filterClaimsByScope(opts.userClaims, opts.scopes),
+	};
+	const token = await opts.keyStore.sign({ claims, header: { typ: "id+jwt" } });
+	return {
+		token,
+		expiresIn,
+		subject: opts.sub,
+		audience: opts.aud,
+		issuer: opts.issuer,
+		// tokenType is intentionally omitted — id_token is not `at+jwt` / `rt+jwt`
+	};
+}

--- a/packages/core/src/grants/idToken.mts
+++ b/packages/core/src/grants/idToken.mts
@@ -6,8 +6,8 @@
 import { randomUUID } from "node:crypto";
 import type { JWTPayload, KeyStore } from "../keys/KeyStore.mjs";
 import type { UserSessionClaims } from "../user-sessions/types.mjs";
-import type { Token } from "./token.mjs";
 import { filterClaimsByScope } from "./claimFilter.mjs";
+import type { Token } from "./token.mjs";
 
 export interface GenerateIdTokenOptions {
 	readonly sub: string;

--- a/packages/core/src/grants/token.mts
+++ b/packages/core/src/grants/token.mts
@@ -35,6 +35,7 @@ export interface Token {
 export interface IntermediateToken {
 	accessToken: Token;
 	refreshToken?: Token;
+	idToken?: Token;
 }
 
 export interface TokenResponse {
@@ -43,11 +44,13 @@ export interface TokenResponse {
 	scope?: string;
 	refresh_token?: string | null;
 	expires_in?: number;
+	id_token?: string;
 }
 
 export const generateTokenResponse = ({
 	accessToken,
 	refreshToken = undefined,
+	idToken = undefined,
 }: IntermediateToken): TokenResponse => {
 	return {
 		access_token: accessToken.token,
@@ -56,6 +59,7 @@ export const generateTokenResponse = ({
 			scope: accessToken.scope,
 			refresh_token: refreshToken ? refreshToken.token : null,
 			expires_in: accessToken.expiresIn,
+			id_token: idToken ? idToken.token : undefined,
 		}),
 	};
 };

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -165,6 +165,7 @@ export { loadYamlMap } from "./repositories/loadYamlMap.mjs";
 export { createDefaultFactories } from "./repositories/RepositoryFactory.mjs";
 export type { Client, Code, CodeData, User } from "./repositories/types.mjs";
 export type { UserRepository } from "./repositories/UserRepository.mjs";
+export { filterClaimsByScope } from "./grants/claimFilter.mjs";
 export { extractUserClaims } from "./user-sessions/claims.mjs";
 export {
 	createUserSessionStoreFactory,

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -50,10 +50,11 @@ export type {
 	FederationTokenStoreFactory,
 	FederationTokens,
 } from "./federation-tokens/types.mjs";
+export { filterClaimsByScope } from "./grants/claimFilter.mjs";
 // id_token generation (OIDC Core §2)
 export {
-	generateIdToken,
 	type GenerateIdTokenOptions,
+	generateIdToken,
 } from "./grants/idToken.mjs";
 // Grant types and interfaces
 export { GrantRegistry } from "./grants/registry.mjs";
@@ -165,7 +166,6 @@ export { loadYamlMap } from "./repositories/loadYamlMap.mjs";
 export { createDefaultFactories } from "./repositories/RepositoryFactory.mjs";
 export type { Client, Code, CodeData, User } from "./repositories/types.mjs";
 export type { UserRepository } from "./repositories/UserRepository.mjs";
-export { filterClaimsByScope } from "./grants/claimFilter.mjs";
 export { extractUserClaims } from "./user-sessions/claims.mjs";
 export {
 	createUserSessionStoreFactory,

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -50,6 +50,11 @@ export type {
 	FederationTokenStoreFactory,
 	FederationTokens,
 } from "./federation-tokens/types.mjs";
+// id_token generation (OIDC Core §2)
+export {
+	generateIdToken,
+	type GenerateIdTokenOptions,
+} from "./grants/idToken.mjs";
 // Grant types and interfaces
 export { GrantRegistry } from "./grants/registry.mjs";
 // Token formatting utility (used by oauth package)

--- a/packages/core/src/routes/OpenidConfiguration.mts
+++ b/packages/core/src/routes/OpenidConfiguration.mts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { Request, RequestHandler, Response, Router } from "express";
+
+type ExpressLike = {
+	Router: () => Router;
+	json: () => RequestHandler;
+	urlencoded: (opts: { extended: boolean }) => RequestHandler;
+};
+
+export interface OidcConfigRouterOptions {
+	issuer: string;
+	signingAlgs: ReadonlyArray<string>;
+}
+
+export function createRouter(express: ExpressLike, opts: OidcConfigRouterOptions): Router {
+	const router = express.Router();
+
+	router.get("/.well-known/openid-configuration", (_req: Request, res: Response) => {
+		const iss = opts.issuer.replace(/\/+$/, "");
+		return res.status(200).json({
+			issuer: opts.issuer,
+			authorization_endpoint: `${iss}/oauth/authorize`,
+			token_endpoint: `${iss}/oauth/token`,
+			userinfo_endpoint: `${iss}/oauth/userinfo`,
+			jwks_uri: `${iss}/.well-known/jwks.json`,
+			introspection_endpoint: `${iss}/oauth/introspect`,
+			response_types_supported: ["code"],
+			subject_types_supported: ["public"],
+			id_token_signing_alg_values_supported: [...opts.signingAlgs],
+			scopes_supported: ["openid", "profile", "email"],
+			token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"],
+			code_challenge_methods_supported: ["S256"],
+			// OUT of F-4 scope: revocation_endpoint, end_session_endpoint,
+			// backchannel_logout_supported, frontchannel_logout_supported —
+			// F-5 will add them when the corresponding routes exist.
+		});
+	});
+
+	return router;
+}

--- a/packages/core/src/routes/__tests__/OpenidConfiguration.test.mts
+++ b/packages/core/src/routes/__tests__/OpenidConfiguration.test.mts
@@ -49,9 +49,10 @@ function createMockRes() {
 	};
 }
 
-async function callRoute(
-	opts: { issuer: string; signingAlgs: string[] },
-): Promise<Record<string, unknown>> {
+async function callRoute(opts: {
+	issuer: string;
+	signingAlgs: string[];
+}): Promise<Record<string, unknown>> {
 	const express = createMockExpress();
 	createRouter(express as any, opts);
 	const handler = express.routes["/.well-known/openid-configuration"];
@@ -74,7 +75,12 @@ describe("GET /.well-known/openid-configuration", () => {
 		expect(body.introspection_endpoint).toBe("https://auth.example.com/oauth/introspect");
 		expect(body.response_types_supported).toEqual(["code"]);
 		expect(body.subject_types_supported).toEqual(["public"]);
-		expect(body.id_token_signing_alg_values_supported).toEqual(["RS256", "ES256", "EdDSA", "HS256"]);
+		expect(body.id_token_signing_alg_values_supported).toEqual([
+			"RS256",
+			"ES256",
+			"EdDSA",
+			"HS256",
+		]);
 		expect(body.scopes_supported).toEqual(["openid", "profile", "email"]);
 		expect(body.code_challenge_methods_supported).toEqual(["S256"]);
 		expect(body.token_endpoint_auth_methods_supported).toEqual(

--- a/packages/core/src/routes/__tests__/OpenidConfiguration.test.mts
+++ b/packages/core/src/routes/__tests__/OpenidConfiguration.test.mts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createRouter } from "#/routes/OpenidConfiguration.mjs";
+
+function createMockExpress() {
+	const routes: Record<string, Function> = {};
+	const router = {
+		get(path: string, handler: Function) {
+			routes[path] = handler;
+			return router;
+		},
+	};
+	return { Router: () => router, routes };
+}
+
+function createMockRes() {
+	let statusCode = 200;
+	let body: unknown;
+	return {
+		status(code: number) {
+			statusCode = code;
+			return this;
+		},
+		json(data: unknown) {
+			body = data;
+			return this;
+		},
+		sendStatus(code: number) {
+			statusCode = code;
+			return this;
+		},
+		getStatusCode: () => statusCode,
+		getBody: () => body,
+	};
+}
+
+async function callRoute(
+	opts: { issuer: string; signingAlgs: string[] },
+): Promise<Record<string, unknown>> {
+	const express = createMockExpress();
+	createRouter(express as any, opts);
+	const handler = express.routes["/.well-known/openid-configuration"];
+	const res = createMockRes();
+	await handler({}, res);
+	return res.getBody() as Record<string, unknown>;
+}
+
+describe("GET /.well-known/openid-configuration", () => {
+	it("returns discovery metadata with F-4 scoped endpoints + signing algs", async () => {
+		const body = await callRoute({
+			issuer: "https://auth.example.com",
+			signingAlgs: ["RS256", "ES256", "EdDSA", "HS256"],
+		});
+		expect(body.issuer).toBe("https://auth.example.com");
+		expect(body.authorization_endpoint).toBe("https://auth.example.com/oauth/authorize");
+		expect(body.token_endpoint).toBe("https://auth.example.com/oauth/token");
+		expect(body.userinfo_endpoint).toBe("https://auth.example.com/oauth/userinfo");
+		expect(body.jwks_uri).toBe("https://auth.example.com/.well-known/jwks.json");
+		expect(body.introspection_endpoint).toBe("https://auth.example.com/oauth/introspect");
+		expect(body.response_types_supported).toEqual(["code"]);
+		expect(body.subject_types_supported).toEqual(["public"]);
+		expect(body.id_token_signing_alg_values_supported).toEqual(["RS256", "ES256", "EdDSA", "HS256"]);
+		expect(body.scopes_supported).toEqual(["openid", "profile", "email"]);
+		expect(body.code_challenge_methods_supported).toEqual(["S256"]);
+		expect(body.token_endpoint_auth_methods_supported).toEqual(
+			expect.arrayContaining(["client_secret_basic", "client_secret_post", "none"]),
+		);
+	});
+
+	it("does NOT advertise revocation_endpoint / end_session_endpoint / backchannel_logout_supported (out of F-4 scope)", async () => {
+		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [] });
+		expect(body.revocation_endpoint).toBeUndefined();
+		expect(body.end_session_endpoint).toBeUndefined();
+		expect(body.backchannel_logout_supported).toBeUndefined();
+	});
+
+	it("strips trailing slashes from issuer when building endpoint URLs", async () => {
+		const body = await callRoute({
+			issuer: "https://auth.example.com///",
+			signingAlgs: [],
+		});
+		expect(body.authorization_endpoint).toBe("https://auth.example.com/oauth/authorize");
+		expect(body.token_endpoint).toBe("https://auth.example.com/oauth/token");
+	});
+});

--- a/packages/oauth/README.ja.md
+++ b/packages/oauth/README.ja.md
@@ -111,6 +111,56 @@ const app = createApp(express, {
 await app.init();
 ```
 
+## TODO-F-4 の変更点
+
+### `authorization_code` グラント — id_token 発行
+
+付与スコープに `openid` が含まれており、かつ `UserSessionStore` が設定されている場合、`authorization_code` グラントはアクセストークン・リフレッシュトークンと合わせて `id_token` を発行する。`id_token` は `@o3co/auth-provider-core` の `generateIdToken` が生成する署名済み JWT で、トークンレスポンスの `id_token` フィールドとして付与される。
+
+id_token が発行される条件:
+
+- 付与スコープに `openid` が含まれること（`/oauth/authorize` 時に `GrantPolicyHook` が設定）
+- `AppOptions.userSessionStore` が設定されていること（ユーザークレームのソースとして使用）
+- コードレコードに `sid` が含まれること（authorize 時にログイン/federation wiring が書き込む）
+- `AppOptions.config.oauth.jwt.issuer` が設定されていること（`iss: ""` の非準拠 JWT を防ぐ）
+
+いずれかの条件が満たされない場合、`id_token` はレスポンスから省略される。その場合も `access_token` と `refresh_token` は通常どおり返される。
+
+発行される `id_token` のクレーム構成:
+
+- `iss`、`sub`、`aud`、`exp`、`iat`、`jti`、`auth_time`、`sid`、`azp` — OIDC Core §2 標準クレーム
+- `nonce` — コードレコードに含まれる場合、そのまま反映（OIDC Core §3.1.3.7）
+- スコープフィルター済みユーザークレーム（下表参照）
+
+### `/oauth/userinfo` — OIDC Core §5.3
+
+```http
+GET /oauth/userinfo
+Authorization: Bearer <access_token>
+```
+
+永続化された `UserSession` を元に、スコープフィルター済みクレームを返す。`oauthModule` が `/oauth/token`・`/oauth/introspect`・`/oauth/authorize` と同じルーターにマウントする。
+
+| 条件 | レスポンス |
+| --- | --- |
+| Bearer トークン未指定または形式不正 | `401`（`WWW-Authenticate: Bearer realm="userinfo"` 付き） |
+| JWT 署名検証失敗 | `401 invalid_token` |
+| `family_id` クレームが失効済み（F-3 cascade） | `401 invalid_token` |
+| セッション未発見またはストアエラー | `401 invalid_token`（フェイルクローズ） |
+| `userSessionStore` 未設定、または `sid` クレームなし | `200 { sub }`（sub のみ、永続クレームなし） |
+| セッションがアクティブ | `200 { sub, ...スコープフィルター済みクレーム }` |
+
+すべてのレスポンスに `Cache-Control: no-store` と `Pragma: no-cache` を付与する（RFC 6750 §5.3）。
+
+スコープ→クレームマッピング（OIDC Core §5.4 標準スコープ）:
+
+| スコープ | 出力されるクレーム |
+| --- | --- |
+| `openid` | *(id_token 発行の可否を制御; `sub` は常に userinfo レスポンスに含まれる)* |
+| `profile` | `name`、`picture` |
+| `email` | `email`、`email_verified` |
+| `groups` | `groups` |
+
 ## TODO-F-3 の変更点
 
 - **`/oauth/introspect` によるカスケード失効。** アクセストークンに `family_id` クレームが含まれ、`AppOptions.refreshTokenStore` が設定されている場合、イントロスペクトエンドポイントはアクティブレスポンスを返す前に `RefreshTokenStore.isFamilyRevoked(familyId)` を呼び出す。ファミリーが失効済み、またはストアに到達できない場合は `{ active: false }` を返す（フェイルクローズ、RFC 7009 §2.1 SHOULD 準拠）。`family_id` クレームを持たない F-3 以前発行のトークンはこのチェックをスキップし、署名のみで検証される。

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -111,6 +111,56 @@ const app = createApp(express, {
 await app.init();
 ```
 
+## TODO-F-4 changes
+
+### `authorization_code` grant — id_token issuance
+
+When the `openid` scope is included in the granted scopes and a `UserSessionStore` is wired, the `authorization_code` grant issues an `id_token` alongside the access token and refresh token. The `id_token` is a signed JWT built by `generateIdToken` (from `@o3co/auth-provider-core`) and appended to the token response as the `id_token` field.
+
+Conditions for id_token issuance:
+
+- `openid` must appear in the granted scopes (set by `GrantPolicyHook` at `/oauth/authorize` time)
+- `AppOptions.userSessionStore` must be wired (session is the source of truth for user claims)
+- The code record must contain `sid` (written by login/federation wiring at authorize time)
+- `AppOptions.config.oauth.jwt.issuer` must be set (prevents emitting a noncompliant `iss: ""` claim)
+
+When any condition is not met, `id_token` is omitted from the response — the token endpoint still returns `access_token` and `refresh_token` normally.
+
+Claim composition of the issued `id_token`:
+
+- `iss`, `sub`, `aud`, `exp`, `iat`, `jti`, `auth_time`, `sid`, `azp` — OIDC Core §2 standard claims
+- `nonce` — reflected verbatim from the code record when present (OIDC Core §3.1.3.7)
+- scope-filtered user claims (see claim mapping table below)
+
+### `/oauth/userinfo` — OIDC Core §5.3
+
+```http
+GET /oauth/userinfo
+Authorization: Bearer <access_token>
+```
+
+Returns scope-filtered claims sourced from the durable `UserSession`. The endpoint is mounted by `oauthModule` alongside the existing `/oauth/token`, `/oauth/introspect`, and `/oauth/authorize` routes.
+
+| Condition | Response |
+| --- | --- |
+| Missing / invalid Bearer token | `401` with `WWW-Authenticate: Bearer realm="userinfo"` |
+| Invalid JWT signature | `401 invalid_token` |
+| `family_id` claim revoked (F-3 cascade) | `401 invalid_token` |
+| Session not found or store error | `401 invalid_token` (fail-closed) |
+| No `userSessionStore` wired or no `sid` claim | `200 { sub }` (sub only, no durable claims) |
+| Session active | `200 { sub, ...scope-filtered claims }` |
+
+All responses set `Cache-Control: no-store` and `Pragma: no-cache` (RFC 6750 §5.3).
+
+Scope-to-claim mapping (OIDC Core §5.4 standard scopes):
+
+| Scope | Emitted claims |
+| --- | --- |
+| `openid` | *(governs id_token issuance; `sub` always included in userinfo response)* |
+| `profile` | `name`, `picture` |
+| `email` | `email`, `email_verified` |
+| `groups` | `groups` |
+
 ## TODO-F-3 changes
 
 - **`/oauth/introspect` cascading revoke.** When the access token carries a `family_id` claim and `AppOptions.refreshTokenStore` is wired, the introspect endpoint calls `RefreshTokenStore.isFamilyRevoked(familyId)` before returning an active response. If the family is revoked or the store is unreachable, the response is `{ active: false }` (fail-closed, per RFC 7009 §2.1 SHOULD). Tokens minted before F-3 that lack a `family_id` claim bypass this check and are validated by signature only.

--- a/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
+++ b/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
@@ -81,7 +81,7 @@ describe("GET /.well-known/openid-configuration", () => {
 			"EdDSA",
 			"HS256",
 		]);
-		expect(body.scopes_supported).toEqual(["openid", "profile", "email"]);
+		expect(body.scopes_supported).toEqual(["openid", "profile", "email", "groups"]);
 		expect(body.code_challenge_methods_supported).toEqual(["S256"]);
 		expect(body.token_endpoint_auth_methods_supported).toEqual(
 			expect.arrayContaining(["client_secret_basic", "client_secret_post", "none"]),
@@ -98,9 +98,22 @@ describe("GET /.well-known/openid-configuration", () => {
 	it("strips trailing slashes from issuer when building endpoint URLs", async () => {
 		const body = await callRoute({
 			issuer: "https://auth.example.com///",
-			signingAlgs: [],
+			signingAlgs: ["RS256"],
 		});
 		expect(body.authorization_endpoint).toBe("https://auth.example.com/oauth/authorize");
 		expect(body.token_endpoint).toBe("https://auth.example.com/oauth/token");
+	});
+
+	it("omits jwks_uri for HS256-only deployments (JWKS route returns 404 for symmetric keys)", async () => {
+		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: ["HS256"] });
+		expect(body.jwks_uri).toBeUndefined();
+	});
+
+	it("advertises jwks_uri when any asymmetric alg is configured (RS256 alongside HS256)", async () => {
+		const body = await callRoute({
+			issuer: "https://auth.example.com",
+			signingAlgs: ["RS256", "HS256"],
+		});
+		expect(body.jwks_uri).toBe("https://auth.example.com/.well-known/jwks.json");
 	});
 });

--- a/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
+++ b/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
@@ -95,11 +95,14 @@ describe("GET /.well-known/openid-configuration", () => {
 		expect(body.backchannel_logout_supported).toBeUndefined();
 	});
 
-	it("strips trailing slashes from issuer when building endpoint URLs", async () => {
+	it("strips trailing slashes from issuer in both the issuer field and endpoint URLs", async () => {
 		const body = await callRoute({
 			issuer: "https://auth.example.com///",
 			signingAlgs: ["RS256"],
 		});
+		// Normalized form is used for both endpoints and the issuer field so
+		// discovery.issuer matches the iss claim on issued tokens.
+		expect(body.issuer).toBe("https://auth.example.com");
 		expect(body.authorization_endpoint).toBe("https://auth.example.com/oauth/authorize");
 		expect(body.token_endpoint).toBe("https://auth.example.com/oauth/token");
 	});

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -829,6 +829,40 @@ describe("createAuthorizationGrant", () => {
 		});
 
 		describe("TODO-F-4: id_token issuance on openid scope", () => {
+			// F-4 reads config.oauth.jwt.issuer directly (not ctx.issuer) for
+			// id_token issuance to avoid using the request-derived host fallback
+			// as an OIDC iss claim. Tests must supply a configured issuer.
+			const mockConfigWithIssuer = {
+				oauth: {
+					jwt: { secret: "test-secret", issuer: "https://auth.example.com" },
+					accessToken: { expiresIn: 3600 },
+					refreshToken: { expiresIn: 86400 },
+					grants: {
+						session: { enabled: true },
+						authorization: { enabled: true },
+						refresh_token: { enabled: true },
+						did: { enabled: true, messageMaxAgeSec: 300 },
+					},
+				},
+			} as unknown as GrantDependencies["config"];
+
+			function makeDepsWithIssuer(
+				consumeByCodeImpl: CodeRepository["consumeByCode"],
+				clientRepository?: ClientRepository,
+			) {
+				return {
+					config: mockConfigWithIssuer,
+					keyStore: createSymmetricKeyStore("test-secret"),
+					codeRepository: {
+						consumeByCode: consumeByCodeImpl,
+						createCode: vi.fn(),
+						getByCode: vi.fn(),
+						removeByCode: vi.fn(),
+					} as unknown as CodeRepository,
+					clientRepository: clientRepository ?? mockClientRepository,
+				};
+			}
+
 			function makeUserSessionStore(session: {
 				sid: string;
 				sub: string;
@@ -869,7 +903,7 @@ describe("createAuthorizationGrant", () => {
 					claims: { email: "a@b.com", emailVerified: true, name: "Alice" },
 				});
 				const deps = {
-					...makeDeps(
+					...makeDepsWithIssuer(
 						vi.fn().mockResolvedValue({
 							code: "c1",
 							sid: "sid-1",
@@ -946,7 +980,7 @@ describe("createAuthorizationGrant", () => {
 					claims: { email: "b@b.com", emailVerified: true, name: "Bob" },
 				});
 				const deps = {
-					...makeDeps(
+					...makeDepsWithIssuer(
 						vi.fn().mockResolvedValue({
 							code: "c2",
 							sid: "sid-2",
@@ -971,7 +1005,7 @@ describe("createAuthorizationGrant", () => {
 
 			it("does NOT include id_token when userSessionStore is not wired (backward compat, F-4-3)", async () => {
 				// No userSessionStore — cannot resolve claims, so id_token is skipped.
-				const deps = makeDeps(
+				const deps = makeDepsWithIssuer(
 					vi.fn().mockResolvedValue({
 						code: "c3",
 						sid: "sid-3",

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -893,6 +893,7 @@ describe("createAuthorizationGrant", () => {
 				if (typeof idTokenStr !== "string") throw new Error("expected id_token string");
 
 				const idPayload = decodeJwt(idTokenStr) as Record<string, unknown>;
+				expect(idPayload.iss).toBe("https://auth.example.com");
 				expect(idPayload.sub).toBe("u-1");
 				expect(idPayload.aud).toBe("client1");
 				expect(idPayload.azp).toBe("client1");
@@ -901,6 +902,39 @@ describe("createAuthorizationGrant", () => {
 				expect(idPayload.email).toBe("a@b.com");
 				// profile scope not granted — name must NOT appear
 				expect(idPayload.name).toBeUndefined();
+			});
+
+			it("does NOT include id_token when issuer is absent (avoids OIDC-noncompliant iss:'')", async () => {
+				const authTime = new Date("2026-04-21T00:00:00Z");
+				const userSessionStore = makeUserSessionStore({
+					sid: "sid-noiss",
+					sub: "u-noiss",
+					authTime,
+					claims: { email: "c@b.com", emailVerified: true },
+				});
+				const deps = {
+					...makeDeps(
+						vi.fn().mockResolvedValue({
+							code: "c-noiss",
+							sid: "sid-noiss",
+							grantedScope: ["openid", "email"],
+							nonce: "client-nonce",
+						}),
+					),
+					userSessionStore,
+				};
+				const handler = createAuthorizationGrant(deps);
+				const { result } = await handler.handle({
+					body: { code: "c-noiss", client_id: "client1" },
+					session: { code: "c-noiss", code_client_id: "client1" },
+					// issuer intentionally omitted
+					metadata: { ip: "127.0.0.1" },
+				});
+
+				expect(result.status).toBe(200);
+				if (!("tokens" in result)) throw new Error("expected tokens");
+				expect(typeof result.tokens.access_token).toBe("string");
+				expect(result.tokens.id_token).toBeUndefined();
 			});
 
 			it("does NOT include id_token when scope lacks openid (F-4-2)", async () => {
@@ -931,6 +965,7 @@ describe("createAuthorizationGrant", () => {
 
 				expect(result.status).toBe(200);
 				if (!("tokens" in result)) throw new Error("expected tokens");
+				expect(typeof result.tokens.access_token).toBe("string");
 				expect(result.tokens.id_token).toBeUndefined();
 			});
 
@@ -953,6 +988,7 @@ describe("createAuthorizationGrant", () => {
 
 				expect(result.status).toBe(200);
 				if (!("tokens" in result)) throw new Error("expected tokens");
+				expect(typeof result.tokens.access_token).toBe("string");
 				expect(result.tokens.id_token).toBeUndefined();
 			});
 		});

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -828,6 +828,135 @@ describe("createAuthorizationGrant", () => {
 			});
 		});
 
+		describe("TODO-F-4: id_token issuance on openid scope", () => {
+			function makeUserSessionStore(session: {
+				sid: string;
+				sub: string;
+				authTime: Date;
+				claims: Record<string, unknown>;
+			}) {
+				return {
+					kind: "spy",
+					linkFamily: vi.fn(async (_sid: string, _fam: string) => {}),
+					registerRP: vi.fn(async (_sid: string, _rp: unknown) => {}),
+					async create() {},
+					async get(querySid: string) {
+						if (querySid !== session.sid) return null;
+						return {
+							sid: session.sid,
+							sub: session.sub,
+							authTime: session.authTime,
+							createdAt: new Date(),
+							expiresAt: new Date(Date.now() + 3600_000),
+							federations: [] as ReadonlyArray<string>,
+							activeRPs: [] as ReadonlyArray<{ clientId: string; registeredAt: Date }>,
+							familyIds: [] as ReadonlyArray<string>,
+							claims: session.claims,
+						};
+					},
+					async updateClaims() {},
+					async removeFederation() {},
+					async delete() {},
+				};
+			}
+
+			it("includes id_token in response when scope contains 'openid' and userSessionStore is wired (F-4-1)", async () => {
+				const authTime = new Date("2026-04-21T00:00:00Z");
+				const userSessionStore = makeUserSessionStore({
+					sid: "sid-1",
+					sub: "u-1",
+					authTime,
+					claims: { email: "a@b.com", emailVerified: true, name: "Alice" },
+				});
+				const deps = {
+					...makeDeps(
+						vi.fn().mockResolvedValue({
+							code: "c1",
+							sid: "sid-1",
+							nonce: "client-nonce",
+							grantedScope: ["openid", "email"],
+						}),
+					),
+					userSessionStore,
+				};
+				const handler = createAuthorizationGrant(deps);
+				const { result } = await handler.handle({
+					body: { code: "c1", client_id: "client1" },
+					session: { code: "c1", code_client_id: "client1" },
+					issuer: "https://auth.example.com",
+					metadata: { ip: "127.0.0.1" },
+				});
+
+				expect(result.status).toBe(200);
+				if (!("tokens" in result)) throw new Error("expected tokens");
+				const idTokenStr = result.tokens.id_token;
+				if (typeof idTokenStr !== "string") throw new Error("expected id_token string");
+
+				const idPayload = decodeJwt(idTokenStr) as Record<string, unknown>;
+				expect(idPayload.sub).toBe("u-1");
+				expect(idPayload.aud).toBe("client1");
+				expect(idPayload.azp).toBe("client1");
+				expect(idPayload.sid).toBe("sid-1");
+				expect(idPayload.nonce).toBe("client-nonce");
+				expect(idPayload.email).toBe("a@b.com");
+				// profile scope not granted — name must NOT appear
+				expect(idPayload.name).toBeUndefined();
+			});
+
+			it("does NOT include id_token when scope lacks openid (F-4-2)", async () => {
+				const authTime = new Date("2026-04-21T00:00:00Z");
+				const userSessionStore = makeUserSessionStore({
+					sid: "sid-2",
+					sub: "u-2",
+					authTime,
+					claims: { email: "b@b.com", emailVerified: true, name: "Bob" },
+				});
+				const deps = {
+					...makeDeps(
+						vi.fn().mockResolvedValue({
+							code: "c2",
+							sid: "sid-2",
+							grantedScope: ["profile", "email"],
+						}),
+					),
+					userSessionStore,
+				};
+				const handler = createAuthorizationGrant(deps);
+				const { result } = await handler.handle({
+					body: { code: "c2", client_id: "client1" },
+					session: { code: "c2", code_client_id: "client1" },
+					issuer: "https://auth.example.com",
+					metadata: { ip: "127.0.0.1" },
+				});
+
+				expect(result.status).toBe(200);
+				if (!("tokens" in result)) throw new Error("expected tokens");
+				expect(result.tokens.id_token).toBeUndefined();
+			});
+
+			it("does NOT include id_token when userSessionStore is not wired (backward compat, F-4-3)", async () => {
+				// No userSessionStore — cannot resolve claims, so id_token is skipped.
+				const deps = makeDeps(
+					vi.fn().mockResolvedValue({
+						code: "c3",
+						sid: "sid-3",
+						grantedScope: ["openid"],
+					}),
+				);
+				const handler = createAuthorizationGrant(deps);
+				const { result } = await handler.handle({
+					body: { code: "c3", client_id: "client1" },
+					session: { code: "c3", code_client_id: "client1" },
+					issuer: "https://auth.example.com",
+					metadata: { ip: "127.0.0.1" },
+				});
+
+				expect(result.status).toBe(200);
+				if (!("tokens" in result)) throw new Error("expected tokens");
+				expect(result.tokens.id_token).toBeUndefined();
+			});
+		});
+
 		describe("TODO-F-3: family_id + sid claims, RP registration", () => {
 			it("happy path: access_token and refresh_token both carry family_id and sid claims (F-3-1)", async () => {
 				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "session-abc" }));

--- a/packages/oauth/src/__tests__/userinfo.test.mts
+++ b/packages/oauth/src/__tests__/userinfo.test.mts
@@ -287,6 +287,66 @@ describe("GET /oauth/userinfo", () => {
 		expect(res.headers["www-authenticate"]).toMatch(/^Bearer/);
 	});
 
+	it("rejects refresh_token (typ: rt+jwt) presented as Bearer (security)", async () => {
+		// Refresh tokens are signed by the same KeyStore and carry sub/sid/scope
+		// claims, so without a typ check they would also pass signature verification.
+		// userinfo MUST accept access tokens only (OIDC Core §5.3.1 + RFC 9068).
+		const rtLikeToken = await new SignJWT({
+			sub: "u-1",
+			aud: "client",
+			scope: "openid email",
+			family_id: "fam-1",
+			sid: "sid-1",
+		})
+			.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+			.setExpirationTime("1h")
+			.setIssuedAt()
+			.sign(secretKey);
+
+		const res = await callUserinfo({
+			token: rtLikeToken,
+			userSessionStore: {
+				kind: "memory",
+				get: vi.fn().mockResolvedValue(baseSession),
+				create: vi.fn(),
+				registerRP: vi.fn(),
+				linkFamily: vi.fn(),
+				updateClaims: vi.fn(),
+				removeFederation: vi.fn(),
+				delete: vi.fn(),
+			},
+			refreshTokenStore: {
+				kind: "memory",
+				isFamilyRevoked: vi.fn().mockResolvedValue(false),
+				rotate: vi.fn(),
+				revokeFamily: vi.fn(),
+			},
+		});
+
+		expect(res.status).toBe(401);
+		expect(res.body.error).toBe("invalid_token");
+		expect(res.headers["www-authenticate"]).toMatch(/^Bearer/);
+	});
+
+	it("rejects id_token (typ: id+jwt) presented as Bearer", async () => {
+		// id_tokens also share the signing key and can carry sub/sid. Belt-and-
+		// suspenders: even if a client misuses an id_token as a bearer, reject it.
+		const idLikeToken = await new SignJWT({
+			sub: "u-1",
+			aud: "client",
+			sid: "sid-1",
+		})
+			.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "id+jwt" })
+			.setExpirationTime("1h")
+			.setIssuedAt()
+			.sign(secretKey);
+
+		const res = await callUserinfo({ token: idLikeToken });
+
+		expect(res.status).toBe(401);
+		expect(res.body.error).toBe("invalid_token");
+	});
+
 	it("sets Cache-Control: no-store on all responses (RFC 6750 §5.3)", async () => {
 		// Success path
 		const token = await mintAT({ family_id: "fam-1", sid: "sid-1", scope: "openid" });

--- a/packages/oauth/src/__tests__/userinfo.test.mts
+++ b/packages/oauth/src/__tests__/userinfo.test.mts
@@ -239,4 +239,84 @@ describe("GET /oauth/userinfo", () => {
 		expect(res.headers["www-authenticate"]).toMatch(/^Bearer/);
 		expect(res.body.error).toBe("invalid_token");
 	});
+
+	it("returns {sub} only when userSessionStore is not wired (backward compat)", async () => {
+		const token = await mintAT({ family_id: "fam-1", sid: "sid-1", scope: "openid email" });
+
+		const res = await callUserinfo({
+			token,
+			userSessionStore: undefined,
+			refreshTokenStore: {
+				kind: "memory",
+				isFamilyRevoked: vi.fn().mockResolvedValue(false),
+				rotate: vi.fn(),
+				revokeFamily: vi.fn(),
+			},
+		});
+
+		expect(res.status).toBe(200);
+		expect(res.body).toEqual({ sub: "u-1" });
+	});
+
+	it("returns 401 invalid_token when userSessionStore.get throws (fail-closed)", async () => {
+		const token = await mintAT({ family_id: "fam-1", sid: "sid-1", scope: "openid email" });
+
+		const res = await callUserinfo({
+			token,
+			userSessionStore: {
+				kind: "memory",
+				get: vi.fn().mockRejectedValue(new Error("redis unavailable")),
+				create: vi.fn(),
+				registerRP: vi.fn(),
+				linkFamily: vi.fn(),
+				updateClaims: vi.fn(),
+				removeFederation: vi.fn(),
+				delete: vi.fn(),
+			},
+			refreshTokenStore: {
+				kind: "memory",
+				isFamilyRevoked: vi.fn().mockResolvedValue(false),
+				rotate: vi.fn(),
+				revokeFamily: vi.fn(),
+			},
+		});
+
+		expect(res.status).toBe(401);
+		expect(res.body.error).toBe("invalid_token");
+		expect(res.body.error_description).toBe("session lookup unavailable");
+		expect(res.headers["www-authenticate"]).toMatch(/^Bearer/);
+	});
+
+	it("sets Cache-Control: no-store on all responses (RFC 6750 §5.3)", async () => {
+		// Success path
+		const token = await mintAT({ family_id: "fam-1", sid: "sid-1", scope: "openid" });
+		const okRes = await callUserinfo({
+			token,
+			userSessionStore: {
+				kind: "memory",
+				get: vi.fn().mockResolvedValue(baseSession),
+				create: vi.fn(),
+				registerRP: vi.fn(),
+				linkFamily: vi.fn(),
+				updateClaims: vi.fn(),
+				removeFederation: vi.fn(),
+				delete: vi.fn(),
+			},
+			refreshTokenStore: {
+				kind: "memory",
+				isFamilyRevoked: vi.fn().mockResolvedValue(false),
+				rotate: vi.fn(),
+				revokeFamily: vi.fn(),
+			},
+		});
+		expect(okRes.status).toBe(200);
+		expect(okRes.headers["cache-control"]).toBe("no-store");
+		expect(okRes.headers.pragma).toBe("no-cache");
+
+		// Error path (no auth header)
+		const errRes = await callUserinfo({ token: null });
+		expect(errRes.status).toBe(401);
+		expect(errRes.headers["cache-control"]).toBe("no-store");
+		expect(errRes.headers.pragma).toBe("no-cache");
+	});
 });

--- a/packages/oauth/src/__tests__/userinfo.test.mts
+++ b/packages/oauth/src/__tests__/userinfo.test.mts
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+	createSymmetricKeyStore,
+	type RefreshTokenStoreBase,
+	type UserSession,
+	type UserSessionStoreBase,
+} from "@o3co/auth-provider-core";
+import express from "express";
+import { SignJWT } from "jose";
+import { createSecretKey } from "node:crypto";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import { createRouter } from "#/routes/userinfo.mjs";
+
+const SECRET = "test-secret-at-least-32-chars!!";
+const keyStore = createSymmetricKeyStore(SECRET);
+const secretKey = createSecretKey(Buffer.from(SECRET));
+
+/**
+ * Mint a signed access token with the given extra claims.
+ * Uses the same symmetric key as the keyStore so verification succeeds.
+ */
+async function mintAT(extra: Record<string, unknown> = {}): Promise<string> {
+	return new SignJWT({ sub: "u-1", aud: "client", scope: "openid email", ...extra })
+		.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "at+jwt" })
+		.setExpirationTime("1h")
+		.setIssuedAt()
+		.sign(secretKey);
+}
+
+interface CallOptions {
+	token: string | null;
+	userSessionStore?: Partial<UserSessionStoreBase>;
+	refreshTokenStore?: Partial<RefreshTokenStoreBase>;
+}
+
+function buildApp(opts: {
+	userSessionStore?: Partial<UserSessionStoreBase>;
+	refreshTokenStore?: Partial<RefreshTokenStoreBase>;
+}) {
+	const app = express();
+	app.use(express.json());
+
+	const router = createRouter(express, {
+		keyStore,
+		userSessionStore: opts.userSessionStore as UserSessionStoreBase | undefined,
+		refreshTokenStore: opts.refreshTokenStore as RefreshTokenStoreBase | undefined,
+	});
+	// Mount at /oauth to match the convention in module.mts
+	app.use("/oauth", router);
+	return app;
+}
+
+async function callUserinfo(opts: CallOptions) {
+	const app = buildApp({
+		userSessionStore: opts.userSessionStore,
+		refreshTokenStore: opts.refreshTokenStore,
+	});
+	const req = request(app).get("/oauth/userinfo");
+	if (opts.token !== null) {
+		req.set("Authorization", `Bearer ${opts.token}`);
+	}
+	return req;
+}
+
+// A minimal but valid UserSession fixture
+const baseSession: UserSession = {
+	sid: "sid-1",
+	sub: "u-1",
+	authTime: new Date(),
+	createdAt: new Date(),
+	expiresAt: new Date(Date.now() + 3_600_000),
+	federations: [],
+	activeRPs: [],
+	familyIds: ["fam-1"],
+	claims: {
+		email: "alice@example.com",
+		emailVerified: true,
+		name: "Alice",
+		picture: "https://example.com/pic",
+	},
+};
+
+describe("GET /oauth/userinfo", () => {
+	it("returns sub + scope-filtered claims for a valid Bearer access_token", async () => {
+		const token = await mintAT({ family_id: "fam-1", sid: "sid-1", scope: "openid email" });
+
+		const res = await callUserinfo({
+			token,
+			userSessionStore: {
+				kind: "memory",
+				get: vi.fn().mockResolvedValue(baseSession),
+				create: vi.fn(),
+				registerRP: vi.fn(),
+				linkFamily: vi.fn(),
+				updateClaims: vi.fn(),
+				removeFederation: vi.fn(),
+				delete: vi.fn(),
+			},
+			refreshTokenStore: {
+				kind: "memory",
+				isFamilyRevoked: vi.fn().mockResolvedValue(false),
+				rotate: vi.fn(),
+				revokeFamily: vi.fn(),
+			},
+		});
+
+		expect(res.status).toBe(200);
+		// scope=openid email → email + email_verified, not name/picture
+		expect(res.body).toEqual({
+			sub: "u-1",
+			email: "alice@example.com",
+			email_verified: true,
+		});
+	});
+
+	it("returns 401 invalid_token when JWT signature is invalid", async () => {
+		const res = await callUserinfo({
+			token: "not.a.valid.jwt",
+			userSessionStore: undefined,
+			refreshTokenStore: undefined,
+		});
+
+		expect(res.status).toBe(401);
+		expect(res.body.error).toBe("invalid_token");
+		expect(res.headers["www-authenticate"]).toBeDefined();
+	});
+
+	it("returns 401 invalid_token when family is revoked", async () => {
+		const token = await mintAT({ family_id: "fam-revoked", sid: "sid-1" });
+
+		const res = await callUserinfo({
+			token,
+			refreshTokenStore: {
+				kind: "memory",
+				isFamilyRevoked: vi.fn().mockResolvedValue(true),
+				rotate: vi.fn(),
+				revokeFamily: vi.fn(),
+			},
+			userSessionStore: {
+				kind: "memory",
+				get: vi.fn().mockResolvedValue(baseSession),
+				create: vi.fn(),
+				registerRP: vi.fn(),
+				linkFamily: vi.fn(),
+				updateClaims: vi.fn(),
+				removeFederation: vi.fn(),
+				delete: vi.fn(),
+			},
+		});
+
+		expect(res.status).toBe(401);
+		expect(res.body.error).toBe("invalid_token");
+	});
+
+	it("returns 401 invalid_token when sid's UserSession is gone", async () => {
+		const token = await mintAT({ family_id: "fam-1", sid: "sid-dead" });
+
+		const res = await callUserinfo({
+			token,
+			userSessionStore: {
+				kind: "memory",
+				get: vi.fn().mockResolvedValue(null),
+				create: vi.fn(),
+				registerRP: vi.fn(),
+				linkFamily: vi.fn(),
+				updateClaims: vi.fn(),
+				removeFederation: vi.fn(),
+				delete: vi.fn(),
+			},
+			refreshTokenStore: {
+				kind: "memory",
+				isFamilyRevoked: vi.fn().mockResolvedValue(false),
+				rotate: vi.fn(),
+				revokeFamily: vi.fn(),
+			},
+		});
+
+		expect(res.status).toBe(401);
+		expect(res.body.error).toBe("invalid_token");
+	});
+
+	it("only emits claims whose scope was granted (profile scope → name only, no email)", async () => {
+		const token = await mintAT({ family_id: "fam-1", sid: "sid-1", scope: "openid profile" });
+
+		const res = await callUserinfo({
+			token,
+			userSessionStore: {
+				kind: "memory",
+				get: vi.fn().mockResolvedValue(baseSession),
+				create: vi.fn(),
+				registerRP: vi.fn(),
+				linkFamily: vi.fn(),
+				updateClaims: vi.fn(),
+				removeFederation: vi.fn(),
+				delete: vi.fn(),
+			},
+			refreshTokenStore: {
+				kind: "memory",
+				isFamilyRevoked: vi.fn().mockResolvedValue(false),
+				rotate: vi.fn(),
+				revokeFamily: vi.fn(),
+			},
+		});
+
+		expect(res.status).toBe(200);
+		// scope=openid profile → name + picture, no email
+		expect(res.body).toEqual({
+			sub: "u-1",
+			name: "Alice",
+			picture: "https://example.com/pic",
+		});
+		expect(res.body).not.toHaveProperty("email");
+	});
+
+	it("missing Authorization header returns 401 with WWW-Authenticate Bearer", async () => {
+		const res = await callUserinfo({
+			token: null,
+			userSessionStore: undefined,
+			refreshTokenStore: undefined,
+		});
+
+		expect(res.status).toBe(401);
+		expect(res.headers["www-authenticate"]).toMatch(/^Bearer/);
+		expect(res.body.error).toBe("invalid_token");
+	});
+});

--- a/packages/oauth/src/__tests__/userinfo.test.mts
+++ b/packages/oauth/src/__tests__/userinfo.test.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { createSecretKey } from "node:crypto";
 import {
 	createSymmetricKeyStore,
 	type RefreshTokenStoreBase,
@@ -22,7 +23,6 @@ import {
 } from "@o3co/auth-provider-core";
 import express from "express";
 import { SignJWT } from "jose";
-import { createSecretKey } from "node:crypto";
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
 import { createRouter } from "#/routes/userinfo.mjs";

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -22,11 +22,11 @@ import {
 	type GrantDependencies,
 	type GrantHandler,
 	type GrantHandlerResult,
-	type Token,
-	type UserSession,
 	generateIdToken,
 	generateToken,
 	generateTokenResponse,
+	type Token,
+	type UserSession,
 } from "@o3co/auth-provider-core";
 import { decodeJwtPayload } from "./_jwtPayload.mjs";
 

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -39,6 +39,17 @@ export const createAuthorizationGrant = (
 	const authorizationConfig = grantsConfig?.authorization as Record<string, unknown> | undefined;
 	const pkceConfig = authorizationConfig?.pkce as Record<string, unknown> | undefined;
 
+	// TODO-F-4: id_token issuance requires a configured issuer URL. We read it
+	// directly from config (not ctx.issuer) because the express adapter falls
+	// back to `req.get("host")` — which is a host string, not an issuer URL —
+	// when config.oauth.jwt.issuer is unset. Emitting a request-derived `iss`
+	// in id_tokens would violate OIDC Core §2 (iss MUST be a URL).
+	const configuredIssuer: string | undefined = (() => {
+		const jwt = (config.oauth as { jwt?: { issuer?: unknown } } | undefined)?.jwt;
+		const value = jwt?.issuer;
+		return typeof value === "string" && value.length > 0 ? value : undefined;
+	})();
+
 	// B-7: structured pkce config (supportedMethods, defaultMethod, required)
 	// Fall back to legacy requireS256 for backward compatibility
 	const supportedMethods: string[] = Array.isArray(pkceConfig?.supportedMethods)
@@ -391,14 +402,16 @@ export const createAuthorizationGrant = (
 			//   F-4-1: openid scope + userSession wired  → id_token issued
 			//   F-4-2: no openid scope                   → id_token omitted
 			//   F-4-3: no userSessionStore               → userSession is null → omitted
-			//   no issuer configured                     → id_token omitted
-			//     (avoids emitting an OIDC-noncompliant `iss: ""` claim; the adapter
-			//      usually falls back to req.get("host"), so this only bites custom
-			//      adapters that pass ctx.issuer = undefined)
+			//   no configured issuer                     → id_token omitted
+			//     We gate on `configuredIssuer` (read directly from
+			//     config.oauth.jwt.issuer at factory time) rather than ctx.issuer,
+			//     because the express adapter falls back to `req.get("host")` when
+			//     config is unset — that is a host string, not an OIDC-compliant
+			//     URL, and using it as `iss` would violate OIDC Core §2.
 			// userSession truthy implies (deps.userSessionStore && sid) were both truthy
 			// earlier, so the `&& sid` guard below is defensive rather than redundant.
 			let idToken: Token | undefined;
-			if (grantedScopes?.includes("openid") && userSession && sid && issuer) {
+			if (grantedScopes?.includes("openid") && userSession && sid && configuredIssuer) {
 				idToken = await generateIdToken({
 					sub: userSession.sub,
 					aud: client_id,
@@ -409,7 +422,7 @@ export const createAuthorizationGrant = (
 					scopes: grantedScopes,
 					userClaims: userSession.claims,
 					keyStore,
-					issuer,
+					issuer: configuredIssuer,
 				});
 			}
 

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -226,7 +226,7 @@ export const createAuthorizationGrant = (
 			const sid = codeData.sid;
 			// TODO-F-4: nonce from the code record — written at /authorize time and
 			// must be reflected verbatim in the id_token per OIDC Core §2.
-			const nonce = codeData.nonce as string | undefined;
+			const nonce = codeData.nonce;
 			if (deps.userSessionStore && !sid) {
 				return {
 					result: {
@@ -387,14 +387,18 @@ export const createAuthorizationGrant = (
 			}
 
 			// TODO-F-4: issue id_token when the openid scope was granted and the
-			// session is available. The condition naturally handles all three cases:
+			// session is available. The condition naturally handles all cases:
 			//   F-4-1: openid scope + userSession wired  → id_token issued
 			//   F-4-2: no openid scope                   → id_token omitted
 			//   F-4-3: no userSessionStore               → userSession is null → omitted
+			//   no issuer configured                     → id_token omitted
+			//     (avoids emitting an OIDC-noncompliant `iss: ""` claim; the adapter
+			//      usually falls back to req.get("host"), so this only bites custom
+			//      adapters that pass ctx.issuer = undefined)
 			// userSession truthy implies (deps.userSessionStore && sid) were both truthy
 			// earlier, so the `&& sid` guard below is defensive rather than redundant.
 			let idToken: Token | undefined;
-			if (grantedScopes?.includes("openid") && userSession && sid) {
+			if (grantedScopes?.includes("openid") && userSession && sid && issuer) {
 				idToken = await generateIdToken({
 					sub: userSession.sub,
 					aud: client_id,
@@ -405,7 +409,7 @@ export const createAuthorizationGrant = (
 					scopes: grantedScopes,
 					userClaims: userSession.claims,
 					keyStore,
-					issuer: issuer ?? "",
+					issuer,
 				});
 			}
 

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -22,6 +22,9 @@ import {
 	type GrantDependencies,
 	type GrantHandler,
 	type GrantHandlerResult,
+	type Token,
+	type UserSession,
+	generateIdToken,
 	generateToken,
 	generateTokenResponse,
 } from "@o3co/auth-provider-core";
@@ -221,6 +224,9 @@ export const createAuthorizationGrant = (
 			// backward-compat regression. When the store IS wired, sid is mandatory
 			// so subsequent linkFamily / registerRP can execute.
 			const sid = codeData.sid;
+			// TODO-F-4: nonce from the code record — written at /authorize time and
+			// must be reflected verbatim in the id_token per OIDC Core §2.
+			const nonce = codeData.nonce as string | undefined;
 			if (deps.userSessionStore && !sid) {
 				return {
 					result: {
@@ -321,13 +327,16 @@ export const createAuthorizationGrant = (
 			// are invisible to logout orchestration.
 			// sid is guaranteed non-null here when deps.userSessionStore is set because
 			// the earlier guard (deps.userSessionStore && !sid) already rejected that case.
+			// TODO-F-4: userSession is lifted outside the block so id_token generation
+			// (below) can use it after the block completes.
+			let userSession: UserSession | null = null;
 			if (deps.userSessionStore && sid) {
 				// Fix I1: validate session still exists (mirrors refresh_token grant pattern).
 				// A session deleted between /authorize and /token exchange must not produce
 				// tokens — they would be orphaned from logout orchestration.
-				let session: Awaited<ReturnType<typeof deps.userSessionStore.get>>;
+				let fetchedSession: Awaited<ReturnType<typeof deps.userSessionStore.get>>;
 				try {
-					session = await deps.userSessionStore.get(sid);
+					fetchedSession = await deps.userSessionStore.get(sid);
 				} catch {
 					return {
 						result: {
@@ -337,7 +346,7 @@ export const createAuthorizationGrant = (
 						},
 					};
 				}
-				if (!session) {
+				if (!fetchedSession) {
 					return {
 						result: {
 							status: 400,
@@ -346,6 +355,7 @@ export const createAuthorizationGrant = (
 						},
 					};
 				}
+				userSession = fetchedSession;
 				// Fix I2: clientRepository.findById is fallible — move inside try/catch
 				// so a throw here returns a controlled 503 instead of propagating to the
 				// express default handler as an unhandled HTML 500.
@@ -376,10 +386,33 @@ export const createAuthorizationGrant = (
 				}
 			}
 
+			// TODO-F-4: issue id_token when the openid scope was granted and the
+			// session is available. The condition naturally handles all three cases:
+			//   F-4-1: openid scope + userSession wired  → id_token issued
+			//   F-4-2: no openid scope                   → id_token omitted
+			//   F-4-3: no userSessionStore               → userSession is null → omitted
+			// userSession truthy implies (deps.userSessionStore && sid) were both truthy
+			// earlier, so the `&& sid` guard below is defensive rather than redundant.
+			let idToken: Token | undefined;
+			if (grantedScopes?.includes("openid") && userSession && sid) {
+				idToken = await generateIdToken({
+					sub: userSession.sub,
+					aud: client_id,
+					azp: client_id,
+					authTime: userSession.authTime,
+					...(nonce ? { nonce } : {}),
+					sid,
+					scopes: grantedScopes,
+					userClaims: userSession.claims,
+					keyStore,
+					issuer: issuer ?? "",
+				});
+			}
+
 			return {
 				result: {
 					status: 200,
-					tokens: generateTokenResponse({ accessToken, refreshToken }),
+					tokens: generateTokenResponse({ accessToken, refreshToken, idToken }),
 				},
 				sessionMutation: {
 					clear: ["code", "code_client_id", "code_redirect_uri", "granted_scopes"],

--- a/packages/oauth/src/module.mts
+++ b/packages/oauth/src/module.mts
@@ -105,6 +105,7 @@ export const oauthModule = (params: {
 			auditSink: context.auditSink,
 			grantPolicy: context.grantPolicy,
 			refreshTokenStore: context.refreshTokenStore,
+			userSessionStore: context.userSessionStore,
 		});
 
 		context.router.use("/oauth", oauthRouter);

--- a/packages/oauth/src/module.mts
+++ b/packages/oauth/src/module.mts
@@ -24,6 +24,7 @@ import {
 } from "@o3co/auth-provider-core";
 import type { RequestHandler, Router } from "express";
 import type { PassportStatic } from "passport";
+import * as oidcConfig from "./routes/OpenidConfiguration.mjs";
 import { createOAuthRouter } from "./routes.mjs";
 
 type ExpressLike = {
@@ -109,5 +110,24 @@ export const oauthModule = (params: {
 		});
 
 		context.router.use("/oauth", oauthRouter);
+
+		// OIDC discovery — mount only when issuer is configured. The module
+		// owns the OAuth endpoints this document advertises (/oauth/authorize,
+		// /oauth/token, /oauth/userinfo, /oauth/introspect), so discovery
+		// belongs here and not in createApp: a deployment that excludes the
+		// OAuth module must not publish a discovery doc pointing at endpoints
+		// that do not exist.
+		const issuer = (config as { oauth?: { jwt?: { issuer?: unknown } } }).oauth?.jwt?.issuer;
+		if (typeof issuer === "string" && issuer.length > 0) {
+			// Advertise only the algorithm the configured KeyStore actually signs
+			// with. Hardcoding the full union would mislead clients to fetch JWKS
+			// expecting a key that is not there (OIDC Core §10.1 + RFC 8414 §2).
+			context.router.use(
+				oidcConfig.createRouter(express, {
+					issuer,
+					signingAlgs: [context.keyStore.algorithm],
+				}),
+			);
+		}
 	},
 });

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -27,10 +27,12 @@ import {
 	type PublicClient,
 	type RateLimiterBase,
 	type RefreshTokenStoreBase,
+	type UserSessionStoreBase,
 } from "@o3co/auth-provider-core";
 import type { Request, RequestHandler, Response, Router } from "express";
 import { decodeProtectedHeader, jwtVerify } from "jose";
 import type { PassportStatic } from "passport";
+import * as userinfo from "./routes/userinfo.mjs";
 
 // Session data type augmentation
 declare module "express-session" {
@@ -64,6 +66,7 @@ export const createOAuthRouter = async (
 		auditSink,
 		grantPolicy,
 		refreshTokenStore,
+		userSessionStore,
 	}: {
 		passport: PassportStatic;
 		registry: GrantRegistry;
@@ -75,6 +78,7 @@ export const createOAuthRouter = async (
 		auditSink?: AuditSinkBase;
 		grantPolicy?: GrantPolicyHookBase;
 		refreshTokenStore?: RefreshTokenStoreBase;
+		userSessionStore?: UserSessionStoreBase;
 	},
 ): Promise<{ router: Router; registry: GrantRegistry }> => {
 	const router = express.Router();
@@ -571,6 +575,9 @@ export const createOAuthRouter = async (
 				error_description: `response_type "${req.query.response_type}" is not supported`,
 			});
 		});
+
+	// OIDC Core §5.3 — UserInfo endpoint
+	router.use(userinfo.createRouter(express, { keyStore, userSessionStore, refreshTokenStore }));
 
 	return { router, registry };
 };

--- a/packages/oauth/src/routes/OpenidConfiguration.mts
+++ b/packages/oauth/src/routes/OpenidConfiguration.mts
@@ -37,7 +37,11 @@ export function createRouter(express: ExpressLike, opts: OidcConfigRouterOptions
 		// asymmetric alg is configured.
 		const hasAsymmetricAlg = opts.signingAlgs.some((alg) => alg !== "HS256");
 		return res.status(200).json({
-			issuer: opts.issuer,
+			// Return the normalized issuer so it matches the `iss` claim minted
+			// on tokens (both use trailing-slash-stripped form). Returning the
+			// raw opts.issuer would cause RPs to reject tokens when iss differs
+			// from discovery.issuer by a trailing slash.
+			issuer: iss,
 			authorization_endpoint: `${iss}/oauth/authorize`,
 			token_endpoint: `${iss}/oauth/token`,
 			userinfo_endpoint: `${iss}/oauth/userinfo`,

--- a/packages/oauth/src/routes/OpenidConfiguration.mts
+++ b/packages/oauth/src/routes/OpenidConfiguration.mts
@@ -31,17 +31,23 @@ export function createRouter(express: ExpressLike, opts: OidcConfigRouterOptions
 
 	router.get("/.well-known/openid-configuration", (_req: Request, res: Response) => {
 		const iss = opts.issuer.replace(/\/+$/, "");
+		// JWKS is not served for symmetric-only deployments (HS256): the
+		// public-key set is empty, so advertising jwks_uri would point
+		// consumers at a 404. Only include jwks_uri when at least one
+		// asymmetric alg is configured.
+		const hasAsymmetricAlg = opts.signingAlgs.some((alg) => alg !== "HS256");
 		return res.status(200).json({
 			issuer: opts.issuer,
 			authorization_endpoint: `${iss}/oauth/authorize`,
 			token_endpoint: `${iss}/oauth/token`,
 			userinfo_endpoint: `${iss}/oauth/userinfo`,
-			jwks_uri: `${iss}/.well-known/jwks.json`,
+			...(hasAsymmetricAlg ? { jwks_uri: `${iss}/.well-known/jwks.json` } : {}),
 			introspection_endpoint: `${iss}/oauth/introspect`,
 			response_types_supported: ["code"],
 			subject_types_supported: ["public"],
 			id_token_signing_alg_values_supported: [...opts.signingAlgs],
-			scopes_supported: ["openid", "profile", "email"],
+			// `groups` is supported by filterClaimsByScope (non-standard but opt-in)
+			scopes_supported: ["openid", "profile", "email", "groups"],
 			token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"],
 			code_challenge_methods_supported: ["S256"],
 			// OUT of F-4 scope: revocation_endpoint, end_session_endpoint,

--- a/packages/oauth/src/routes/userinfo.mts
+++ b/packages/oauth/src/routes/userinfo.mts
@@ -20,8 +20,8 @@ import {
 	type RefreshTokenStoreBase,
 	type UserSessionStoreBase,
 } from "@o3co/auth-provider-core";
-import { decodeProtectedHeader, jwtVerify } from "jose";
 import type { Request, RequestHandler, Response, Router } from "express";
+import { decodeProtectedHeader, jwtVerify } from "jose";
 
 type ExpressLike = {
 	Router: () => Router;
@@ -85,9 +85,7 @@ export function createRouter(express: ExpressLike, opts: UserinfoRouterOptions):
 			payload = verified.payload as Record<string, unknown>;
 		} catch {
 			res.setHeader("WWW-Authenticate", 'Bearer realm="userinfo", error="invalid_token"');
-			return res
-				.status(401)
-				.json({ error: "invalid_token", error_description: "invalid token" });
+			return res.status(401).json({ error: "invalid_token", error_description: "invalid token" });
 		}
 
 		// F-3 cascade revoke: check family_id against RefreshTokenStore.
@@ -143,9 +141,7 @@ export function createRouter(express: ExpressLike, opts: UserinfoRouterOptions):
 		}
 		if (!session) {
 			res.setHeader("WWW-Authenticate", 'Bearer realm="userinfo", error="invalid_token"');
-			return res
-				.status(401)
-				.json({ error: "invalid_token", error_description: "session_invalid" });
+			return res.status(401).json({ error: "invalid_token", error_description: "session_invalid" });
 		}
 
 		// Return sub + scope-filtered claims per OIDC Core §5.4

--- a/packages/oauth/src/routes/userinfo.mts
+++ b/packages/oauth/src/routes/userinfo.mts
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+	filterClaimsByScope,
+	type KeyStore,
+	type RefreshTokenStoreBase,
+	type UserSessionStoreBase,
+} from "@o3co/auth-provider-core";
+import { decodeProtectedHeader, jwtVerify } from "jose";
+import type { Request, RequestHandler, Response, Router } from "express";
+
+type ExpressLike = {
+	Router: () => Router;
+	json: () => RequestHandler;
+	urlencoded: (opts: { extended: boolean }) => RequestHandler;
+};
+
+export interface UserinfoRouterOptions {
+	keyStore: KeyStore;
+	userSessionStore?: UserSessionStoreBase;
+	refreshTokenStore?: RefreshTokenStoreBase;
+}
+
+/**
+ * OIDC Core §5.3 — UserInfo Endpoint.
+ *
+ * Accepts Bearer access_token JWTs and returns scope-filtered claims from
+ * the durable UserSession. Revocation is checked via family_id (cascade
+ * revoke per F-3) and sid (session liveness).
+ *
+ * Error responses follow Bearer Token Usage (RFC 6750 §3.1): 401 with
+ * WWW-Authenticate header. Fail-closed on store errors.
+ */
+export function createRouter(express: ExpressLike, opts: UserinfoRouterOptions): Router {
+	const router = express.Router();
+
+	router.get("/userinfo", async (req: Request, res: Response) => {
+		// RFC 6750 §2.1: Bearer token in Authorization header
+		const auth = req.headers.authorization;
+		if (!auth?.startsWith("Bearer ")) {
+			res.setHeader("WWW-Authenticate", 'Bearer realm="userinfo"');
+			return res
+				.status(401)
+				.json({ error: "invalid_token", error_description: "missing Bearer token" });
+		}
+		const token = auth.slice(7);
+
+		// Verify JWT signature via KeyStore
+		let payload: Record<string, unknown>;
+		try {
+			const { kid } = decodeProtectedHeader(token);
+			const key = await opts.keyStore.getVerificationKey(
+				kid ?? opts.keyStore.getSigningKidFallback(),
+			);
+			const verified = await jwtVerify(token, key);
+			payload = verified.payload as Record<string, unknown>;
+		} catch {
+			res.setHeader("WWW-Authenticate", 'Bearer realm="userinfo", error="invalid_token"');
+			return res
+				.status(401)
+				.json({ error: "invalid_token", error_description: "invalid signature" });
+		}
+
+		// F-3 cascade revoke: check family_id against RefreshTokenStore
+		const familyId = typeof payload.family_id === "string" ? payload.family_id : null;
+		if (familyId !== null && opts.refreshTokenStore) {
+			let revoked: boolean;
+			try {
+				revoked = await opts.refreshTokenStore.isFamilyRevoked(familyId);
+			} catch {
+				// Fail-closed: cannot determine revocation state → treat as revoked
+				res.setHeader("WWW-Authenticate", 'Bearer realm="userinfo", error="invalid_token"');
+				return res
+					.status(401)
+					.json({ error: "invalid_token", error_description: "revocation check unavailable" });
+			}
+			if (revoked) {
+				res.setHeader("WWW-Authenticate", 'Bearer realm="userinfo", error="invalid_token"');
+				return res
+					.status(401)
+					.json({ error: "invalid_token", error_description: "family revoked" });
+			}
+		}
+
+		// Require sub and sid in payload
+		const sub = typeof payload.sub === "string" ? payload.sub : null;
+		const sid = typeof payload.sid === "string" ? payload.sid : null;
+		if (!sub) {
+			res.setHeader("WWW-Authenticate", 'Bearer realm="userinfo", error="invalid_token"');
+			return res
+				.status(401)
+				.json({ error: "invalid_token", error_description: "missing sub claim" });
+		}
+
+		// Without a session store, return only sub (no durable claim source)
+		if (!opts.userSessionStore || !sid) {
+			return res.status(200).json({ sub });
+		}
+
+		// Validate session liveness
+		const session = await opts.userSessionStore.get(sid);
+		if (!session) {
+			res.setHeader("WWW-Authenticate", 'Bearer realm="userinfo", error="invalid_token"');
+			return res
+				.status(401)
+				.json({ error: "invalid_token", error_description: "session_invalid" });
+		}
+
+		// Return sub + scope-filtered claims per OIDC Core §5.4
+		const scopes =
+			typeof payload.scope === "string" ? payload.scope.split(" ").filter(Boolean) : [];
+		const filtered = filterClaimsByScope(session.claims, scopes);
+		return res.status(200).json({ sub, ...filtered });
+	});
+
+	return router;
+}

--- a/packages/oauth/src/routes/userinfo.mts
+++ b/packages/oauth/src/routes/userinfo.mts
@@ -49,6 +49,12 @@ export function createRouter(express: ExpressLike, opts: UserinfoRouterOptions):
 	const router = express.Router();
 
 	router.get("/userinfo", async (req: Request, res: Response) => {
+		// RFC 6750 §5.3 + §6.1: bearer-authenticated responses MUST NOT be cached
+		// by intermediaries. Set this once at the top so it applies to every
+		// response path (200 success, 401 error).
+		res.setHeader("Cache-Control", "no-store");
+		res.setHeader("Pragma", "no-cache");
+
 		// RFC 6750 §2.1: Bearer token in Authorization header
 		const auth = req.headers.authorization;
 		if (!auth?.startsWith("Bearer ")) {
@@ -75,7 +81,10 @@ export function createRouter(express: ExpressLike, opts: UserinfoRouterOptions):
 				.json({ error: "invalid_token", error_description: "invalid signature" });
 		}
 
-		// F-3 cascade revoke: check family_id against RefreshTokenStore
+		// F-3 cascade revoke: check family_id against RefreshTokenStore.
+		// Precondition: only activates when the JWT carries a family_id claim —
+		// tokens minted before F-3 lack this claim and bypass the cascade check
+		// (legacy backward-compat). New tokens always carry family_id per F-3.
 		const familyId = typeof payload.family_id === "string" ? payload.family_id : null;
 		if (familyId !== null && opts.refreshTokenStore) {
 			let revoked: boolean;
@@ -111,8 +120,18 @@ export function createRouter(express: ExpressLike, opts: UserinfoRouterOptions):
 			return res.status(200).json({ sub });
 		}
 
-		// Validate session liveness
-		const session = await opts.userSessionStore.get(sid);
+		// Validate session liveness. Fail-closed on store throw (symmetric with
+		// the refreshTokenStore cascade above): a backend outage must not leak
+		// claims, and returning 401 invalid_token keeps parity with RFC 6750.
+		let session: Awaited<ReturnType<typeof opts.userSessionStore.get>>;
+		try {
+			session = await opts.userSessionStore.get(sid);
+		} catch {
+			res.setHeader("WWW-Authenticate", 'Bearer realm="userinfo", error="invalid_token"');
+			return res
+				.status(401)
+				.json({ error: "invalid_token", error_description: "session lookup unavailable" });
+		}
 		if (!session) {
 			res.setHeader("WWW-Authenticate", 'Bearer realm="userinfo", error="invalid_token"');
 			return res

--- a/packages/oauth/src/routes/userinfo.mts
+++ b/packages/oauth/src/routes/userinfo.mts
@@ -112,7 +112,8 @@ export function createRouter(express: ExpressLike, opts: UserinfoRouterOptions):
 			}
 		}
 
-		// Require sub and sid in payload
+		// sub is required; sid is optional (needed for session-backed claims —
+		// when absent or no userSessionStore wired, we return {sub} only).
 		const sub = typeof payload.sub === "string" ? payload.sub : null;
 		const sid = typeof payload.sid === "string" ? payload.sid : null;
 		if (!sub) {

--- a/packages/oauth/src/routes/userinfo.mts
+++ b/packages/oauth/src/routes/userinfo.mts
@@ -65,12 +65,21 @@ export function createRouter(express: ExpressLike, opts: UserinfoRouterOptions):
 		}
 		const token = auth.slice(7);
 
-		// Verify JWT signature via KeyStore
+		// Verify JWT signature + reject non-access tokens. Refresh tokens
+		// (typ: rt+jwt) and id_tokens (typ: id+jwt) are signed by the same
+		// KeyStore and carry sub/sid/scope claims, so without a typ check
+		// they would also pass signature verification here. RFC 9068
+		// establishes `typ: "at+jwt"` as the indicator that a JWT is
+		// specifically an OAuth 2.0 access token; userinfo is an access-token
+		// resource (OIDC Core §5.3.1), so we require that typ exactly.
 		let payload: Record<string, unknown>;
 		try {
-			const { kid } = decodeProtectedHeader(token);
+			const header = decodeProtectedHeader(token);
+			if (header.typ !== "at+jwt") {
+				throw new Error("invalid token type");
+			}
 			const key = await opts.keyStore.getVerificationKey(
-				kid ?? opts.keyStore.getSigningKidFallback(),
+				header.kid ?? opts.keyStore.getSigningKidFallback(),
 			);
 			const verified = await jwtVerify(token, key);
 			payload = verified.payload as Record<string, unknown>;
@@ -78,7 +87,7 @@ export function createRouter(express: ExpressLike, opts: UserinfoRouterOptions):
 			res.setHeader("WWW-Authenticate", 'Bearer realm="userinfo", error="invalid_token"');
 			return res
 				.status(401)
-				.json({ error: "invalid_token", error_description: "invalid signature" });
+				.json({ error: "invalid_token", error_description: "invalid token" });
 		}
 
 		// F-3 cascade revoke: check family_id against RefreshTokenStore.


### PR DESCRIPTION
## Summary

Completes OIDC Core 1.0 compliance for the auth flow. Follows TODO-F-3 (access_token family_id+sid claims + /introspect cascade).

- **id_token issuance** on `authorization_code` grant when `scope=openid` + `userSessionStore` wired + `issuer` configured
- **`GET /oauth/userinfo`** — Bearer access_token auth (requires `typ: at+jwt`), cascade revoke via family_id, session liveness via sid, scope-filtered claims, `Cache-Control: no-store`, fail-closed on store errors
- **`GET /.well-known/openid-configuration`** — RFC 8414 / OIDC Discovery 1.0 metadata, signing algs sourced from `keyStore.algorithm`
- New core helpers: `generateIdToken`, `filterClaimsByScope` (strict allowlist: profile → name/picture, email → email/email_verified, groups → groups)
- `TokenResponse` gained optional `id_token`
- Module-wiring fix: `oauthModule` threads `userSessionStore` through `createOAuthRouter` (C1 pattern from F-3)

## Security

- `/userinfo` rejects non-access tokens (`typ !== "at+jwt"`) — prevents refresh_token / id_token being presented as Bearer access (regression tests added)
- Discovery advertises only the KeyStore's configured algorithm, not all algs supported by the factory
- Fail-closed on store throws (UserSessionStore.get and RefreshTokenStore.isFamilyRevoked → 401 invalid_token)
- `Cache-Control: no-store` + `Pragma: no-cache` on all /userinfo responses per RFC 6750 §5.3

## Backward compat

All F-4 features degrade cleanly:
- deployments without `userSessionStore` → no id_token, /userinfo returns `{sub}` only
- deployments without `openid` scope → no id_token, AT+RT issued as before
- deployments without configured issuer → discovery route not mounted, no id_token issued (avoids OIDC-noncompliant `iss: ""`)

## Review

- 2-stage review (spec compliance + code quality) per task
- Final multi-agent-review (Claude + Codex) found:
  - **Codex P1** (Critical, security): /userinfo accepted refresh_token as Bearer — fixed with typ check + regression tests
  - **Claude I1 + Codex P2** (convergent, Important): discovery signing_algs hardcoded — now sourced from `keyStore.algorithm`
  - Minor per-task fixes rolled in along the way (Cache-Control, issuer fallback, UserSessionStore throw handling)

## Test plan

- [x] All 912 tests pass (7 packages): core 362, oauth 136, did 134 (+2 todo), session 121 (+1 skipped), foundation 25, create-app 130, standalone 4
- [x] 21 new tests on F-4 paths
- [x] Spec compliance verified per task
- [x] Security: typ=at+jwt check tested (rt+jwt + id+jwt both rejected)
- [x] Backward compat: deployments without userSessionStore / issuer / openid scope all pass

Plan: `.claude/superpowers/plans/2026-04-21-todo-f-4-id-token-userinfo-discovery.md`
Spec: `.claude/superpowers/specs/2026-04-21-todo-f-federation-token-lifecycle-design.md` Sections 3.3 / 6.4 / 6.5 / 9.2–9.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)