### PR TITLE
feat(standalone): per-environment HOCON config overlay

### DIFF
--- a/create-app/src/__tests__/index.test.mts
+++ b/create-app/src/__tests__/index.test.mts
@@ -23,6 +23,8 @@ describe("scaffold", () => {
 		expect(existsSync(join(targetDir, "tsconfig.json"))).toBe(true);
 		expect(existsSync(join(targetDir, "src", "app.mts"))).toBe(true);
 		expect(existsSync(join(targetDir, "config", "application.conf"))).toBe(true);
+		expect(existsSync(join(targetDir, "config", "development.conf"))).toBe(true);
+		expect(existsSync(join(targetDir, "config", "production.conf"))).toBe(true);
 	});
 
 	it("rewrites package.json name to project name", () => {

--- a/templates/standalone/README.ja.md
+++ b/templates/standalone/README.ja.md
@@ -23,6 +23,20 @@ pnpm start
 
 設定は `config/application.conf`（HOCON 形式）から読み込まれます。各値は対応する環境変数で上書きできます。
 
+### 環境別コンフィグ overlay
+
+`src/app.mts` は 2 層構成でコンフィグを読み込みます:
+
+1. **`config/application.conf`** — アプリの基本デフォルト。
+2. **`config/{ENV}.conf`** — 現在の環境の overlay。
+   `ENV = CONFIG_ENV || NODE_ENV || "development"` で決まります。
+
+overlay の値は `application.conf` を上書きします。scaffold には
+`development.conf` と `production.conf` が同梱されています。別の環境
+（例: `staging`）を追加するときは `config/staging.conf` を作成し、
+`CONFIG_ENV=staging` を設定してください。`{ENV}.conf` が存在しない場合は
+起動時にエラーになります（タイポを silent に素通りさせず fail-fast します）。
+
 ### HTTP
 
 | 変数 | デフォルト | 説明 |

--- a/templates/standalone/README.md
+++ b/templates/standalone/README.md
@@ -23,6 +23,20 @@ pnpm start
 
 Configuration is loaded from `config/application.conf` (HOCON format). Each value can be overridden with the corresponding environment variable.
 
+### Environment-specific config overlay
+
+`src/app.mts` loads configuration in two layers:
+
+1. **`config/application.conf`** — base defaults for the app.
+2. **`config/{ENV}.conf`** — overlay for the current environment, where
+   `ENV = CONFIG_ENV || NODE_ENV || "development"`.
+
+Values in the overlay take precedence over `application.conf`. The scaffold
+ships with `development.conf` and `production.conf`. To add another
+environment (e.g. `staging`), create `config/staging.conf` and set
+`CONFIG_ENV=staging`. A missing `{ENV}.conf` is a boot-time error — typos
+fail fast rather than silently falling back to defaults.
+
 ### HTTP
 
 | Variable | Default | Description |

--- a/templates/standalone/config/development.conf
+++ b/templates/standalone/config/development.conf
@@ -1,0 +1,8 @@
+# Environment overlay for development.
+# Loaded when CONFIG_ENV (or NODE_ENV) is "development" — the default.
+# Values here override application.conf.
+
+session {
+  # Local HTTP development: do not require HTTPS for the session cookie.
+  secure = false
+}

--- a/templates/standalone/config/development.conf
+++ b/templates/standalone/config/development.conf
@@ -1,8 +1,8 @@
 # Environment overlay for development.
 # Loaded when CONFIG_ENV (or NODE_ENV) is "development" — the default.
 # Values here override application.conf.
-
-session {
-  # Local HTTP development: do not require HTTPS for the session cookie.
-  secure = false
-}
+#
+# Most values are controlled via environment variables (see ${?VAR}
+# substitutions in application.conf). Override entries here only when
+# you need a fixed development-specific value that cannot come from
+# an environment variable.

--- a/templates/standalone/config/production.conf
+++ b/templates/standalone/config/production.conf
@@ -1,0 +1,10 @@
+# Environment overlay for production.
+# Loaded when CONFIG_ENV (or NODE_ENV) is "production".
+# Values here override application.conf.
+#
+# Most production-sensitive values (OAUTH_JWT_SECRET, SESSION_SECRET, REDIS URLs,
+# federation client secrets, etc.) should be supplied via environment variables —
+# see the ${?VAR} substitutions in application.conf.
+#
+# Override entries here only when a value must be fixed per-environment rather
+# than per-deployment (e.g. feature flags turned on only in production).

--- a/templates/standalone/src/app.mts
+++ b/templates/standalone/src/app.mts
@@ -50,8 +50,16 @@ import logger from "#/logger.mjs";
 // boot-time error (fail-fast on typos or unconfigured environments).
 const env = process.env.CONFIG_ENV || process.env.NODE_ENV || "development";
 const configDir = new URL("../config/", import.meta.url);
-const applicationConfPath = fileURLToPath(new URL("application.conf", configDir));
-const envConfPath = fileURLToPath(new URL(`${env}.conf`, configDir));
+const configDirPath = fileURLToPath(configDir);
+const applicationConfPath = path.join(configDirPath, "application.conf");
+const envConfPath = path.resolve(configDirPath, `${env}.conf`);
+// Reject env names whose resolved path escapes configDir (e.g. "../secrets").
+// The overlay must be an immediate child of configDir, not a nested path.
+if (path.dirname(envConfPath) !== configDirPath) {
+	throw new Error(
+		`Invalid config environment name: "${env}" resolves outside ${configDirPath}`,
+	);
+}
 const config: AppConfig = validate(
 	parseFile(envConfPath).withFallback(parseFile(applicationConfPath)),
 	AppConfigSchema,

--- a/templates/standalone/src/app.mts
+++ b/templates/standalone/src/app.mts
@@ -48,7 +48,7 @@ import logger from "#/logger.mjs";
 // Layering: {ENV}.conf overrides application.conf.
 // ENV = CONFIG_ENV || NODE_ENV || "development". A missing {ENV}.conf is a
 // boot-time error (fail-fast on typos or unconfigured environments).
-const env = process.env.CONFIG_ENV ?? process.env.NODE_ENV ?? "development";
+const env = process.env.CONFIG_ENV || process.env.NODE_ENV || "development";
 const configDir = new URL("../config/", import.meta.url);
 const applicationConfPath = fileURLToPath(new URL("application.conf", configDir));
 const envConfPath = fileURLToPath(new URL(`${env}.conf`, configDir));

--- a/templates/standalone/src/app.mts
+++ b/templates/standalone/src/app.mts
@@ -45,8 +45,15 @@ import passport from "passport";
 import logger from "#/logger.mjs";
 
 // Step 1: Load and validate application config (HOCON → Zod schema).
+// Layering: {ENV}.conf overrides application.conf.
+// ENV = CONFIG_ENV || NODE_ENV || "development". A missing {ENV}.conf is a
+// boot-time error (fail-fast on typos or unconfigured environments).
+const env = process.env.CONFIG_ENV ?? process.env.NODE_ENV ?? "development";
+const configDir = new URL("../config/", import.meta.url);
+const applicationConfPath = fileURLToPath(new URL("application.conf", configDir));
+const envConfPath = fileURLToPath(new URL(`${env}.conf`, configDir));
 const config: AppConfig = validate(
-	parseFile(fileURLToPath(new URL("../config/application.conf", import.meta.url))),
+	parseFile(envConfPath).withFallback(parseFile(applicationConfPath)),
 	AppConfigSchema,
 );
 

--- a/templates/standalone/src/app.mts
+++ b/templates/standalone/src/app.mts
@@ -56,9 +56,7 @@ const envConfPath = path.resolve(configDirPath, `${env}.conf`);
 // Reject env names whose resolved path escapes configDir (e.g. "../secrets").
 // The overlay must be an immediate child of configDir, not a nested path.
 if (path.dirname(envConfPath) !== configDirPath) {
-	throw new Error(
-		`Invalid config environment name: "${env}" resolves outside ${configDirPath}`,
-	);
+	throw new Error(`Invalid config environment name: "${env}" resolves outside ${configDirPath}`);
 }
 const config: AppConfig = validate(
 	parseFile(envConfPath).withFallback(parseFile(applicationConfPath)),


### PR DESCRIPTION
## Summary

- Add `config/{ENV}.conf` overlay selection to the `standalone` scaffold template, layered on top of `config/application.conf`
- Env resolution: `CONFIG_ENV || NODE_ENV || "development"` (`||` not `??` so empty envvars in Docker/K8s fall through)
- Scaffold ships `development.conf` and `production.conf` (both comment-only skeletons — env-var substitutions in `application.conf` remain the primary override mechanism)
- Missing `{ENV}.conf` throws ENOENT at boot (fail-fast on typos)
- README (EN + JA) documents the overlay behaviour
- Scaffold existence test extended to cover the two new files

## Design notes

- HOCON spec prohibits substitutions inside `include` paths, so the env selection lives in TS (`templates/standalone/src/app.mts`), not in `application.conf`
- `reference.conf` / module-owned defaults layer is out of scope — deferred to v0.5.0 when federation/session modules are split into their own packages
- Overlays are intentionally comment-only so `${?VAR}` substitutions in `application.conf` stay effective as the primary override mechanism (Codex review caught an earlier version that hard-set `session.secure = false` and silently broke `SESSION_SECURE` env override)

## Test plan

- [x] `pnpm --filter @o3co/auth-provider-standalone run build` — tsc clean
- [x] `pnpm --filter create-o3co-auth-provider test` — 130/130 tests pass
- [x] Multi-agent review (Claude + Codex) — Codex P2 finding addressed in commit `abc2b96`
- [ ] Manual: scaffold a throwaway app, set `CONFIG_ENV=staging` with no `staging.conf` → confirm ENOENT on boot
- [ ] Manual: verify `SESSION_SECURE=false` env override still works in the scaffolded app (regression check against the Codex finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)