### PR TITLE
fix(standalone): config containment check accepts trailing-slash configDir

### DIFF
--- a/templates/standalone/src/__tests__/configPath.test.mts
+++ b/templates/standalone/src/__tests__/configPath.test.mts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveConfigPaths } from "../configPath.mjs";
+
+describe("resolveConfigPaths", () => {
+	it("accepts a configDirPath with a trailing slash (regression: fileURLToPath preserves trailing /)", () => {
+		const { applicationConfPath, envConfPath } = resolveConfigPaths(
+			"/home/node/templates/standalone/config/",
+			"production",
+		);
+		expect(applicationConfPath).toBe("/home/node/templates/standalone/config/application.conf");
+		expect(envConfPath).toBe("/home/node/templates/standalone/config/production.conf");
+	});
+
+	it("accepts a configDirPath without a trailing slash", () => {
+		const { applicationConfPath, envConfPath } = resolveConfigPaths(
+			"/home/node/templates/standalone/config",
+			"development",
+		);
+		expect(applicationConfPath).toBe("/home/node/templates/standalone/config/application.conf");
+		expect(envConfPath).toBe("/home/node/templates/standalone/config/development.conf");
+	});
+
+	it("rejects env names that resolve outside configDirPath (path traversal)", () => {
+		expect(() =>
+			resolveConfigPaths("/home/node/templates/standalone/config/", "../secrets"),
+		).toThrow(/resolves outside/);
+	});
+
+	it("rejects env names containing a path separator", () => {
+		expect(() =>
+			resolveConfigPaths("/home/node/templates/standalone/config/", "nested/env"),
+		).toThrow(/resolves outside/);
+	});
+});

--- a/templates/standalone/src/app.mts
+++ b/templates/standalone/src/app.mts
@@ -43,6 +43,7 @@ import helmet from "helmet";
 import passport from "passport";
 
 import logger from "#/logger.mjs";
+import { resolveConfigPaths } from "./configPath.mjs";
 
 // Step 1: Load and validate application config (HOCON → Zod schema).
 // Layering: {ENV}.conf overrides application.conf.
@@ -51,13 +52,7 @@ import logger from "#/logger.mjs";
 const env = process.env.CONFIG_ENV || process.env.NODE_ENV || "development";
 const configDir = new URL("../config/", import.meta.url);
 const configDirPath = fileURLToPath(configDir);
-const applicationConfPath = path.join(configDirPath, "application.conf");
-const envConfPath = path.resolve(configDirPath, `${env}.conf`);
-// Reject env names whose resolved path escapes configDir (e.g. "../secrets").
-// The overlay must be an immediate child of configDir, not a nested path.
-if (path.dirname(envConfPath) !== configDirPath) {
-	throw new Error(`Invalid config environment name: "${env}" resolves outside ${configDirPath}`);
-}
+const { applicationConfPath, envConfPath } = resolveConfigPaths(configDirPath, env);
 const config: AppConfig = validate(
 	parseFile(envConfPath).withFallback(parseFile(applicationConfPath)),
 	AppConfigSchema,

--- a/templates/standalone/src/configPath.mts
+++ b/templates/standalone/src/configPath.mts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from "node:path";
+
+export interface ResolvedConfigPaths {
+	readonly applicationConfPath: string;
+	readonly envConfPath: string;
+}
+
+export function resolveConfigPaths(configDirPath: string, env: string): ResolvedConfigPaths {
+	// path.resolve strips trailing slashes that fileURLToPath may preserve, so
+	// the containment check below compares equal shapes (path.dirname never
+	// returns a trailing separator).
+	const normalizedConfigDir = path.resolve(configDirPath);
+	const applicationConfPath = path.join(normalizedConfigDir, "application.conf");
+	const envConfPath = path.resolve(normalizedConfigDir, `${env}.conf`);
+	if (path.dirname(envConfPath) !== normalizedConfigDir) {
+		throw new Error(
+			`Invalid config environment name: "${env}" resolves outside ${normalizedConfigDir}`,
+		);
+	}
+	return { applicationConfPath, envConfPath };
+}


### PR DESCRIPTION
## Summary

- Containment check in `templates/standalone/src/app.mts` compared `path.dirname(envConfPath)` (no trailing separator) against `fileURLToPath(new URL("../config/", ...))` (trailing slash preserved) → **always unequal**. Standalone template throws at boot for every env name, breaking all deployments.
- Regression introduced in `aeb603f` (per-environment HOCON overlay feature).
- Fix: extract logic into `resolveConfigPaths()` pure function, normalize `configDirPath` via `path.resolve` before comparison. Regression tests for trailing-slash, no-trailing-slash, and path-traversal inputs.

## Impact before fix

All three env paths throw at boot:
- `NODE_ENV=production` (E2E docker) → throw
- `NODE_ENV=development` (local) → throw
- `NODE_ENV` unset (defaults to `"development"`) → throw

Discovered by running `make test-e2e` in the auth repo against current develop.

## Test plan

- [x] Unit: 4 new tests in `templates/standalone/src/__tests__/configPath.test.mts` (trailing-slash accept / no-trailing-slash accept / path-traversal reject / separator-in-env-name reject)
- [x] `make build`: all 8 packages green
- [x] `make test`: 1071 tests passing (standalone 4 → 8)
- [x] `pnpm run lint`: 0 errors
- [x] **E2E smoke** (auth repo `make test-e2e`): all containers Healthy (redis + provider + proxy + policy-verifier), token-flow 4/4 + ABAC 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)