### PR TITLE
feat(oauth)!: OIDC logout + federation disconnect + back/front-channel (TODO-F-5)

### DIFF
--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -223,6 +223,12 @@ interface Client {
   clientSecret: string;
   allowedRedirectUris: string[];
   allowedScopes: string[];
+  // ログアウトメタデータ (TODO-F-5):
+  postLogoutRedirectUris?: string[];
+  backchannelLogoutUri?: string;
+  backchannelLogoutSessionRequired?: boolean; // デフォルト: true
+  frontchannelLogoutUri?: string;
+  frontchannelLogoutSessionRequired?: boolean; // デフォルト: true
 }
 
 type PublicClient = Omit<Client, "clientSecret">;
@@ -616,8 +622,51 @@ OIDC Discovery 1.0 メタデータエンドポイント。OAuth モジュール�
 - `scopes_supported: ["openid", "profile", "email", "groups"]`
 - `token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"]`
 - `code_challenge_methods_supported: ["S256"]`
+- `end_session_endpoint` — TODO-F-5 で追加
+- `backchannel_logout_supported: true` — TODO-F-5 で追加
+- `backchannel_logout_session_supported: true` — TODO-F-5 で追加
+- `frontchannel_logout_supported: true` — TODO-F-5 で追加
+- `frontchannel_logout_session_supported: true` — TODO-F-5 で追加
 
-追加エンドポイントが必要なフィールド（`revocation_endpoint`、`end_session_endpoint`、back/front-channel logout）は F-4 では省略し、TODO-F-5 で追加予定。
+### ログアウトヘルパー (TODO-F-5)
+
+`@o3co/auth-provider-oauth` の `POST /oauth/logout` が使用する低レベルヘルパー。
+
+#### `generateLogoutToken`
+
+```typescript
+interface GenerateLogoutTokenOptions {
+  readonly issuer: string;
+  readonly sub: string;
+  readonly aud: string | string[];
+  readonly sid?: string;
+  readonly includeSid?: boolean; // デフォルト true
+  readonly keyStore: KeyStore;
+  readonly expiresIn?: number; // デフォルト 300 秒
+}
+
+function generateLogoutToken(opts: GenerateLogoutTokenOptions): Promise<Token>;
+```
+
+OIDC Back-Channel Logout 1.0 §2.4 の `logout_token` JWT に署名して返す。ヘッダーは `typ: logout+jwt`。クレーム構成: `iss`、`sub`、`aud`、`iat`、`exp`、`jti`、および `{ [BACKCHANNEL_LOGOUT_EVENT_URI]: {} }` を値に持つ `events`。デフォルトで `sid` を含む。`backchannel_logout_session_required: false` で登録した RP 向けには `includeSid: false` を指定する。デフォルト TTL は 300 秒。`nonce` クレームは仕様 §2.4 の要件により常に含まれない。
+
+#### `BACKCHANNEL_LOGOUT_EVENT_URI`
+
+```typescript
+const BACKCHANNEL_LOGOUT_EVENT_URI: "http://schemas.openid.net/event/backchannel-logout";
+```
+
+すべての `logout_token` の `events` クレームに必要な正規イベント URI。このリテラルを各所で繰り返さずに参照できるようにエクスポートされている。
+
+#### `Logger`
+
+```typescript
+interface Logger {
+  warn(message: string, ...args: unknown[]): void;
+}
+```
+
+`cascadeLogout`、`broadcastBackchannelLogout` などの内部コールサイトが受け付ける最小の構造的ロガーインターフェース。`console`、pino、winston、bunyan など、互換 shape を持つオブジェクトであれば構造的に適合する。内部コールサイトが必要になった時点で追加メソッド（`info`、`error`、`debug`）を追加する。
 
 ## 関連
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -223,6 +223,12 @@ interface Client {
   clientSecret: string;
   allowedRedirectUris: string[];
   allowedScopes: string[];
+  // Logout metadata (TODO-F-5):
+  postLogoutRedirectUris?: string[];
+  backchannelLogoutUri?: string;
+  backchannelLogoutSessionRequired?: boolean; // default: true
+  frontchannelLogoutUri?: string;
+  frontchannelLogoutSessionRequired?: boolean; // default: true
 }
 
 type PublicClient = Omit<Client, "clientSecret">;
@@ -617,8 +623,51 @@ OIDC Discovery 1.0 metadata endpoint. Registered by the OAuth module (`@o3co/aut
 - `scopes_supported: ["openid", "profile", "email", "groups"]`
 - `token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"]`
 - `code_challenge_methods_supported: ["S256"]`
+- `end_session_endpoint` — added in TODO-F-5
+- `backchannel_logout_supported: true` — added in TODO-F-5
+- `backchannel_logout_session_supported: true` — added in TODO-F-5
+- `frontchannel_logout_supported: true` — added in TODO-F-5
+- `frontchannel_logout_session_supported: true` — added in TODO-F-5
 
-Fields that require additional endpoints (`revocation_endpoint`, `end_session_endpoint`, back/front-channel logout) are omitted in F-4 and will be added in TODO-F-5.
+### Logout helpers (TODO-F-5)
+
+Low-level helpers used by `POST /oauth/logout` in `@o3co/auth-provider-oauth`.
+
+#### `generateLogoutToken`
+
+```typescript
+interface GenerateLogoutTokenOptions {
+  readonly issuer: string;
+  readonly sub: string;
+  readonly aud: string | string[];
+  readonly sid?: string;
+  readonly includeSid?: boolean; // default true
+  readonly keyStore: KeyStore;
+  readonly expiresIn?: number; // default 300 s
+}
+
+function generateLogoutToken(opts: GenerateLogoutTokenOptions): Promise<Token>;
+```
+
+Generates a signed `logout_token` JWT (OIDC Back-Channel Logout 1.0 §2.4). Header `typ: logout+jwt`. Claim composition: `iss`, `sub`, `aud`, `iat`, `exp`, `jti`, and `events` carrying `{ [BACKCHANNEL_LOGOUT_EVENT_URI]: {} }`. The `sid` claim is included by default; set `includeSid: false` for RPs registered with `backchannel_logout_session_required: false`. Default TTL is 300 s. The `nonce` claim is never included (spec §2.4 requirement).
+
+#### `BACKCHANNEL_LOGOUT_EVENT_URI`
+
+```typescript
+const BACKCHANNEL_LOGOUT_EVENT_URI: "http://schemas.openid.net/event/backchannel-logout";
+```
+
+The canonical event URI required in every `logout_token`'s `events` claim. Exported so downstream code and tests can reference it without re-literalizing.
+
+#### `Logger`
+
+```typescript
+interface Logger {
+  warn(message: string, ...args: unknown[]): void;
+}
+```
+
+Minimal structural logger interface accepted by `cascadeLogout`, `broadcastBackchannelLogout`, and other internal call sites. Structurally compatible with `console`, pino, winston, bunyan, etc. Additional methods (`info`, `error`, `debug`) are added when an internal consumer needs them.
 
 ## See Also
 

--- a/packages/core/src/grants/__tests__/logoutToken.test.mts
+++ b/packages/core/src/grants/__tests__/logoutToken.test.mts
@@ -1,0 +1,100 @@
+import { decodeJwt, decodeProtectedHeader } from "jose";
+import { describe, expect, it } from "vitest";
+import { createSymmetricKeyStore } from "#/keys/KeyStore.mjs";
+import { generateLogoutToken } from "../logoutToken.mjs";
+
+describe("generateLogoutToken (OIDC Back-Channel Logout 1.0)", () => {
+	const keyStore = createSymmetricKeyStore("test-secret-32-chars-xxxxxxxxxx");
+
+	it("emits typ: logout+jwt header", async () => {
+		const { token } = await generateLogoutToken({
+			issuer: "iss",
+			sub: "u",
+			aud: "c",
+			sid: "s",
+			keyStore,
+		});
+		expect(decodeProtectedHeader(token).typ).toBe("logout+jwt");
+	});
+
+	it("includes required claims: iss, sub, aud, iat, jti, events, sid", async () => {
+		const { token } = await generateLogoutToken({
+			issuer: "https://auth",
+			sub: "u-1",
+			aud: "rp",
+			sid: "sid-1",
+			keyStore,
+		});
+		const p = decodeJwt(token);
+		expect(p.iss).toBe("https://auth");
+		expect(p.sub).toBe("u-1");
+		expect(p.aud).toBe("rp");
+		expect(p.sid).toBe("sid-1");
+		expect(typeof p.iat).toBe("number");
+		expect(typeof p.jti).toBe("string");
+		expect(p.events).toEqual({ "http://schemas.openid.net/event/backchannel-logout": {} });
+	});
+
+	it("does NOT include nonce claim (spec §2.4 forbids nonce)", async () => {
+		const { token } = await generateLogoutToken({
+			issuer: "iss",
+			sub: "u",
+			aud: "c",
+			sid: "s",
+			keyStore,
+		});
+		expect((decodeJwt(token) as Record<string, unknown>).nonce).toBeUndefined();
+	});
+
+	it("omits sid when includeSid: false (honors backchannelLogoutSessionRequired=false)", async () => {
+		const { token } = await generateLogoutToken({
+			issuer: "iss",
+			sub: "u",
+			aud: "c",
+			keyStore,
+			includeSid: false,
+		});
+		expect((decodeJwt(token) as Record<string, unknown>).sid).toBeUndefined();
+	});
+
+	it("short TTL by default (5 minutes)", async () => {
+		const { token } = await generateLogoutToken({
+			issuer: "iss",
+			sub: "u",
+			aud: "c",
+			sid: "s",
+			keyStore,
+		});
+		const p = decodeJwt(token);
+		expect((p.exp as number) - (p.iat as number)).toBe(300);
+	});
+
+	it("throws when sid is empty string and includeSid is true (default)", async () => {
+		await expect(
+			generateLogoutToken({ issuer: "iss", sub: "u", aud: "c", sid: "", keyStore }),
+		).rejects.toThrow(/sid must not be empty/);
+	});
+
+	it("does not throw on empty sid when includeSid is false (sid omitted anyway)", async () => {
+		const { token } = await generateLogoutToken({
+			issuer: "iss",
+			sub: "u",
+			aud: "c",
+			sid: "",
+			keyStore,
+			includeSid: false,
+		});
+		expect((decodeJwt(token) as Record<string, unknown>).sid).toBeUndefined();
+	});
+
+	it("accepts aud as array of strings", async () => {
+		const { token } = await generateLogoutToken({
+			issuer: "iss",
+			sub: "u",
+			aud: ["rp1", "rp2"],
+			sid: "s",
+			keyStore,
+		});
+		expect(decodeJwt(token).aud).toEqual(["rp1", "rp2"]);
+	});
+});

--- a/packages/core/src/grants/logoutToken.mts
+++ b/packages/core/src/grants/logoutToken.mts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { JWTPayload, KeyStore } from "../keys/KeyStore.mjs";
+import type { Token } from "./token.mjs";
+
+/**
+ * Options for `generateLogoutToken` (OIDC Back-Channel Logout 1.0).
+ */
+export interface GenerateLogoutTokenOptions {
+	/** Issuer URL (MUST match the id_token `iss` claim for the session being logged out). */
+	readonly issuer: string;
+	/** Subject identifier of the user being logged out. */
+	readonly sub: string;
+	/** Audience — the client_id of the RP receiving this logout_token. */
+	readonly aud: string | string[];
+	/** Session identifier (MUST match the id_token `sid` claim when present). */
+	readonly sid?: string;
+	/**
+	 * Whether to include the `sid` claim. Defaults to `true` for security — most RPs
+	 * require sid to correlate the logout with their local session. Set to `false`
+	 * only when the RP registered with `backchannel_logout_session_required: false`.
+	 */
+	readonly includeSid?: boolean;
+	/** JWT signer. */
+	readonly keyStore: KeyStore;
+	/** TTL in seconds. Defaults to 300 (5 minutes) per Back-Channel Logout 1.0 best practice. */
+	readonly expiresIn?: number;
+}
+
+export const BACKCHANNEL_LOGOUT_EVENT_URI = "http://schemas.openid.net/event/backchannel-logout";
+
+/**
+ * Generates a signed logout_token JWT (OIDC Back-Channel Logout 1.0 §2.4).
+ *
+ * Claim composition:
+ *   - iss, sub, aud (required)
+ *   - iat, exp (seconds since epoch; default TTL 300s)
+ *   - jti (unique token identifier)
+ *   - events: { [BACKCHANNEL_LOGOUT_EVENT_URI]: {} } (required by spec)
+ *   - sid (session identifier; included by default, omit with includeSid: false)
+ *
+ * Spec constraints enforced:
+ *   - nonce MUST NOT be present (§2.4)
+ *   - typ header set to "logout+jwt"
+ */
+export async function generateLogoutToken(opts: GenerateLogoutTokenOptions): Promise<Token> {
+	if ((opts.includeSid ?? true) && opts.sid !== undefined && opts.sid === "") {
+		throw new Error("generateLogoutToken: sid must not be empty when includeSid is true");
+	}
+	const now = Math.floor(Date.now() / 1000);
+	const expiresIn = opts.expiresIn ?? 300;
+	const includeSid = opts.includeSid ?? true;
+	const claims: JWTPayload = {
+		iss: opts.issuer,
+		sub: opts.sub,
+		aud: opts.aud,
+		iat: now,
+		exp: now + expiresIn,
+		jti: randomUUID(),
+		events: { [BACKCHANNEL_LOGOUT_EVENT_URI]: {} },
+		...(includeSid && opts.sid ? { sid: opts.sid } : {}),
+	};
+	const token = await opts.keyStore.sign({ claims, header: { typ: "logout+jwt" } });
+	// Token.audience is string — join multi-audience arrays with comma for storage.
+	const audience = Array.isArray(opts.aud) ? opts.aud.join(",") : opts.aud;
+	return {
+		token,
+		expiresIn,
+		subject: opts.sub,
+		audience,
+		issuer: opts.issuer,
+		// tokenType is intentionally omitted — logout_token is not at+jwt / rt+jwt.
+	};
+}

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -56,6 +56,12 @@ export {
 	type GenerateIdTokenOptions,
 	generateIdToken,
 } from "./grants/idToken.mjs";
+// logout_token generation (OIDC Back-Channel Logout 1.0 §2.4)
+export {
+	BACKCHANNEL_LOGOUT_EVENT_URI,
+	type GenerateLogoutTokenOptions,
+	generateLogoutToken,
+} from "./grants/logoutToken.mjs";
 // Grant types and interfaces
 export { GrantRegistry } from "./grants/registry.mjs";
 // Token formatting utility (used by oauth package)

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -102,6 +102,8 @@ export {
 	createAsymmetricKeyStore,
 	createSymmetricKeyStore,
 } from "./keys/KeyStore.mjs";
+// Logging
+export type { Logger } from "./logging/Logger.mjs";
 export { createMfaProviderFactory } from "./mfa/factory.mjs";
 export type { MfaRouteDeps } from "./mfa/route.mjs";
 export { createMfaRouter } from "./mfa/route.mjs";

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -125,7 +125,12 @@ export type {
 } from "./mfa/types.mjs";
 export { supportsEnrollment, supportsRevocation } from "./mfa/types.mjs";
 // Module system
-export type { FederationProviderHandle, Module, ModuleContext, PathResolver } from "./modules/index.mjs";
+export type {
+	FederationProviderHandle,
+	Module,
+	ModuleContext,
+	PathResolver,
+} from "./modules/index.mjs";
 export { createGrantPolicyHookFactory } from "./policy/factory.mjs";
 // Grant policy
 export type {

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -125,7 +125,7 @@ export type {
 } from "./mfa/types.mjs";
 export { supportsEnrollment, supportsRevocation } from "./mfa/types.mjs";
 // Module system
-export type { Module, ModuleContext, PathResolver } from "./modules/index.mjs";
+export type { FederationProviderHandle, Module, ModuleContext, PathResolver } from "./modules/index.mjs";
 export { createGrantPolicyHookFactory } from "./policy/factory.mjs";
 // Grant policy
 export type {

--- a/packages/core/src/logging/Logger.mts
+++ b/packages/core/src/logging/Logger.mts
@@ -14,10 +14,15 @@
  */
 
 /**
- * Minimal structural logger interface for logout helpers.
- * Accepts `console` and any structured logger (pino, winston, etc.)
- * with a compatible `warn(message, ...args)` signature.
+ * Minimal structural logger interface used by @o3co/auth-provider internals.
+ *
+ * Structurally compatible with `console`, pino, winston, bunyan, etc. Consumers
+ * can pass any object matching the subset of methods used at each call site.
+ *
+ * Additional methods (`info`, `error`, `debug`) will be added when an internal
+ * call site needs them — kept minimal until then to avoid implementers having
+ * to stub unused methods.
  */
-export interface LogoutLogger {
+export interface Logger {
 	warn(message: string, ...args: unknown[]): void;
 }

--- a/packages/core/src/modules/index.mts
+++ b/packages/core/src/modules/index.mts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export type { Module, ModuleContext, PathResolver } from "./types.mjs";
+export type { FederationProviderHandle, Module, ModuleContext, PathResolver } from "./types.mjs";

--- a/packages/core/src/modules/types.mts
+++ b/packages/core/src/modules/types.mts
@@ -34,6 +34,20 @@ import type { UserSessionStoreBase } from "../user-sessions/types.mjs";
 export type PathResolver = (specifier: string) => string;
 
 /**
+ * Minimal structural type for a federation provider as seen from ModuleContext.
+ *
+ * `FederationProviderBase` is defined in `@o3co/auth-provider-session`, which depends
+ * on core — a direct import would create a circular dependency. This structural alias
+ * captures only the shape that consumers of `ModuleContext.federationProviders` need
+ * to look up providers. Modules that need the full capability surface (e.g. `endSession`)
+ * import `FederationProviderBase` and `supportsLogout` from `@o3co/auth-provider-session`
+ * and narrow with `instanceof` / type guards after reading from the map.
+ */
+export interface FederationProviderHandle {
+	readonly name: string;
+}
+
+/**
  * Context provided to each Module during initialization.
  * config is typed as CoreConfig & Record<string, unknown> to allow modules
  * to cast to their specific config shape while remaining compatible with
@@ -54,6 +68,25 @@ export interface ModuleContext {
 	grantPolicy?: GrantPolicyHookBase;
 	userSessionStore?: UserSessionStoreBase;
 	federationTokenStore?: FederationTokenStoreBase;
+	/**
+	 * Federation providers Map, populated by the session module during its init phase.
+	 * Populated during the session module's `init` phase. Other modules that need
+	 * to resolve providers (e.g. the oauth logout router) MUST read this field
+	 * LAZILY — either from a callback passed at request time, or in their own
+	 * handler logic — because module `init` order is not guaranteed relative to
+	 * the session module. Eagerly capturing this field during another module's
+	 * `init` will silently produce `undefined` when the session module inits
+	 * later in the sequence.
+	 *
+	 * `undefined` when no federation is configured or the session module isn't
+	 * registered. Writers MUST populate this exactly once during their own `init`.
+	 *
+	 * NOTE: This is the one non-readonly field on ModuleContext. It is intentionally
+	 * mutable so the session module can populate it during its own init without the
+	 * platform needing prior knowledge of which providers are configured. All other
+	 * consumers treat it as read-only after init completes.
+	 */
+	federationProviders?: ReadonlyMap<string, FederationProviderHandle>;
 }
 
 /**

--- a/packages/core/src/repositories/InMemoryClientRepository.mts
+++ b/packages/core/src/repositories/InMemoryClientRepository.mts
@@ -20,6 +20,31 @@ import { z } from "zod";
 import type { ClientRepository, PublicClient } from "./ClientRepository.mjs";
 
 /**
+ * Validates that a URL string uses only `http:` or `https:` schemes.
+ * Rejects `javascript:`, `data:`, `file:`, and other dangerous schemes that
+ * could enable XSS when embedded in `<iframe src="...">` (front-channel logout)
+ * or used in redirect flows.
+ *
+ * @internal — shared only with unit tests in this package.
+ */
+const httpUrlSchema = z
+	.string()
+	.url()
+	.refine(
+		(u) => {
+			try {
+				const scheme = new URL(u).protocol;
+				return scheme === "https:" || scheme === "http:";
+			} catch {
+				// new URL() threw — the string is not a valid absolute URL;
+				// z.string().url() already rejects it, so return false here too.
+				return false;
+			}
+		},
+		{ message: "URL must use http: or https: scheme" },
+	);
+
+/**
  * @internal
  *
  * Zod schema for per-client configuration entries consumed by the in-memory and
@@ -35,8 +60,10 @@ export const ClientEntrySchema = z
 		allowedRedirectUris: z.array(z.string()).default([]),
 		allowedScopes: z.array(z.string()).default([]),
 		// NEW (TODO-F-5): Logout metadata.
-		postLogoutRedirectUris: z.array(z.string().url()).optional(),
-		backchannelLogoutUri: z.string().url().optional(),
+		// Use httpUrlSchema (not z.string().url()) for fields that end up in iframe src
+		// or redirect targets — rejects javascript:, data:, file: to prevent XSS.
+		postLogoutRedirectUris: z.array(httpUrlSchema).optional(),
+		backchannelLogoutUri: httpUrlSchema.optional(),
 		// NOTE: OIDC Back-Channel Logout 1.0 §2.2 defines backchannel_logout_session_required
 		// as defaulting to `false` when omitted. This implementation intentionally defaults to
 		// `true` to include `sid` in logout_token by default, which mitigates CSRF / session-
@@ -45,7 +72,7 @@ export const ClientEntrySchema = z
 		// to `false`. The OIDC Discovery metadata (`backchannel_logout_session_supported`,
 		// `frontchannel_logout_session_supported`) must advertise `true` — see Task 7.
 		backchannelLogoutSessionRequired: z.boolean().optional().default(true),
-		frontchannelLogoutUri: z.string().url().optional(),
+		frontchannelLogoutUri: httpUrlSchema.optional(),
 		frontchannelLogoutSessionRequired: z.boolean().optional().default(true),
 	})
 	.strict();

--- a/packages/core/src/repositories/InMemoryClientRepository.mts
+++ b/packages/core/src/repositories/InMemoryClientRepository.mts
@@ -19,11 +19,34 @@ import bcrypt from "bcrypt";
 import { z } from "zod";
 import type { ClientRepository, PublicClient } from "./ClientRepository.mjs";
 
+/**
+ * @internal
+ *
+ * Zod schema for per-client configuration entries consumed by the in-memory and
+ * YAML client repositories. NOT part of the public API — consumers implementing
+ * a custom `ClientRepository` should define their own input schema suited to
+ * their backing store (database row, JWT claims, LDAP attributes, etc.).
+ * This schema is exported only to share fixtures with unit tests within the
+ * package.
+ */
 export const ClientEntrySchema = z
 	.object({
 		clientSecret: z.string().min(1),
 		allowedRedirectUris: z.array(z.string()).default([]),
 		allowedScopes: z.array(z.string()).default([]),
+		// NEW (TODO-F-5): Logout metadata.
+		postLogoutRedirectUris: z.array(z.string().url()).optional(),
+		backchannelLogoutUri: z.string().url().optional(),
+		// NOTE: OIDC Back-Channel Logout 1.0 §2.2 defines backchannel_logout_session_required
+		// as defaulting to `false` when omitted. This implementation intentionally defaults to
+		// `true` to include `sid` in logout_token by default, which mitigates CSRF / session-
+		// confusion risk for self-hosted deployments where RPs often cannot correlate logouts
+		// without sid. Clients that want the spec-default behavior must set the field explicitly
+		// to `false`. The OIDC Discovery metadata (`backchannel_logout_session_supported`,
+		// `frontchannel_logout_session_supported`) must advertise `true` — see Task 7.
+		backchannelLogoutSessionRequired: z.boolean().optional().default(true),
+		frontchannelLogoutUri: z.string().url().optional(),
+		frontchannelLogoutSessionRequired: z.boolean().optional().default(true),
 	})
 	.strict();
 
@@ -33,7 +56,11 @@ export class InMemoryClientRepository implements ClientRepository {
 	private clients: Map<string, ClientEntry>;
 
 	constructor(clients: Map<string, ClientEntry>) {
-		this.clients = clients;
+		// Parse each entry through the schema to enforce defaults (e.g. backchannelLogoutSessionRequired
+		// and frontchannelLogoutSessionRequired default to `true`).
+		this.clients = new Map(
+			Array.from(clients.entries()).map(([id, entry]) => [id, ClientEntrySchema.parse(entry)]),
+		);
 	}
 
 	async findById(clientId: string): Promise<PublicClient | null> {
@@ -43,6 +70,17 @@ export class InMemoryClientRepository implements ClientRepository {
 			clientId,
 			allowedRedirectUris: entry.allowedRedirectUris,
 			allowedScopes: entry.allowedScopes,
+			...(entry.postLogoutRedirectUris !== undefined && {
+				postLogoutRedirectUris: entry.postLogoutRedirectUris,
+			}),
+			...(entry.backchannelLogoutUri !== undefined && {
+				backchannelLogoutUri: entry.backchannelLogoutUri,
+			}),
+			backchannelLogoutSessionRequired: entry.backchannelLogoutSessionRequired,
+			...(entry.frontchannelLogoutUri !== undefined && {
+				frontchannelLogoutUri: entry.frontchannelLogoutUri,
+			}),
+			frontchannelLogoutSessionRequired: entry.frontchannelLogoutSessionRequired,
 		};
 	}
 
@@ -68,6 +106,17 @@ export class InMemoryClientRepository implements ClientRepository {
 			clientId,
 			allowedRedirectUris: entry.allowedRedirectUris,
 			allowedScopes: entry.allowedScopes,
+			...(entry.postLogoutRedirectUris !== undefined && {
+				postLogoutRedirectUris: entry.postLogoutRedirectUris,
+			}),
+			...(entry.backchannelLogoutUri !== undefined && {
+				backchannelLogoutUri: entry.backchannelLogoutUri,
+			}),
+			backchannelLogoutSessionRequired: entry.backchannelLogoutSessionRequired,
+			...(entry.frontchannelLogoutUri !== undefined && {
+				frontchannelLogoutUri: entry.frontchannelLogoutUri,
+			}),
+			frontchannelLogoutSessionRequired: entry.frontchannelLogoutSessionRequired,
 		};
 	}
 }

--- a/packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts
+++ b/packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts
@@ -151,6 +151,45 @@ describe("InMemoryClientRepository", () => {
 		});
 	});
 
+	describe("ClientEntrySchema URL scheme allowlist (F-5 XSS hardening)", () => {
+		const baseEntry = {
+			clientSecret: "secret",
+			allowedRedirectUris: [],
+			allowedScopes: [],
+		};
+
+		it.each([
+			["postLogoutRedirectUris", { postLogoutRedirectUris: ["javascript:alert(1)"] }],
+			["postLogoutRedirectUris", { postLogoutRedirectUris: ["data:text/html,<script>alert(1)</script>"] }],
+			["postLogoutRedirectUris", { postLogoutRedirectUris: ["file:///etc/passwd"] }],
+			["backchannelLogoutUri", { backchannelLogoutUri: "javascript:alert(1)" }],
+			["frontchannelLogoutUri", { frontchannelLogoutUri: "javascript:alert(1)" }],
+		])("rejects %s with scheme %s", (_field, override) => {
+			const result = ClientEntrySchema.safeParse({ ...baseEntry, ...override });
+			expect(result.success).toBe(false);
+		});
+
+		it("accepts https: scheme for all three logout URI fields", () => {
+			const result = ClientEntrySchema.safeParse({
+				...baseEntry,
+				postLogoutRedirectUris: ["https://rp.example/logged-out"],
+				backchannelLogoutUri: "https://rp.example/backchannel-logout",
+				frontchannelLogoutUri: "https://rp.example/fc-logout",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("accepts http: scheme for local/dev URIs", () => {
+			const result = ClientEntrySchema.safeParse({
+				...baseEntry,
+				postLogoutRedirectUris: ["http://localhost:3000/logged-out"],
+				backchannelLogoutUri: "http://localhost:3000/back-logout",
+				frontchannelLogoutUri: "http://localhost:3000/fc-logout",
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+
 	describe("authenticate", () => {
 		it("returns client with correct plain text secret", async () => {
 			const repo = new InMemoryClientRepository(

--- a/packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts
+++ b/packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts
@@ -15,7 +15,10 @@
  */
 import bcrypt from "bcrypt";
 import { describe, expect, it } from "vitest";
-import { ClientEntrySchema, InMemoryClientRepository } from "#/repositories/InMemoryClientRepository.mjs";
+import {
+	ClientEntrySchema,
+	InMemoryClientRepository,
+} from "#/repositories/InMemoryClientRepository.mjs";
 
 describe("InMemoryClientRepository", () => {
 	describe("findById", () => {
@@ -160,7 +163,10 @@ describe("InMemoryClientRepository", () => {
 
 		it.each([
 			["postLogoutRedirectUris", { postLogoutRedirectUris: ["javascript:alert(1)"] }],
-			["postLogoutRedirectUris", { postLogoutRedirectUris: ["data:text/html,<script>alert(1)</script>"] }],
+			[
+				"postLogoutRedirectUris",
+				{ postLogoutRedirectUris: ["data:text/html,<script>alert(1)</script>"] },
+			],
 			["postLogoutRedirectUris", { postLogoutRedirectUris: ["file:///etc/passwd"] }],
 			["backchannelLogoutUri", { backchannelLogoutUri: "javascript:alert(1)" }],
 			["frontchannelLogoutUri", { frontchannelLogoutUri: "javascript:alert(1)" }],

--- a/packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts
+++ b/packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts
@@ -15,7 +15,7 @@
  */
 import bcrypt from "bcrypt";
 import { describe, expect, it } from "vitest";
-import { InMemoryClientRepository } from "#/repositories/InMemoryClientRepository.mjs";
+import { ClientEntrySchema, InMemoryClientRepository } from "#/repositories/InMemoryClientRepository.mjs";
 
 describe("InMemoryClientRepository", () => {
 	describe("findById", () => {
@@ -55,6 +55,99 @@ describe("InMemoryClientRepository", () => {
 			);
 			const client = await repo.findById("nonexistent-client");
 			expect(client).toBeNull();
+		});
+	});
+
+	describe("logout metadata fields round-trip", () => {
+		it("preserves all logout fields when set", async () => {
+			const repo = new InMemoryClientRepository(
+				new Map([
+					[
+						"logout-client",
+						{
+							clientSecret: "secret",
+							allowedRedirectUris: ["http://localhost:3000/callback"],
+							allowedScopes: ["openid"],
+							postLogoutRedirectUris: [
+								"http://localhost:3000/logged-out",
+								"http://localhost:3000/home",
+							],
+							backchannelLogoutUri: "http://localhost:3000/backchannel-logout",
+							backchannelLogoutSessionRequired: false,
+							frontchannelLogoutUri: "http://localhost:3000/frontchannel-logout",
+							frontchannelLogoutSessionRequired: false,
+						},
+					],
+				]),
+			);
+			const client = await repo.findById("logout-client");
+			expect(client).not.toBeNull();
+			expect(client?.postLogoutRedirectUris).toEqual([
+				"http://localhost:3000/logged-out",
+				"http://localhost:3000/home",
+			]);
+			expect(client?.backchannelLogoutUri).toBe("http://localhost:3000/backchannel-logout");
+			expect(client?.backchannelLogoutSessionRequired).toBe(false);
+			expect(client?.frontchannelLogoutUri).toBe("http://localhost:3000/frontchannel-logout");
+			expect(client?.frontchannelLogoutSessionRequired).toBe(false);
+		});
+
+		it("omits optional logout URI fields when not set, but session-required booleans default to true", async () => {
+			const repo = new InMemoryClientRepository(
+				new Map([
+					[
+						"no-logout-client",
+						{
+							clientSecret: "secret",
+							allowedRedirectUris: [],
+							allowedScopes: [],
+						},
+					],
+				]),
+			);
+			const client = await repo.findById("no-logout-client");
+			expect(client).not.toBeNull();
+			// URI fields remain absent when not configured.
+			expect(client).not.toHaveProperty("postLogoutRedirectUris");
+			expect(client).not.toHaveProperty("backchannelLogoutUri");
+			expect(client).not.toHaveProperty("frontchannelLogoutUri");
+			// Session-required booleans default to true (intentional deviation from OIDC spec default
+			// of false — see ClientEntrySchema for rationale).
+			expect(client?.backchannelLogoutSessionRequired).toBe(true);
+			expect(client?.frontchannelLogoutSessionRequired).toBe(true);
+		});
+
+		it("explicit false is preserved (not overwritten by default)", async () => {
+			const repo = new InMemoryClientRepository(
+				new Map([
+					[
+						"explicit-false-client",
+						{
+							clientSecret: "secret",
+							allowedRedirectUris: [],
+							allowedScopes: [],
+							backchannelLogoutSessionRequired: false,
+							frontchannelLogoutSessionRequired: false,
+						},
+					],
+				]),
+			);
+			const client = await repo.findById("explicit-false-client");
+			expect(client).not.toBeNull();
+			expect(client?.backchannelLogoutSessionRequired).toBe(false);
+			expect(client?.frontchannelLogoutSessionRequired).toBe(false);
+		});
+	});
+
+	describe("ClientEntrySchema URI validation", () => {
+		it("rejects an invalid URL in backchannelLogoutUri", () => {
+			const result = ClientEntrySchema.safeParse({
+				clientSecret: "secret",
+				allowedRedirectUris: [],
+				allowedScopes: [],
+				backchannelLogoutUri: "not-a-url",
+			});
+			expect(result.success).toBe(false);
 		});
 	});
 

--- a/packages/core/src/repositories/types.mts
+++ b/packages/core/src/repositories/types.mts
@@ -19,6 +19,16 @@ export interface Client {
 	clientSecret: string;
 	allowedRedirectUris: string[];
 	allowedScopes: string[];
+	// NEW (TODO-F-5): Logout metadata.
+	postLogoutRedirectUris?: string[];
+	backchannelLogoutUri?: string;
+	// default: true (includes sid in logout_token) — intentional deviation from OIDC Back-Channel
+	// Logout 1.0 §2.2 spec default of false, to default to the safer behavior. See ClientEntrySchema.
+	backchannelLogoutSessionRequired?: boolean;
+	frontchannelLogoutUri?: string;
+	// default: true (includes sid in frontchannel logout iframe URL) — intentional deviation from OIDC
+	// Front-Channel Logout 1.0 spec default of false, to default to the safer behavior. See ClientEntrySchema.
+	frontchannelLogoutSessionRequired?: boolean;
 }
 
 export interface User {

--- a/packages/core/src/user-sessions/__tests__/memory.test.mts
+++ b/packages/core/src/user-sessions/__tests__/memory.test.mts
@@ -61,6 +61,36 @@ describe("in-memory UserSessionStore", () => {
 		expect(s?.activeRPs[0]?.backchannelLogoutUri).toBe("https://rp/bc");
 	});
 
+	it("registerRP round-trips backchannelLogoutSessionRequired and frontchannelLogoutSessionRequired", async () => {
+		await store.create(baseInput);
+		await store.registerRP("sid-1", {
+			clientId: "rp-flags",
+			backchannelLogoutUri: "https://rp/bc",
+			backchannelLogoutSessionRequired: false,
+			frontchannelLogoutUri: "https://rp/fc",
+			frontchannelLogoutSessionRequired: false,
+			registeredAt: new Date(),
+		});
+		const s = await store.get("sid-1");
+		const rp = s?.activeRPs[0];
+		expect(rp?.backchannelLogoutSessionRequired).toBe(false);
+		expect(rp?.frontchannelLogoutSessionRequired).toBe(false);
+	});
+
+	it("get deep-copies backchannelLogoutSessionRequired and frontchannelLogoutSessionRequired", async () => {
+		await store.create(baseInput);
+		await store.registerRP("sid-1", {
+			clientId: "rp-flags",
+			backchannelLogoutSessionRequired: true,
+			frontchannelLogoutSessionRequired: true,
+			registeredAt: new Date(),
+		});
+		const first = await store.get("sid-1");
+		const second = await store.get("sid-1");
+		expect(first?.activeRPs[0]?.backchannelLogoutSessionRequired).toBe(true);
+		expect(second?.activeRPs[0]?.backchannelLogoutSessionRequired).toBe(true);
+	});
+
 	it("linkFamily appends without duplicates", async () => {
 		await store.create(baseInput);
 		await store.linkFamily("sid-1", "fam-1");

--- a/packages/core/src/user-sessions/__tests__/redis.test.mts
+++ b/packages/core/src/user-sessions/__tests__/redis.test.mts
@@ -95,6 +95,22 @@ describe("redis UserSessionStore", () => {
 		expect(s?.activeRPs).toHaveLength(1);
 	});
 
+	it("registerRP round-trips backchannelLogoutSessionRequired and frontchannelLogoutSessionRequired through JSON envelope", async () => {
+		await store.create(base);
+		await store.registerRP("sid-1", {
+			clientId: "rp-flags",
+			backchannelLogoutUri: "https://rp/bc",
+			backchannelLogoutSessionRequired: false,
+			frontchannelLogoutUri: "https://rp/fc",
+			frontchannelLogoutSessionRequired: false,
+			registeredAt: new Date(),
+		});
+		const s = await store.get("sid-1");
+		const rp = s?.activeRPs[0];
+		expect(rp?.backchannelLogoutSessionRequired).toBe(false);
+		expect(rp?.frontchannelLogoutSessionRequired).toBe(false);
+	});
+
 	it("delete removes the key", async () => {
 		await store.create(base);
 		await store.delete("sid-1");

--- a/packages/core/src/user-sessions/adapters/memory.mts
+++ b/packages/core/src/user-sessions/adapters/memory.mts
@@ -90,7 +90,9 @@ export function createInMemoryUserSessionStore(): UserSessionStoreBase {
 				activeRPs: s.activeRPs.map((r) => ({
 					clientId: r.clientId,
 					backchannelLogoutUri: r.backchannelLogoutUri,
+					backchannelLogoutSessionRequired: r.backchannelLogoutSessionRequired,
 					frontchannelLogoutUri: r.frontchannelLogoutUri,
+					frontchannelLogoutSessionRequired: r.frontchannelLogoutSessionRequired,
 					registeredAt: new Date(r.registeredAt.getTime()),
 				})),
 				familyIds: [...s.familyIds],
@@ -104,7 +106,9 @@ export function createInMemoryUserSessionStore(): UserSessionStoreBase {
 			const rpCopy: RegisteredRP = {
 				clientId: rp.clientId,
 				backchannelLogoutUri: rp.backchannelLogoutUri,
+				backchannelLogoutSessionRequired: rp.backchannelLogoutSessionRequired,
 				frontchannelLogoutUri: rp.frontchannelLogoutUri,
+				frontchannelLogoutSessionRequired: rp.frontchannelLogoutSessionRequired,
 				registeredAt: new Date(rp.registeredAt.getTime()),
 			};
 			s.activeRPs = [...s.activeRPs.filter((r) => r.clientId !== rp.clientId), rpCopy];

--- a/packages/core/src/user-sessions/adapters/redis.mts
+++ b/packages/core/src/user-sessions/adapters/redis.mts
@@ -36,7 +36,9 @@ interface Envelope {
 	activeRPs: {
 		clientId: string;
 		backchannelLogoutUri?: string;
+		backchannelLogoutSessionRequired?: boolean;
 		frontchannelLogoutUri?: string;
+		frontchannelLogoutSessionRequired?: boolean;
 		registeredAtMs: number;
 	}[];
 	familyIds: string[];
@@ -53,7 +55,9 @@ const toEnvelope = (s: UserSession): Envelope => ({
 	activeRPs: s.activeRPs.map((r) => ({
 		clientId: r.clientId,
 		backchannelLogoutUri: r.backchannelLogoutUri,
+		backchannelLogoutSessionRequired: r.backchannelLogoutSessionRequired,
 		frontchannelLogoutUri: r.frontchannelLogoutUri,
+		frontchannelLogoutSessionRequired: r.frontchannelLogoutSessionRequired,
 		registeredAtMs: r.registeredAt.getTime(),
 	})),
 	familyIds: [...s.familyIds],
@@ -70,7 +74,9 @@ const fromEnvelope = (e: Envelope): UserSession => ({
 	activeRPs: e.activeRPs.map((r) => ({
 		clientId: r.clientId,
 		backchannelLogoutUri: r.backchannelLogoutUri,
+		backchannelLogoutSessionRequired: r.backchannelLogoutSessionRequired,
 		frontchannelLogoutUri: r.frontchannelLogoutUri,
+		frontchannelLogoutSessionRequired: r.frontchannelLogoutSessionRequired,
 		registeredAt: new Date(r.registeredAtMs),
 	})),
 	familyIds: e.familyIds,
@@ -156,7 +162,9 @@ export function createRedisUserSessionStore(
 				{
 					clientId: rp.clientId,
 					backchannelLogoutUri: rp.backchannelLogoutUri,
+					backchannelLogoutSessionRequired: rp.backchannelLogoutSessionRequired,
 					frontchannelLogoutUri: rp.frontchannelLogoutUri,
+					frontchannelLogoutSessionRequired: rp.frontchannelLogoutSessionRequired,
 					registeredAtMs: rp.registeredAt.getTime(),
 				},
 			];

--- a/packages/core/src/user-sessions/types.mts
+++ b/packages/core/src/user-sessions/types.mts
@@ -27,7 +27,9 @@ export interface UserSessionClaims {
 export interface RegisteredRP {
 	readonly clientId: string;
 	readonly backchannelLogoutUri?: string;
+	readonly backchannelLogoutSessionRequired?: boolean;
 	readonly frontchannelLogoutUri?: string;
+	readonly frontchannelLogoutSessionRequired?: boolean;
 	readonly registeredAt: Date;
 }
 

--- a/packages/oauth/README.ja.md
+++ b/packages/oauth/README.ja.md
@@ -168,6 +168,59 @@ Authorization: Bearer <access_token>
 - **`authorization_code` グラント — `sid` の必要条件。** グラントは `CodeData` レコードから `sid` を読み取る。発行トークンに `sid` クレームを含めるには、F-2/F-3 のログインワイアリング（ローカルログインまたはフェデレーションコールバックがコードに `sid` を書き込む処理）が必要。
 - **`refresh_token` グラント — セッション検証。** `AppOptions.userSessionStore` が設定されており、かつリフレッシュトークンに `sid` クレームが含まれる場合、グラントは `userSessionStore.get(sid)` を呼び出してセッションがまだアクティブかを検証する。セッションが存在しない場合は `400 invalid_grant`、ストアエラーの場合は `503 temporarily_unavailable` を返す。
 
+## TODO-F-5 の変更点 — ログアウトエンドポイント
+
+OAuth モジュールは `userSessionStore`、`federationTokenStore`、`refreshTokenStore`、`oauth.jwt.issuer` が設定されている場合に 2 つのログアウトルートを公開する。
+
+### POST /oauth/logout
+
+OIDC RP-Initiated Logout 1.0 の `end_session_endpoint`。`application/x-www-form-urlencoded` を受け付ける:
+
+- `id_token_hint`（必須） — このプロバイダーが発行した署名済み id_token。`sid` クレームでセッションを特定する
+- `post_logout_redirect_uri`（任意） — `client.postLogoutRedirectUris` のいずれかと完全一致する必要がある
+- `state`（任意） — `post_logout_redirect_uri` へのリダイレクト時にそのまま返す
+
+フロー: `id_token_hint` を検証 → セッションを取得 → `backchannelLogoutUri` を持つすべての RP に OIDC Back-Channel Logout 1.0 の `logout_token` を POST → ストアカスケード（リフレッシュファミリー失効・フェデレーショントークン削除・セッション削除）を実行 → 以下のいずれかで応答:
+
+- `frontchannelLogoutUri` を持つ RP ごとに `<iframe>` を含む `text/html` ページ（q 値付きネゴシエーションで `Accept: text/html` が優先された場合）
+- 最初のフェデレーションの IdP end-session URL への `303` リダイレクト（そのフェデレーションプロバイダーが `SupportsLogout` を実装している場合）
+- `post_logout_redirect_uri` への `303` リダイレクト（クライアントのアローリストに一致する場合）
+- `200 {"logged_out": true}`（フォールバック）
+
+カスケード失敗時は `503 {"error": "temporarily_unavailable"}` を返す。カスケードの実行順序は仕様により固定されており、ステップ 1（リフレッシュファミリー失効）とステップ 3（セッション削除）は失敗時にそのまま終了し、ステップ 2（フェデレーショントークン削除）はベストエフォートで失敗してもカスケードを継続する。
+
+### POST /oauth/federation/:name/logout
+
+プロバイダー単位のフェデレーション切断。Authorization ヘッダーに `Bearer <access_token>`（`typ: at+jwt`）を指定する。ボディ（任意）: `post_logout_redirect_uri`、`state`。
+
+フロー: access_token を検証 → ファミリーが失効していないか確認 → セッションを取得 → 該当フェデレーションがセッションに紐付いていることを確認 → フェデレーショントークンを削除 → セッションからフェデレーションを削除 → プロバイダーが `SupportsLogout` を実装している場合は IdP end-session URL にリダイレクト。それ以外は `200 {"disconnected": true}` を返す。
+
+IdP end-session 呼び出しが失敗した場合、ローカル状態はすでにクリア済みのため `200 {"disconnected": true}` を返し、オペレーター向けに `federation.logout.idp_unreachable` 監査イベントを出力する。
+
+セッションに指定フェデレーションが存在しない場合は `404 {"error": "federation_not_linked"}` を返す。
+
+### ディスカバリーメタデータ
+
+`GET /.well-known/openid-configuration` に以下が追加された:
+
+- `end_session_endpoint`
+- `backchannel_logout_supported: true`
+- `backchannel_logout_session_supported: true` — デフォルトで `logout_token` に `sid` を含む
+- `frontchannel_logout_supported: true`
+- `frontchannel_logout_session_supported: true` — デフォルトでフロントチャネルの iframe URL に `sid` を含む
+
+`session_supported` のデフォルト `true` は OIDC Back-Channel Logout 1.0 §2.2 の仕様デフォルト（`false`）から意図的に逸脱している。仕様デフォルトの動作が必要なクライアントは、クライアントレコードで `backchannelLogoutSessionRequired: false` または `frontchannelLogoutSessionRequired: false` を設定すること。
+
+### クライアントレコードのログアウトメタデータ
+
+各 `Client` はログアウト動作を制御する 5 つのオプションフィールドをサポートする:
+
+- `postLogoutRedirectUris?: string[]` — `POST /oauth/logout` の `post_logout_redirect_uri` 許可リスト
+- `backchannelLogoutUri?: string` — `logout_token` の POST を受け取る URI
+- `backchannelLogoutSessionRequired?: boolean` — デフォルト `true`。`false` にすると `logout_token` から `sid` を除外する
+- `frontchannelLogoutUri?: string` — フロントチャネルの iframe src
+- `frontchannelLogoutSessionRequired?: boolean` — デフォルト `true`。`false` にすると iframe URL から `sid` を除外する
+
 ## 関連
 
 - [`@o3co/auth-provider-session`](../session/README.ja.md) — セッションログイン / フェデレーションルート

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -168,6 +168,59 @@ Scope-to-claim mapping (OIDC Core §5.4 standard scopes):
 - **`authorization_code` grant — `sid` requirement.** The grant reads `sid` from the `CodeData` record. Deployments must have the F-2/F-3 login wiring in place (local login or federation callback writing `sid` onto the code) for the `sid` claim to be present in issued tokens.
 - **`refresh_token` grant — session validation.** When `AppOptions.userSessionStore` is wired and the refresh token carries a `sid` claim, the grant calls `userSessionStore.get(sid)` to verify the session is still active. A missing session returns `400 invalid_grant`; a store error returns `503 temporarily_unavailable`.
 
+## TODO-F-5 changes — Logout endpoints
+
+The OAuth module exposes two logout-related routes when wired with `userSessionStore`, `federationTokenStore`, `refreshTokenStore`, and `oauth.jwt.issuer`:
+
+### POST /oauth/logout
+
+OIDC RP-Initiated Logout 1.0 `end_session_endpoint`. Accepts `application/x-www-form-urlencoded`:
+
+- `id_token_hint` (required) — signed id_token from this provider; `sid` claim identifies the session
+- `post_logout_redirect_uri` (optional) — must match one of `client.postLogoutRedirectUris` exactly
+- `state` (optional) — round-tripped when redirecting to `post_logout_redirect_uri`
+
+Flow: verifies `id_token_hint` → loads session → broadcasts OIDC Back-Channel Logout 1.0 `logout_token` to every RP with `backchannelLogoutUri` → executes store cascade (refresh-family revoke, federation-token delete, session delete) → responds with one of:
+
+- `text/html` page with `<iframe>` per RP with `frontchannelLogoutUri` (when `Accept: text/html` wins q-weighted negotiation)
+- `303` to first-federation IdP end-session URL (when that federation's provider implements `SupportsLogout`)
+- `303` to `post_logout_redirect_uri` (when it matches the client's allowlist)
+- `200 {"logged_out": true}` (fallback)
+
+Cascade failure returns `503 {"error": "temporarily_unavailable"}`. The cascade order is fixed per the spec: step 1 (refresh-family revoke) and step 3 (session delete) fail hard; step 2 (federation-token delete) is best-effort and logs a warning on failure without aborting the cascade.
+
+### POST /oauth/federation/:name/logout
+
+Provider-scoped federation disconnect. Authorization: `Bearer <access_token>` with `typ: at+jwt`. Optional body: `post_logout_redirect_uri`, `state`.
+
+Flow: verifies access_token → checks family not revoked → loads session → verifies federation is linked → deletes federation token → removes federation from session → if the provider implements `SupportsLogout`, redirects to the IdP end-session URL; otherwise returns `200 {"disconnected": true}`.
+
+If the IdP end-session call throws, local state is already cleared; the response is `200 {"disconnected": true}` and an audit event `federation.logout.idp_unreachable` is emitted for operator visibility.
+
+Returns `404 {"error": "federation_not_linked"}` when the named federation is not in the session.
+
+### Discovery metadata
+
+`GET /.well-known/openid-configuration` now advertises:
+
+- `end_session_endpoint`
+- `backchannel_logout_supported: true`
+- `backchannel_logout_session_supported: true` — `logout_token` includes `sid` by default
+- `frontchannel_logout_supported: true`
+- `frontchannel_logout_session_supported: true` — front-channel iframe URL includes `sid` by default
+
+The `session_supported` defaults of `true` intentionally deviate from OIDC Back-Channel Logout 1.0 §2.2 (spec default: `false`). Clients that require the spec-default behavior must set `backchannelLogoutSessionRequired: false` or `frontchannelLogoutSessionRequired: false` on their client record.
+
+### Client record logout metadata
+
+Each `Client` supports five optional fields for logout behavior:
+
+- `postLogoutRedirectUris?: string[]` — allowlist for `POST /oauth/logout`'s `post_logout_redirect_uri`
+- `backchannelLogoutUri?: string` — receives `logout_token` POST
+- `backchannelLogoutSessionRequired?: boolean` — default `true`; set `false` to exclude `sid` from `logout_token`
+- `frontchannelLogoutUri?: string` — iframe src target
+- `frontchannelLogoutSessionRequired?: boolean` — default `true`; set `false` to exclude `sid` from iframe URL
+
 ## See Also
 
 - [`@o3co/auth-provider-session`](../session/README.md) — session login / federation routes

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -34,6 +34,7 @@
 	},
 	"dependencies": {
 		"@o3co/auth-provider-core": "workspace:*",
+		"accepts": "^1.3.8",
 		"jose": "^6.2.2"
 	},
 	"peerDependencies": {
@@ -50,6 +51,7 @@
 		}
 	},
 	"devDependencies": {
+		"@types/accepts": "^1.3.7",
 		"@types/express": "^5.0.6",
 		"@types/express-session": "^1",
 		"@types/passport": "^1",

--- a/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
+++ b/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
@@ -95,24 +95,40 @@ describe("GET /.well-known/openid-configuration", () => {
 	});
 
 	it("advertises end_session_endpoint per OIDC RP-Initiated Logout 1.0", async () => {
-		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [], logoutSupported: true });
+		const body = await callRoute({
+			issuer: "https://auth.example.com",
+			signingAlgs: [],
+			logoutSupported: true,
+		});
 		expect(body.end_session_endpoint).toBe("https://auth.example.com/oauth/logout");
 	});
 
 	it("advertises Back-Channel Logout support per OIDC Back-Channel Logout 1.0", async () => {
-		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [], logoutSupported: true });
+		const body = await callRoute({
+			issuer: "https://auth.example.com",
+			signingAlgs: [],
+			logoutSupported: true,
+		});
 		expect(body.backchannel_logout_supported).toBe(true);
 		expect(body.backchannel_logout_session_supported).toBe(true);
 	});
 
 	it("advertises Front-Channel Logout support per OIDC Front-Channel Logout 1.0", async () => {
-		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [], logoutSupported: true });
+		const body = await callRoute({
+			issuer: "https://auth.example.com",
+			signingAlgs: [],
+			logoutSupported: true,
+		});
 		expect(body.frontchannel_logout_supported).toBe(true);
 		expect(body.frontchannel_logout_session_supported).toBe(true);
 	});
 
 	it("omits all 5 logout fields when logoutSupported is false (stores not configured)", async () => {
-		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [], logoutSupported: false });
+		const body = await callRoute({
+			issuer: "https://auth.example.com",
+			signingAlgs: [],
+			logoutSupported: false,
+		});
 		expect(body.end_session_endpoint).toBeUndefined();
 		expect(body.backchannel_logout_supported).toBeUndefined();
 		expect(body.backchannel_logout_session_supported).toBeUndefined();

--- a/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
+++ b/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
@@ -52,6 +52,7 @@ function createMockRes() {
 async function callRoute(opts: {
 	issuer: string;
 	signingAlgs: string[];
+	logoutSupported?: boolean;
 }): Promise<Record<string, unknown>> {
 	const express = createMockExpress();
 	createRouter(express as any, opts);
@@ -94,20 +95,29 @@ describe("GET /.well-known/openid-configuration", () => {
 	});
 
 	it("advertises end_session_endpoint per OIDC RP-Initiated Logout 1.0", async () => {
-		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [] });
+		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [], logoutSupported: true });
 		expect(body.end_session_endpoint).toBe("https://auth.example.com/oauth/logout");
 	});
 
 	it("advertises Back-Channel Logout support per OIDC Back-Channel Logout 1.0", async () => {
-		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [] });
+		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [], logoutSupported: true });
 		expect(body.backchannel_logout_supported).toBe(true);
 		expect(body.backchannel_logout_session_supported).toBe(true);
 	});
 
 	it("advertises Front-Channel Logout support per OIDC Front-Channel Logout 1.0", async () => {
-		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [] });
+		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [], logoutSupported: true });
 		expect(body.frontchannel_logout_supported).toBe(true);
 		expect(body.frontchannel_logout_session_supported).toBe(true);
+	});
+
+	it("omits all 5 logout fields when logoutSupported is false (stores not configured)", async () => {
+		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [], logoutSupported: false });
+		expect(body.end_session_endpoint).toBeUndefined();
+		expect(body.backchannel_logout_supported).toBeUndefined();
+		expect(body.backchannel_logout_session_supported).toBeUndefined();
+		expect(body.frontchannel_logout_supported).toBeUndefined();
+		expect(body.frontchannel_logout_session_supported).toBeUndefined();
 	});
 
 	it("strips trailing slashes from issuer in both the issuer field and endpoint URLs", async () => {

--- a/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
+++ b/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
@@ -88,11 +88,26 @@ describe("GET /.well-known/openid-configuration", () => {
 		);
 	});
 
-	it("does NOT advertise revocation_endpoint / end_session_endpoint / backchannel_logout_supported (out of F-4 scope)", async () => {
+	it("does NOT advertise revocation_endpoint (out of F-5 scope)", async () => {
 		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [] });
 		expect(body.revocation_endpoint).toBeUndefined();
-		expect(body.end_session_endpoint).toBeUndefined();
-		expect(body.backchannel_logout_supported).toBeUndefined();
+	});
+
+	it("advertises end_session_endpoint per OIDC RP-Initiated Logout 1.0", async () => {
+		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [] });
+		expect(body.end_session_endpoint).toBe("https://auth.example.com/oauth/logout");
+	});
+
+	it("advertises Back-Channel Logout support per OIDC Back-Channel Logout 1.0", async () => {
+		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [] });
+		expect(body.backchannel_logout_supported).toBe(true);
+		expect(body.backchannel_logout_session_supported).toBe(true);
+	});
+
+	it("advertises Front-Channel Logout support per OIDC Front-Channel Logout 1.0", async () => {
+		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [] });
+		expect(body.frontchannel_logout_supported).toBe(true);
+		expect(body.frontchannel_logout_session_supported).toBe(true);
 	});
 
 	it("strips trailing slashes from issuer in both the issuer field and endpoint URLs", async () => {

--- a/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
+++ b/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
@@ -123,6 +123,16 @@ describe("GET /.well-known/openid-configuration", () => {
 		expect(body.frontchannel_logout_session_supported).toBe(true);
 	});
 
+	it("omits all logout fields when logoutSupported is not set (default false — explicit opt-in required)", async () => {
+		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: [] });
+		// No logoutSupported option passed — default must be false (safe default for direct users)
+		expect(body.end_session_endpoint).toBeUndefined();
+		expect(body.backchannel_logout_supported).toBeUndefined();
+		expect(body.backchannel_logout_session_supported).toBeUndefined();
+		expect(body.frontchannel_logout_supported).toBeUndefined();
+		expect(body.frontchannel_logout_session_supported).toBeUndefined();
+	});
+
 	it("omits all 5 logout fields when logoutSupported is false (stores not configured)", async () => {
 		const body = await callRoute({
 			issuer: "https://auth.example.com",

--- a/packages/oauth/src/__tests__/logout.test.mts
+++ b/packages/oauth/src/__tests__/logout.test.mts
@@ -50,6 +50,24 @@ async function mintIdToken(extra: Record<string, unknown> = {}): Promise<string>
 		.sign(secretKey);
 }
 
+/**
+ * Mint an access token (typ: at+jwt) for use with POST /oauth/federation/:name/logout.
+ * Includes sid, sub, and family_id by default.
+ */
+async function mintAccessToken(extra: Record<string, unknown> = {}): Promise<string> {
+	return new SignJWT({
+		sub: "u-1",
+		sid: "sid-1",
+		family_id: "fam-1",
+		...extra,
+	})
+		.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "at+jwt" })
+		.setExpirationTime("1h")
+		.setIssuedAt()
+		.setIssuer("https://auth.example.com")
+		.sign(secretKey);
+}
+
 // A minimal valid UserSession with no federations (simplifies most test cases)
 const baseSession: UserSession = {
 	sid: "sid-1",
@@ -438,6 +456,240 @@ describe("POST /oauth/logout", () => {
 				const res = await postLogout(app, { id_token_hint: token });
 				// Logout still succeeds (best-effort federation end-session)
 				expect(res.status).toBe(200);
+				expect(warnSpy).toHaveBeenCalled();
+				expect(consoleWarnSpy).not.toHaveBeenCalled();
+			} finally {
+				consoleWarnSpy.mockRestore();
+			}
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// POST /oauth/federation/:name/logout
+// ---------------------------------------------------------------------------
+
+/** Session that has google linked */
+const sessionWithGoogle: UserSession = {
+	...baseSession,
+	federations: ["google"],
+};
+
+function buildFedLogoutApp(opts: BuildAppOpts = {}) {
+	return buildApp({
+		sessionStore: makeSessionStore({ get: vi.fn().mockResolvedValue(sessionWithGoogle) }),
+		...opts,
+	});
+}
+
+async function postFedLogout(
+	app: ReturnType<typeof express>,
+	name: string,
+	token: string,
+	body: Record<string, string> = {},
+	headers: Record<string, string> = {},
+) {
+	const req = request(app)
+		.post(`/oauth/federation/${name}/logout`)
+		.type("form")
+		.set("Authorization", `Bearer ${token}`);
+	for (const [k, v] of Object.entries(headers)) {
+		req.set(k, v);
+	}
+	return req.send(body);
+}
+
+describe("POST /oauth/federation/:name/logout", () => {
+	describe("happy path WITH endSession capability", () => {
+		it("returns 303 redirect to provider end-session URL", async () => {
+			const endSessionUrl = new URL("https://accounts.google.com/o/oauth2/revoke?token=id-hint");
+			const mockProvider: FederationProviderHandle & {
+				endSession: (req: unknown) => Promise<{ url: URL; method: "GET" }>;
+			} = {
+				name: "google",
+				endSession: vi.fn().mockResolvedValue({ url: endSessionUrl, method: "GET" }),
+			};
+			const app = buildFedLogoutApp({
+				getFederationProviders: () =>
+					new Map<string, FederationProviderHandle>([["google", mockProvider]]),
+			});
+			const token = await mintAccessToken();
+
+			const res = await postFedLogout(app, "google", token);
+
+			expect(res.status).toBe(303);
+			expect(res.headers.location).toContain("accounts.google.com");
+			expect(mockProvider.endSession).toHaveBeenCalledOnce();
+			expect(res.headers["cache-control"]).toBe("no-store");
+		});
+	});
+
+	describe("happy path WITHOUT endSession capability", () => {
+		it("returns 200 JSON { disconnected: true } when provider has no endSession method", async () => {
+			const bareProvider: FederationProviderHandle = { name: "github" };
+			const sessionWithGithub: UserSession = { ...baseSession, federations: ["github"] };
+			const app = buildApp({
+				sessionStore: makeSessionStore({ get: vi.fn().mockResolvedValue(sessionWithGithub) }),
+				getFederationProviders: () =>
+					new Map<string, FederationProviderHandle>([["github", bareProvider]]),
+			});
+			const token = await mintAccessToken();
+
+			const res = await postFedLogout(app, "github", token);
+
+			expect(res.status).toBe(200);
+			expect(res.body).toEqual({ disconnected: true });
+			expect(res.headers["cache-control"]).toBe("no-store");
+		});
+	});
+
+	describe("missing Authorization header", () => {
+		it("returns 401 invalid_token", async () => {
+			const app = buildFedLogoutApp();
+			const res = await request(app)
+				.post("/oauth/federation/google/logout")
+				.type("form")
+				.send({});
+
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_token");
+		});
+	});
+
+	describe("wrong token type (rt+jwt)", () => {
+		it("returns 401 invalid_token when typ is not at+jwt", async () => {
+			const refreshToken = await new SignJWT({ sub: "u-1", sid: "sid-1", family_id: "fam-1" })
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setExpirationTime("1h")
+				.setIssuedAt()
+				.sign(secretKey);
+			const app = buildFedLogoutApp();
+
+			const res = await postFedLogout(app, "google", refreshToken);
+
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_token");
+		});
+	});
+
+	describe("invalid signature", () => {
+		it("returns 401 invalid_token", async () => {
+			const app = buildFedLogoutApp();
+
+			const res = await postFedLogout(app, "google", "not.a.valid.jwt");
+
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_token");
+		});
+	});
+
+	describe("family revoked", () => {
+		it("returns 401 invalid_token when isFamilyRevoked returns true", async () => {
+			const refreshStore = makeRefreshStore({
+				isFamilyRevoked: vi.fn().mockResolvedValue(true),
+			});
+			const app = buildFedLogoutApp({ refreshStore });
+			const token = await mintAccessToken();
+
+			const res = await postFedLogout(app, "google", token);
+
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_token");
+		});
+	});
+
+	describe("session null", () => {
+		it("returns 401 invalid_token when session is not found", async () => {
+			const app = buildApp({
+				sessionStore: makeSessionStore({ get: vi.fn().mockResolvedValue(null) }),
+			});
+			const token = await mintAccessToken();
+
+			const res = await postFedLogout(app, "google", token);
+
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_token");
+		});
+	});
+
+	describe("federation not linked", () => {
+		it("returns 404 federation_not_linked when federation is absent from session", async () => {
+			// sessionWithGoogle only has google, so 'github' is not linked
+			const app = buildFedLogoutApp();
+			const token = await mintAccessToken();
+
+			const res = await postFedLogout(app, "github", token);
+
+			expect(res.status).toBe(404);
+			expect(res.body.error).toBe("federation_not_linked");
+		});
+	});
+
+	describe("federationTokenStore.delete throws", () => {
+		it("returns 503 when delete fails after local state was partially cleared", async () => {
+			const fedTokenStore = makeFedTokenStore({
+				delete: vi.fn().mockRejectedValue(new Error("redis down")),
+			});
+			const app = buildFedLogoutApp({ fedTokenStore });
+			const token = await mintAccessToken();
+
+			const res = await postFedLogout(app, "google", token);
+
+			expect(res.status).toBe(503);
+			expect(res.body.error).toBe("temporarily_unavailable");
+			expect(res.headers["cache-control"]).toBe("no-store");
+		});
+	});
+
+	describe("provider.endSession throws (soft-fail)", () => {
+		it("returns 200 { disconnected: true } when endSession throws (local state already cleared)", async () => {
+			const throwingProvider: FederationProviderHandle & {
+				endSession: () => Promise<never>;
+			} = {
+				name: "google",
+				endSession: vi.fn().mockRejectedValue(new Error("IdP unreachable")),
+			};
+			const app = buildFedLogoutApp({
+				getFederationProviders: () =>
+					new Map<string, FederationProviderHandle>([["google", throwingProvider]]),
+			});
+			const token = await mintAccessToken();
+
+			const res = await postFedLogout(app, "google", token);
+
+			// Local state cleared before endSession call; soft-fail returns 200
+			expect(res.status).toBe(200);
+			expect(res.body).toEqual({ disconnected: true });
+			expect(res.headers["cache-control"]).toBe("no-store");
+		});
+	});
+
+	describe("getFederationProviders returns undefined (no federation configured)", () => {
+		it("returns 200 { disconnected: true } when providers map is undefined", async () => {
+			const app = buildFedLogoutApp({ getFederationProviders: () => undefined });
+			const token = await mintAccessToken();
+
+			const res = await postFedLogout(app, "google", token);
+
+			expect(res.status).toBe(200);
+			expect(res.body).toEqual({ disconnected: true });
+		});
+	});
+
+	describe("logger routing", () => {
+		it("routes /federation/:name/logout failures to opts.logger (not console)", async () => {
+			const warnSpy = vi.fn<(message: string, ...args: unknown[]) => void>();
+			const logger: Logger = { warn: warnSpy };
+			const fedTokenStore = makeFedTokenStore({
+				delete: vi.fn().mockRejectedValue(new Error("boom")),
+			});
+			const app = buildFedLogoutApp({ fedTokenStore, logger });
+			const token = await mintAccessToken();
+
+			const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			try {
+				const res = await postFedLogout(app, "google", token);
+				expect(res.status).toBe(503);
 				expect(warnSpy).toHaveBeenCalled();
 				expect(consoleWarnSpy).not.toHaveBeenCalled();
 			} finally {

--- a/packages/oauth/src/__tests__/logout.test.mts
+++ b/packages/oauth/src/__tests__/logout.test.mts
@@ -730,10 +730,7 @@ describe("POST /oauth/federation/:name/logout", () => {
 	describe("missing Authorization header", () => {
 		it("returns 401 invalid_token", async () => {
 			const app = buildFedLogoutApp();
-			const res = await request(app)
-				.post("/oauth/federation/google/logout")
-				.type("form")
-				.send({});
+			const res = await request(app).post("/oauth/federation/google/logout").type("form").send({});
 
 			expect(res.status).toBe(401);
 			expect(res.body.error).toBe("invalid_token");
@@ -863,10 +860,7 @@ describe("POST /oauth/federation/:name/logout", () => {
 	describe("WWW-Authenticate header on 401 paths", () => {
 		it("missing Authorization header returns WWW-Authenticate: Bearer error=invalid_token", async () => {
 			const app = buildFedLogoutApp();
-			const res = await request(app)
-				.post("/oauth/federation/google/logout")
-				.type("form")
-				.send({});
+			const res = await request(app).post("/oauth/federation/google/logout").type("form").send({});
 
 			expect(res.status).toBe(401);
 			expect(res.headers["www-authenticate"]).toMatch(/Bearer/);
@@ -940,7 +934,10 @@ describe("POST /oauth/federation/:name/logout", () => {
 describe("audit events", () => {
 	describe("federation.logout.idp_unreachable", () => {
 		it("emits when provider.endSession throws (orphan IdP session)", async () => {
-			const auditSink: AuditSinkBase = { kind: "mock", record: vi.fn().mockResolvedValue(undefined) };
+			const auditSink: AuditSinkBase = {
+				kind: "mock",
+				record: vi.fn().mockResolvedValue(undefined),
+			};
 			const throwingProvider: FederationProviderHandle & { endSession: () => Promise<never> } = {
 				name: "google",
 				endSession: vi.fn().mockRejectedValue(new Error("IdP down")),
@@ -966,7 +963,10 @@ describe("audit events", () => {
 
 	describe("federation.logout.success", () => {
 		it("emits with redirected_to_idp: true when endSession succeeds (303 path)", async () => {
-			const auditSink: AuditSinkBase = { kind: "mock", record: vi.fn().mockResolvedValue(undefined) };
+			const auditSink: AuditSinkBase = {
+				kind: "mock",
+				record: vi.fn().mockResolvedValue(undefined),
+			};
 			const endSessionUrl = new URL("https://accounts.google.com/logout");
 			const mockProvider: FederationProviderHandle & {
 				endSession: (req: unknown) => Promise<{ url: URL; method: "GET" }>;
@@ -993,7 +993,10 @@ describe("audit events", () => {
 		});
 
 		it("emits with redirected_to_idp: false when provider has no endSession (200 path)", async () => {
-			const auditSink: AuditSinkBase = { kind: "mock", record: vi.fn().mockResolvedValue(undefined) };
+			const auditSink: AuditSinkBase = {
+				kind: "mock",
+				record: vi.fn().mockResolvedValue(undefined),
+			};
 			const bareProvider: FederationProviderHandle = { name: "github" };
 			const sessionWithGithub: UserSession = { ...baseSession, federations: ["github"] };
 			const app = buildApp({
@@ -1018,7 +1021,10 @@ describe("audit events", () => {
 
 	describe("logout.success", () => {
 		it("emits on POST /oauth/logout happy path", async () => {
-			const auditSink: AuditSinkBase = { kind: "mock", record: vi.fn().mockResolvedValue(undefined) };
+			const auditSink: AuditSinkBase = {
+				kind: "mock",
+				record: vi.fn().mockResolvedValue(undefined),
+			};
 			const app = buildApp({ auditSink });
 			const token = await mintIdToken();
 
@@ -1036,7 +1042,10 @@ describe("audit events", () => {
 
 	describe("logout.cascade_failed", () => {
 		it("emits on 503 cascade failure", async () => {
-			const auditSink: AuditSinkBase = { kind: "mock", record: vi.fn().mockResolvedValue(undefined) };
+			const auditSink: AuditSinkBase = {
+				kind: "mock",
+				record: vi.fn().mockResolvedValue(undefined),
+			};
 			const refreshStore = makeRefreshStore({
 				revokeFamily: vi.fn().mockRejectedValue(new Error("redis down")),
 			});

--- a/packages/oauth/src/__tests__/logout.test.mts
+++ b/packages/oauth/src/__tests__/logout.test.mts
@@ -505,6 +505,65 @@ describe("POST /oauth/logout", () => {
 		});
 	});
 
+	describe("Cache-Control / Pragma headers", () => {
+		it("200 JSON success path sets Cache-Control: no-store and Pragma: no-cache", async () => {
+			const app = buildApp();
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, { id_token_hint: token });
+
+			expect(res.status).toBe(200);
+			expect(res.headers["cache-control"]).toBe("no-store");
+			expect(res.headers.pragma).toBe("no-cache");
+		});
+
+		it("503 cascade failure sets Cache-Control: no-store and Pragma: no-cache", async () => {
+			const refreshStore = makeRefreshStore({
+				revokeFamily: vi.fn().mockRejectedValue(new Error("redis down")),
+			});
+			const app = buildApp({ refreshStore });
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, { id_token_hint: token });
+
+			expect(res.status).toBe(503);
+			expect(res.headers["cache-control"]).toBe("no-store");
+			expect(res.headers.pragma).toBe("no-cache");
+		});
+
+		it("400 invalid id_token_hint sets Cache-Control: no-store and Pragma: no-cache", async () => {
+			const app = buildApp();
+
+			const res = await postLogout(app, { id_token_hint: "not.a.valid.jwt" });
+
+			expect(res.status).toBe(400);
+			expect(res.headers["cache-control"]).toBe("no-store");
+			expect(res.headers.pragma).toBe("no-cache");
+		});
+
+		it("200 HTML front-channel response sets Cache-Control: no-store and Pragma: no-cache", async () => {
+			const sessionWithRP: UserSession = {
+				...baseSession,
+				activeRPs: [
+					{
+						clientId: "rp-1",
+						frontchannelLogoutUri: "https://rp1.example.com/fc-logout",
+						registeredAt: new Date(),
+					},
+				],
+			};
+			const sessionStore = makeSessionStore({ get: vi.fn().mockResolvedValue(sessionWithRP) });
+			const app = buildApp({ sessionStore });
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, { id_token_hint: token }, { Accept: "text/html" });
+
+			expect(res.status).toBe(200);
+			expect(res.headers["cache-control"]).toBe("no-store");
+			expect(res.headers.pragma).toBe("no-cache");
+		});
+	});
+
 	describe("q-weighted Accept header content negotiation", () => {
 		it("application/json > text/html returns JSON (not HTML)", async () => {
 			const sessionWithRP: UserSession = {
@@ -798,6 +857,56 @@ describe("POST /oauth/federation/:name/logout", () => {
 
 			expect(res.status).toBe(200);
 			expect(res.body).toEqual({ disconnected: true });
+		});
+	});
+
+	describe("WWW-Authenticate header on 401 paths", () => {
+		it("missing Authorization header returns WWW-Authenticate: Bearer error=invalid_token", async () => {
+			const app = buildFedLogoutApp();
+			const res = await request(app)
+				.post("/oauth/federation/google/logout")
+				.type("form")
+				.send({});
+
+			expect(res.status).toBe(401);
+			expect(res.headers["www-authenticate"]).toMatch(/Bearer/);
+			expect(res.headers["www-authenticate"]).toMatch(/error="invalid_token"/);
+		});
+
+		it("invalid signature returns WWW-Authenticate: Bearer error=invalid_token", async () => {
+			const app = buildFedLogoutApp();
+			const res = await postFedLogout(app, "google", "not.a.valid.jwt");
+
+			expect(res.status).toBe(401);
+			expect(res.headers["www-authenticate"]).toMatch(/Bearer/);
+			expect(res.headers["www-authenticate"]).toMatch(/error="invalid_token"/);
+		});
+
+		it("family revoked returns WWW-Authenticate: Bearer error=invalid_token", async () => {
+			const refreshStore = makeRefreshStore({
+				isFamilyRevoked: vi.fn().mockResolvedValue(true),
+			});
+			const app = buildFedLogoutApp({ refreshStore });
+			const token = await mintAccessToken();
+
+			const res = await postFedLogout(app, "google", token);
+
+			expect(res.status).toBe(401);
+			expect(res.headers["www-authenticate"]).toMatch(/Bearer/);
+			expect(res.headers["www-authenticate"]).toMatch(/error="invalid_token"/);
+		});
+
+		it("session not found returns WWW-Authenticate: Bearer error=invalid_token", async () => {
+			const app = buildApp({
+				sessionStore: makeSessionStore({ get: vi.fn().mockResolvedValue(null) }),
+			});
+			const token = await mintAccessToken();
+
+			const res = await postFedLogout(app, "google", token);
+
+			expect(res.status).toBe(401);
+			expect(res.headers["www-authenticate"]).toMatch(/Bearer/);
+			expect(res.headers["www-authenticate"]).toMatch(/error="invalid_token"/);
 		});
 	});
 

--- a/packages/oauth/src/__tests__/logout.test.mts
+++ b/packages/oauth/src/__tests__/logout.test.mts
@@ -16,6 +16,7 @@
 
 import { createSecretKey } from "node:crypto";
 import {
+	type AuditSinkBase,
 	type ClientRepository,
 	createSymmetricKeyStore,
 	type FederationProviderHandle,
@@ -133,6 +134,7 @@ interface BuildAppOpts {
 	/** Getter for federation providers — evaluated at request time. */
 	getFederationProviders?: () => ReadonlyMap<string, FederationProviderHandle> | undefined;
 	logger?: Logger;
+	auditSink?: AuditSinkBase;
 }
 
 function buildApp(opts: BuildAppOpts = {}) {
@@ -148,6 +150,7 @@ function buildApp(opts: BuildAppOpts = {}) {
 		// Stub fetchImpl so broadcast never makes real network calls
 		fetchImpl: vi.fn().mockResolvedValue({ ok: true }),
 		logger: opts.logger,
+		auditSink: opts.auditSink,
 	});
 	app.use("/oauth", router);
 	return app;
@@ -695,6 +698,129 @@ describe("POST /oauth/federation/:name/logout", () => {
 			} finally {
 				consoleWarnSpy.mockRestore();
 			}
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Audit event observability
+// ---------------------------------------------------------------------------
+
+describe("audit events", () => {
+	describe("federation.logout.idp_unreachable", () => {
+		it("emits when provider.endSession throws (orphan IdP session)", async () => {
+			const auditSink: AuditSinkBase = { kind: "mock", record: vi.fn().mockResolvedValue(undefined) };
+			const throwingProvider: FederationProviderHandle & { endSession: () => Promise<never> } = {
+				name: "google",
+				endSession: vi.fn().mockRejectedValue(new Error("IdP down")),
+			};
+			const app = buildFedLogoutApp({
+				auditSink,
+				getFederationProviders: () =>
+					new Map<string, FederationProviderHandle>([["google", throwingProvider]]),
+			});
+			const token = await mintAccessToken();
+
+			const res = await postFedLogout(app, "google", token);
+
+			expect(res.status).toBe(200);
+			expect(auditSink.record).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "federation.logout.idp_unreachable",
+					details: expect.objectContaining({ federation: "google", error: "IdP down" }),
+				}),
+			);
+		});
+	});
+
+	describe("federation.logout.success", () => {
+		it("emits with redirected_to_idp: true when endSession succeeds (303 path)", async () => {
+			const auditSink: AuditSinkBase = { kind: "mock", record: vi.fn().mockResolvedValue(undefined) };
+			const endSessionUrl = new URL("https://accounts.google.com/logout");
+			const mockProvider: FederationProviderHandle & {
+				endSession: (req: unknown) => Promise<{ url: URL; method: "GET" }>;
+			} = {
+				name: "google",
+				endSession: vi.fn().mockResolvedValue({ url: endSessionUrl, method: "GET" }),
+			};
+			const app = buildFedLogoutApp({
+				auditSink,
+				getFederationProviders: () =>
+					new Map<string, FederationProviderHandle>([["google", mockProvider]]),
+			});
+			const token = await mintAccessToken();
+
+			const res = await postFedLogout(app, "google", token);
+
+			expect(res.status).toBe(303);
+			expect(auditSink.record).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "federation.logout.success",
+					details: expect.objectContaining({ federation: "google", redirected_to_idp: true }),
+				}),
+			);
+		});
+
+		it("emits with redirected_to_idp: false when provider has no endSession (200 path)", async () => {
+			const auditSink: AuditSinkBase = { kind: "mock", record: vi.fn().mockResolvedValue(undefined) };
+			const bareProvider: FederationProviderHandle = { name: "github" };
+			const sessionWithGithub: UserSession = { ...baseSession, federations: ["github"] };
+			const app = buildApp({
+				auditSink,
+				sessionStore: makeSessionStore({ get: vi.fn().mockResolvedValue(sessionWithGithub) }),
+				getFederationProviders: () =>
+					new Map<string, FederationProviderHandle>([["github", bareProvider]]),
+			});
+			const token = await mintAccessToken();
+
+			const res = await postFedLogout(app, "github", token);
+
+			expect(res.status).toBe(200);
+			expect(auditSink.record).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "federation.logout.success",
+					details: expect.objectContaining({ federation: "github", redirected_to_idp: false }),
+				}),
+			);
+		});
+	});
+
+	describe("logout.success", () => {
+		it("emits on POST /oauth/logout happy path", async () => {
+			const auditSink: AuditSinkBase = { kind: "mock", record: vi.fn().mockResolvedValue(undefined) };
+			const app = buildApp({ auditSink });
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, { id_token_hint: token });
+
+			expect(res.status).toBe(200);
+			expect(auditSink.record).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "logout.success",
+					details: expect.objectContaining({ sid: "sid-1" }),
+				}),
+			);
+		});
+	});
+
+	describe("logout.cascade_failed", () => {
+		it("emits on 503 cascade failure", async () => {
+			const auditSink: AuditSinkBase = { kind: "mock", record: vi.fn().mockResolvedValue(undefined) };
+			const refreshStore = makeRefreshStore({
+				revokeFamily: vi.fn().mockRejectedValue(new Error("redis down")),
+			});
+			const app = buildApp({ auditSink, refreshStore });
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, { id_token_hint: token });
+
+			expect(res.status).toBe(503);
+			expect(auditSink.record).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "logout.cascade_failed",
+					details: expect.objectContaining({ sid: "sid-1", step: 1 }),
+				}),
+			);
 		});
 	});
 });

--- a/packages/oauth/src/__tests__/logout.test.mts
+++ b/packages/oauth/src/__tests__/logout.test.mts
@@ -133,6 +133,8 @@ interface BuildAppOpts {
 	clientRepo?: ClientRepository;
 	/** Getter for federation providers — evaluated at request time. */
 	getFederationProviders?: () => ReadonlyMap<string, FederationProviderHandle> | undefined;
+	/** Override fetch for broadcast testing. Defaults to a no-op stub. */
+	fetchImpl?: typeof fetch;
 	logger?: Logger;
 	auditSink?: AuditSinkBase;
 }
@@ -148,7 +150,7 @@ function buildApp(opts: BuildAppOpts = {}) {
 		clientRepository: opts.clientRepo ?? makeClientRepo(),
 		getFederationProviders: opts.getFederationProviders ?? (() => undefined),
 		// Stub fetchImpl so broadcast never makes real network calls
-		fetchImpl: vi.fn().mockResolvedValue({ ok: true }),
+		fetchImpl: opts.fetchImpl ?? vi.fn().mockResolvedValue({ ok: true }),
 		logger: opts.logger,
 		auditSink: opts.auditSink,
 	});
@@ -254,6 +256,47 @@ describe("POST /oauth/logout", () => {
 		});
 	});
 
+	describe("backchannelLogoutSessionRequired:false omits sid from logout_token", () => {
+		it("RP with backchannelLogoutSessionRequired:false → fetch called without sid in logout_token", async () => {
+			const capturedBodies: string[] = [];
+			const fetchSpy = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
+				if (init?.body) capturedBodies.push(String(init.body));
+				return { ok: true };
+			});
+			const sessionWithRP: UserSession = {
+				...baseSession,
+				sub: "u-1",
+				activeRPs: [
+					{
+						clientId: "rp-no-sid",
+						backchannelLogoutUri: "https://rp.example.com/back-logout",
+						backchannelLogoutSessionRequired: false,
+						registeredAt: new Date(),
+					},
+				],
+			};
+			const sessionStore = makeSessionStore({ get: vi.fn().mockResolvedValue(sessionWithRP) });
+			const app = buildApp({ sessionStore, fetchImpl: fetchSpy });
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, { id_token_hint: token });
+
+			expect(res.status).toBe(200);
+			expect(fetchSpy).toHaveBeenCalledOnce();
+			// The logout_token body is URL-encoded; extract and decode it
+			expect(capturedBodies).toHaveLength(1);
+			const params = new URLSearchParams(capturedBodies[0]);
+			const logoutToken = params.get("logout_token");
+			expect(logoutToken).toBeTruthy();
+			if (!logoutToken) throw new Error("logout_token missing from broadcast request body");
+			// Decode JWT payload (no signature verification needed — we minted it)
+			const payloadBase64 = logoutToken.split(".")[1];
+			const payload = JSON.parse(Buffer.from(payloadBase64, "base64url").toString("utf8"));
+			// backchannelLogoutSessionRequired:false → sid MUST be absent
+			expect(payload.sid).toBeUndefined();
+		});
+	});
+
 	describe("front-channel HTML response", () => {
 		it("Accept: text/html + session has frontchannelLogoutUri RP → 200 text/html with <iframe>", async () => {
 			const sessionWithRP: UserSession = {
@@ -276,6 +319,85 @@ describe("POST /oauth/logout", () => {
 			expect(res.headers["content-type"]).toMatch(/text\/html/);
 			expect(res.text).toContain("<iframe");
 			expect(res.text).toContain("rp1.example.com");
+		});
+	});
+
+	describe("HTML branch open-redirect defense", () => {
+		it("unregistered post_logout_redirect_uri is NOT embedded in redirect script (open redirect defense)", async () => {
+			const sessionWithRP: UserSession = {
+				...baseSession,
+				activeRPs: [
+					{
+						clientId: "client-1",
+						frontchannelLogoutUri: "https://rp1.example.com/fc-logout",
+						registeredAt: new Date(),
+					},
+				],
+			};
+			// Client does NOT include evil.example in postLogoutRedirectUris
+			const clientRepo = makeClientRepo({
+				findById: vi.fn().mockResolvedValue({
+					clientId: "client-1",
+					allowedRedirectUris: [],
+					allowedScopes: [],
+					postLogoutRedirectUris: ["https://trusted.example.com/logged-out"],
+				}),
+			});
+			const sessionStore = makeSessionStore({ get: vi.fn().mockResolvedValue(sessionWithRP) });
+			const app = buildApp({ sessionStore, clientRepo });
+			const token = await mintIdToken();
+
+			const res = await postLogout(
+				app,
+				{
+					id_token_hint: token,
+					post_logout_redirect_uri: "https://evil.example/steal",
+				},
+				{ Accept: "text/html" },
+			);
+
+			expect(res.status).toBe(200);
+			expect(res.headers["content-type"]).toMatch(/text\/html/);
+			// Body MUST NOT contain the attacker-controlled URL
+			expect(res.text).not.toContain("evil.example");
+		});
+
+		it("registered post_logout_redirect_uri IS embedded in HTML redirect script", async () => {
+			const sessionWithRP: UserSession = {
+				...baseSession,
+				activeRPs: [
+					{
+						clientId: "client-1",
+						frontchannelLogoutUri: "https://rp1.example.com/fc-logout",
+						registeredAt: new Date(),
+					},
+				],
+			};
+			const clientRepo = makeClientRepo({
+				findById: vi.fn().mockResolvedValue({
+					clientId: "client-1",
+					allowedRedirectUris: [],
+					allowedScopes: [],
+					postLogoutRedirectUris: ["https://trusted.example.com/logged-out"],
+				}),
+			});
+			const sessionStore = makeSessionStore({ get: vi.fn().mockResolvedValue(sessionWithRP) });
+			const app = buildApp({ sessionStore, clientRepo });
+			const token = await mintIdToken();
+
+			const res = await postLogout(
+				app,
+				{
+					id_token_hint: token,
+					post_logout_redirect_uri: "https://trusted.example.com/logged-out",
+				},
+				{ Accept: "text/html" },
+			);
+
+			expect(res.status).toBe(200);
+			expect(res.headers["content-type"]).toMatch(/text\/html/);
+			// The validated URI MUST appear in the page
+			expect(res.text).toContain("trusted.example.com");
 		});
 	});
 

--- a/packages/oauth/src/__tests__/logout.test.mts
+++ b/packages/oauth/src/__tests__/logout.test.mts
@@ -1,0 +1,448 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSecretKey } from "node:crypto";
+import {
+	type ClientRepository,
+	createSymmetricKeyStore,
+	type FederationProviderHandle,
+	type FederationTokenStoreBase,
+	type Logger,
+	type RefreshTokenStoreBase,
+	type UserSession,
+	type UserSessionStoreBase,
+} from "@o3co/auth-provider-core";
+import express from "express";
+import { SignJWT } from "jose";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import { createRouter } from "#/routes/logout.mjs";
+
+const SECRET = "test-secret-at-least-32-chars!!";
+const keyStore = createSymmetricKeyStore(SECRET);
+const secretKey = createSecretKey(Buffer.from(SECRET));
+
+/** Mint an id_token with the given claims. */
+async function mintIdToken(extra: Record<string, unknown> = {}): Promise<string> {
+	return new SignJWT({
+		sub: "u-1",
+		aud: "client-1",
+		sid: "sid-1",
+		...extra,
+	})
+		.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "JWT" })
+		.setExpirationTime("1h")
+		.setIssuedAt()
+		.setIssuer("https://auth.example.com")
+		.sign(secretKey);
+}
+
+// A minimal valid UserSession with no federations (simplifies most test cases)
+const baseSession: UserSession = {
+	sid: "sid-1",
+	sub: "u-1",
+	authTime: new Date(),
+	createdAt: new Date(),
+	expiresAt: new Date(Date.now() + 3_600_000),
+	federations: [],
+	activeRPs: [],
+	familyIds: ["fam-1"],
+	claims: { email: "alice@example.com" },
+};
+
+function makeSessionStore(override?: Partial<UserSessionStoreBase>): UserSessionStoreBase {
+	return {
+		kind: "memory",
+		create: vi.fn(),
+		get: vi.fn().mockResolvedValue(baseSession),
+		registerRP: vi.fn(),
+		linkFamily: vi.fn(),
+		updateClaims: vi.fn(),
+		removeFederation: vi.fn(),
+		delete: vi.fn(),
+		...override,
+	};
+}
+
+function makeRefreshStore(override?: Partial<RefreshTokenStoreBase>): RefreshTokenStoreBase {
+	return {
+		kind: "memory",
+		isFamilyRevoked: vi.fn().mockResolvedValue(false),
+		rotate: vi.fn(),
+		revokeFamily: vi.fn().mockResolvedValue(undefined),
+		...override,
+	};
+}
+
+function makeFedTokenStore(override?: Partial<FederationTokenStoreBase>): FederationTokenStoreBase {
+	return {
+		kind: "memory",
+		attach: vi.fn(),
+		get: vi.fn().mockResolvedValue(null),
+		update: vi.fn(),
+		deleteBySession: vi.fn().mockResolvedValue(undefined),
+		delete: vi.fn(),
+		...override,
+	};
+}
+
+function makeClientRepo(override?: Partial<ClientRepository>): ClientRepository {
+	return {
+		findById: vi.fn().mockResolvedValue(null),
+		authenticate: vi.fn(),
+		...override,
+	};
+}
+
+interface BuildAppOpts {
+	sessionStore?: UserSessionStoreBase;
+	refreshStore?: RefreshTokenStoreBase;
+	fedTokenStore?: FederationTokenStoreBase;
+	clientRepo?: ClientRepository;
+	/** Getter for federation providers — evaluated at request time. */
+	getFederationProviders?: () => ReadonlyMap<string, FederationProviderHandle> | undefined;
+	logger?: Logger;
+}
+
+function buildApp(opts: BuildAppOpts = {}) {
+	const app = express();
+	const router = createRouter(express, {
+		keyStore,
+		issuer: "https://auth.example.com",
+		userSessionStore: opts.sessionStore ?? makeSessionStore(),
+		refreshTokenStore: opts.refreshStore ?? makeRefreshStore(),
+		federationTokenStore: opts.fedTokenStore ?? makeFedTokenStore(),
+		clientRepository: opts.clientRepo ?? makeClientRepo(),
+		getFederationProviders: opts.getFederationProviders ?? (() => undefined),
+		// Stub fetchImpl so broadcast never makes real network calls
+		fetchImpl: vi.fn().mockResolvedValue({ ok: true }),
+		logger: opts.logger,
+	});
+	app.use("/oauth", router);
+	return app;
+}
+
+async function postLogout(
+	app: ReturnType<typeof express>,
+	body: Record<string, string | undefined>,
+	headers: Record<string, string> = {},
+) {
+	const req = request(app).post("/oauth/logout").type("form");
+	for (const [k, v] of Object.entries(headers)) {
+		req.set(k, v);
+	}
+	// Only send defined values
+	const filteredBody = Object.fromEntries(
+		Object.entries(body).filter(([, v]) => v !== undefined),
+	) as Record<string, string>;
+	return req.send(filteredBody);
+}
+
+describe("POST /oauth/logout", () => {
+	describe("happy path", () => {
+		it("valid id_token_hint + session → cascadeLogout called, returns JSON { logged_out: true }", async () => {
+			const sessionStore = makeSessionStore();
+			const refreshStore = makeRefreshStore();
+			const fedTokenStore = makeFedTokenStore();
+			const app = buildApp({ sessionStore, refreshStore, fedTokenStore });
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, { id_token_hint: token });
+
+			expect(res.status).toBe(200);
+			expect(res.body).toEqual({ logged_out: true });
+			// cascadeLogout step 1: revokeFamily called for each familyId
+			expect(refreshStore.revokeFamily).toHaveBeenCalledWith("fam-1");
+			// cascadeLogout step 3: session deleted
+			expect(sessionStore.delete).toHaveBeenCalledWith("sid-1");
+			// cascadeLogout step 2: federation tokens cleared
+			expect(fedTokenStore.deleteBySession).toHaveBeenCalledWith("sid-1");
+		});
+	});
+
+	describe("session missing (defensive no-op)", () => {
+		it("userSessionStore.get → null → 200 JSON, cascadeLogout NOT called", async () => {
+			const sessionStore = makeSessionStore({ get: vi.fn().mockResolvedValue(null) });
+			const refreshStore = makeRefreshStore();
+			const app = buildApp({ sessionStore, refreshStore });
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, { id_token_hint: token });
+
+			expect(res.status).toBe(200);
+			expect(res.body).toEqual({ logged_out: true });
+			expect(refreshStore.revokeFamily).not.toHaveBeenCalled();
+			expect(sessionStore.delete).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("id_token_hint invalid signature", () => {
+		it("returns 400 invalid_token", async () => {
+			const app = buildApp();
+
+			const res = await postLogout(app, { id_token_hint: "not.a.valid.jwt" });
+
+			expect(res.status).toBe(400);
+			expect(res.body.error).toBe("invalid_token");
+		});
+	});
+
+	describe("id_token_hint missing sid claim", () => {
+		it("returns 400 invalid_request", async () => {
+			const app = buildApp();
+			// Mint a token without sid
+			const token = await new SignJWT({ sub: "u-1", aud: "client-1" })
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "JWT" })
+				.setExpirationTime("1h")
+				.setIssuedAt()
+				.sign(secretKey);
+
+			const res = await postLogout(app, { id_token_hint: token });
+
+			expect(res.status).toBe(400);
+			expect(res.body.error).toBe("invalid_request");
+			expect(res.body.error_description).toMatch(/sid/);
+		});
+	});
+
+	describe("cascadeLogout returns failed (step 1: revokeFamily throws)", () => {
+		it("returns 503 temporarily_unavailable", async () => {
+			const refreshStore = makeRefreshStore({
+				revokeFamily: vi.fn().mockRejectedValue(new Error("redis down")),
+			});
+			const app = buildApp({ refreshStore });
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, { id_token_hint: token });
+
+			expect(res.status).toBe(503);
+			expect(res.body.error).toBe("temporarily_unavailable");
+		});
+	});
+
+	describe("front-channel HTML response", () => {
+		it("Accept: text/html + session has frontchannelLogoutUri RP → 200 text/html with <iframe>", async () => {
+			const sessionWithRP: UserSession = {
+				...baseSession,
+				activeRPs: [
+					{
+						clientId: "rp-1",
+						frontchannelLogoutUri: "https://rp1.example.com/fc-logout",
+						registeredAt: new Date(),
+					},
+				],
+			};
+			const sessionStore = makeSessionStore({ get: vi.fn().mockResolvedValue(sessionWithRP) });
+			const app = buildApp({ sessionStore });
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, { id_token_hint: token }, { Accept: "text/html" });
+
+			expect(res.status).toBe(200);
+			expect(res.headers["content-type"]).toMatch(/text\/html/);
+			expect(res.text).toContain("<iframe");
+			expect(res.text).toContain("rp1.example.com");
+		});
+	});
+
+	describe("post_logout_redirect_uri in allowlist", () => {
+		it("returns 303 redirect to post_logout_redirect_uri with state appended", async () => {
+			const clientRepo = makeClientRepo({
+				findById: vi.fn().mockResolvedValue({
+					clientId: "client-1",
+					allowedRedirectUris: [],
+					allowedScopes: [],
+					postLogoutRedirectUris: ["https://app.example.com/logged-out"],
+				}),
+			});
+			const app = buildApp({ clientRepo });
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, {
+				id_token_hint: token,
+				post_logout_redirect_uri: "https://app.example.com/logged-out",
+				state: "csrf-abc",
+			});
+
+			expect(res.status).toBe(303);
+			expect(res.headers.location).toContain("https://app.example.com/logged-out");
+			expect(res.headers.location).toContain("state=csrf-abc");
+		});
+	});
+
+	describe("post_logout_redirect_uri NOT in allowlist", () => {
+		it("falls back to 200 JSON (no redirect)", async () => {
+			const clientRepo = makeClientRepo({
+				findById: vi.fn().mockResolvedValue({
+					clientId: "client-1",
+					allowedRedirectUris: [],
+					allowedScopes: [],
+					postLogoutRedirectUris: ["https://trusted.example.com/logged-out"],
+				}),
+			});
+			const app = buildApp({ clientRepo });
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, {
+				id_token_hint: token,
+				post_logout_redirect_uri: "https://evil.example.com/steal",
+			});
+
+			expect(res.status).toBe(200);
+			expect(res.body).toEqual({ logged_out: true });
+		});
+	});
+
+	describe("federation end-session redirect", () => {
+		it("session.federations has provider with endSession → 303 to mock endSession URL", async () => {
+			const sessionWithFed: UserSession = {
+				...baseSession,
+				federations: ["google"],
+			};
+			const sessionStore = makeSessionStore({ get: vi.fn().mockResolvedValue(sessionWithFed) });
+
+			const mockEndSessionUrl = new URL("https://accounts.google.com/logout?id_token_hint=x");
+			const mockProvider: FederationProviderHandle & {
+				endSession: (req: unknown) => Promise<{ url: URL; method: "GET" }>;
+			} = {
+				name: "google",
+				endSession: vi.fn().mockResolvedValue({ url: mockEndSessionUrl, method: "GET" }),
+			};
+			const federationProviders = new Map<string, FederationProviderHandle>([
+				["google", mockProvider],
+			]);
+
+			const app = buildApp({ sessionStore, getFederationProviders: () => federationProviders });
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, { id_token_hint: token });
+
+			expect(res.status).toBe(303);
+			expect(res.headers.location).toContain("accounts.google.com");
+			expect(mockProvider.endSession).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe("id_token_hint missing entirely", () => {
+		it("returns 400 invalid_request", async () => {
+			const app = buildApp();
+
+			const res = await postLogout(app, {});
+
+			expect(res.status).toBe(400);
+			expect(res.body.error).toBe("invalid_request");
+		});
+	});
+
+	describe("userSessionStore.get throws (fail-closed)", () => {
+		it("returns 503 temporarily_unavailable when userSessionStore.get throws", async () => {
+			const throwingStore = makeSessionStore({
+				get: vi.fn().mockRejectedValue(new Error("redis down")),
+			});
+			const app = buildApp({ sessionStore: throwingStore });
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, { id_token_hint: token });
+
+			expect(res.status).toBe(503);
+			expect(res.body.error).toBe("temporarily_unavailable");
+		});
+	});
+
+	describe("q-weighted Accept header content negotiation", () => {
+		it("application/json > text/html returns JSON (not HTML)", async () => {
+			const sessionWithRP: UserSession = {
+				...baseSession,
+				activeRPs: [
+					{
+						clientId: "rp-1",
+						frontchannelLogoutUri: "https://rp1.example.com/fc-logout",
+						registeredAt: new Date(),
+					},
+				],
+			};
+			const sessionStore = makeSessionStore({ get: vi.fn().mockResolvedValue(sessionWithRP) });
+			const app = buildApp({ sessionStore });
+			const token = await mintIdToken();
+
+			const res = await postLogout(
+				app,
+				{ id_token_hint: token },
+				{ Accept: "application/json, text/html;q=0.1" },
+			);
+
+			expect(res.headers["content-type"]).toMatch(/json/);
+			expect(res.body.logged_out).toBe(true);
+		});
+
+		it("Accept: */* falls back to JSON (not HTML)", async () => {
+			const sessionWithRP: UserSession = {
+				...baseSession,
+				activeRPs: [
+					{
+						clientId: "rp-1",
+						frontchannelLogoutUri: "https://rp1.example.com/fc-logout",
+						registeredAt: new Date(),
+					},
+				],
+			};
+			const sessionStore = makeSessionStore({ get: vi.fn().mockResolvedValue(sessionWithRP) });
+			const app = buildApp({ sessionStore });
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, { id_token_hint: token }, { Accept: "*/*" });
+
+			expect(res.headers["content-type"]).toMatch(/json/);
+			expect(res.body.logged_out).toBe(true);
+		});
+	});
+
+	describe("logger routing for handler-level warnings", () => {
+		it("routes federation endSession failure warning to opts.logger (not console)", async () => {
+			const sessionWithFed: UserSession = {
+				...baseSession,
+				federations: ["google"],
+			};
+			const sessionStore = makeSessionStore({ get: vi.fn().mockResolvedValue(sessionWithFed) });
+			const throwingProvider: FederationProviderHandle & {
+				endSession: () => Promise<never>;
+			} = {
+				name: "google",
+				endSession: vi.fn().mockRejectedValue(new Error("IdP down")),
+			};
+			const warnSpy = vi.fn<(message: string, ...args: unknown[]) => void>();
+			const logger: Logger = { warn: warnSpy };
+			const app = buildApp({
+				sessionStore,
+				getFederationProviders: () =>
+					new Map<string, FederationProviderHandle>([["google", throwingProvider]]),
+				logger,
+			});
+			const token = await mintIdToken();
+
+			const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			try {
+				const res = await postLogout(app, { id_token_hint: token });
+				// Logout still succeeds (best-effort federation end-session)
+				expect(res.status).toBe(200);
+				expect(warnSpy).toHaveBeenCalled();
+				expect(consoleWarnSpy).not.toHaveBeenCalled();
+			} finally {
+				consoleWarnSpy.mockRestore();
+			}
+		});
+	});
+});

--- a/packages/oauth/src/__tests__/logout.test.mts
+++ b/packages/oauth/src/__tests__/logout.test.mts
@@ -904,6 +904,31 @@ describe("POST /oauth/federation/:name/logout", () => {
 		});
 	});
 
+	describe("Cache-Control / Pragma headers", () => {
+		it("401 missing Bearer sets both Cache-Control: no-store and Pragma: no-cache", async () => {
+			const app = buildFedLogoutApp();
+			const res = await request(app).post("/oauth/federation/google/logout").type("form").send({});
+
+			expect(res.status).toBe(401);
+			expect(res.headers["cache-control"]).toBe("no-store");
+			expect(res.headers.pragma).toBe("no-cache");
+		});
+
+		it("503 federationTokenStore.delete throw sets both Cache-Control: no-store and Pragma: no-cache", async () => {
+			const fedTokenStore = makeFedTokenStore({
+				delete: vi.fn().mockRejectedValue(new Error("redis down")),
+			});
+			const app = buildFedLogoutApp({ fedTokenStore });
+			const token = await mintAccessToken();
+
+			const res = await postFedLogout(app, "google", token);
+
+			expect(res.status).toBe(503);
+			expect(res.headers["cache-control"]).toBe("no-store");
+			expect(res.headers.pragma).toBe("no-cache");
+		});
+	});
+
 	describe("logger routing", () => {
 		it("routes /federation/:name/logout failures to opts.logger (not console)", async () => {
 			const warnSpy = vi.fn<(message: string, ...args: unknown[]) => void>();

--- a/packages/oauth/src/__tests__/module.test.mts
+++ b/packages/oauth/src/__tests__/module.test.mts
@@ -238,7 +238,11 @@ describe("oauthModule", () => {
 		// Step 1: oauth module inits (federationProviders still undefined on ctx)
 		const oauth = oauthModule({
 			clientRepository: { findById: vi.fn(), authenticate: vi.fn() } as ClientRepository,
-			codeRepository: { createCode: vi.fn(), getCode: vi.fn(), deleteCode: vi.fn() } as unknown as CodeRepository,
+			codeRepository: {
+				createCode: vi.fn(),
+				getCode: vi.fn(),
+				deleteCode: vi.fn(),
+			} as unknown as CodeRepository,
 			express,
 		});
 		await oauth.init(ctx);

--- a/packages/oauth/src/__tests__/module.test.mts
+++ b/packages/oauth/src/__tests__/module.test.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { createSecretKey } from "node:crypto";
 import {
 	type AppConfig,
 	type AuditEvent,
@@ -21,12 +22,18 @@ import {
 	type ClientRepository,
 	type CodeRepository,
 	createSymmetricKeyStore,
+	type FederationProviderHandle,
+	type FederationTokenStoreBase,
 	GrantRegistry,
 	type ModuleContext,
 	type RateLimiterBase,
+	type RefreshTokenStoreBase,
+	type UserSession,
+	type UserSessionStoreBase,
 } from "@o3co/auth-provider-core";
 import type { Router } from "express";
 import express from "express";
+import { SignJWT } from "jose";
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
 import { oauthModule } from "#/module.mjs";
@@ -139,5 +146,123 @@ describe("oauthModule", () => {
 			(call: unknown[]) => call[0] === "/oauth",
 		);
 		expect(oauthCall).toBeDefined();
+	});
+
+	// -----------------------------------------------------------------------
+	// Integration: lazy getFederationProviders closure
+	//
+	// Proves that composing modules as [oauthModule, sessionModule, ...] (oauth
+	// inits FIRST) still correctly resolves federation providers at request time
+	// because createOAuthRouter receives `() => context.federationProviders`
+	// rather than a snapshot of the map value at init time.
+	// -----------------------------------------------------------------------
+	it("federation logout works when oauth module inits BEFORE context.federationProviders is populated (lazy closure)", async () => {
+		const SECRET = "test-secret-at-least-32-chars!!";
+		const secretKey = createSecretKey(Buffer.from(SECRET));
+
+		// A minimal access token for POST /oauth/federation/:name/logout
+		const accessToken = await new SignJWT({ sub: "u-1", sid: "sid-1", family_id: "fam-1" })
+			.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "at+jwt" })
+			.setExpirationTime("1h")
+			.setIssuedAt()
+			.sign(secretKey);
+
+		// Session has "google" linked
+		const session: UserSession = {
+			sid: "sid-1",
+			sub: "u-1",
+			authTime: new Date(),
+			createdAt: new Date(),
+			expiresAt: new Date(Date.now() + 3_600_000),
+			federations: ["google"],
+			activeRPs: [],
+			familyIds: ["fam-1"],
+			claims: {},
+		};
+
+		const sessionStore: UserSessionStoreBase = {
+			kind: "memory",
+			create: vi.fn(),
+			get: vi.fn().mockResolvedValue(session),
+			registerRP: vi.fn(),
+			linkFamily: vi.fn(),
+			updateClaims: vi.fn(),
+			removeFederation: vi.fn().mockResolvedValue(undefined),
+			delete: vi.fn(),
+		};
+
+		const refreshStore: RefreshTokenStoreBase = {
+			kind: "memory",
+			isFamilyRevoked: vi.fn().mockResolvedValue(false),
+			rotate: vi.fn(),
+			revokeFamily: vi.fn().mockResolvedValue(undefined),
+		};
+
+		const fedTokenStore: FederationTokenStoreBase = {
+			kind: "memory",
+			attach: vi.fn(),
+			get: vi.fn().mockResolvedValue({ idToken: "id-token-hint" }),
+			update: vi.fn(),
+			deleteBySession: vi.fn().mockResolvedValue(undefined),
+			delete: vi.fn().mockResolvedValue(undefined),
+		};
+
+		// The provider's endSession returns a redirect URL
+		const endSessionUrl = new URL("https://accounts.google.com/logout?hint=id-token-hint");
+		const googleProvider: FederationProviderHandle & {
+			endSession: (req: unknown) => Promise<{ url: URL; method: "GET" }>;
+		} = {
+			name: "google",
+			endSession: vi.fn().mockResolvedValue({ url: endSessionUrl, method: "GET" }),
+		};
+
+		// Build context — federationProviders is undefined at construction time,
+		// simulating the state when oauthModule.init runs before sessionModule.init.
+		const rootRouter = express.Router();
+		const ctx: ModuleContext = makeContext({
+			config: {
+				...mockConfig,
+				oauth: {
+					...mockConfig.oauth,
+					jwt: { secret: SECRET, issuer: "https://auth.example.com" },
+				},
+			} as unknown as AppConfig,
+			keyStore: createSymmetricKeyStore(SECRET),
+			router: rootRouter,
+			refreshTokenStore: refreshStore,
+			userSessionStore: sessionStore,
+			federationTokenStore: fedTokenStore,
+			// NOT setting federationProviders yet — simulates oauth init running first
+		});
+
+		// Step 1: oauth module inits (federationProviders still undefined on ctx)
+		const oauth = oauthModule({
+			clientRepository: { findById: vi.fn(), authenticate: vi.fn() } as ClientRepository,
+			codeRepository: { createCode: vi.fn(), getCode: vi.fn(), deleteCode: vi.fn() } as unknown as CodeRepository,
+			express,
+		});
+		await oauth.init(ctx);
+
+		// Step 2: "session module" sets federationProviders AFTER oauth init — simulates
+		// the real module composition order where session inits after oauth.
+		ctx.federationProviders = new Map<string, FederationProviderHandle>([
+			["google", googleProvider],
+		]);
+
+		// Step 3: issue a real HTTP request — the closure in createOAuthRouter reads
+		// context.federationProviders at request time, so it picks up the map set above.
+		const app = express();
+		app.use(rootRouter);
+
+		const res = await request(app)
+			.post("/oauth/federation/google/logout")
+			.type("form")
+			.set("Authorization", `Bearer ${accessToken}`)
+			.send({});
+
+		// The lazy closure resolved the provider → endSession redirect
+		expect(res.status).toBe(303);
+		expect(res.headers.location).toContain("accounts.google.com");
+		expect(googleProvider.endSession).toHaveBeenCalledOnce();
 	});
 });

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -377,8 +377,12 @@ export const createAuthorizationGrant = (
 						clientId: client_id,
 						backchannelLogoutUri: (clientRecord as Record<string, unknown> | null)
 							?.backchannelLogoutUri as string | undefined,
+						backchannelLogoutSessionRequired: (clientRecord as Record<string, unknown> | null)
+							?.backchannelLogoutSessionRequired as boolean | undefined,
 						frontchannelLogoutUri: (clientRecord as Record<string, unknown> | null)
 							?.frontchannelLogoutUri as string | undefined,
+						frontchannelLogoutSessionRequired: (clientRecord as Record<string, unknown> | null)
+							?.frontchannelLogoutSessionRequired as boolean | undefined,
 						registeredAt: new Date(),
 					});
 				} catch {

--- a/packages/oauth/src/index.mts
+++ b/packages/oauth/src/index.mts
@@ -24,6 +24,11 @@ export type {
 	CascadeLogoutResult,
 } from "./logout/cascadeLogout.mjs";
 export { cascadeLogout } from "./logout/cascadeLogout.mjs";
+export {
+	type FrontchannelRP,
+	type RenderFrontchannelLogoutHtmlOptions,
+	renderFrontchannelLogoutHtml,
+} from "./logout/renderFrontchannel.mjs";
 export { oauthModule } from "./module.mjs";
 export { oauthAuthorizationModule } from "./oauthAuthorization.mjs";
 export { oauthSessionModule } from "./oauthSession.mjs";

--- a/packages/oauth/src/index.mts
+++ b/packages/oauth/src/index.mts
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 
+export {
+	type BroadcastBackchannelLogger,
+	type BroadcastBackchannelLogoutOptions,
+	type BroadcastRP,
+	broadcastBackchannelLogout,
+} from "./logout/broadcastBackchannel.mjs";
 export type {
 	CascadeLogoutLogger,
 	CascadeLogoutOptions,
 	CascadeLogoutResult,
 } from "./logout/cascadeLogout.mjs";
 export { cascadeLogout } from "./logout/cascadeLogout.mjs";
+export type { LogoutLogger } from "./logout/types.mjs";
 export { oauthModule } from "./module.mjs";
 export { oauthAuthorizationModule } from "./oauthAuthorization.mjs";
 export { oauthSessionModule } from "./oauthSession.mjs";

--- a/packages/oauth/src/index.mts
+++ b/packages/oauth/src/index.mts
@@ -13,6 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+export type {
+	CascadeLogoutLogger,
+	CascadeLogoutOptions,
+	CascadeLogoutResult,
+} from "./logout/cascadeLogout.mjs";
+export { cascadeLogout } from "./logout/cascadeLogout.mjs";
 export { oauthModule } from "./module.mjs";
 export { oauthAuthorizationModule } from "./oauthAuthorization.mjs";
 export { oauthSessionModule } from "./oauthSession.mjs";

--- a/packages/oauth/src/index.mts
+++ b/packages/oauth/src/index.mts
@@ -15,18 +15,15 @@
  */
 
 export {
-	type BroadcastBackchannelLogger,
 	type BroadcastBackchannelLogoutOptions,
 	type BroadcastRP,
 	broadcastBackchannelLogout,
 } from "./logout/broadcastBackchannel.mjs";
 export type {
-	CascadeLogoutLogger,
 	CascadeLogoutOptions,
 	CascadeLogoutResult,
 } from "./logout/cascadeLogout.mjs";
 export { cascadeLogout } from "./logout/cascadeLogout.mjs";
-export type { LogoutLogger } from "./logout/types.mjs";
 export { oauthModule } from "./module.mjs";
 export { oauthAuthorizationModule } from "./oauthAuthorization.mjs";
 export { oauthSessionModule } from "./oauthSession.mjs";

--- a/packages/oauth/src/logout/__tests__/broadcastBackchannel.test.mts
+++ b/packages/oauth/src/logout/__tests__/broadcastBackchannel.test.mts
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSymmetricKeyStore } from "@o3co/auth-provider-core";
+import { decodeJwt } from "jose";
+import { describe, expect, it, vi } from "vitest";
+import { broadcastBackchannelLogout } from "../broadcastBackchannel.mjs";
+
+const keyStore = createSymmetricKeyStore("test-secret-32-chars-xxxxxxxxxx");
+
+describe("broadcastBackchannelLogout", () => {
+	it("POSTs logout_token to each RP's backchannelLogoutUri in parallel", async () => {
+		const fetchMock = vi.fn(async () => ({ ok: true, status: 204, statusText: "No Content" }));
+		await broadcastBackchannelLogout({
+			rps: [
+				{
+					clientId: "rp1",
+					backchannelLogoutUri: "https://rp1.example/bc",
+					backchannelLogoutSessionRequired: true,
+				},
+				{
+					clientId: "rp2",
+					backchannelLogoutUri: "https://rp2.example/bc",
+					backchannelLogoutSessionRequired: true,
+				},
+			],
+			issuer: "iss",
+			sub: "u",
+			sid: "sid-1",
+			keyStore,
+			fetchImpl: fetchMock as unknown as typeof fetch,
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		// Parallel dispatch — call order is non-deterministic; find rp1 by URL.
+		const calls = fetchMock.mock.calls as unknown as [string, RequestInit][];
+		const rp1Call = calls.find((c) => c[0] === "https://rp1.example/bc");
+		expect(rp1Call).toBeDefined();
+		const init = rp1Call?.[1];
+		expect(init?.method).toBe("POST");
+		const headers = init?.headers as Record<string, string>;
+		expect(headers?.["Content-Type"]).toBe("application/x-www-form-urlencoded");
+		const body = String(init?.body);
+		expect(body).toMatch(/^logout_token=/);
+		// Confirm rp2 was also called.
+		expect(calls.find((c) => c[0] === "https://rp2.example/bc")).toBeDefined();
+	});
+
+	it("skips RPs without backchannelLogoutUri", async () => {
+		const fetchMock = vi.fn(async () => ({ ok: true, status: 204, statusText: "" }));
+		await broadcastBackchannelLogout({
+			rps: [
+				{ clientId: "rp1" }, // no URI
+				{ clientId: "rp2", backchannelLogoutUri: "https://rp2.example/bc" },
+			],
+			issuer: "iss",
+			sub: "u",
+			sid: "sid-1",
+			keyStore,
+			fetchImpl: fetchMock as unknown as typeof fetch,
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const skipCalls = fetchMock.mock.calls as unknown as [string, RequestInit][];
+		expect(skipCalls[0]?.[0]).toBe("https://rp2.example/bc");
+	});
+
+	it("excludes sid from logout_token when backchannelLogoutSessionRequired: false", async () => {
+		const fetchMock = vi.fn(async () => ({ ok: true, status: 204, statusText: "" }));
+		await broadcastBackchannelLogout({
+			rps: [
+				{
+					clientId: "rp1",
+					backchannelLogoutUri: "https://rp.example/bc",
+					backchannelLogoutSessionRequired: false,
+				},
+			],
+			issuer: "iss",
+			sub: "u",
+			sid: "sid-1",
+			keyStore,
+			fetchImpl: fetchMock as unknown as typeof fetch,
+		});
+		const excludeCalls = fetchMock.mock.calls as unknown as [string, RequestInit][];
+		const body = String(excludeCalls[0]?.[1]?.body);
+		const params = new URLSearchParams(body);
+		const logoutToken = params.get("logout_token");
+		expect(logoutToken).not.toBeNull();
+		// cast through unknown to avoid non-null assertion
+		expect(
+			(decodeJwt(logoutToken as unknown as string) as Record<string, unknown>).sid,
+		).toBeUndefined();
+	});
+
+	it("includes sid by default (backchannelLogoutSessionRequired defaults to true)", async () => {
+		const fetchMock = vi.fn(async () => ({ ok: true, status: 204, statusText: "" }));
+		await broadcastBackchannelLogout({
+			rps: [{ clientId: "rp1", backchannelLogoutUri: "https://rp.example/bc" }],
+			issuer: "iss",
+			sub: "u",
+			sid: "sid-1",
+			keyStore,
+			fetchImpl: fetchMock as unknown as typeof fetch,
+		});
+		const includesCalls = fetchMock.mock.calls as unknown as [string, RequestInit][];
+		const body = String(includesCalls[0]?.[1]?.body);
+		const logoutToken = new URLSearchParams(body).get("logout_token");
+		expect(logoutToken).not.toBeNull();
+		expect((decodeJwt(logoutToken as unknown as string) as Record<string, unknown>).sid).toBe(
+			"sid-1",
+		);
+	});
+
+	it("times out slow RPs without delaying others (uses AbortController)", async () => {
+		const slow = vi.fn((url: string, init?: RequestInit) => {
+			void url;
+			return new Promise<Response>((_resolve, reject) => {
+				init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+			});
+		});
+		const fast = vi.fn(async (_url: string, _init?: RequestInit) => ({
+			ok: true,
+			status: 204,
+			statusText: "",
+		}));
+		const fetchImpl = vi.fn((url: string, init?: RequestInit) => {
+			return url === "https://slow.example/bc" ? slow(url, init) : fast(url, init);
+		}) as unknown as typeof fetch;
+		const logger = { warn: vi.fn() };
+		const start = Date.now();
+		await broadcastBackchannelLogout({
+			rps: [
+				{ clientId: "slow", backchannelLogoutUri: "https://slow.example/bc" },
+				{ clientId: "fast", backchannelLogoutUri: "https://fast.example/bc" },
+			],
+			issuer: "iss",
+			sub: "u",
+			sid: "sid",
+			keyStore,
+			fetchImpl,
+			timeoutMs: 200,
+			logger,
+		});
+		expect(Date.now() - start).toBeLessThan(2_000);
+		expect(fast).toHaveBeenCalled();
+		expect(logger.warn).toHaveBeenCalled();
+	}, 10_000);
+
+	it("4xx/5xx RP responses are logged as warnings; broadcast resolves without throwing", async () => {
+		const fetchMock = vi.fn(async () => ({
+			ok: false,
+			status: 500,
+			statusText: "Internal Server Error",
+		}));
+		const logger = { warn: vi.fn() };
+		await expect(
+			broadcastBackchannelLogout({
+				rps: [{ clientId: "rp1", backchannelLogoutUri: "https://rp.example/bc" }],
+				issuer: "iss",
+				sub: "u",
+				sid: "sid",
+				keyStore,
+				fetchImpl: fetchMock as unknown as typeof fetch,
+				logger,
+			}),
+		).resolves.toBeUndefined();
+		expect(logger.warn).toHaveBeenCalled();
+	});
+
+	it("uses opts.logger over console.warn when provided", async () => {
+		const fetchMock = vi.fn(async () => ({ ok: false, status: 500, statusText: "" }));
+		const logger = { warn: vi.fn() };
+		const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			await broadcastBackchannelLogout({
+				rps: [{ clientId: "rp1", backchannelLogoutUri: "https://rp.example/bc" }],
+				issuer: "iss",
+				sub: "u",
+				sid: "sid",
+				keyStore,
+				fetchImpl: fetchMock as unknown as typeof fetch,
+				logger,
+			});
+			expect(logger.warn).toHaveBeenCalled();
+			expect(consoleWarnSpy).not.toHaveBeenCalled();
+		} finally {
+			consoleWarnSpy.mockRestore();
+		}
+	});
+
+	it("never throws even if all RPs fail (best-effort guarantee)", async () => {
+		const fetchMock = vi.fn(async () => {
+			throw new Error("network partition");
+		});
+		const logger = { warn: vi.fn() };
+		await expect(
+			broadcastBackchannelLogout({
+				rps: [
+					{ clientId: "rp1", backchannelLogoutUri: "https://a/bc" },
+					{ clientId: "rp2", backchannelLogoutUri: "https://b/bc" },
+				],
+				issuer: "iss",
+				sub: "u",
+				sid: "sid",
+				keyStore,
+				fetchImpl: fetchMock as unknown as typeof fetch,
+				logger,
+			}),
+		).resolves.toBeUndefined();
+		expect(logger.warn).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/oauth/src/logout/__tests__/cascadeLogout.test.mts
+++ b/packages/oauth/src/logout/__tests__/cascadeLogout.test.mts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+	FederationTokenStoreBase,
+	RefreshTokenStoreBase,
+	UserSessionStoreBase,
+} from "@o3co/auth-provider-core";
+import { cascadeLogout } from "../cascadeLogout.mjs";
+
+const okRefresh = () =>
+	({ revokeFamily: vi.fn().mockResolvedValue(undefined) }) as unknown as RefreshTokenStoreBase;
+const okFederation = () =>
+	({ deleteBySession: vi.fn().mockResolvedValue(undefined) }) as unknown as FederationTokenStoreBase;
+const okSession = () =>
+	({ delete: vi.fn().mockResolvedValue(undefined) }) as unknown as UserSessionStoreBase;
+
+describe("cascadeLogout (spec Section 14.2)", () => {
+	it("executes in fixed order: revokeFamily (each) → deleteBySession → delete", async () => {
+		const rts = okRefresh();
+		const fts = okFederation();
+		const uss = okSession();
+		const result = await cascadeLogout({
+			sid: "sid-1",
+			familyIds: ["fam-1", "fam-2"],
+			refreshTokenStore: rts,
+			federationTokenStore: fts,
+			userSessionStore: uss,
+		});
+		expect(result.outcome).toBe("done");
+		expect((rts as unknown as { revokeFamily: typeof vi.fn }).revokeFamily).toHaveBeenCalledTimes(2);
+		expect((rts as unknown as { revokeFamily: typeof vi.fn }).revokeFamily).toHaveBeenNthCalledWith(1, "fam-1");
+		expect((rts as unknown as { revokeFamily: typeof vi.fn }).revokeFamily).toHaveBeenNthCalledWith(2, "fam-2");
+		expect((fts as unknown as { deleteBySession: typeof vi.fn }).deleteBySession).toHaveBeenCalledWith("sid-1");
+		expect((uss as unknown as { delete: typeof vi.fn }).delete).toHaveBeenCalledWith("sid-1");
+	});
+
+	it("step-1 throw → outcome: failed, step: 1; steps 2/3 NOT executed", async () => {
+		const rts = { revokeFamily: vi.fn().mockRejectedValue(new Error("redis down")) };
+		const fts = okFederation();
+		const uss = okSession();
+		const result = await cascadeLogout({
+			sid: "s",
+			familyIds: ["f"],
+			refreshTokenStore: rts as unknown as RefreshTokenStoreBase,
+			federationTokenStore: fts,
+			userSessionStore: uss,
+		});
+		expect(result.outcome).toBe("failed");
+		if (result.outcome === "failed") {
+			expect(result.step).toBe(1);
+			expect(result.error).toBeInstanceOf(Error);
+		}
+		expect((fts as unknown as { deleteBySession: typeof vi.fn }).deleteBySession).not.toHaveBeenCalled();
+		expect((uss as unknown as { delete: typeof vi.fn }).delete).not.toHaveBeenCalled();
+	});
+
+	it("step-2 throw → outcome: done, continues to step 3 (best-effort)", async () => {
+		const rts = okRefresh();
+		const fts = { deleteBySession: vi.fn().mockRejectedValue(new Error("net")) };
+		const uss = okSession();
+		const warnings: unknown[] = [];
+		const originalWarn = console.warn;
+		console.warn = (...args: unknown[]) => {
+			warnings.push(args);
+		};
+		try {
+			const result = await cascadeLogout({
+				sid: "s",
+				familyIds: ["f"],
+				refreshTokenStore: rts,
+				federationTokenStore: fts as unknown as FederationTokenStoreBase,
+				userSessionStore: uss,
+			});
+			expect(result.outcome).toBe("done");
+			expect((uss as unknown as { delete: typeof vi.fn }).delete).toHaveBeenCalled();
+			expect(warnings.length).toBeGreaterThan(0);
+		} finally {
+			console.warn = originalWarn;
+		}
+	});
+
+	it("routes step-2 warning to opts.logger when provided (not console.warn)", async () => {
+		const rts = okRefresh();
+		const fts = { deleteBySession: vi.fn().mockRejectedValue(new Error("net")) };
+		const uss = okSession();
+		const loggerWarn = vi.fn();
+		const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const result = await cascadeLogout({
+				sid: "s",
+				familyIds: ["f"],
+				refreshTokenStore: rts,
+				federationTokenStore: fts as unknown as FederationTokenStoreBase,
+				userSessionStore: uss,
+				logger: { warn: loggerWarn },
+			});
+			expect(result.outcome).toBe("done");
+			expect(loggerWarn).toHaveBeenCalledTimes(1);
+			expect(loggerWarn.mock.calls[0]?.[0]).toMatch(/cascadeLogout/);
+			expect(consoleWarnSpy).not.toHaveBeenCalled();
+		} finally {
+			consoleWarnSpy.mockRestore();
+		}
+	});
+
+	it("step-3 throw → outcome: failed, step: 3", async () => {
+		const rts = okRefresh();
+		const fts = okFederation();
+		const uss = { delete: vi.fn().mockRejectedValue(new Error("redis down")) };
+		const result = await cascadeLogout({
+			sid: "s",
+			familyIds: ["f"],
+			refreshTokenStore: rts,
+			federationTokenStore: fts,
+			userSessionStore: uss as unknown as UserSessionStoreBase,
+		});
+		expect(result.outcome).toBe("failed");
+		if (result.outcome === "failed") {
+			expect(result.step).toBe(3);
+		}
+	});
+
+	it("empty familyIds array skips step 1 and still runs 2+3", async () => {
+		const rts = okRefresh();
+		const fts = okFederation();
+		const uss = okSession();
+		await cascadeLogout({
+			sid: "s",
+			familyIds: [],
+			refreshTokenStore: rts,
+			federationTokenStore: fts,
+			userSessionStore: uss,
+		});
+		expect((rts as unknown as { revokeFamily: typeof vi.fn }).revokeFamily).not.toHaveBeenCalled();
+		expect((fts as unknown as { deleteBySession: typeof vi.fn }).deleteBySession).toHaveBeenCalled();
+		expect((uss as unknown as { delete: typeof vi.fn }).delete).toHaveBeenCalled();
+	});
+});

--- a/packages/oauth/src/logout/__tests__/cascadeLogout.test.mts
+++ b/packages/oauth/src/logout/__tests__/cascadeLogout.test.mts
@@ -1,15 +1,17 @@
-import { describe, expect, it, vi } from "vitest";
 import type {
 	FederationTokenStoreBase,
 	RefreshTokenStoreBase,
 	UserSessionStoreBase,
 } from "@o3co/auth-provider-core";
+import { describe, expect, it, vi } from "vitest";
 import { cascadeLogout } from "../cascadeLogout.mjs";
 
 const okRefresh = () =>
 	({ revokeFamily: vi.fn().mockResolvedValue(undefined) }) as unknown as RefreshTokenStoreBase;
 const okFederation = () =>
-	({ deleteBySession: vi.fn().mockResolvedValue(undefined) }) as unknown as FederationTokenStoreBase;
+	({
+		deleteBySession: vi.fn().mockResolvedValue(undefined),
+	}) as unknown as FederationTokenStoreBase;
 const okSession = () =>
 	({ delete: vi.fn().mockResolvedValue(undefined) }) as unknown as UserSessionStoreBase;
 
@@ -26,10 +28,20 @@ describe("cascadeLogout (spec Section 14.2)", () => {
 			userSessionStore: uss,
 		});
 		expect(result.outcome).toBe("done");
-		expect((rts as unknown as { revokeFamily: typeof vi.fn }).revokeFamily).toHaveBeenCalledTimes(2);
-		expect((rts as unknown as { revokeFamily: typeof vi.fn }).revokeFamily).toHaveBeenNthCalledWith(1, "fam-1");
-		expect((rts as unknown as { revokeFamily: typeof vi.fn }).revokeFamily).toHaveBeenNthCalledWith(2, "fam-2");
-		expect((fts as unknown as { deleteBySession: typeof vi.fn }).deleteBySession).toHaveBeenCalledWith("sid-1");
+		expect((rts as unknown as { revokeFamily: typeof vi.fn }).revokeFamily).toHaveBeenCalledTimes(
+			2,
+		);
+		expect((rts as unknown as { revokeFamily: typeof vi.fn }).revokeFamily).toHaveBeenNthCalledWith(
+			1,
+			"fam-1",
+		);
+		expect((rts as unknown as { revokeFamily: typeof vi.fn }).revokeFamily).toHaveBeenNthCalledWith(
+			2,
+			"fam-2",
+		);
+		expect(
+			(fts as unknown as { deleteBySession: typeof vi.fn }).deleteBySession,
+		).toHaveBeenCalledWith("sid-1");
 		expect((uss as unknown as { delete: typeof vi.fn }).delete).toHaveBeenCalledWith("sid-1");
 	});
 
@@ -49,7 +61,9 @@ describe("cascadeLogout (spec Section 14.2)", () => {
 			expect(result.step).toBe(1);
 			expect(result.error).toBeInstanceOf(Error);
 		}
-		expect((fts as unknown as { deleteBySession: typeof vi.fn }).deleteBySession).not.toHaveBeenCalled();
+		expect(
+			(fts as unknown as { deleteBySession: typeof vi.fn }).deleteBySession,
+		).not.toHaveBeenCalled();
 		expect((uss as unknown as { delete: typeof vi.fn }).delete).not.toHaveBeenCalled();
 	});
 
@@ -131,7 +145,9 @@ describe("cascadeLogout (spec Section 14.2)", () => {
 			userSessionStore: uss,
 		});
 		expect((rts as unknown as { revokeFamily: typeof vi.fn }).revokeFamily).not.toHaveBeenCalled();
-		expect((fts as unknown as { deleteBySession: typeof vi.fn }).deleteBySession).toHaveBeenCalled();
+		expect(
+			(fts as unknown as { deleteBySession: typeof vi.fn }).deleteBySession,
+		).toHaveBeenCalled();
 		expect((uss as unknown as { delete: typeof vi.fn }).delete).toHaveBeenCalled();
 	});
 });

--- a/packages/oauth/src/logout/__tests__/renderFrontchannel.test.mts
+++ b/packages/oauth/src/logout/__tests__/renderFrontchannel.test.mts
@@ -5,8 +5,16 @@ describe("renderFrontchannelLogoutHtml", () => {
 	it("emits one iframe per RP with frontchannelLogoutUri", () => {
 		const html = renderFrontchannelLogoutHtml({
 			rps: [
-				{ clientId: "rp1", frontchannelLogoutUri: "https://rp1.example/fc", frontchannelLogoutSessionRequired: true },
-				{ clientId: "rp2", frontchannelLogoutUri: "https://rp2.example/fc", frontchannelLogoutSessionRequired: true },
+				{
+					clientId: "rp1",
+					frontchannelLogoutUri: "https://rp1.example/fc",
+					frontchannelLogoutSessionRequired: true,
+				},
+				{
+					clientId: "rp2",
+					frontchannelLogoutUri: "https://rp2.example/fc",
+					frontchannelLogoutSessionRequired: true,
+				},
 				{ clientId: "rp3" }, // no frontchannelLogoutUri — skipped
 			],
 			issuer: "https://auth.example",
@@ -179,10 +187,7 @@ describe("renderFrontchannelLogoutHtml", () => {
 		// exactly one iframe in the output
 		expect([...html.matchAll(/<iframe/g)].length).toBe(1);
 		// warning was logged for the bad RP
-		expect(logger.warn).toHaveBeenCalledWith(
-			expect.stringContaining("bad"),
-			expect.anything(),
-		);
+		expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("bad"), expect.anything());
 	});
 
 	it("postLogoutRedirectUri is safe against </script> injection (CSP-safe pattern)", () => {
@@ -190,7 +195,7 @@ describe("renderFrontchannelLogoutHtml", () => {
 			rps: [],
 			issuer: "iss",
 			sid: "sid",
-			postLogoutRedirectUri: 'https://evil.example/</script><script>alert(1)</script>',
+			postLogoutRedirectUri: "https://evil.example/</script><script>alert(1)</script>",
 		});
 		// The literal </script> must not appear in the output — it would prematurely
 		// close the inline <script> block wrapping the redirect.

--- a/packages/oauth/src/logout/__tests__/renderFrontchannel.test.mts
+++ b/packages/oauth/src/logout/__tests__/renderFrontchannel.test.mts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it } from "vitest";
+import { assert, describe, expect, it, vi } from "vitest";
 import { renderFrontchannelLogoutHtml } from "../renderFrontchannel.mjs";
 
 describe("renderFrontchannelLogoutHtml", () => {
@@ -159,6 +159,30 @@ describe("renderFrontchannelLogoutHtml", () => {
 		});
 		expect(html).not.toContain("setTimeout");
 		expect(html).not.toContain("window.location.href");
+	});
+
+	it("skips RPs with invalid frontchannelLogoutUri instead of throwing", () => {
+		const logger = { warn: vi.fn() };
+		const html = renderFrontchannelLogoutHtml({
+			rps: [
+				{ clientId: "good", frontchannelLogoutUri: "https://good.example/fc" },
+				{ clientId: "bad", frontchannelLogoutUri: "not-a-url" },
+			],
+			issuer: "https://auth.example",
+			sid: "sid-1",
+			logger,
+		});
+		// good RP still produces an iframe
+		expect(html).toContain("good.example");
+		// bad RP is skipped
+		expect(html).not.toContain("not-a-url");
+		// exactly one iframe in the output
+		expect([...html.matchAll(/<iframe/g)].length).toBe(1);
+		// warning was logged for the bad RP
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining("bad"),
+			expect.anything(),
+		);
 	});
 
 	it("postLogoutRedirectUri is safe against </script> injection (CSP-safe pattern)", () => {

--- a/packages/oauth/src/logout/__tests__/renderFrontchannel.test.mts
+++ b/packages/oauth/src/logout/__tests__/renderFrontchannel.test.mts
@@ -1,0 +1,177 @@
+import { assert, describe, expect, it } from "vitest";
+import { renderFrontchannelLogoutHtml } from "../renderFrontchannel.mjs";
+
+describe("renderFrontchannelLogoutHtml", () => {
+	it("emits one iframe per RP with frontchannelLogoutUri", () => {
+		const html = renderFrontchannelLogoutHtml({
+			rps: [
+				{ clientId: "rp1", frontchannelLogoutUri: "https://rp1.example/fc", frontchannelLogoutSessionRequired: true },
+				{ clientId: "rp2", frontchannelLogoutUri: "https://rp2.example/fc", frontchannelLogoutSessionRequired: true },
+				{ clientId: "rp3" }, // no frontchannelLogoutUri — skipped
+			],
+			issuer: "https://auth.example",
+			sid: "sid-1",
+		});
+		expect(html).toContain("https://rp1.example/fc");
+		expect(html).toContain("https://rp2.example/fc");
+		expect(html).not.toContain("rp3");
+		expect([...html.matchAll(/<iframe/g)].length).toBe(2);
+	});
+
+	it("appends iss + sid query params to iframe URLs when frontchannelLogoutSessionRequired: true", () => {
+		const html = renderFrontchannelLogoutHtml({
+			rps: [
+				{
+					clientId: "rp",
+					frontchannelLogoutUri: "https://rp.example/fc",
+					frontchannelLogoutSessionRequired: true,
+				},
+			],
+			issuer: "https://auth.example",
+			sid: "sid-1",
+		});
+		// Because HTML-escaping converts & → &amp;, check either form defensively.
+		expect(html).toMatch(
+			/https:\/\/rp\.example\/fc\?iss=https%3A%2F%2Fauth\.example(?:&|&amp;)sid=sid-1/,
+		);
+	});
+
+	it("omits sid when frontchannelLogoutSessionRequired: false", () => {
+		const html = renderFrontchannelLogoutHtml({
+			rps: [
+				{
+					clientId: "rp",
+					frontchannelLogoutUri: "https://rp.example/fc",
+					frontchannelLogoutSessionRequired: false,
+				},
+			],
+			issuer: "iss",
+			sid: "sid-1",
+		});
+		expect(html).toMatch(/https:\/\/rp\.example\/fc\?iss=/);
+		expect(html).not.toContain("sid=sid-1");
+	});
+
+	it("includes sid by default when frontchannelLogoutSessionRequired is undefined", () => {
+		const html = renderFrontchannelLogoutHtml({
+			rps: [{ clientId: "rp", frontchannelLogoutUri: "https://rp.example/fc" }],
+			issuer: "iss",
+			sid: "sid-1",
+		});
+		expect(html).toContain("sid=sid-1");
+	});
+
+	it("iframe URL with untrusted chars is neutralized (percent-encoded by URL normalization)", () => {
+		const html = renderFrontchannelLogoutHtml({
+			rps: [
+				{
+					clientId: "evil",
+					frontchannelLogoutUri: 'https://evil.example/fc?x="><script>alert(1)</script>',
+					frontchannelLogoutSessionRequired: false,
+				},
+			],
+			issuer: "iss",
+			sid: "sid",
+		});
+		// Whatever encoding form, the raw injection must not appear:
+		expect(html).not.toContain('"><script>alert(1)</script>');
+		// new URL() percent-encodes `<`, `>`, `"`, `(`, `)`, `/` during normalization.
+		// The closing tag encodes as %3C%2Fscript%3E (%2F = '/'):
+		expect(html).toMatch(/%3Cscript%3Ealert%281%29%3C%2Fscript%3E/);
+	});
+
+	it("preserves fragment in frontchannelLogoutUri (fragment must come after query)", () => {
+		const html = renderFrontchannelLogoutHtml({
+			rps: [{ clientId: "rp", frontchannelLogoutUri: "https://rp.example/fc#app-route" }],
+			issuer: "https://auth.example",
+			sid: "sid-1",
+		});
+		// Expected: ...fc?iss=...&sid=...#app-route
+		// Find the iframe src attribute content (HTML-escaped form in output)
+		const match = html.match(/<iframe src="([^"]+)"/);
+		assert(match !== null, "expected an iframe src in the rendered HTML");
+		const src = (match[1] ?? "").replace(/&amp;/g, "&"); // undo HTML escape
+		// Query params come before fragment:
+		const queryIdx = src.indexOf("?");
+		const fragIdx = src.indexOf("#");
+		expect(queryIdx).toBeGreaterThan(-1);
+		expect(fragIdx).toBeGreaterThan(queryIdx);
+		// Fragment is preserved:
+		expect(src).toContain("#app-route");
+		// Both params are in the query portion:
+		expect(src.substring(queryIdx, fragIdx)).toContain("iss=");
+		expect(src.substring(queryIdx, fragIdx)).toContain("sid=sid-1");
+	});
+
+	it("appends to existing query string with `&` separator", () => {
+		const html = renderFrontchannelLogoutHtml({
+			rps: [{ clientId: "rp", frontchannelLogoutUri: "https://rp.example/fc?tenant=foo" }],
+			issuer: "iss",
+			sid: "sid-1",
+		});
+		const match = html.match(/<iframe src="([^"]+)"/);
+		assert(match !== null, "expected an iframe src in the rendered HTML");
+		const src = (match[1] ?? "").replace(/&amp;/g, "&");
+		expect(src).toMatch(/^https:\/\/rp\.example\/fc\?tenant=foo&iss=iss&sid=sid-1$/);
+	});
+
+	it("includes referrerpolicy=no-referrer on each iframe (Front-Channel Logout §2 hardening)", () => {
+		const html = renderFrontchannelLogoutHtml({
+			rps: [
+				{ clientId: "rp1", frontchannelLogoutUri: "https://rp1.example/fc" },
+				{ clientId: "rp2", frontchannelLogoutUri: "https://rp2.example/fc" },
+			],
+			issuer: "iss",
+			sid: "sid",
+		});
+		const iframeCount = (html.match(/<iframe[^>]*referrerpolicy="no-referrer"/g) ?? []).length;
+		expect(iframeCount).toBe(2);
+	});
+
+	it("redirects to postLogoutRedirectUri via setTimeout when provided", () => {
+		const html = renderFrontchannelLogoutHtml({
+			rps: [],
+			issuer: "iss",
+			sid: "sid",
+			postLogoutRedirectUri: "https://rp.example/logged-out",
+		});
+		expect(html).toContain("https://rp.example/logged-out");
+		expect(html).toMatch(/window\.location\.href/);
+		expect(html).toMatch(/setTimeout/);
+	});
+
+	it("uses custom redirectDelayMs when provided", () => {
+		const html = renderFrontchannelLogoutHtml({
+			rps: [],
+			issuer: "iss",
+			sid: "sid",
+			postLogoutRedirectUri: "https://rp.example/logged-out",
+			redirectDelayMs: 500,
+		});
+		expect(html).toContain(", 500)");
+	});
+
+	it("no redirect script when postLogoutRedirectUri is absent", () => {
+		const html = renderFrontchannelLogoutHtml({
+			rps: [{ clientId: "rp", frontchannelLogoutUri: "https://rp.example/fc" }],
+			issuer: "iss",
+			sid: "sid",
+		});
+		expect(html).not.toContain("setTimeout");
+		expect(html).not.toContain("window.location.href");
+	});
+
+	it("postLogoutRedirectUri is safe against </script> injection (CSP-safe pattern)", () => {
+		const html = renderFrontchannelLogoutHtml({
+			rps: [],
+			issuer: "iss",
+			sid: "sid",
+			postLogoutRedirectUri: 'https://evil.example/</script><script>alert(1)</script>',
+		});
+		// The literal </script> must not appear in the output — it would prematurely
+		// close the inline <script> block wrapping the redirect.
+		expect(html).not.toContain("</script><script>");
+		// The escaped form (\u003c/script\u003e) is what we expect instead.
+		expect(html).toContain("\\u003c/script");
+	});
+});

--- a/packages/oauth/src/logout/broadcastBackchannel.mts
+++ b/packages/oauth/src/logout/broadcastBackchannel.mts
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 
-import { generateLogoutToken, type KeyStore } from "@o3co/auth-provider-core";
-import type { LogoutLogger } from "./types.mjs";
-
-export type { LogoutLogger } from "./types.mjs";
+import { generateLogoutToken, type KeyStore, type Logger } from "@o3co/auth-provider-core";
 
 export interface BroadcastRP {
 	readonly clientId: string;
@@ -42,11 +39,8 @@ export interface BroadcastBackchannelLogoutOptions {
 	/** Per-request timeout in milliseconds. Defaults to 5000ms. */
 	readonly timeoutMs?: number;
 	/** Optional structured logger. Defaults to `console`. */
-	readonly logger?: LogoutLogger;
+	readonly logger?: Logger;
 }
-
-/** Re-export for consumers that need the logger interface by its broadcast-specific name. */
-export type BroadcastBackchannelLogger = LogoutLogger;
 
 const DEFAULT_TIMEOUT_MS = 5_000;
 

--- a/packages/oauth/src/logout/broadcastBackchannel.mts
+++ b/packages/oauth/src/logout/broadcastBackchannel.mts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { generateLogoutToken, type KeyStore } from "@o3co/auth-provider-core";
+import type { LogoutLogger } from "./types.mjs";
+
+export type { LogoutLogger } from "./types.mjs";
+
+export interface BroadcastRP {
+	readonly clientId: string;
+	readonly backchannelLogoutUri?: string;
+	/**
+	 * Whether the RP requires `sid` in the logout_token for session correlation.
+	 * Defaults to `true` — include sid unless explicitly set to `false`.
+	 */
+	readonly backchannelLogoutSessionRequired?: boolean;
+}
+
+export interface BroadcastBackchannelLogoutOptions {
+	readonly rps: ReadonlyArray<BroadcastRP>;
+	/** Issuer URL of this auth provider. */
+	readonly issuer: string;
+	/** Subject identifier of the user being logged out. */
+	readonly sub: string;
+	/** Session ID being terminated. Included in each logout_token when the RP requires sid. */
+	readonly sid: string;
+	readonly keyStore: KeyStore;
+	/** Override for unit tests. Defaults to the global `fetch`. */
+	readonly fetchImpl?: typeof fetch;
+	/** Per-request timeout in milliseconds. Defaults to 5000ms. */
+	readonly timeoutMs?: number;
+	/** Optional structured logger. Defaults to `console`. */
+	readonly logger?: LogoutLogger;
+}
+
+/** Re-export for consumers that need the logger interface by its broadcast-specific name. */
+export type BroadcastBackchannelLogger = LogoutLogger;
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+/**
+ * Best-effort parallel POST of OIDC Back-Channel Logout 1.0 logout_token to each RP's
+ * `backchannelLogoutUri`. Never throws; 4xx/5xx/network/timeout failures are logged via
+ * `opts.logger ?? console`. RPs without a `backchannelLogoutUri` are skipped.
+ */
+export async function broadcastBackchannelLogout(
+	opts: BroadcastBackchannelLogoutOptions,
+): Promise<void> {
+	const fetchImpl = opts.fetchImpl ?? fetch;
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const logger = opts.logger ?? console;
+
+	const tasks = opts.rps
+		.filter(
+			(rp): rp is BroadcastRP & { backchannelLogoutUri: string } =>
+				typeof rp.backchannelLogoutUri === "string" && rp.backchannelLogoutUri.length > 0,
+		)
+		.map(async (rp) => {
+			try {
+				const includeSid = rp.backchannelLogoutSessionRequired !== false;
+				const { token } = await generateLogoutToken({
+					issuer: opts.issuer,
+					sub: opts.sub,
+					aud: rp.clientId,
+					sid: opts.sid,
+					includeSid,
+					keyStore: opts.keyStore,
+				});
+				const body = new URLSearchParams({ logout_token: token }).toString();
+				const abort = new AbortController();
+				const timer = setTimeout(() => abort.abort(), timeoutMs);
+				try {
+					const res = await fetchImpl(rp.backchannelLogoutUri, {
+						method: "POST",
+						headers: { "Content-Type": "application/x-www-form-urlencoded" },
+						body,
+						signal: abort.signal,
+					});
+					if (!res.ok) {
+						logger.warn(
+							`broadcastBackchannelLogout: RP ${rp.clientId} returned ${res.status} ${res.statusText ?? ""}`.trim(),
+						);
+					}
+				} catch (err) {
+					logger.warn(
+						`broadcastBackchannelLogout: RP ${rp.clientId} POST to ${rp.backchannelLogoutUri} failed:`,
+						err,
+					);
+				} finally {
+					clearTimeout(timer);
+				}
+			} catch (err) {
+				logger.warn(`broadcastBackchannelLogout: RP ${rp.clientId} broadcast failed:`, err);
+			}
+		});
+
+	await Promise.all(tasks);
+}

--- a/packages/oauth/src/logout/cascadeLogout.mts
+++ b/packages/oauth/src/logout/cascadeLogout.mts
@@ -15,20 +15,10 @@
 
 import type {
 	FederationTokenStoreBase,
+	Logger,
 	RefreshTokenStoreBase,
 	UserSessionStoreBase,
 } from "@o3co/auth-provider-core";
-import type { LogoutLogger } from "./types.mjs";
-
-/**
- * Minimal structural logger interface for cascadeLogout.
- * Accepts `console` and any structured logger (pino, winston, etc.)
- * with a compatible `warn(message, ...args)` signature.
- *
- * @deprecated Use `LogoutLogger` from `./types.mjs` directly. This alias is kept
- * for backward compatibility.
- */
-export type CascadeLogoutLogger = LogoutLogger;
 
 export interface CascadeLogoutOptions {
 	readonly sid: string;
@@ -41,7 +31,7 @@ export interface CascadeLogoutOptions {
 	 * Defaults to `console`. Provide a pino/winston/etc instance with a compatible
 	 * `warn(message, ...args)` signature to route failures into your observability stack.
 	 */
-	readonly logger?: CascadeLogoutLogger;
+	readonly logger?: Logger;
 }
 
 export type CascadeLogoutResult =

--- a/packages/oauth/src/logout/cascadeLogout.mts
+++ b/packages/oauth/src/logout/cascadeLogout.mts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+	FederationTokenStoreBase,
+	RefreshTokenStoreBase,
+	UserSessionStoreBase,
+} from "@o3co/auth-provider-core";
+
+/**
+ * Minimal structural logger interface for cascadeLogout.
+ * Accepts `console` and any structured logger (pino, winston, etc.)
+ * with a compatible `warn(message, ...args)` signature.
+ */
+export interface CascadeLogoutLogger {
+	warn(message: string, ...args: unknown[]): void;
+}
+
+export interface CascadeLogoutOptions {
+	readonly sid: string;
+	readonly familyIds: ReadonlyArray<string>;
+	readonly refreshTokenStore: RefreshTokenStoreBase;
+	readonly federationTokenStore: FederationTokenStoreBase;
+	readonly userSessionStore: UserSessionStoreBase;
+	/**
+	 * Optional structured logger for the step-2 best-effort warning.
+	 * Defaults to `console`. Provide a pino/winston/etc instance with a compatible
+	 * `warn(message, ...args)` signature to route failures into your observability stack.
+	 */
+	readonly logger?: CascadeLogoutLogger;
+}
+
+export type CascadeLogoutResult =
+	| { readonly outcome: "done" }
+	| { readonly outcome: "failed"; readonly step: 1 | 2 | 3; readonly error: unknown };
+
+/**
+ * Executes the three-step logout cascade in the fixed order mandated by spec
+ * Section 14.2:
+ *   1. revokeFamily (all families) — throw ⇒ 503 (steps 2+3 skipped; retry safe).
+ *   2. deleteBySession (federation tokens) — best-effort; throw ⇒ warn + continue.
+ *      Orphaned federation tokens eventually GC by TTL.
+ *   3. delete (session record) — throw ⇒ 503 (steps 1+2 are idempotent, retry converges).
+ *
+ * Caller responsibilities:
+ *   - Map `outcome: "failed"` to HTTP 503.
+ *   - Run Back-Channel / Front-Channel / IdP-logout phases separately — this helper
+ *     only handles the store cascade.
+ *
+ * @param opts.logger - Optional structured logger for the step-2 best-effort warning.
+ *   Defaults to `console`. Provide a pino/winston/etc instance with a compatible
+ *   `warn(message, ...args)` signature to route failures into your observability stack.
+ */
+export async function cascadeLogout(opts: CascadeLogoutOptions): Promise<CascadeLogoutResult> {
+	// Step 1: revoke each family.
+	for (const familyId of opts.familyIds) {
+		try {
+			await opts.refreshTokenStore.revokeFamily(familyId);
+		} catch (error) {
+			return { outcome: "failed", step: 1, error };
+		}
+	}
+
+	// Step 2: delete federation tokens. Best-effort.
+	try {
+		await opts.federationTokenStore.deleteBySession(opts.sid);
+	} catch (error) {
+		const logger = opts.logger ?? console;
+		logger.warn(
+			`cascadeLogout: FederationTokenStore.deleteBySession(${opts.sid}) failed (continuing):`,
+			error,
+		);
+	}
+
+	// Step 3: delete session record.
+	try {
+		await opts.userSessionStore.delete(opts.sid);
+	} catch (error) {
+		return { outcome: "failed", step: 3, error };
+	}
+
+	return { outcome: "done" };
+}

--- a/packages/oauth/src/logout/cascadeLogout.mts
+++ b/packages/oauth/src/logout/cascadeLogout.mts
@@ -18,15 +18,17 @@ import type {
 	RefreshTokenStoreBase,
 	UserSessionStoreBase,
 } from "@o3co/auth-provider-core";
+import type { LogoutLogger } from "./types.mjs";
 
 /**
  * Minimal structural logger interface for cascadeLogout.
  * Accepts `console` and any structured logger (pino, winston, etc.)
  * with a compatible `warn(message, ...args)` signature.
+ *
+ * @deprecated Use `LogoutLogger` from `./types.mjs` directly. This alias is kept
+ * for backward compatibility.
  */
-export interface CascadeLogoutLogger {
-	warn(message: string, ...args: unknown[]): void;
-}
+export type CascadeLogoutLogger = LogoutLogger;
 
 export interface CascadeLogoutOptions {
 	readonly sid: string;

--- a/packages/oauth/src/logout/renderFrontchannel.mts
+++ b/packages/oauth/src/logout/renderFrontchannel.mts
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import type { Logger } from "@o3co/auth-provider-core";
+
 export interface FrontchannelRP {
 	readonly clientId: string;
 	readonly frontchannelLogoutUri?: string;
@@ -27,6 +29,11 @@ export interface RenderFrontchannelLogoutHtmlOptions {
 	readonly postLogoutRedirectUri?: string;
 	/** Defaults to 2000ms. */
 	readonly redirectDelayMs?: number;
+	/**
+	 * Optional logger for warning when an RP's frontchannelLogoutUri is invalid
+	 * and its iframe must be skipped. Falls back to `console` when omitted.
+	 */
+	readonly logger?: Logger;
 }
 
 const HTML_ESCAPE: Record<string, string> = {
@@ -84,6 +91,7 @@ function buildIframeUrl(baseUri: string, issuer: string, sid: string | undefined
  * `Content-Type: text/html; charset=utf-8`.
  */
 export function renderFrontchannelLogoutHtml(opts: RenderFrontchannelLogoutHtmlOptions): string {
+	const logger = opts.logger ?? console;
 	const iframes = opts.rps
 		.filter(
 			(rp): rp is FrontchannelRP & { frontchannelLogoutUri: string } =>
@@ -94,17 +102,31 @@ export function renderFrontchannelLogoutHtml(opts: RenderFrontchannelLogoutHtmlO
 			// existing query string or a fragment. Manual string-concat would produce
 			// `https://rp/fc#frag?iss=...` where the browser treats the query as
 			// part of the fragment — the RP never receives iss/sid.
-			const includeSid = rp.frontchannelLogoutSessionRequired !== false;
-			const iframeSrc = buildIframeUrl(
-				rp.frontchannelLogoutUri,
-				opts.issuer,
-				includeSid ? opts.sid : undefined,
-			);
-			// escapeHtml is still required: new URL() percent-encodes for URL context
-			// but the value is being placed inside an HTML attribute, so & must become
-			// &amp; to produce well-formed HTML.
-			return `<iframe src="${escapeHtml(iframeSrc)}" style="display:none" aria-hidden="true" referrerpolicy="no-referrer"></iframe>`;
+			//
+			// Per-RP try/catch: if new URL() throws (invalid or relative URI that slipped
+			// past schema validation, or corrupted store record), skip that RP's iframe
+			// rather than propagating the throw after cascadeLogout has already cleared
+			// session state (which would produce a 500 with an empty response body).
+			try {
+				const includeSid = rp.frontchannelLogoutSessionRequired !== false;
+				const iframeSrc = buildIframeUrl(
+					rp.frontchannelLogoutUri,
+					opts.issuer,
+					includeSid ? opts.sid : undefined,
+				);
+				// escapeHtml is still required: new URL() percent-encodes for URL context
+				// but the value is being placed inside an HTML attribute, so & must become
+				// &amp; to produce well-formed HTML.
+				return `<iframe src="${escapeHtml(iframeSrc)}" style="display:none" aria-hidden="true" referrerpolicy="no-referrer"></iframe>`;
+			} catch (err) {
+				logger.warn(
+					`renderFrontchannelLogoutHtml: failed to build iframe for RP ${rp.clientId} (skipping):`,
+					err,
+				);
+				return ""; // skipped; filtered out below
+			}
 		})
+		.filter((s) => s.length > 0)
 		.join("\n    ");
 
 	const delay = opts.redirectDelayMs ?? DEFAULT_REDIRECT_DELAY_MS;

--- a/packages/oauth/src/logout/renderFrontchannel.mts
+++ b/packages/oauth/src/logout/renderFrontchannel.mts
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface FrontchannelRP {
+	readonly clientId: string;
+	readonly frontchannelLogoutUri?: string;
+	/** Defaults to `true` — append sid so RPs can correlate sessions. */
+	readonly frontchannelLogoutSessionRequired?: boolean;
+}
+
+export interface RenderFrontchannelLogoutHtmlOptions {
+	readonly rps: ReadonlyArray<FrontchannelRP>;
+	readonly issuer: string;
+	readonly sid: string;
+	readonly postLogoutRedirectUri?: string;
+	/** Defaults to 2000ms. */
+	readonly redirectDelayMs?: number;
+}
+
+const HTML_ESCAPE: Record<string, string> = {
+	"&": "&amp;",
+	"<": "&lt;",
+	">": "&gt;",
+	'"': "&quot;",
+	"'": "&#39;",
+};
+
+function escapeHtml(s: string): string {
+	return s.replace(/[&<>"']/g, (c) => HTML_ESCAPE[c] ?? c);
+}
+
+/**
+ * JSON-stringifies a string, then escapes `<` and `>` as `\u003c` / `\u003e` so
+ * an embedded `</script>` cannot prematurely close an inline `<script>` block.
+ *
+ * This is the standard CSP-safe pattern for embedding untrusted strings in
+ * inline JS — see OWASP "JSON in HTML" guidance. Plain `JSON.stringify` alone
+ * is not sufficient: it escapes `"`, but leaves `<` and `>` literal, which
+ * allows `</script><script>alert(1)</script>` to break out of the inline JS
+ * context even though the payload would otherwise be bound as a safe string.
+ */
+function safeJsStringLiteral(s: string): string {
+	return JSON.stringify(s).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
+}
+
+const DEFAULT_REDIRECT_DELAY_MS = 2_000;
+
+/**
+ * Builds an iframe src URL by appending `iss` (and optionally `sid`) query
+ * parameters to `baseUri`. Uses `new URL()` + `searchParams.set()` so that:
+ *  - Existing query params are preserved with `&` separator.
+ *  - Fragment identifiers remain at the end of the URL (RFC 3986 §3.5), so
+ *    query params are not swallowed as fragment content by the browser.
+ */
+function buildIframeUrl(baseUri: string, issuer: string, sid: string | undefined): string {
+	const url = new URL(baseUri);
+	url.searchParams.set("iss", issuer);
+	if (sid !== undefined) {
+		url.searchParams.set("sid", sid);
+	}
+	return url.toString();
+}
+
+/**
+ * Renders an OIDC Front-Channel Logout 1.0 HTML page: one hidden `<iframe>` per RP
+ * that has a `frontchannelLogoutUri`. Each iframe URL carries `iss` and optionally
+ * `sid` query parameters (sid included when `frontchannelLogoutSessionRequired`
+ * is not explicitly `false`). When `postLogoutRedirectUri` is provided, appends
+ * a `<script>` that redirects after `redirectDelayMs` to let iframes load.
+ *
+ * Pure function: does no I/O, returns a string. Callers MUST send with
+ * `Content-Type: text/html; charset=utf-8`.
+ */
+export function renderFrontchannelLogoutHtml(opts: RenderFrontchannelLogoutHtmlOptions): string {
+	const iframes = opts.rps
+		.filter(
+			(rp): rp is FrontchannelRP & { frontchannelLogoutUri: string } =>
+				typeof rp.frontchannelLogoutUri === "string" && rp.frontchannelLogoutUri.length > 0,
+		)
+		.map((rp) => {
+			// Use new URL() + searchParams to correctly handle URIs that contain an
+			// existing query string or a fragment. Manual string-concat would produce
+			// `https://rp/fc#frag?iss=...` where the browser treats the query as
+			// part of the fragment — the RP never receives iss/sid.
+			const includeSid = rp.frontchannelLogoutSessionRequired !== false;
+			const iframeSrc = buildIframeUrl(
+				rp.frontchannelLogoutUri,
+				opts.issuer,
+				includeSid ? opts.sid : undefined,
+			);
+			// escapeHtml is still required: new URL() percent-encodes for URL context
+			// but the value is being placed inside an HTML attribute, so & must become
+			// &amp; to produce well-formed HTML.
+			return `<iframe src="${escapeHtml(iframeSrc)}" style="display:none" aria-hidden="true" referrerpolicy="no-referrer"></iframe>`;
+		})
+		.join("\n    ");
+
+	const delay = opts.redirectDelayMs ?? DEFAULT_REDIRECT_DELAY_MS;
+	const redirect = opts.postLogoutRedirectUri
+		? `<script>setTimeout(() => { window.location.href = ${safeJsStringLiteral(opts.postLogoutRedirectUri)}; }, ${delay});</script>`
+		: "";
+
+	return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Signing out…</title></head>
+<body>
+  <p>Signing you out…</p>
+  ${iframes}
+  ${redirect}
+</body>
+</html>`;
+}

--- a/packages/oauth/src/logout/types.mts
+++ b/packages/oauth/src/logout/types.mts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Minimal structural logger interface for logout helpers.
+ * Accepts `console` and any structured logger (pino, winston, etc.)
+ * with a compatible `warn(message, ...args)` signature.
+ */
+export interface LogoutLogger {
+	warn(message: string, ...args: unknown[]): void;
+}

--- a/packages/oauth/src/module.mts
+++ b/packages/oauth/src/module.mts
@@ -107,6 +107,11 @@ export const oauthModule = (params: {
 			grantPolicy: context.grantPolicy,
 			refreshTokenStore: context.refreshTokenStore,
 			userSessionStore: context.userSessionStore,
+			federationTokenStore: context.federationTokenStore,
+			// Lazy closure: evaluated at request time, not at init time.
+			// Captures `context` by reference so federation providers written by
+			// sessionModule.init() are visible regardless of module init order.
+			getFederationProviders: () => context.federationProviders,
 		});
 
 		context.router.use("/oauth", oauthRouter);

--- a/packages/oauth/src/module.mts
+++ b/packages/oauth/src/module.mts
@@ -127,10 +127,19 @@ export const oauthModule = (params: {
 			// Advertise only the algorithm the configured KeyStore actually signs
 			// with. Hardcoding the full union would mislead clients to fetch JWKS
 			// expecting a key that is not there (OIDC Core §10.1 + RFC 8414 §2).
+			//
+			// logoutSupported mirrors the condition used in createOAuthRouter to mount
+			// the logout router. When any required store is absent, the logout route
+			// is not registered and discovery must not advertise the 5 logout fields.
+			const logoutSupported =
+				!!context.userSessionStore &&
+				!!context.federationTokenStore &&
+				!!context.refreshTokenStore;
 			context.router.use(
 				oidcConfig.createRouter(express, {
 					issuer,
 					signingAlgs: [context.keyStore.algorithm],
+					logoutSupported,
 				}),
 			);
 		}

--- a/packages/oauth/src/module.mts
+++ b/packages/oauth/src/module.mts
@@ -132,9 +132,7 @@ export const oauthModule = (params: {
 			// the logout router. When any required store is absent, the logout route
 			// is not registered and discovery must not advertise the 5 logout fields.
 			const logoutSupported =
-				!!context.userSessionStore &&
-				!!context.federationTokenStore &&
-				!!context.refreshTokenStore;
+				!!context.userSessionStore && !!context.federationTokenStore && !!context.refreshTokenStore;
 			context.router.use(
 				oidcConfig.createRouter(express, {
 					issuer,

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -610,6 +610,7 @@ export const createOAuthRouter = async (
 				refreshTokenStore,
 				clientRepository,
 				getFederationProviders,
+				auditSink,
 			}),
 		);
 	}

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -595,7 +595,13 @@ export const createOAuthRouter = async (
 	// federationTokenStore is required for POST /oauth/federation/:name/logout.
 	// issuer is required for logout_token signing in POST /oauth/logout.
 	const issuer = (config as { oauth?: { jwt?: { issuer?: unknown } } }).oauth?.jwt?.issuer;
-	if (userSessionStore && federationTokenStore && refreshTokenStore && typeof issuer === "string") {
+	if (
+		userSessionStore &&
+		federationTokenStore &&
+		refreshTokenStore &&
+		typeof issuer === "string" &&
+		issuer.length > 0
+	) {
 		router.use(
 			logoutRoute.createRouter(express, {
 				keyStore,

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -595,12 +595,7 @@ export const createOAuthRouter = async (
 	// federationTokenStore is required for POST /oauth/federation/:name/logout.
 	// issuer is required for logout_token signing in POST /oauth/logout.
 	const issuer = (config as { oauth?: { jwt?: { issuer?: unknown } } }).oauth?.jwt?.issuer;
-	if (
-		userSessionStore &&
-		federationTokenStore &&
-		refreshTokenStore &&
-		typeof issuer === "string"
-	) {
+	if (userSessionStore && federationTokenStore && refreshTokenStore && typeof issuer === "string") {
 		router.use(
 			logoutRoute.createRouter(express, {
 				keyStore,

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -20,6 +20,8 @@ import {
 	type ClientRepository,
 	type CodeRepository,
 	emitAuditEvent,
+	type FederationProviderHandle,
+	type FederationTokenStoreBase,
 	formatObject,
 	type GrantPolicyHookBase,
 	type GrantRegistry,
@@ -32,6 +34,7 @@ import {
 import type { Request, RequestHandler, Response, Router } from "express";
 import { decodeProtectedHeader, jwtVerify } from "jose";
 import type { PassportStatic } from "passport";
+import * as logoutRoute from "./routes/logout.mjs";
 import * as userinfo from "./routes/userinfo.mjs";
 
 // Session data type augmentation
@@ -67,6 +70,8 @@ export const createOAuthRouter = async (
 		grantPolicy,
 		refreshTokenStore,
 		userSessionStore,
+		federationTokenStore,
+		getFederationProviders = () => undefined,
 	}: {
 		passport: PassportStatic;
 		registry: GrantRegistry;
@@ -79,6 +84,13 @@ export const createOAuthRouter = async (
 		grantPolicy?: GrantPolicyHookBase;
 		refreshTokenStore?: RefreshTokenStoreBase;
 		userSessionStore?: UserSessionStoreBase;
+		federationTokenStore?: FederationTokenStoreBase;
+		/**
+		 * Lazy getter for the federation providers Map. Evaluated at request time so
+		 * module init order does not affect resolution — pass `() => context.federationProviders`
+		 * from `module.mts`. Defaults to `() => undefined` when not provided.
+		 */
+		getFederationProviders?: () => ReadonlyMap<string, FederationProviderHandle> | undefined;
 	},
 ): Promise<{ router: Router; registry: GrantRegistry }> => {
 	const router = express.Router();
@@ -578,6 +590,29 @@ export const createOAuthRouter = async (
 
 	// OIDC Core §5.3 — UserInfo endpoint
 	router.use(userinfo.createRouter(express, { keyStore, userSessionStore, refreshTokenStore }));
+
+	// Logout endpoints — mount only when all required stores + issuer are present.
+	// federationTokenStore is required for POST /oauth/federation/:name/logout.
+	// issuer is required for logout_token signing in POST /oauth/logout.
+	const issuer = (config as { oauth?: { jwt?: { issuer?: unknown } } }).oauth?.jwt?.issuer;
+	if (
+		userSessionStore &&
+		federationTokenStore &&
+		refreshTokenStore &&
+		typeof issuer === "string"
+	) {
+		router.use(
+			logoutRoute.createRouter(express, {
+				keyStore,
+				issuer,
+				userSessionStore,
+				federationTokenStore,
+				refreshTokenStore,
+				clientRepository,
+				getFederationProviders,
+			}),
+		);
+	}
 
 	return { router, registry };
 };

--- a/packages/oauth/src/routes/OpenidConfiguration.mts
+++ b/packages/oauth/src/routes/OpenidConfiguration.mts
@@ -24,6 +24,14 @@ type ExpressLike = {
 export interface OidcConfigRouterOptions {
 	issuer: string;
 	signingAlgs: ReadonlyArray<string>;
+	/**
+	 * When false, omit end_session_endpoint and backchannel/frontchannel logout_supported
+	 * fields from the discovery response. Set to false when the required stores
+	 * (userSessionStore, federationTokenStore, refreshTokenStore) are not configured
+	 * and the logout router is therefore not mounted.
+	 * Defaults to true for backward compatibility.
+	 */
+	logoutSupported?: boolean;
 }
 
 export function createRouter(express: ExpressLike, opts: OidcConfigRouterOptions): Router {
@@ -47,12 +55,19 @@ export function createRouter(express: ExpressLike, opts: OidcConfigRouterOptions
 			userinfo_endpoint: `${iss}/oauth/userinfo`,
 			...(hasAsymmetricAlg ? { jwks_uri: `${iss}/.well-known/jwks.json` } : {}),
 			introspection_endpoint: `${iss}/oauth/introspect`,
-			// TODO-F-5: RP-Initiated Logout 1.0 + Back-Channel Logout 1.0 + Front-Channel Logout 1.0.
-			end_session_endpoint: `${iss}/oauth/logout`,
-			backchannel_logout_supported: true,
-			backchannel_logout_session_supported: true,
-			frontchannel_logout_supported: true,
-			frontchannel_logout_session_supported: true,
+			// Logout discovery fields are only advertised when the logout router is mounted.
+			// opts.logoutSupported defaults to true for backward compatibility; pass false
+			// explicitly when userSessionStore / federationTokenStore / refreshTokenStore
+			// are absent and the /oauth/logout route is therefore not registered.
+			...(opts.logoutSupported !== false
+				? {
+					end_session_endpoint: `${iss}/oauth/logout`,
+					backchannel_logout_supported: true,
+					backchannel_logout_session_supported: true,
+					frontchannel_logout_supported: true,
+					frontchannel_logout_session_supported: true,
+				}
+				: {}),
 			response_types_supported: ["code"],
 			subject_types_supported: ["public"],
 			id_token_signing_alg_values_supported: [...opts.signingAlgs],

--- a/packages/oauth/src/routes/OpenidConfiguration.mts
+++ b/packages/oauth/src/routes/OpenidConfiguration.mts
@@ -47,6 +47,12 @@ export function createRouter(express: ExpressLike, opts: OidcConfigRouterOptions
 			userinfo_endpoint: `${iss}/oauth/userinfo`,
 			...(hasAsymmetricAlg ? { jwks_uri: `${iss}/.well-known/jwks.json` } : {}),
 			introspection_endpoint: `${iss}/oauth/introspect`,
+			// TODO-F-5: RP-Initiated Logout 1.0 + Back-Channel Logout 1.0 + Front-Channel Logout 1.0.
+			end_session_endpoint: `${iss}/oauth/logout`,
+			backchannel_logout_supported: true,
+			backchannel_logout_session_supported: true,
+			frontchannel_logout_supported: true,
+			frontchannel_logout_session_supported: true,
 			response_types_supported: ["code"],
 			subject_types_supported: ["public"],
 			id_token_signing_alg_values_supported: [...opts.signingAlgs],
@@ -54,9 +60,6 @@ export function createRouter(express: ExpressLike, opts: OidcConfigRouterOptions
 			scopes_supported: ["openid", "profile", "email", "groups"],
 			token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"],
 			code_challenge_methods_supported: ["S256"],
-			// OUT of F-4 scope: revocation_endpoint, end_session_endpoint,
-			// backchannel_logout_supported, frontchannel_logout_supported —
-			// F-5 will add them when the corresponding routes exist.
 		});
 	});
 

--- a/packages/oauth/src/routes/OpenidConfiguration.mts
+++ b/packages/oauth/src/routes/OpenidConfiguration.mts
@@ -61,12 +61,12 @@ export function createRouter(express: ExpressLike, opts: OidcConfigRouterOptions
 			// are absent and the /oauth/logout route is therefore not registered.
 			...(opts.logoutSupported !== false
 				? {
-					end_session_endpoint: `${iss}/oauth/logout`,
-					backchannel_logout_supported: true,
-					backchannel_logout_session_supported: true,
-					frontchannel_logout_supported: true,
-					frontchannel_logout_session_supported: true,
-				}
+						end_session_endpoint: `${iss}/oauth/logout`,
+						backchannel_logout_supported: true,
+						backchannel_logout_session_supported: true,
+						frontchannel_logout_supported: true,
+						frontchannel_logout_session_supported: true,
+					}
 				: {}),
 			response_types_supported: ["code"],
 			subject_types_supported: ["public"],

--- a/packages/oauth/src/routes/OpenidConfiguration.mts
+++ b/packages/oauth/src/routes/OpenidConfiguration.mts
@@ -25,11 +25,11 @@ export interface OidcConfigRouterOptions {
 	issuer: string;
 	signingAlgs: ReadonlyArray<string>;
 	/**
-	 * When false, omit end_session_endpoint and backchannel/frontchannel logout_supported
-	 * fields from the discovery response. Set to false when the required stores
-	 * (userSessionStore, federationTokenStore, refreshTokenStore) are not configured
-	 * and the logout router is therefore not mounted.
-	 * Defaults to true for backward compatibility.
+	 * When true, advertise end_session_endpoint and backchannel/frontchannel logout_supported
+	 * fields in the discovery response. Must be set explicitly — defaults to false so that
+	 * callers who use this router directly (bypassing oauthModule) do not accidentally
+	 * advertise logout support without mounting the logout route.
+	 * oauthModule sets this to the computed `!!stores && !!issuer` expression.
 	 */
 	logoutSupported?: boolean;
 }
@@ -56,10 +56,10 @@ export function createRouter(express: ExpressLike, opts: OidcConfigRouterOptions
 			...(hasAsymmetricAlg ? { jwks_uri: `${iss}/.well-known/jwks.json` } : {}),
 			introspection_endpoint: `${iss}/oauth/introspect`,
 			// Logout discovery fields are only advertised when the logout router is mounted.
-			// opts.logoutSupported defaults to true for backward compatibility; pass false
-			// explicitly when userSessionStore / federationTokenStore / refreshTokenStore
-			// are absent and the /oauth/logout route is therefore not registered.
-			...(opts.logoutSupported !== false
+			// opts.logoutSupported defaults to false (explicit opt-in); oauthModule sets it
+			// to the computed !!stores && !!issuer expression. Callers who use createRouter
+			// directly must pass logoutSupported: true explicitly.
+			...(opts.logoutSupported === true
 				? {
 						end_session_endpoint: `${iss}/oauth/logout`,
 						backchannel_logout_supported: true,

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -15,6 +15,7 @@
  */
 
 import type {
+	AuditSinkBase,
 	ClientRepository,
 	FederationProviderHandle,
 	FederationTokenStoreBase,
@@ -23,6 +24,7 @@ import type {
 	RefreshTokenStoreBase,
 	UserSessionStoreBase,
 } from "@o3co/auth-provider-core";
+import { emitAuditEvent } from "@o3co/auth-provider-core";
 import accepts from "accepts";
 import type { Request, RequestHandler, Response, Router } from "express";
 import { decodeProtectedHeader, jwtVerify } from "jose";
@@ -82,6 +84,8 @@ export interface LogoutRouterOptions {
 	fetchImpl?: typeof fetch;
 	/** Structured logger shared with broadcastBackchannelLogout and cascadeLogout. */
 	logger?: Logger;
+	/** Audit sink for operator observability events. No-op when undefined. */
+	auditSink?: AuditSinkBase;
 }
 
 /**
@@ -162,8 +166,7 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			// Step 3: Extract family_id, sid, sub from verified payload.
 			const familyId = typeof payload.family_id === "string" ? payload.family_id : null;
 			const sid = typeof payload.sid === "string" ? payload.sid : null;
-			// sub is not strictly required for this endpoint but extracted for future use.
-			// const sub = typeof payload.sub === "string" ? payload.sub : null;
+			const sub = typeof payload.sub === "string" ? payload.sub : null;
 
 			// Step 4: Check family revocation. Fail-closed: any throw → 401.
 			if (familyId !== null) {
@@ -182,6 +185,14 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 					});
 				}
 				if (revoked) {
+					emitAuditEvent(opts.auditSink, {
+						timestamp: new Date(),
+						type: "logout.family_revoked",
+						subject: sub ?? undefined,
+						ip: req.ip,
+						userAgent: req.get("user-agent"),
+						details: { sid: sid ?? undefined },
+					});
 					res.setHeader("Cache-Control", "no-store");
 					return res.status(401).json({
 						error: "invalid_token",
@@ -290,6 +301,14 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 						state: typeof state === "string" ? state : undefined,
 					});
 					// Local state already cleared — redirect to IdP end-session URL.
+					emitAuditEvent(opts.auditSink, {
+						timestamp: new Date(),
+						type: "federation.logout.success",
+						subject: sub ?? undefined,
+						ip: req.ip,
+						userAgent: req.get("user-agent"),
+						details: { federation: name, redirected_to_idp: true },
+					});
 					res.setHeader("Cache-Control", "no-store");
 					res.setHeader("Pragma", "no-cache");
 					return res.redirect(303, endSessionResult.url.toString());
@@ -300,12 +319,31 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 						`/oauth/federation/${name}/logout: provider.endSession failed (orphan IdP session):`,
 						error,
 					);
+					emitAuditEvent(opts.auditSink, {
+						timestamp: new Date(),
+						type: "federation.logout.idp_unreachable",
+						subject: sub ?? undefined,
+						ip: req.ip,
+						userAgent: req.get("user-agent"),
+						details: {
+							federation: name,
+							error: error instanceof Error ? error.message : String(error),
+						},
+					});
 					res.setHeader("Cache-Control", "no-store");
 					return res.status(200).json({ disconnected: true });
 				}
 			}
 
 			// Step 12: No endSession support → return 200 disconnected.
+			emitAuditEvent(opts.auditSink, {
+				timestamp: new Date(),
+				type: "federation.logout.success",
+				subject: sub ?? undefined,
+				ip: req.ip,
+				userAgent: req.get("user-agent"),
+				details: { federation: name, redirected_to_idp: false },
+			});
 			res.setHeader("Cache-Control", "no-store");
 			return res.status(200).json({ disconnected: true });
 		},
@@ -435,6 +473,14 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			});
 
 			if (cascade.outcome === "failed") {
+				emitAuditEvent(opts.auditSink, {
+					timestamp: new Date(),
+					type: "logout.cascade_failed",
+					subject: sub ?? undefined,
+					ip: req.ip,
+					userAgent: req.get("user-agent"),
+					details: { sid, step: cascade.step },
+				});
 				return res.status(503).json({
 					error: "temporarily_unavailable",
 					error_description: "logout cascade failed",
@@ -442,6 +488,19 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			}
 
 			// Step 7: Select response.
+
+			// Emit logout.success before all terminal success response paths.
+			// Placed here (after cascade, before response selection) so every
+			// success branch (HTML / IdP redirect / post-logout redirect / JSON)
+			// emits exactly once without duplicating the call.
+			emitAuditEvent(opts.auditSink, {
+				timestamp: new Date(),
+				type: "logout.success",
+				subject: sub ?? undefined,
+				ip: req.ip,
+				userAgent: req.get("user-agent"),
+				details: { sid, federations: session.federations },
+			});
 
 			// 7a: Front-channel logout — if Accept: text/html AND any RP has a frontchannelLogoutUri.
 			// Use q-weighted negotiation: application/json is first so Accept: */* defaults to JSON.

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -129,6 +129,7 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			// uses "Bearer". We do a case-insensitive prefix check per §2.1 common usage.
 			if (!auth || !/^Bearer /i.test(auth)) {
 				res.setHeader("Cache-Control", "no-store");
+				res.setHeader("WWW-Authenticate", 'Bearer error="invalid_token", error_description="missing Bearer token"');
 				return res.status(401).json({
 					error: "invalid_token",
 					error_description: "missing Bearer token",
@@ -157,6 +158,7 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 					error instanceof Error ? error.message : String(error),
 				);
 				res.setHeader("Cache-Control", "no-store");
+				res.setHeader("WWW-Authenticate", 'Bearer error="invalid_token", error_description="invalid token"');
 				return res.status(401).json({
 					error: "invalid_token",
 					error_description: "invalid token",
@@ -194,6 +196,7 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 						details: { sid: sid ?? undefined },
 					});
 					res.setHeader("Cache-Control", "no-store");
+					res.setHeader("WWW-Authenticate", 'Bearer error="invalid_token", error_description="family revoked"');
 					return res.status(401).json({
 						error: "invalid_token",
 						error_description: "family revoked",
@@ -204,6 +207,7 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			// Step 5: sid is required to look up the session.
 			if (!sid) {
 				res.setHeader("Cache-Control", "no-store");
+				res.setHeader("WWW-Authenticate", 'Bearer error="invalid_token", error_description="missing sid claim"');
 				return res.status(401).json({
 					error: "invalid_token",
 					error_description: "missing sid claim",
@@ -227,6 +231,7 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			}
 			if (!session) {
 				res.setHeader("Cache-Control", "no-store");
+				res.setHeader("WWW-Authenticate", 'Bearer error="invalid_token", error_description="session not found"');
 				return res.status(401).json({
 					error: "invalid_token",
 					error_description: "session not found",
@@ -354,6 +359,10 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 		"/logout",
 		express.urlencoded({ extended: false }),
 		async (req: Request, res: Response) => {
+			// RFC 6749 §5.1 / RFC 9207: cache headers on every response path.
+			res.setHeader("Cache-Control", "no-store");
+			res.setHeader("Pragma", "no-cache");
+
 			const {
 				id_token_hint: idTokenHint,
 				post_logout_redirect_uri: postLogoutRedirectUri,
@@ -532,6 +541,7 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 					sid,
 					// Use the allowlist-validated URI — prevents open redirect via HTML branch.
 					postLogoutRedirectUri: validatedPostLogoutRedirectUri,
+					logger: opts.logger,
 				});
 				res.setHeader("Content-Type", "text/html; charset=utf-8");
 				return res.status(200).send(html);

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -106,6 +106,211 @@ export interface LogoutRouterOptions {
 export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): Router {
 	const router = express.Router();
 
+	// POST /federation/:name/logout — mounted under /oauth → POST /oauth/federation/:name/logout
+	router.post(
+		"/federation/:name/logout",
+		express.urlencoded({ extended: false }),
+		async (req: Request, res: Response) => {
+			const { name } = req.params as { name: string };
+			const {
+				post_logout_redirect_uri: postLogoutRedirectUri,
+				state,
+			} = req.body as Record<string, string | undefined>;
+
+			const logger = opts.logger ?? console;
+
+			// Step 1: Extract Bearer access_token from Authorization header.
+			const auth = req.headers.authorization;
+			// RFC 6750 §2.1: "Bearer" is case-insensitive in practice but the spec
+			// uses "Bearer". We do a case-insensitive prefix check per §2.1 common usage.
+			if (!auth || !/^Bearer /i.test(auth)) {
+				res.setHeader("Cache-Control", "no-store");
+				return res.status(401).json({
+					error: "invalid_token",
+					error_description: "missing Bearer token",
+				});
+			}
+			const token = auth.slice(auth.indexOf(" ") + 1);
+
+			// Step 2: Verify JWT signature + check typ === "at+jwt".
+			// Reject refresh (rt+jwt), id (id+jwt), and logout (logout+jwt) tokens.
+			let payload: Record<string, unknown>;
+			try {
+				const header = decodeProtectedHeader(token);
+				if (header.typ !== "at+jwt") {
+					throw new Error("invalid token type");
+				}
+				const key = await opts.keyStore.getVerificationKey(
+					header.kid ?? opts.keyStore.getSigningKidFallback(),
+				);
+				const verified = await jwtVerify(token, key);
+				payload = verified.payload as Record<string, unknown>;
+			} catch (error) {
+				// Log the reason at warn level — keep minimal (don't log the token itself,
+				// since this path can be attacker-driven).
+				logger.warn(
+					`/oauth/federation/${name}/logout: jwtVerify failed:`,
+					error instanceof Error ? error.message : String(error),
+				);
+				res.setHeader("Cache-Control", "no-store");
+				return res.status(401).json({
+					error: "invalid_token",
+					error_description: "invalid token",
+				});
+			}
+
+			// Step 3: Extract family_id, sid, sub from verified payload.
+			const familyId = typeof payload.family_id === "string" ? payload.family_id : null;
+			const sid = typeof payload.sid === "string" ? payload.sid : null;
+			// sub is not strictly required for this endpoint but extracted for future use.
+			// const sub = typeof payload.sub === "string" ? payload.sub : null;
+
+			// Step 4: Check family revocation. Fail-closed: any throw → 401.
+			if (familyId !== null) {
+				let revoked: boolean;
+				try {
+					revoked = await opts.refreshTokenStore.isFamilyRevoked(familyId);
+				} catch (error) {
+					logger.warn(
+						`/oauth/federation/${name}/logout: isFamilyRevoked failed (refresh store outage):`,
+						error,
+					);
+					res.setHeader("Cache-Control", "no-store");
+					return res.status(401).json({
+						error: "invalid_token",
+						error_description: "revocation check unavailable",
+					});
+				}
+				if (revoked) {
+					res.setHeader("Cache-Control", "no-store");
+					return res.status(401).json({
+						error: "invalid_token",
+						error_description: "family revoked",
+					});
+				}
+			}
+
+			// Step 5: sid is required to look up the session.
+			if (!sid) {
+				res.setHeader("Cache-Control", "no-store");
+				return res.status(401).json({
+					error: "invalid_token",
+					error_description: "missing sid claim",
+				});
+			}
+
+			// Step 6: Load session. null → 401 (no session = token is effectively invalid).
+			let session: Awaited<ReturnType<typeof opts.userSessionStore.get>>;
+			try {
+				session = await opts.userSessionStore.get(sid);
+			} catch (error) {
+				logger.warn(
+					`/oauth/federation/${name}/logout: userSessionStore.get failed:`,
+					error,
+				);
+				res.setHeader("Cache-Control", "no-store");
+				return res.status(503).json({
+					error: "temporarily_unavailable",
+					error_description: "session store unavailable",
+				});
+			}
+			if (!session) {
+				res.setHeader("Cache-Control", "no-store");
+				return res.status(401).json({
+					error: "invalid_token",
+					error_description: "session not found",
+				});
+			}
+
+			// Step 7: Verify the named federation is linked to this session.
+			if (!session.federations.includes(name)) {
+				res.setHeader("Cache-Control", "no-store");
+				return res.status(404).json({
+					error: "federation_not_linked",
+					error_description: `federation "${name}" is not linked to this session`,
+				});
+			}
+
+			// Step 8: Get federation tokens (may be null — best-effort idTokenHint).
+			let fedTokens: Awaited<ReturnType<typeof opts.federationTokenStore.get>>;
+			try {
+				fedTokens = await opts.federationTokenStore.get(sid, name);
+			} catch (error) {
+				logger.warn(
+					`/oauth/federation/${name}/logout: federationTokenStore.get failed:`,
+					error,
+				);
+				res.setHeader("Cache-Control", "no-store");
+				return res.status(503).json({
+					error: "temporarily_unavailable",
+					error_description: "federation token store unavailable",
+				});
+			}
+
+			// Step 9: Delete federation token record.
+			try {
+				await opts.federationTokenStore.delete(sid, name);
+			} catch (error) {
+				logger.warn(
+					`/oauth/federation/${name}/logout: federationTokenStore.delete failed:`,
+					error,
+				);
+				res.setHeader("Cache-Control", "no-store");
+				return res.status(503).json({
+					error: "temporarily_unavailable",
+					error_description: "federation token store unavailable",
+				});
+			}
+
+			// Step 10: Remove federation link from session.
+			try {
+				await opts.userSessionStore.removeFederation(sid, name);
+			} catch (error) {
+				logger.warn(
+					`/oauth/federation/${name}/logout: userSessionStore.removeFederation failed:`,
+					error,
+				);
+				res.setHeader("Cache-Control", "no-store");
+				return res.status(503).json({
+					error: "temporarily_unavailable",
+					error_description: "session store unavailable",
+				});
+			}
+
+			// Step 11: Attempt IdP end-session redirect (best-effort).
+			// getFederationProviders() is called at request time (lazy) so module init order
+			// does not affect resolution — the closure captures `context` by reference.
+			const provider = opts.getFederationProviders()?.get(name);
+			if (supportsEndSession(provider)) {
+				try {
+					const endSessionResult = await provider.endSession({
+						idTokenHint: fedTokens?.idToken ?? undefined,
+						postLogoutRedirectUri:
+							typeof postLogoutRedirectUri === "string" ? postLogoutRedirectUri : undefined,
+						state: typeof state === "string" ? state : undefined,
+					});
+					// Local state already cleared — redirect to IdP end-session URL.
+					res.setHeader("Cache-Control", "no-store");
+					res.setHeader("Pragma", "no-cache");
+					return res.redirect(303, endSessionResult.url.toString());
+				} catch (error) {
+					// Best-effort: IdP logout failed but local state is already cleared.
+					// Log at warn — "orphan IdP session" case, critical for operators.
+					logger.warn(
+						`/oauth/federation/${name}/logout: provider.endSession failed (orphan IdP session):`,
+						error,
+					);
+					res.setHeader("Cache-Control", "no-store");
+					return res.status(200).json({ disconnected: true });
+				}
+			}
+
+			// Step 12: No endSession support → return 200 disconnected.
+			res.setHeader("Cache-Control", "no-store");
+			return res.status(200).json({ disconnected: true });
+		},
+	);
+
 	// POST /logout — mounted under /oauth → POST /oauth/logout
 	router.post(
 		"/logout",

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -502,6 +502,21 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 				details: { sid, federations: session.federations },
 			});
 
+			// Validate post_logout_redirect_uri against the initiating client's allowlist ONCE.
+			// Both the HTML branch (7a) and the redirect branch (7c) use this validated value.
+			// Invalid or missing URIs become undefined — fall through to JSON fallback.
+			let validatedPostLogoutRedirectUri: string | undefined;
+			if (typeof postLogoutRedirectUri === "string" && postLogoutRedirectUri.length > 0 && aud) {
+				try {
+					const client = await opts.clientRepository.findById(aud);
+					if (client?.postLogoutRedirectUris?.includes(postLogoutRedirectUri)) {
+						validatedPostLogoutRedirectUri = postLogoutRedirectUri;
+					}
+				} catch {
+					// Client repo throw → treat as unvalidated; fall through to JSON
+				}
+			}
+
 			// 7a: Front-channel logout — if Accept: text/html AND any RP has a frontchannelLogoutUri.
 			// Use q-weighted negotiation: application/json is first so Accept: */* defaults to JSON.
 			// Only when text/html explicitly outranks json (e.g. browser requests) do we serve HTML.
@@ -515,8 +530,8 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 					rps: session.activeRPs,
 					issuer: opts.issuer,
 					sid,
-					postLogoutRedirectUri:
-						typeof postLogoutRedirectUri === "string" ? postLogoutRedirectUri : undefined,
+					// Use the allowlist-validated URI — prevents open redirect via HTML branch.
+					postLogoutRedirectUri: validatedPostLogoutRedirectUri,
 				});
 				res.setHeader("Content-Type", "text/html; charset=utf-8");
 				return res.status(200).send(html);
@@ -527,21 +542,13 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 				return res.redirect(303, endSessionUri);
 			}
 
-			// 7c: post_logout_redirect_uri — validate against client allowlist.
-			if (typeof postLogoutRedirectUri === "string" && postLogoutRedirectUri.length > 0 && aud) {
-				let client: Awaited<ReturnType<typeof opts.clientRepository.findById>> | null = null;
-				try {
-					client = await opts.clientRepository.findById(aud);
-				} catch {
-					// Fall through to JSON on lookup failure
+			// 7c: post_logout_redirect_uri — use the already-validated value (allowlist checked above).
+			if (validatedPostLogoutRedirectUri) {
+				const redirectUrl = new URL(validatedPostLogoutRedirectUri);
+				if (typeof state === "string" && state.length > 0) {
+					redirectUrl.searchParams.set("state", state);
 				}
-				if (client?.postLogoutRedirectUris?.includes(postLogoutRedirectUri)) {
-					const redirectUrl = new URL(postLogoutRedirectUri);
-					if (typeof state === "string" && state.length > 0) {
-						redirectUrl.searchParams.set("state", state);
-					}
-					return res.redirect(303, redirectUrl.toString());
-				}
+				return res.redirect(303, redirectUrl.toString());
 			}
 
 			// 7d: Default — JSON success.

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -123,20 +123,22 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 
 			const logger = opts.logger ?? console;
 
+			// RFC 6749 §5.1 / RFC 9207: cache headers on every response path.
+			res.setHeader("Cache-Control", "no-store");
+			res.setHeader("Pragma", "no-cache");
+
 			// Step 1: Extract Bearer access_token from Authorization header.
 			const auth = req.headers.authorization;
 			// RFC 6750 §2.1: "Bearer" is case-insensitive in practice but the spec
 			// uses "Bearer". We do a case-insensitive prefix check per §2.1 common usage.
 			if (!auth || !/^Bearer /i.test(auth)) {
-				res.setHeader("Cache-Control", "no-store");
 				res.setHeader(
 					"WWW-Authenticate",
 					'Bearer error="invalid_token", error_description="missing Bearer token"',
 				);
-				return res.status(401).json({
-					error: "invalid_token",
-					error_description: "missing Bearer token",
-				});
+				return res
+					.status(401)
+					.json({ error: "invalid_token", error_description: "missing Bearer token" });
 			}
 			const token = auth.slice(auth.indexOf(" ") + 1);
 
@@ -160,7 +162,6 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 					`/oauth/federation/${name}/logout: jwtVerify failed:`,
 					error instanceof Error ? error.message : String(error),
 				);
-				res.setHeader("Cache-Control", "no-store");
 				res.setHeader(
 					"WWW-Authenticate",
 					'Bearer error="invalid_token", error_description="invalid token"',
@@ -186,7 +187,6 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 						`/oauth/federation/${name}/logout: isFamilyRevoked failed (refresh store outage):`,
 						error,
 					);
-					res.setHeader("Cache-Control", "no-store");
 					return res.status(401).json({
 						error: "invalid_token",
 						error_description: "revocation check unavailable",
@@ -201,7 +201,6 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 						userAgent: req.get("user-agent"),
 						details: { sid: sid ?? undefined },
 					});
-					res.setHeader("Cache-Control", "no-store");
 					res.setHeader(
 						"WWW-Authenticate",
 						'Bearer error="invalid_token", error_description="family revoked"',
@@ -215,7 +214,6 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 
 			// Step 5: sid is required to look up the session.
 			if (!sid) {
-				res.setHeader("Cache-Control", "no-store");
 				res.setHeader(
 					"WWW-Authenticate",
 					'Bearer error="invalid_token", error_description="missing sid claim"',
@@ -232,14 +230,12 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 				session = await opts.userSessionStore.get(sid);
 			} catch (error) {
 				logger.warn(`/oauth/federation/${name}/logout: userSessionStore.get failed:`, error);
-				res.setHeader("Cache-Control", "no-store");
 				return res.status(503).json({
 					error: "temporarily_unavailable",
 					error_description: "session store unavailable",
 				});
 			}
 			if (!session) {
-				res.setHeader("Cache-Control", "no-store");
 				res.setHeader(
 					"WWW-Authenticate",
 					'Bearer error="invalid_token", error_description="session not found"',
@@ -252,7 +248,6 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 
 			// Step 7: Verify the named federation is linked to this session.
 			if (!session.federations.includes(name)) {
-				res.setHeader("Cache-Control", "no-store");
 				return res.status(404).json({
 					error: "federation_not_linked",
 					error_description: `federation "${name}" is not linked to this session`,
@@ -265,7 +260,6 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 				fedTokens = await opts.federationTokenStore.get(sid, name);
 			} catch (error) {
 				logger.warn(`/oauth/federation/${name}/logout: federationTokenStore.get failed:`, error);
-				res.setHeader("Cache-Control", "no-store");
 				return res.status(503).json({
 					error: "temporarily_unavailable",
 					error_description: "federation token store unavailable",
@@ -277,7 +271,6 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 				await opts.federationTokenStore.delete(sid, name);
 			} catch (error) {
 				logger.warn(`/oauth/federation/${name}/logout: federationTokenStore.delete failed:`, error);
-				res.setHeader("Cache-Control", "no-store");
 				return res.status(503).json({
 					error: "temporarily_unavailable",
 					error_description: "federation token store unavailable",
@@ -292,7 +285,6 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 					`/oauth/federation/${name}/logout: userSessionStore.removeFederation failed:`,
 					error,
 				);
-				res.setHeader("Cache-Control", "no-store");
 				return res.status(503).json({
 					error: "temporarily_unavailable",
 					error_description: "session store unavailable",
@@ -320,8 +312,6 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 						userAgent: req.get("user-agent"),
 						details: { federation: name, redirected_to_idp: true },
 					});
-					res.setHeader("Cache-Control", "no-store");
-					res.setHeader("Pragma", "no-cache");
 					return res.redirect(303, endSessionResult.url.toString());
 				} catch (error) {
 					// Best-effort: IdP logout failed but local state is already cleared.
@@ -341,7 +331,6 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 							error: error instanceof Error ? error.message : String(error),
 						},
 					});
-					res.setHeader("Cache-Control", "no-store");
 					return res.status(200).json({ disconnected: true });
 				}
 			}
@@ -355,7 +344,6 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 				userAgent: req.get("user-agent"),
 				details: { federation: name, redirected_to_idp: false },
 			});
-			res.setHeader("Cache-Control", "no-store");
 			return res.status(200).json({ disconnected: true });
 		},
 	);

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+	ClientRepository,
+	FederationProviderHandle,
+	FederationTokenStoreBase,
+	KeyStore,
+	Logger,
+	RefreshTokenStoreBase,
+	UserSessionStoreBase,
+} from "@o3co/auth-provider-core";
+import accepts from "accepts";
+import type { Request, RequestHandler, Response, Router } from "express";
+import { decodeProtectedHeader, jwtVerify } from "jose";
+import { broadcastBackchannelLogout } from "../logout/broadcastBackchannel.mjs";
+import { cascadeLogout } from "../logout/cascadeLogout.mjs";
+import { renderFrontchannelLogoutHtml } from "../logout/renderFrontchannel.mjs";
+
+type ExpressLike = {
+	Router: () => Router;
+	json: () => RequestHandler;
+	urlencoded: (opts: { extended: boolean }) => RequestHandler;
+};
+
+/**
+ * Minimal structural capability interface for OIDC RP-Initiated Logout.
+ *
+ * `SupportsLogout` and `FederationProviderBase` live in `@o3co/auth-provider-session`,
+ * which depends on core — importing them here would create a circular package dependency.
+ * This local structural type captures only the end-session surface needed by the logout route.
+ * The `supportsEndSession` type guard below performs the duck-type check at runtime.
+ */
+interface SupportsEndSession {
+	endSession(req: {
+		idTokenHint?: string;
+		postLogoutRedirectUri?: string;
+		state?: string;
+	}): Promise<{ url: URL; method: "GET" }>;
+}
+
+/**
+ * Duck-type guard: does `provider` expose an `endSession` method?
+ * Returns `false` for null/undefined so callers can pass Map.get() results directly.
+ */
+function supportsEndSession(
+	provider: FederationProviderHandle | undefined | null,
+): provider is FederationProviderHandle & SupportsEndSession {
+	if (provider == null) return false;
+	return typeof (provider as { endSession?: unknown }).endSession === "function";
+}
+
+export interface LogoutRouterOptions {
+	keyStore: KeyStore;
+	/** Issuer URL of this auth provider — used for logout_token `iss` claim and iframe `iss` param. */
+	issuer: string;
+	userSessionStore: UserSessionStoreBase;
+	federationTokenStore: FederationTokenStoreBase;
+	refreshTokenStore: RefreshTokenStoreBase;
+	clientRepository: ClientRepository;
+	/**
+	 * Getter for the federation providers Map. Evaluated at request time (not at
+	 * router construction time) so module init order does not matter — Task 6b
+	 * will pass `() => context.federationProviders` rather than a captured Map
+	 * reference. Returns undefined when federation is not configured.
+	 */
+	getFederationProviders: () => ReadonlyMap<string, FederationProviderHandle> | undefined;
+	/** Override for unit tests. Defaults to the global `fetch`. */
+	fetchImpl?: typeof fetch;
+	/** Structured logger shared with broadcastBackchannelLogout and cascadeLogout. */
+	logger?: Logger;
+}
+
+/**
+ * OIDC RP-Initiated Logout 1.0 — POST /oauth/logout
+ *
+ * Accepts application/x-www-form-urlencoded with:
+ *   - id_token_hint (required)
+ *   - post_logout_redirect_uri (optional)
+ *   - state (optional)
+ *
+ * Flow:
+ *   1. Verify id_token_hint via keyStore. Fail → 400 invalid_token.
+ *   2. Extract `sid` and `aud` (= client_id). Missing sid → 400 invalid_request.
+ *   3. Load session from userSessionStore. Missing → 200 JSON { logged_out: true } (no-op).
+ *   4. Broadcast Back-Channel Logout to all registered RPs (best-effort).
+ *   5. Resolve IdP end-session URI for the first federation (if any, if provider supportsEndSession).
+ *   6. Cascade logout (revokeFamily + deleteBySession + delete session).
+ *   7. Respond: front-channel HTML | IdP redirect | post-logout redirect | 200 JSON.
+ *
+ * /oauth/federation/:name/logout is handled in Task 6b (not this file).
+ */
+export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): Router {
+	const router = express.Router();
+
+	// POST /logout — mounted under /oauth → POST /oauth/logout
+	router.post(
+		"/logout",
+		express.urlencoded({ extended: false }),
+		async (req: Request, res: Response) => {
+			const {
+				id_token_hint: idTokenHint,
+				post_logout_redirect_uri: postLogoutRedirectUri,
+				state,
+			} = req.body as Record<string, string | undefined>;
+
+			// Step 1: Verify id_token_hint.
+			if (typeof idTokenHint !== "string" || idTokenHint.length === 0) {
+				return res.status(400).json({
+					error: "invalid_request",
+					error_description: "id_token_hint is required",
+				});
+			}
+
+			let payload: Record<string, unknown>;
+			try {
+				const header = decodeProtectedHeader(idTokenHint);
+				const key = await opts.keyStore.getVerificationKey(
+					header.kid ?? opts.keyStore.getSigningKidFallback(),
+				);
+				const verified = await jwtVerify(idTokenHint, key);
+				payload = verified.payload as Record<string, unknown>;
+			} catch {
+				return res.status(400).json({
+					error: "invalid_token",
+					error_description: "id_token_hint verification failed",
+				});
+			}
+
+			// Step 2: Extract sid and aud (client_id).
+			const sid = typeof payload.sid === "string" ? payload.sid : null;
+			const sub = typeof payload.sub === "string" ? payload.sub : null;
+			const rawAud = payload.aud;
+			const aud: string | null =
+				typeof rawAud === "string"
+					? rawAud
+					: Array.isArray(rawAud) && typeof rawAud[0] === "string"
+						? rawAud[0]
+						: null;
+
+			if (!sid) {
+				return res.status(400).json({
+					error: "invalid_request",
+					error_description: "id_token_hint missing sid claim",
+				});
+			}
+
+			// Step 3: Load session. Missing → defensive 200 no-op.
+			let session: Awaited<ReturnType<typeof opts.userSessionStore.get>>;
+			try {
+				session = await opts.userSessionStore.get(sid);
+			} catch (err) {
+				const logger = opts.logger ?? console;
+				logger.warn("POST /oauth/logout: userSessionStore.get failed", err);
+				return res.status(503).json({
+					error: "temporarily_unavailable",
+					error_description: "session store unavailable",
+				});
+			}
+
+			if (!session) {
+				return res.status(200).json({ logged_out: true });
+			}
+
+			// Step 4: Broadcast Back-Channel Logout (best-effort — never throws).
+			if (sub) {
+				await broadcastBackchannelLogout({
+					rps: session.activeRPs,
+					issuer: opts.issuer,
+					sub,
+					sid,
+					keyStore: opts.keyStore,
+					fetchImpl: opts.fetchImpl,
+					logger: opts.logger,
+				});
+			}
+
+			// Step 5: Resolve IdP end-session URI for the FIRST federation (spec Open Issue #2).
+			// getFederationProviders() is called at request time so module init order does not matter.
+			let endSessionUri: string | undefined;
+			const firstFederation = session.federations[0];
+			if (firstFederation) {
+				const providers = opts.getFederationProviders();
+				const provider = providers?.get(firstFederation);
+				if (supportsEndSession(provider)) {
+					try {
+						let idTokenHintForIdP: string | undefined;
+						try {
+							const tokens = await opts.federationTokenStore.get(sid, firstFederation);
+							idTokenHintForIdP = tokens?.idToken ?? undefined;
+						} catch {
+							// Best-effort: if we can't get the federation token, proceed without idTokenHint
+						}
+						const result = await provider.endSession({
+							idTokenHint: idTokenHintForIdP,
+							postLogoutRedirectUri:
+								typeof postLogoutRedirectUri === "string" ? postLogoutRedirectUri : undefined,
+							state: typeof state === "string" ? state : undefined,
+						});
+						endSessionUri = result.url.toString();
+					} catch (err) {
+						// Best-effort: log and proceed without IdP redirect
+						const logger = opts.logger ?? console;
+						logger.warn(`POST /oauth/logout: federation ${firstFederation} endSession failed`, err);
+					}
+				}
+			}
+
+			// Step 6: Cascade logout.
+			const cascade = await cascadeLogout({
+				sid,
+				familyIds: session.familyIds,
+				refreshTokenStore: opts.refreshTokenStore,
+				federationTokenStore: opts.federationTokenStore,
+				userSessionStore: opts.userSessionStore,
+				logger: opts.logger,
+			});
+
+			if (cascade.outcome === "failed") {
+				return res.status(503).json({
+					error: "temporarily_unavailable",
+					error_description: "logout cascade failed",
+				});
+			}
+
+			// Step 7: Select response.
+
+			// 7a: Front-channel logout — if Accept: text/html AND any RP has a frontchannelLogoutUri.
+			// Use q-weighted negotiation: application/json is first so Accept: */* defaults to JSON.
+			// Only when text/html explicitly outranks json (e.g. browser requests) do we serve HTML.
+			const negotiated = accepts(req).type(["application/json", "text/html"]);
+			const acceptsHtml = negotiated === "text/html";
+			const hasFrontchannel = session.activeRPs.some(
+				(rp) => typeof rp.frontchannelLogoutUri === "string" && rp.frontchannelLogoutUri.length > 0,
+			);
+			if (acceptsHtml && hasFrontchannel) {
+				const html = renderFrontchannelLogoutHtml({
+					rps: session.activeRPs,
+					issuer: opts.issuer,
+					sid,
+					postLogoutRedirectUri:
+						typeof postLogoutRedirectUri === "string" ? postLogoutRedirectUri : undefined,
+				});
+				res.setHeader("Content-Type", "text/html; charset=utf-8");
+				return res.status(200).send(html);
+			}
+
+			// 7b: IdP end-session redirect.
+			if (endSessionUri) {
+				return res.redirect(303, endSessionUri);
+			}
+
+			// 7c: post_logout_redirect_uri — validate against client allowlist.
+			if (typeof postLogoutRedirectUri === "string" && postLogoutRedirectUri.length > 0 && aud) {
+				let client: Awaited<ReturnType<typeof opts.clientRepository.findById>> | null = null;
+				try {
+					client = await opts.clientRepository.findById(aud);
+				} catch {
+					// Fall through to JSON on lookup failure
+				}
+				if (client?.postLogoutRedirectUris?.includes(postLogoutRedirectUri)) {
+					const redirectUrl = new URL(postLogoutRedirectUri);
+					if (typeof state === "string" && state.length > 0) {
+						redirectUrl.searchParams.set("state", state);
+					}
+					return res.redirect(303, redirectUrl.toString());
+				}
+			}
+
+			// 7d: Default — JSON success.
+			return res.status(200).json({ logged_out: true });
+		},
+	);
+
+	return router;
+}

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -116,10 +116,10 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 		express.urlencoded({ extended: false }),
 		async (req: Request, res: Response) => {
 			const { name } = req.params as { name: string };
-			const {
-				post_logout_redirect_uri: postLogoutRedirectUri,
-				state,
-			} = req.body as Record<string, string | undefined>;
+			const { post_logout_redirect_uri: postLogoutRedirectUri, state } = req.body as Record<
+				string,
+				string | undefined
+			>;
 
 			const logger = opts.logger ?? console;
 
@@ -129,7 +129,10 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			// uses "Bearer". We do a case-insensitive prefix check per §2.1 common usage.
 			if (!auth || !/^Bearer /i.test(auth)) {
 				res.setHeader("Cache-Control", "no-store");
-				res.setHeader("WWW-Authenticate", 'Bearer error="invalid_token", error_description="missing Bearer token"');
+				res.setHeader(
+					"WWW-Authenticate",
+					'Bearer error="invalid_token", error_description="missing Bearer token"',
+				);
 				return res.status(401).json({
 					error: "invalid_token",
 					error_description: "missing Bearer token",
@@ -158,7 +161,10 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 					error instanceof Error ? error.message : String(error),
 				);
 				res.setHeader("Cache-Control", "no-store");
-				res.setHeader("WWW-Authenticate", 'Bearer error="invalid_token", error_description="invalid token"');
+				res.setHeader(
+					"WWW-Authenticate",
+					'Bearer error="invalid_token", error_description="invalid token"',
+				);
 				return res.status(401).json({
 					error: "invalid_token",
 					error_description: "invalid token",
@@ -196,7 +202,10 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 						details: { sid: sid ?? undefined },
 					});
 					res.setHeader("Cache-Control", "no-store");
-					res.setHeader("WWW-Authenticate", 'Bearer error="invalid_token", error_description="family revoked"');
+					res.setHeader(
+						"WWW-Authenticate",
+						'Bearer error="invalid_token", error_description="family revoked"',
+					);
 					return res.status(401).json({
 						error: "invalid_token",
 						error_description: "family revoked",
@@ -207,7 +216,10 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			// Step 5: sid is required to look up the session.
 			if (!sid) {
 				res.setHeader("Cache-Control", "no-store");
-				res.setHeader("WWW-Authenticate", 'Bearer error="invalid_token", error_description="missing sid claim"');
+				res.setHeader(
+					"WWW-Authenticate",
+					'Bearer error="invalid_token", error_description="missing sid claim"',
+				);
 				return res.status(401).json({
 					error: "invalid_token",
 					error_description: "missing sid claim",
@@ -219,10 +231,7 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			try {
 				session = await opts.userSessionStore.get(sid);
 			} catch (error) {
-				logger.warn(
-					`/oauth/federation/${name}/logout: userSessionStore.get failed:`,
-					error,
-				);
+				logger.warn(`/oauth/federation/${name}/logout: userSessionStore.get failed:`, error);
 				res.setHeader("Cache-Control", "no-store");
 				return res.status(503).json({
 					error: "temporarily_unavailable",
@@ -231,7 +240,10 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			}
 			if (!session) {
 				res.setHeader("Cache-Control", "no-store");
-				res.setHeader("WWW-Authenticate", 'Bearer error="invalid_token", error_description="session not found"');
+				res.setHeader(
+					"WWW-Authenticate",
+					'Bearer error="invalid_token", error_description="session not found"',
+				);
 				return res.status(401).json({
 					error: "invalid_token",
 					error_description: "session not found",
@@ -252,10 +264,7 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			try {
 				fedTokens = await opts.federationTokenStore.get(sid, name);
 			} catch (error) {
-				logger.warn(
-					`/oauth/federation/${name}/logout: federationTokenStore.get failed:`,
-					error,
-				);
+				logger.warn(`/oauth/federation/${name}/logout: federationTokenStore.get failed:`, error);
 				res.setHeader("Cache-Control", "no-store");
 				return res.status(503).json({
 					error: "temporarily_unavailable",
@@ -267,10 +276,7 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			try {
 				await opts.federationTokenStore.delete(sid, name);
 			} catch (error) {
-				logger.warn(
-					`/oauth/federation/${name}/logout: federationTokenStore.delete failed:`,
-					error,
-				);
+				logger.warn(`/oauth/federation/${name}/logout: federationTokenStore.delete failed:`, error);
 				res.setHeader("Cache-Control", "no-store");
 				return res.status(503).json({
 					error: "temporarily_unavailable",

--- a/packages/session/src/module.mts
+++ b/packages/session/src/module.mts
@@ -166,6 +166,12 @@ export const _sessionModuleImpl = (params: SessionModuleInternalOptions): Module
 			federationProviders.set(name, provider);
 		}
 
+		// Expose the Map for other modules that need to resolve providers at request
+		// time (e.g. oauth's /oauth/logout for federation end-session). Consumers MUST
+		// read this lazily via a getter in their handler — they cannot capture the
+		// reference during their own init because module init order is not guaranteed.
+		context.federationProviders = federationProviders;
+
 		// Initialize passport with pathResolver and optional store bindings.
 		// userSessionStore / federationTokenStore are optional on ModuleContext (F-1);
 		// if absent, createPassport receives undefined and the built-in

--- a/packages/session/src/module.mts
+++ b/packages/session/src/module.mts
@@ -166,11 +166,11 @@ export const _sessionModuleImpl = (params: SessionModuleInternalOptions): Module
 			federationProviders.set(name, provider);
 		}
 
-		// Expose the Map for other modules that need to resolve providers at request
-		// time (e.g. oauth's /oauth/logout for federation end-session). Consumers MUST
-		// read this lazily via a getter in their handler — they cannot capture the
-		// reference during their own init because module init order is not guaranteed.
-		context.federationProviders = federationProviders;
+		// Expose a snapshot of the federation providers for other modules that need
+		// to resolve providers at request time (e.g. oauth's /oauth/logout). A copy
+		// is passed — not the original Map — so consumers cannot corrupt the session
+		// module's internal provider registry by mutating the shared reference.
+		context.federationProviders = new Map(federationProviders);
 
 		// Initialize passport with pathResolver and optional store bindings.
 		// userSessionStore / federationTokenStore are optional on ModuleContext (F-1);


### PR DESCRIPTION
## Summary

Implements TODO-F-5 — OIDC RP-Initiated Logout 1.0 + Back-Channel Logout 1.0 + Front-Channel Logout 1.0 + federation provider disconnect.

### Endpoints

- `POST /oauth/logout` — OIDC end_session_endpoint. id_token_hint verification → broadcast back-channel logout_token → cascade (refresh-family revoke → federation-token delete → session delete) → response select (HTML front-channel iframe / federation end-session 303 / post_logout_redirect_uri 303 / JSON fallback).
- `POST /oauth/federation/:name/logout` — provider-scoped disconnect. Bearer `at+jwt` → local cleanup (federationTokenStore.delete + userSessionStore.removeFederation) → optional IdP redirect (soft-fail on provider throw).

### Helpers (new)

- `generateLogoutToken` (core) — Back-Channel Logout 1.0 JWT, `typ: logout+jwt`, default TTL 300s. Exports `BACKCHANNEL_LOGOUT_EVENT_URI`.
- `cascadeLogout` (oauth) — orchestrator per spec §14.2.
- `broadcastBackchannelLogout` (oauth) — parallel POST with AbortController timeout, never throws.
- `renderFrontchannelLogoutHtml` (oauth) — iframe HTML with CSP-safe JSON-in-script embedding, referrerpolicy=no-referrer.
- `Logger` (core) — minimal `{ warn }` interface, shared across logout helpers.

### Contracts

- `Client` schema gains 5 optional fields: `postLogoutRedirectUris`, `backchannelLogoutUri`, `backchannelLogoutSessionRequired` (default true), `frontchannelLogoutUri`, `frontchannelLogoutSessionRequired` (default true). The `true` defaults are an intentional deviation from OIDC §2.2's `false` spec default, favoring secure sid propagation.
- `ModuleContext.federationProviders` — lazy-read via getter so module init order does not matter. Session module populates during its init.
- `RegisteredRP` carries the two `*SessionRequired` flags end-to-end (memory + redis adapters, authorization.mts registerRP propagation).

### Discovery

`/.well-known/openid-configuration` advertises `end_session_endpoint` + 4 logout support flags **only when all logout prerequisites (3 stores + issuer) are wired**. Otherwise the 5 fields are omitted to avoid 404 at advertised URLs.

### Observability

5 new audit events: `logout.success`, `logout.cascade_failed`, `logout.family_revoked`, `federation.logout.success`, `federation.logout.idp_unreachable`.

### Known Tradeoffs

- `broadcastBackchannelLogout` is `await`ed inside the route, so a slow RP can delay the response up to 5s (default timeout). Default choice favors logged visibility over throughput.
- `id_token_hint` on `/oauth/logout` is accepted leniently (no `typ` check) for compat with RPs that sign id_tokens with `typ: JWT` historically. `/oauth/federation/:name/logout` requires strict `typ: at+jwt` on Bearer.

## Test plan

- [x] `make test` — 996 tests pass across 7 packages (oauth 206, core 375, session 121+1skip, did 134+2todo, create-app 130, foundation 25, standalone 4)
- [x] `multi-agent-review develop..HEAD` — 3 findings fixed (open-redirect in HTML branch, RegisteredRP propagation, discovery gate)
- [ ] CI green
- [ ] Copilot review round

🤖 Generated with [Claude Code](https://claude.com/claude-code)