### PR TITLE
fix(core): memory UserSessionStore tests use dynamic expiresAt

### DIFF
--- a/packages/core/src/user-sessions/__tests__/memory.test.mts
+++ b/packages/core/src/user-sessions/__tests__/memory.test.mts
@@ -16,8 +16,8 @@ describe("in-memory UserSessionStore", () => {
 	const baseInput = {
 		sid: "sid-1",
 		sub: "user-1",
-		authTime: new Date("2026-04-21T00:00:00Z"),
-		expiresAt: new Date("2026-04-22T00:00:00Z"),
+		authTime: new Date(Date.now() - 3600_000),
+		expiresAt: new Date(Date.now() + 3600_000),
 		claims: { email: "a@b.com" },
 	};
 


### PR DESCRIPTION
## Summary
- Hardcoded `expiresAt: new Date("2026-04-22T00:00:00Z")` in `memory.test.mts` baseInput expired on 2026-04-22, causing 9 tests to fail as the in-memory store GC'd sessions on `get()` immediately after `create()`.
- Switched to `Date.now() + 3600_000` to mirror `redis.test.mts` (which already uses the dynamic pattern).

## Test plan
- [x] `pnpm vitest run packages/core/src/user-sessions/__tests__/memory.test.mts` — 15/15 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)