### PR TITLE
fix(ci): restore full test run alongside coverage (#88)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           fi
           echo "No vendor import leaks found in public .d.mts."
       - run: pnpm -r --if-present run typecheck
+      - run: pnpm run test
       - run: pnpm run test:coverage
 
       - name: Upload coverage to Codecov (core)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,12 @@
 - If code was written before its test, delete it and start over from the test.
 - When generating implementation plans, every task must include explicit RED → GREEN → REFACTOR steps.
 
+## Workspace Scripts
+
+- Every workspace under `packages/**`, `templates/**`, and `create-app` **must** define a `test` script.
+- The root `test` script runs `pnpm -r run test` **without** `--if-present` on purpose: if any workspace lacks `test`, CI fails loudly rather than silently skipping it. Do not add `--if-present` here — see issue #88 for the regression this prevents.
+- Coverage is a per-package concern. Only `packages/**` define `test:coverage`. The root `test:coverage` is filtered to `./packages/**` and keeps `--if-present` so that a future package without coverage wiring does not break CI.
+
 ## Module Resolution
 
 Each package uses Node.js [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) with a conditional `development` / `default` mapping:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"docs": "typedoc",
 		"lint": "biome check packages/ templates/ create-app/",
 		"test": "pnpm -r run test",
-		"test:coverage": "pnpm -r --if-present run test:coverage",
+		"test:coverage": "pnpm -r --filter \"./packages/**\" --if-present run test:coverage",
 		"audit": "pnpm audit --audit-level=high"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Fixes #88.

## Summary

- Restore `pnpm run test` in CI before the coverage step. PR #87 replaced it with `pnpm run test:coverage`, which silently skipped workspaces without a `test:coverage` script (`create-app`, `templates/standalone`).
- Narrow root `test:coverage` to `./packages/**` so the script name matches its scope.
- Document the invariant in AGENTS.md: root `test` intentionally omits `--if-present` to prevent silent skips from recurring.

## Why the asymmetric scripts

- `test`: runs for every workspace. Intentionally **no** `--if-present` — if any workspace lacks `test`, CI fails loudly (this is the invariant #88 is built on).
- `test:coverage`: filtered to `packages/**` and keeps `--if-present`. Coverage is a per-package concern; templates and `create-app` are distributables, not coverage targets. `--if-present` lets a future package land without coverage wiring without breaking CI.

## Verification

Local runs on this branch:

- `pnpm run test` — all 7 workspaces run, including `templates/standalone` (8 tests) and `create-app`.
- `pnpm run test:coverage` — `Scope: 5 of 8 workspace projects` (core / did / foundation / oauth / session only).

## Review

Multi-agent review (Claude code-reviewer + Codex) before commit:
- Codex: no correctness issue found.
- Claude: approve; recommended documenting the `--if-present` invariant in AGENTS.md so the silent-skip class of bug cannot re-enter via a well-intentioned "symmetry" fix. Applied.

## Test plan

- [ ] CI build-and-test passes
- [ ] CI log shows both `pnpm run test` (all workspaces) and `pnpm run test:coverage` (packages only) steps
- [ ] Codecov still receives the 5 per-package uploads