### PR TITLE
feat!: split federation providers into per-provider packages (v0.5.0)

### DIFF
--- a/.claude/superpowers/specs/2026-04-23-federation-provider-package-split-design.md
+++ b/.claude/superpowers/specs/2026-04-23-federation-provider-package-split-design.md
@@ -1,0 +1,330 @@
+# Federation Provider Package Split Design
+
+**Date:** 2026-04-23
+**Release target:** v0.5.0
+**Status:** Draft for implementation planning
+
+## Goal
+
+Split the built-in Google and GitHub federation providers out of
+`@o3co/auth-provider-session` into one package per provider:
+
+- `@o3co/auth-provider-federation-google`
+- `@o3co/auth-provider-federation-github`
+
+`@o3co/auth-provider-session` must own only the federation route layer and the
+shared `FederationProvider` contract. It must not know concrete provider
+implementations.
+
+This is a breaking v0.5.0 change. v0.4.0 already carried TODO-F and passport
+exit breakage; provider package extraction intentionally lands in the next
+minor to keep migration boundaries legible.
+
+## Decisions
+
+### Package placement
+
+Use the hybrid path:
+
+- During 0.x, keep provider packages inside the `auth.provider` monorepo under
+  `packages/federation-google` and `packages/federation-github`.
+- Revisit repo split after the provider surface has stabilized or external
+  provider maintainers need independent ownership.
+
+Rationale:
+
+- Shared CI and release automation already exist for `packages/*`.
+- Provider packages need tight version alignment with the session contract until
+  1.0.
+- Tests can move with minimal tooling churn.
+- Future CLI work can still map provider names to npm package names without
+  requiring separate repositories.
+
+### Ownership boundaries
+
+Stay in `@o3co/auth-provider-session`:
+
+- `FederationProvider`
+- `FederationProfile`
+- `FederationResult`
+- capability interfaces and guards:
+  - `SupportsRefresh`
+  - `SupportsLogout`
+  - `SupportsClaimMapping`
+- `FederationProviderFactory`
+- `createFederationProviderFactory`
+- route-layer PKCE state generation and callback handling
+- public federation helper utilities needed by provider packages:
+  - `validateRedirect`
+  - `resolveCallbackRedirect`
+  - `codeChallenge`
+
+Move out:
+
+- `createGoogleProvider`
+- `GoogleProviderConfig`
+- `createGithubProvider`
+- `GithubProviderConfig`
+- Google/GitHub provider tests
+- `openid-client` dependency used only by concrete providers
+
+Delete:
+
+- `registerBuiltinFederations`
+- session's runtime imports from `./federations/google.mjs` and
+  `./federations/github.mjs`
+
+Do not introduce `@o3co/auth-provider-federation-common` in v0.5.0. Exporting
+the small helper surface from session keeps the dependency graph simpler. A
+common package can be introduced later only if multiple non-session packages
+need non-contract shared code that no longer belongs in session.
+
+### Registration model
+
+Consumers are responsible for provider registration. `sessionModule` must accept
+an explicitly configured factory:
+
+```ts
+import { createFederationProviderFactory, sessionModule } from "@o3co/auth-provider-session";
+import { registerGoogleFederation } from "@o3co/auth-provider-federation-google";
+import { registerGithubFederation } from "@o3co/auth-provider-federation-github";
+
+const federationProviderFactory = createFederationProviderFactory();
+registerGoogleFederation(federationProviderFactory);
+registerGithubFederation(federationProviderFactory);
+
+sessionModule({
+  userRepository,
+  express,
+  federationProviderFactory,
+});
+```
+
+`SessionModuleOptions` adds:
+
+```ts
+federationProviderFactory?: FederationProviderFactory;
+```
+
+Default behavior:
+
+- If omitted, session creates an empty factory.
+- If `config.federations` has enabled entries whose `type` is unregistered,
+  boot fails with the existing adapter-factory "unknown type" error.
+- The error should mention provider package registration when practical.
+
+The current `_federationFactory` test-only option should be replaced with, or
+made an alias of, the public `federationProviderFactory` option.
+
+## Provider Package API
+
+### Google
+
+Package: `@o3co/auth-provider-federation-google`
+
+Exports:
+
+```ts
+export type { GoogleProviderConfig };
+export { createGoogleProvider, registerGoogleFederation };
+```
+
+Registration:
+
+```ts
+function registerGoogleFederation(factory: FederationProviderFactory): void;
+```
+
+The function registers type `"google"` and narrows builder config before calling
+`createGoogleProvider`.
+
+### GitHub
+
+Package: `@o3co/auth-provider-federation-github`
+
+Exports:
+
+```ts
+export type { GithubProviderConfig };
+export { createGithubProvider, registerGithubFederation };
+```
+
+Registration:
+
+```ts
+function registerGithubFederation(factory: FederationProviderFactory): void;
+```
+
+The function registers type `"github"` and narrows builder config before calling
+`createGithubProvider`.
+
+Function names intentionally use `Github` to match existing code style. Package
+names use lowercase `github`.
+
+## Dependency Graph
+
+Allowed:
+
+```text
+@o3co/auth-provider-federation-google
+  -> @o3co/auth-provider-session
+  -> @o3co/auth-provider-core
+
+@o3co/auth-provider-federation-github
+  -> @o3co/auth-provider-session
+  -> @o3co/auth-provider-core
+```
+
+Forbidden:
+
+```text
+@o3co/auth-provider-session
+  -> @o3co/auth-provider-federation-google
+@o3co/auth-provider-session
+  -> @o3co/auth-provider-federation-github
+```
+
+Provider packages depend on session for the public contract and helper exports.
+Session must remain provider-agnostic.
+
+## Version Policy
+
+During monorepo development:
+
+- package dependencies use `workspace:*`.
+
+At publish time:
+
+- provider packages declare `@o3co/auth-provider-session` as a peer dependency
+  with the same minor line, starting with `^0.5.0`.
+- provider packages also use session as a dev dependency for local tests/builds.
+- `openid-client` belongs in each provider package's regular dependencies, not
+  in session.
+
+Because 0.x semver is intentionally conservative, any breaking change to
+`FederationProvider` or capability types must be released in lockstep across
+session and provider packages.
+
+## Migration
+
+Before v0.5.0:
+
+```ts
+import { sessionModule } from "@o3co/auth-provider-session";
+
+sessionModule({ userRepository, express });
+```
+
+Google/GitHub worked because session registered built-ins internally.
+
+After v0.5.0:
+
+```ts
+import {
+  createFederationProviderFactory,
+  sessionModule,
+} from "@o3co/auth-provider-session";
+import { registerGoogleFederation } from "@o3co/auth-provider-federation-google";
+import { registerGithubFederation } from "@o3co/auth-provider-federation-github";
+
+const federationProviderFactory = createFederationProviderFactory();
+registerGoogleFederation(federationProviderFactory);
+registerGithubFederation(federationProviderFactory);
+
+sessionModule({
+  userRepository,
+  express,
+  federationProviderFactory,
+});
+```
+
+No codemod is required for v0.5.0. The migration is small enough for a guide
+section in `CHANGELOG.md`, `packages/session/README.md`, and
+`packages/session/README.ja.md`.
+
+`templates/standalone` must install and register provider packages when its
+default config includes Google/GitHub federation examples. If the default
+template disables all federations, it can still show commented registration
+examples.
+
+## CLI Relationship
+
+`add-federation <name>` is deferred to v0.6.0 or later.
+
+v0.5.0 still needs to be CLI-ready:
+
+- One provider equals one npm package.
+- Registration function names follow a predictable pattern.
+- README snippets show the exact install/import/register steps.
+- Package names are stable enough for a future CLI registry map.
+
+## Tests
+
+Move provider-specific tests:
+
+- `packages/session/src/federations/__tests__/google.test.mts`
+  -> `packages/federation-google/src/__tests__/google.test.mts`
+- `packages/session/src/federations/__tests__/github.test.mts`
+  -> `packages/federation-github/src/__tests__/github.test.mts`
+
+Keep in session:
+
+- factory creation tests for empty factory behavior
+- session module tests that inject a configured factory
+- route tests using fake providers
+- capability guard tests
+- helper tests for redirect validation and PKCE helpers
+
+Add contract checks:
+
+- session has no import path containing `federation-google`, `federation-github`,
+  `./federations/google`, or `./federations/github`
+- built package declarations for session do not expose provider-specific types
+- provider packages compile against only session public exports, not session
+  internal subpaths
+
+## Release and Documentation Work
+
+Implementation planning must include:
+
+- `pnpm-workspace.yaml` includes the new packages through existing
+  `packages/*`.
+- new package `package.json` files contain:
+  - `exports`
+  - `files`
+  - `repository.directory`
+  - `license`
+  - `build`, `typecheck`, `test`, `test:coverage`
+- root `pnpm -r run test` still passes; every workspace must define `test`.
+- typedoc config includes the new packages or intentionally excludes provider
+  packages with a documented reason.
+- `CHANGELOG.md` has a v0.5.0 breaking migration section.
+- `templates/standalone/src/app.mts` registers the provider packages.
+- `create-app` scaffolding includes provider package dependencies when the
+  standalone template requires them.
+- downstream composition roots, especially dplaas auth repos, are searched for:
+  - `registerBuiltinFederations`
+  - `createGoogleProvider`
+  - `createGithubProvider`
+
+## Acceptance Criteria
+
+- `@o3co/auth-provider-session` exposes no Google/GitHub provider factories.
+- `@o3co/auth-provider-session` has no runtime dependency on `openid-client`
+  unless another session-owned feature requires it.
+- Google and GitHub provider packages can be used independently.
+- A consumer can boot with no federation packages installed when no federations
+  are enabled.
+- A consumer with enabled Google/GitHub config must explicitly install and
+  register the matching provider package.
+- Existing Google/GitHub behavior is preserved after explicit registration.
+- The default standalone template remains runnable.
+
+## Open Follow-Ups
+
+- Decide whether provider packages should be included in generated API docs in
+  v0.5.0.
+- Decide whether unregistered provider errors should be enriched in
+  `AdapterFactory` globally or wrapped only by `sessionModule`.
+- Revisit separate repositories after v1.0 or after a third-party-maintained
+  provider appears.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- `@o3co/auth-provider-federation-google` package with `createGoogleProvider()` and `registerGoogleFederation(factory)`.
+- `@o3co/auth-provider-federation-github` package with `createGithubProvider()` and `registerGithubFederation(factory)`.
+- `sessionModule({ federationProviderFactory })` option for composition roots that explicitly register federation provider packages.
+- `validateRedirect`, `resolveCallbackRedirect`, and `codeChallenge` exports from `@o3co/auth-provider-session` for provider package implementations.
+
+### Changed
+
+- **Breaking**: Google and GitHub federation providers are no longer bundled in `@o3co/auth-provider-session`. Consumers must install provider packages, register them with `createFederationProviderFactory()`, and pass the factory to `sessionModule`.
+- `templates/standalone` registers `@o3co/auth-provider-federation-google` explicitly for the default Google federation config.
+
+### Removed
+
+- **Breaking**: `registerBuiltinFederations`, `createGoogleProvider`, and `createGithubProvider` are removed from `@o3co/auth-provider-session`.
+- `openid-client` is no longer a runtime dependency of `@o3co/auth-provider-session`; it belongs to the concrete provider packages.
+
 ## [0.4.1] - 2026-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `@o3co/auth-provider-federation-google` package with `createGoogleProvider()` and `registerGoogleFederation(factory)`.
 - `@o3co/auth-provider-federation-github` package with `createGithubProvider()` and `registerGithubFederation(factory)`.
 - `sessionModule({ federationProviderFactory })` option for composition roots that explicitly register federation provider packages.
-- `validateRedirect`, `resolveCallbackRedirect`, and `codeChallenge` exports from `@o3co/auth-provider-session` for provider package implementations.
+- `validateRedirect` and `resolveCallbackRedirect` exports from `@o3co/auth-provider-session` for provider package implementations. (`codeChallenge` was already exported since v0.4.0.)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ await init();
 - **core** — Interfaces, config schemas, token service, app factory. Always required.
 - **oauth** — OAuth routes (`/oauth/token`, `/oauth/authorize`, `/oauth/introspect`). Required for any token issuance.
 - **did** — DID authentication grant. Optional — only needed if you use DID-based auth.
-- **session** — Session login + OAuth federation (Google, GitHub, extensible). Optional — skip for API-only deployments.
+- **session** — Session login + provider-registered OAuth federation. Optional — skip for API-only deployments.
+- **federation-google / federation-github** — Concrete OAuth federation providers. Optional — install only the providers you register.
 - **foundation** — Production repository adapters (Redis code store, HTTP user lookup). Optional.
 
 ## Packages
@@ -141,7 +142,9 @@ await init();
 | [`packages/core`](packages/core/) | `@o3co/auth-provider-core` | Grant registry, token service, repository interfaces, config schemas |
 | [`packages/did`](packages/did/) | `@o3co/auth-provider-did` | DID authentication grant with pluggable resolver |
 | [`packages/oauth`](packages/oauth/) | `@o3co/auth-provider-oauth` | OAuth routes: `/oauth/token`, `/oauth/authorize`, `/oauth/introspect` |
-| [`packages/session`](packages/session/) | `@o3co/auth-provider-session` | Session routes, Passport.js, OAuth federation (Google, GitHub, extensible) |
+| [`packages/session`](packages/session/) | `@o3co/auth-provider-session` | Session routes and provider-registered OAuth federation |
+| [`packages/federation-google`](packages/federation-google/) | `@o3co/auth-provider-federation-google` | Google OAuth/OIDC federation provider |
+| [`packages/federation-github`](packages/federation-github/) | `@o3co/auth-provider-federation-github` | GitHub OAuth federation provider |
 | [`packages/foundation`](packages/foundation/) | `@o3co/auth-provider-foundation` | Redis code store, HTTP user/client repositories |
 | [`templates/standalone`](templates/standalone/) | — | Deployable server template (composition root) |
 | [`create-app`](create-app/) | `create-o3co-auth-provider` | CLI scaffolder |

--- a/create-app/scripts/copy-templates.mjs
+++ b/create-app/scripts/copy-templates.mjs
@@ -27,6 +27,9 @@ const readVersion = (pkgPath) => {
 const versions = {
 	"@o3co/auth-provider-core": readVersion("../../packages/core/package.json"),
 	"@o3co/auth-provider-did": readVersion("../../packages/did/package.json"),
+	"@o3co/auth-provider-federation-google": readVersion(
+		"../../packages/federation-google/package.json",
+	),
 	"@o3co/auth-provider-oauth": readVersion("../../packages/oauth/package.json"),
 	"@o3co/auth-provider-session": readVersion("../../packages/session/package.json"),
 	"@o3co/auth-provider-foundation": readVersion("../../packages/foundation/package.json"),

--- a/create-app/scripts/copy-templates.mjs
+++ b/create-app/scripts/copy-templates.mjs
@@ -30,6 +30,9 @@ const versions = {
 	"@o3co/auth-provider-federation-google": readVersion(
 		"../../packages/federation-google/package.json",
 	),
+	"@o3co/auth-provider-federation-github": readVersion(
+		"../../packages/federation-github/package.json",
+	),
 	"@o3co/auth-provider-oauth": readVersion("../../packages/oauth/package.json"),
 	"@o3co/auth-provider-session": readVersion("../../packages/session/package.json"),
 	"@o3co/auth-provider-foundation": readVersion("../../packages/foundation/package.json"),

--- a/create-app/src/__tests__/index.test.mts
+++ b/create-app/src/__tests__/index.test.mts
@@ -52,6 +52,7 @@ describe("scaffold", () => {
 
 		// Specific checks
 		expect(pkg.dependencies["@o3co/auth-provider-core"]).toMatch(/^\^/);
+		expect(pkg.dependencies["@o3co/auth-provider-federation-google"]).toMatch(/^\^/);
 		expect(pkg.dependencies["@o3co/auth-provider-foundation"]).toMatch(/^\^/);
 	});
 

--- a/create-app/src/__tests__/index.test.mts
+++ b/create-app/src/__tests__/index.test.mts
@@ -53,6 +53,7 @@ describe("scaffold", () => {
 		// Specific checks
 		expect(pkg.dependencies["@o3co/auth-provider-core"]).toMatch(/^\^/);
 		expect(pkg.dependencies["@o3co/auth-provider-federation-google"]).toMatch(/^\^/);
+		expect(pkg.dependencies["@o3co/auth-provider-federation-github"]).toBeUndefined();
 		expect(pkg.dependencies["@o3co/auth-provider-foundation"]).toMatch(/^\^/);
 	});
 
@@ -70,6 +71,13 @@ describe("scaffold", () => {
 
 		const pkg = JSON.parse(readFileSync(join(targetDir, "package.json"), "utf-8"));
 		expect(pkg.name).toBe("@piratis-blossoms/auth.provider");
+	});
+
+	it("ships versions for optional federation provider packages", () => {
+		const versions = JSON.parse(readFileSync(join("templates", "versions.json"), "utf-8"));
+
+		expect(versions["@o3co/auth-provider-federation-google"]).toBe("0.0.0");
+		expect(versions["@o3co/auth-provider-federation-github"]).toBe("0.0.0");
 	});
 });
 

--- a/packages/federation-github/README.md
+++ b/packages/federation-github/README.md
@@ -1,0 +1,11 @@
+# @o3co/auth-provider-federation-github
+
+GitHub federation provider for `auth.provider`.
+
+```ts
+import { createFederationProviderFactory } from "@o3co/auth-provider-session";
+import { registerGithubFederation } from "@o3co/auth-provider-federation-github";
+
+const federationProviderFactory = createFederationProviderFactory();
+registerGithubFederation(federationProviderFactory);
+```

--- a/packages/federation-github/package.json
+++ b/packages/federation-github/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "@o3co/auth-provider-session",
-	"description": "Session and federation routes module for auth.provider",
+	"name": "@o3co/auth-provider-federation-github",
+	"description": "GitHub federation provider for auth.provider",
 	"version": "0.0.0",
 	"license": "Apache-2.0",
 	"type": "module",
@@ -18,7 +18,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/o3co/auth.provider.git",
-		"directory": "packages/session"
+		"directory": "packages/federation-github"
 	},
 	"imports": {
 		"#/*": {
@@ -34,20 +34,13 @@
 		"test:coverage": "vitest run --coverage"
 	},
 	"dependencies": {
-		"@o3co/auth-provider-core": "workspace:*",
-		"connect-redis": "^9.0.0",
-		"express-rate-limit": "^8.3.1",
-		"redis": "^5.12.1"
+		"openid-client": "^6.8.3"
 	},
 	"peerDependencies": {
-		"express": "^5.0.0"
+		"@o3co/auth-provider-session": "workspace:*"
 	},
 	"devDependencies": {
-		"@types/express": "^5.0.6",
-		"@types/express-session": "^1",
-		"@types/supertest": "^7.2.0",
-		"express": "^5.2.1",
-		"supertest": "^7.2.2",
+		"@o3co/auth-provider-session": "workspace:*",
 		"typescript": "^5.9.3",
 		"vitest": "^4.1.2",
 		"@vitest/coverage-v8": "^4.1.2"

--- a/packages/federation-github/package.json
+++ b/packages/federation-github/package.json
@@ -37,7 +37,7 @@
 		"openid-client": "^6.8.3"
 	},
 	"peerDependencies": {
-		"@o3co/auth-provider-session": "workspace:*"
+		"@o3co/auth-provider-session": "^0.0.0"
 	},
 	"devDependencies": {
 		"@o3co/auth-provider-session": "workspace:*",

--- a/packages/federation-github/src/__tests__/github.test.mts
+++ b/packages/federation-github/src/__tests__/github.test.mts
@@ -8,6 +8,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+import { createFederationProviderFactory } from "@o3co/auth-provider-session";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
@@ -42,7 +43,7 @@ vi.mock("openid-client", () => ({
 	skipSubjectCheck: hoisted.skipSubjectCheckSym,
 }));
 
-import { createGithubProvider } from "../github.mjs";
+import { createGithubProvider, registerGithubFederation } from "../github.mjs";
 
 describe("createGithubProvider on openid-client", () => {
 	const baseConfig = {
@@ -60,6 +61,25 @@ describe("createGithubProvider on openid-client", () => {
 		const p = createGithubProvider(baseConfig);
 		expect(p.name).toBe("github");
 		expect([...p.scope]).toEqual(["read:user", "user:email"]);
+	});
+
+	it("registerGithubFederation registers the github factory type", async () => {
+		const factory = createFederationProviderFactory();
+		registerGithubFederation(factory);
+
+		const p = await factory.create({ type: "github", ...baseConfig });
+
+		expect(factory.registeredTypes()).toEqual(["github"]);
+		expect(p.name).toBe("github");
+	});
+
+	it("registerGithubFederation throws when required builder fields are missing", async () => {
+		const factory = createFederationProviderFactory();
+		registerGithubFederation(factory);
+
+		await expect(factory.create({ type: "github", name: "github" })).rejects.toThrow(
+			/clientId|clientSecret|callbackURL/i,
+		);
 	});
 
 	it("buildAuthorizationUrl forwards redirect_uri/state/code_challenge to openid-client with GitHub authorize URL", () => {

--- a/packages/federation-github/src/github.mts
+++ b/packages/federation-github/src/github.mts
@@ -14,19 +14,21 @@
  * limitations under the License.
  */
 
+import {
+	codeChallenge,
+	type EndSessionRequest,
+	type EndSessionResult,
+	type FederationProfile,
+	type FederationProvider,
+	type FederationProviderFactory,
+	type FederationResult,
+	type MappedClaims,
+	resolveCallbackRedirect,
+	type SupportsClaimMapping,
+	type SupportsLogout,
+	validateRedirect,
+} from "@o3co/auth-provider-session";
 import * as oidc from "openid-client";
-import { resolveCallbackRedirect, validateRedirect } from "./helpers.mjs";
-import { codeChallenge } from "./pkce.mjs";
-import type {
-	EndSessionRequest,
-	EndSessionResult,
-	FederationProfile,
-	FederationProvider,
-	FederationResult,
-	MappedClaims,
-	SupportsClaimMapping,
-	SupportsLogout,
-} from "./types.mjs";
 
 const GITHUB_ISSUER = "https://github.com";
 const SCOPES = ["read:user", "user:email"] as const;
@@ -50,6 +52,32 @@ export interface GithubProviderConfig {
 }
 
 type GithubProvider = FederationProvider & SupportsLogout & SupportsClaimMapping;
+
+function narrowGithubConfig(config: Record<string, unknown>): GithubProviderConfig {
+	const name = typeof config.name === "string" ? config.name : undefined;
+	const clientId = typeof config.clientId === "string" ? config.clientId : undefined;
+	const clientSecret = typeof config.clientSecret === "string" ? config.clientSecret : undefined;
+	const callbackURL = typeof config.callbackURL === "string" ? config.callbackURL : undefined;
+	if (!name || !clientId || !clientSecret || !callbackURL) {
+		throw new Error("GitHub federation requires name, clientId, clientSecret, and callbackURL");
+	}
+	return {
+		name,
+		clientId,
+		clientSecret,
+		callbackURL,
+		sessionDomain: typeof config.sessionDomain === "string" ? config.sessionDomain : undefined,
+		authCallbackUrl:
+			typeof config.authCallbackUrl === "string" ? config.authCallbackUrl : undefined,
+		clientUrl: typeof config.clientUrl === "string" ? config.clientUrl : undefined,
+		endSessionEndpoint:
+			typeof config.endSessionEndpoint === "string" ? config.endSessionEndpoint : undefined,
+	};
+}
+
+export function registerGithubFederation(factory: FederationProviderFactory): void {
+	factory.register("github", async (config) => createGithubProvider(narrowGithubConfig(config)));
+}
 
 export function createGithubProvider(config: GithubProviderConfig): GithubProvider {
 	if (!config.clientId || !config.clientSecret || !config.callbackURL) {

--- a/packages/federation-github/src/github.mts
+++ b/packages/federation-github/src/github.mts
@@ -51,7 +51,7 @@ export interface GithubProviderConfig {
 	endSessionEndpoint?: string;
 }
 
-type GithubProvider = FederationProvider & SupportsLogout & SupportsClaimMapping;
+export type GithubProvider = FederationProvider & SupportsLogout & SupportsClaimMapping;
 
 function narrowGithubConfig(config: Record<string, unknown>): GithubProviderConfig {
 	const name = typeof config.name === "string" ? config.name : undefined;

--- a/packages/federation-github/src/index.mts
+++ b/packages/federation-github/src/index.mts
@@ -14,11 +14,5 @@
  * limitations under the License.
  */
 
-import { type AdapterFactory, createAdapterFactory } from "@o3co/auth-provider-core";
-import type { FederationProvider } from "./types.mjs";
-
-export type FederationProviderFactory = AdapterFactory<FederationProvider>;
-
-export function createFederationProviderFactory(): FederationProviderFactory {
-	return createAdapterFactory<FederationProvider>("FederationProvider");
-}
+export type { GithubProviderConfig } from "./github.mjs";
+export { createGithubProvider, registerGithubFederation } from "./github.mjs";

--- a/packages/federation-github/src/index.mts
+++ b/packages/federation-github/src/index.mts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export type { GithubProviderConfig } from "./github.mjs";
+export type { GithubProvider, GithubProviderConfig } from "./github.mjs";
 export { createGithubProvider, registerGithubFederation } from "./github.mjs";

--- a/packages/federation-github/tsconfig.json
+++ b/packages/federation-github/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist/",
+		"paths": {
+			"#/*": ["./src/*"]
+		}
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
+}

--- a/packages/federation-github/vitest.config.mts
+++ b/packages/federation-github/vitest.config.mts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/__tests__/**/*.test.mts"],
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "json", "json-summary"],
+			reportsDirectory: "./coverage",
+			include: ["src/**/*.mts"],
+			exclude: ["src/**/__tests__/**", "src/**/*.d.mts", "dist/**"],
+			all: true,
+		},
+	},
+});

--- a/packages/federation-google/README.md
+++ b/packages/federation-google/README.md
@@ -1,0 +1,11 @@
+# @o3co/auth-provider-federation-google
+
+Google federation provider for `auth.provider`.
+
+```ts
+import { createFederationProviderFactory } from "@o3co/auth-provider-session";
+import { registerGoogleFederation } from "@o3co/auth-provider-federation-google";
+
+const federationProviderFactory = createFederationProviderFactory();
+registerGoogleFederation(federationProviderFactory);
+```

--- a/packages/federation-google/package.json
+++ b/packages/federation-google/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "@o3co/auth-provider-session",
-	"description": "Session and federation routes module for auth.provider",
+	"name": "@o3co/auth-provider-federation-google",
+	"description": "Google federation provider for auth.provider",
 	"version": "0.0.0",
 	"license": "Apache-2.0",
 	"type": "module",
@@ -18,7 +18,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/o3co/auth.provider.git",
-		"directory": "packages/session"
+		"directory": "packages/federation-google"
 	},
 	"imports": {
 		"#/*": {
@@ -34,20 +34,13 @@
 		"test:coverage": "vitest run --coverage"
 	},
 	"dependencies": {
-		"@o3co/auth-provider-core": "workspace:*",
-		"connect-redis": "^9.0.0",
-		"express-rate-limit": "^8.3.1",
-		"redis": "^5.12.1"
+		"openid-client": "^6.8.3"
 	},
 	"peerDependencies": {
-		"express": "^5.0.0"
+		"@o3co/auth-provider-session": "workspace:*"
 	},
 	"devDependencies": {
-		"@types/express": "^5.0.6",
-		"@types/express-session": "^1",
-		"@types/supertest": "^7.2.0",
-		"express": "^5.2.1",
-		"supertest": "^7.2.2",
+		"@o3co/auth-provider-session": "workspace:*",
 		"typescript": "^5.9.3",
 		"vitest": "^4.1.2",
 		"@vitest/coverage-v8": "^4.1.2"

--- a/packages/federation-google/package.json
+++ b/packages/federation-google/package.json
@@ -37,7 +37,7 @@
 		"openid-client": "^6.8.3"
 	},
 	"peerDependencies": {
-		"@o3co/auth-provider-session": "workspace:*"
+		"@o3co/auth-provider-session": "^0.0.0"
 	},
 	"devDependencies": {
 		"@o3co/auth-provider-session": "workspace:*",

--- a/packages/federation-google/src/__tests__/google.test.mts
+++ b/packages/federation-google/src/__tests__/google.test.mts
@@ -8,6 +8,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+import { createFederationProviderFactory } from "@o3co/auth-provider-session";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
@@ -42,7 +43,7 @@ vi.mock("openid-client", () => ({
 	skipSubjectCheck: hoisted.skipSubjectCheckSym,
 }));
 
-import { createGoogleProvider } from "../google.mjs";
+import { createGoogleProvider, registerGoogleFederation } from "../google.mjs";
 
 describe("createGoogleProvider on openid-client", () => {
 	const baseConfig = {
@@ -60,6 +61,25 @@ describe("createGoogleProvider on openid-client", () => {
 		const p = createGoogleProvider(baseConfig);
 		expect(p.name).toBe("google");
 		expect([...p.scope]).toEqual(["openid", "profile", "email"]);
+	});
+
+	it("registerGoogleFederation registers the google factory type", async () => {
+		const factory = createFederationProviderFactory();
+		registerGoogleFederation(factory);
+
+		const p = await factory.create({ type: "google", ...baseConfig });
+
+		expect(factory.registeredTypes()).toEqual(["google"]);
+		expect(p.name).toBe("google");
+	});
+
+	it("registerGoogleFederation throws when required builder fields are missing", async () => {
+		const factory = createFederationProviderFactory();
+		registerGoogleFederation(factory);
+
+		await expect(factory.create({ type: "google", name: "google" })).rejects.toThrow(
+			/clientId|clientSecret|callbackURL/i,
+		);
 	});
 
 	it("buildAuthorizationUrl forwards redirect_uri/state/code_challenge/access_type to openid-client", () => {

--- a/packages/federation-google/src/google.mts
+++ b/packages/federation-google/src/google.mts
@@ -52,7 +52,10 @@ export interface GoogleProviderConfig {
 	endSessionEndpoint?: string;
 }
 
-type GoogleProvider = FederationProvider & SupportsRefresh & SupportsLogout & SupportsClaimMapping;
+export type GoogleProvider = FederationProvider &
+	SupportsRefresh &
+	SupportsLogout &
+	SupportsClaimMapping;
 
 function narrowGoogleConfig(config: Record<string, unknown>): GoogleProviderConfig {
 	const name = typeof config.name === "string" ? config.name : undefined;

--- a/packages/federation-google/src/google.mts
+++ b/packages/federation-google/src/google.mts
@@ -14,21 +14,23 @@
  * limitations under the License.
  */
 
+import {
+	codeChallenge,
+	type EndSessionRequest,
+	type EndSessionResult,
+	type FederationProfile,
+	type FederationProvider,
+	type FederationProviderFactory,
+	type FederationResult,
+	type MappedClaims,
+	type RefreshedTokens,
+	resolveCallbackRedirect,
+	type SupportsClaimMapping,
+	type SupportsLogout,
+	type SupportsRefresh,
+	validateRedirect,
+} from "@o3co/auth-provider-session";
 import * as oidc from "openid-client";
-import { resolveCallbackRedirect, validateRedirect } from "./helpers.mjs";
-import { codeChallenge } from "./pkce.mjs";
-import type {
-	EndSessionRequest,
-	EndSessionResult,
-	FederationProfile,
-	FederationProvider,
-	FederationResult,
-	MappedClaims,
-	RefreshedTokens,
-	SupportsClaimMapping,
-	SupportsLogout,
-	SupportsRefresh,
-} from "./types.mjs";
 
 const GOOGLE_ISSUER = "https://accounts.google.com";
 const SCOPES = ["openid", "profile", "email"] as const;
@@ -51,6 +53,32 @@ export interface GoogleProviderConfig {
 }
 
 type GoogleProvider = FederationProvider & SupportsRefresh & SupportsLogout & SupportsClaimMapping;
+
+function narrowGoogleConfig(config: Record<string, unknown>): GoogleProviderConfig {
+	const name = typeof config.name === "string" ? config.name : undefined;
+	const clientId = typeof config.clientId === "string" ? config.clientId : undefined;
+	const clientSecret = typeof config.clientSecret === "string" ? config.clientSecret : undefined;
+	const callbackURL = typeof config.callbackURL === "string" ? config.callbackURL : undefined;
+	if (!name || !clientId || !clientSecret || !callbackURL) {
+		throw new Error("Google federation requires name, clientId, clientSecret, and callbackURL");
+	}
+	return {
+		name,
+		clientId,
+		clientSecret,
+		callbackURL,
+		sessionDomain: typeof config.sessionDomain === "string" ? config.sessionDomain : undefined,
+		authCallbackUrl:
+			typeof config.authCallbackUrl === "string" ? config.authCallbackUrl : undefined,
+		clientUrl: typeof config.clientUrl === "string" ? config.clientUrl : undefined,
+		endSessionEndpoint:
+			typeof config.endSessionEndpoint === "string" ? config.endSessionEndpoint : undefined,
+	};
+}
+
+export function registerGoogleFederation(factory: FederationProviderFactory): void {
+	factory.register("google", async (config) => createGoogleProvider(narrowGoogleConfig(config)));
+}
 
 export function createGoogleProvider(config: GoogleProviderConfig): GoogleProvider {
 	if (!config.clientId || !config.clientSecret || !config.callbackURL) {

--- a/packages/federation-google/src/index.mts
+++ b/packages/federation-google/src/index.mts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export type { GoogleProviderConfig } from "./google.mjs";
+export type { GoogleProvider, GoogleProviderConfig } from "./google.mjs";
 export { createGoogleProvider, registerGoogleFederation } from "./google.mjs";

--- a/packages/federation-google/src/index.mts
+++ b/packages/federation-google/src/index.mts
@@ -14,11 +14,5 @@
  * limitations under the License.
  */
 
-import { type AdapterFactory, createAdapterFactory } from "@o3co/auth-provider-core";
-import type { FederationProvider } from "./types.mjs";
-
-export type FederationProviderFactory = AdapterFactory<FederationProvider>;
-
-export function createFederationProviderFactory(): FederationProviderFactory {
-	return createAdapterFactory<FederationProvider>("FederationProvider");
-}
+export type { GoogleProviderConfig } from "./google.mjs";
+export { createGoogleProvider, registerGoogleFederation } from "./google.mjs";

--- a/packages/federation-google/tsconfig.json
+++ b/packages/federation-google/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist/",
+		"paths": {
+			"#/*": ["./src/*"]
+		}
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
+}

--- a/packages/federation-google/vitest.config.mts
+++ b/packages/federation-google/vitest.config.mts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/__tests__/**/*.test.mts"],
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "json", "json-summary"],
+			reportsDirectory: "./coverage",
+			include: ["src/**/*.mts"],
+			exclude: ["src/**/__tests__/**", "src/**/*.d.mts", "dist/**"],
+			all: true,
+		},
+	},
+});

--- a/packages/session/README.ja.md
+++ b/packages/session/README.ja.md
@@ -2,7 +2,7 @@
 
 [auth.provider](../../README.md) 向けセッション・フェデレーションルートモジュール。
 
-ユーザー名/パスワードログイン、ログアウト、OAuth 2.0 フェデレーション（Google、GitHub、およびカスタムプロバイダー）を担当する。内部的には RFC 6749 認可コードフローを使用し、組み込みの Google/GitHub プロバイダーは openid-client で実装されている。
+ユーザー名/パスワードログイン、ログアウト、`FederationProviderFactory` に登録されたプロバイダー向けの OAuth 2.0 フェデレーションを担当する。内部的には RFC 6749 認可コードフローを使用する。Google / GitHub などの具体プロバイダーは別パッケージに分離されている。
 
 ## インストール
 
@@ -23,9 +23,6 @@ peer dependencies（ワークスペースルートに別途インストール）
 express@^5.0.0
 ```
 
-組み込みフェデレーションプロバイダー（Google、GitHub）は `openid-client ^6.8.3` を使用する（peer dep ではなく `dependencies` エントリ）。
-
-
 ## パブリック API
 
 ### `sessionModule`
@@ -34,6 +31,7 @@ express@^5.0.0
 function sessionModule(params: {
   userRepository: UserRepository;
   express?: ExpressLike;
+  federationProviderFactory?: FederationProviderFactory;
 }): Module;
 ```
 
@@ -58,52 +56,7 @@ function sessionModule(params: {
 function createFederationProviderFactory(): FederationProviderFactory;
 ```
 
-組み込みタイプが未登録の空の `FederationProviderFactory`（`AdapterFactory<FederationProvider>`）を返す。`registerBuiltinFederations(factory)` を呼び出して組み込みの `"google"` と `"github"` を登録し、`factory.register(type, builder)` で独自タイプを追加できる。
-
----
-
-### `registerBuiltinFederations`
-
-```typescript
-function registerBuiltinFederations(factory: FederationProviderFactory): void;
-```
-
-組み込みフェデレーションアダプターを `factory` に登録する:
-
-| タイプ | プロバイダー | 依存ライブラリ（バンドル済み） |
-| --- | --- | --- |
-| `"google"` | `createGoogleProvider` | `openid-client ^6.8.3` |
-| `"github"` | `createGithubProvider` | `openid-client ^6.8.3` |
-
----
-
-### `createGoogleProvider`
-
-```typescript
-function createGoogleProvider(config: {
-  name: string;
-  clientId: string;
-  clientSecret: string;
-  callbackURL: string;
-}): FederationProvider;
-```
-
-Google OIDC 用の `FederationProvider` を生成する。`openid-client` を使って `https://accounts.google.com` から OIDC ディスカバリーでエンドポイントを取得する。`name` を変えることでマルチテナント構成（例: `google` と `google-work` を別インスタンスとして共存）が可能。
-
----
-
-### `createGithubProvider`
-
-```typescript
-function createGithubProvider(config: {
-  name: string;
-  clientId: string;
-  clientSecret: string;
-  callbackURL: string;
-}): FederationProvider;
-```
-
-GitHub OAuth 2.0 用の `FederationProvider` を生成する。`openid-client` を使用（追加の peer dep 不要）。デフォルトのスコープは `["read:user", "user:email"]`。`FederationProfile.sub` は GitHub の数値ユーザー ID。フェデレーショントークンのフォーマットは `${federationName}:${sub}`（`federationName` はプロバイダーに設定した `name`）。
+プロバイダータイプが未登録の空の `FederationProviderFactory`（`AdapterFactory<FederationProvider>`）を返す。具体プロバイダーパッケージをインストールして composition root で登録し、その factory を `sessionModule` に渡す。
 
 ---
 
@@ -167,7 +120,7 @@ function supportsLogout(
 ): provider is FederationProvider & SupportsLogout;
 ```
 
-組み込みの `"google"` / `"github"` は `SupportsLogout` を **実装しない**。Google は OIDC end-session endpoint を公開しておらず、GitHub は OAuth2 only のため、それぞれ end_session endpoint を持たない。Microsoft Entra ID / Auth0 / Okta 等の integration ではカスタム provider 側で capability を足すことで対応する。
+プロバイダーパッケージは、上流 IdP が end-session endpoint を提供する場合に `SupportsLogout` を実装できる。Microsoft Entra ID / Auth0 / Okta 等の integration ではカスタム provider 側で capability を足すことで対応する。
 
 カスタム provider の最小実装例:
 
@@ -252,7 +205,7 @@ function supportsClaimMapping(
 ): provider is FederationProvider & SupportsClaimMapping;
 ```
 
-`SupportsClaimMapping` を実装した provider は、`FederationProfile` を OIDC 標準のクレーム名に変換する。組み込みの `"google"` / `"github"` はこの capability を実装している。カスタム provider は `mapClaims` メソッドを追加することで対応できる:
+`SupportsClaimMapping` を実装した provider は、`FederationProfile` を OIDC 標準のクレーム名に変換する。カスタム provider は `mapClaims` メソッドを追加することで対応できる:
 
 ```ts
 import { supportsClaimMapping } from "@o3co/auth-provider-session";
@@ -297,15 +250,15 @@ if (supportsRefresh(provider)) {
 
 ---
 
-### 組み込みプロバイダーのメモ
+### プロバイダーパッケージのメモ
 
-**Google プロバイダー（`createGoogleProvider`）**
+**`@o3co/auth-provider-federation-google`**
 
 - デフォルトで `openid profile email` スコープをリクエストする。
-- `https://accounts.google.com` の OIDC ディスカバリーでエンドポイントを取得する。
+- 安定した Google OAuth/OIDC endpoint を使用する。
 - `FederationProfile.sub` は Google のアカウント数値 ID。
 
-**GitHub プロバイダー（`createGithubProvider`）**
+**`@o3co/auth-provider-federation-github`**
 
 - デフォルトスコープは `["read:user", "user:email"]`。
 - プロファイルオブジェクトに `email` フィールドが含まれない場合、GitHub `/user/emails` API を呼び出してプライマリの確認済みメールアドレスを取得することでプロファイルを補完する。
@@ -341,7 +294,14 @@ type FederationResult<T> =
 ```typescript
 import express from "express";
 import { createApp } from "@o3co/auth-provider-core";
-import { sessionModule } from "@o3co/auth-provider-session";
+import {
+  createFederationProviderFactory,
+  sessionModule,
+} from "@o3co/auth-provider-session";
+import { registerGoogleFederation } from "@o3co/auth-provider-federation-google";
+
+const federationProviderFactory = createFederationProviderFactory();
+registerGoogleFederation(federationProviderFactory);
 
 const app = createApp(express, {
   config,
@@ -349,13 +309,14 @@ const app = createApp(express, {
   modules: [
     sessionModule({
       userRepository,
+      federationProviderFactory,
     }),
   ],
 });
 await app.init();
 ```
 
-`sessionModule` は内部で `createFederationProviderFactory` + `registerBuiltinFederations` を使い、`config.federations` を読み込んでプロバイダーを自動的にセットアップする。
+`sessionModule` は composition root から渡された factory を使って `config.federations` のプロバイダーを生成する。設定で有効なタイプが未登録の場合は起動時に fail-fast する。
 
 ### HOCON フェデレーション設定
 
@@ -411,16 +372,13 @@ federations {
 
 ```typescript
 import {
+  codeChallenge,
   createFederationProviderFactory,
-  registerBuiltinFederations,
   type FederationProvider,
   type FederationProviderFactory,
 } from "@o3co/auth-provider-session";
-import { codeChallenge } from "@o3co/auth-provider-session/federations/pkce.mjs";
 
-// ファクトリーを生成して組み込みを登録
 const factory = createFederationProviderFactory();
-registerBuiltinFederations(factory);
 
 // カスタムプロバイダータイプを登録
 factory.register("microsoft", async (config) => {
@@ -511,7 +469,7 @@ class CustomProvider implements FederationProviderBase {
 **変更後（v0.4.0、純粋関数インターフェース）:**
 
 ```ts
-import { codeChallenge } from "@o3co/auth-provider-session/federations/pkce.mjs";
+import { codeChallenge } from "@o3co/auth-provider-session";
 
 class CustomProvider implements FederationProvider, SupportsClaimMapping {
   readonly name = "custom";

--- a/packages/session/README.md
+++ b/packages/session/README.md
@@ -2,7 +2,10 @@
 
 Session and federation routes module for [auth.provider](../../README.md).
 
-Handles username/password login, logout, and OAuth 2.0 federation (Google, GitHub, and any provider registered via `FederationProviderFactory`). Uses RFC 6749 authorization code flow internally, with built-in Google/GitHub providers backed by openid-client.
+Handles username/password login, logout, and OAuth 2.0 federation for providers
+registered with `FederationProviderFactory`. Uses RFC 6749 authorization code
+flow internally. Concrete providers such as Google and GitHub live in separate
+provider packages.
 
 ## Install
 
@@ -23,8 +26,6 @@ Peer dependencies (install separately in the workspace root):
 express@^5.0.0
 ```
 
-The built-in federation providers (Google, GitHub) use `openid-client ^6.8.3` (a `dependencies` entry, not a peer dep).
-
 ## Public API
 
 ### `sessionModule`
@@ -33,6 +34,7 @@ The built-in federation providers (Google, GitHub) use `openid-client ^6.8.3` (a
 function sessionModule(params: {
   userRepository: UserRepository;
   express?: ExpressLike;
+  federationProviderFactory?: FederationProviderFactory;
 }): Module;
 ```
 
@@ -57,52 +59,7 @@ The `:name` path parameter corresponds to the federation key in `config.federati
 function createFederationProviderFactory(): FederationProviderFactory;
 ```
 
-Creates an empty `FederationProviderFactory` (an `AdapterFactory<FederationProvider>` with no built-in types registered). Call `registerBuiltinFederations(factory)` to register the built-in `"google"` and `"github"` types, then call `factory.register(type, builder)` to add your own.
-
----
-
-### `registerBuiltinFederations`
-
-```typescript
-function registerBuiltinFederations(factory: FederationProviderFactory): void;
-```
-
-Registers the built-in federation adapters into `factory`:
-
-| Type       | Provider               | Dependency (bundled)  |
-|------------|------------------------|-----------------------|
-| `"google"` | `createGoogleProvider` | `openid-client ^6.8.3` |
-| `"github"` | `createGithubProvider` | `openid-client ^6.8.3` |
-
----
-
-### `createGoogleProvider`
-
-```typescript
-function createGoogleProvider(config: {
-  name: string;
-  clientId: string;
-  clientSecret: string;
-  callbackURL: string;
-}): FederationProvider;
-```
-
-Creates a `FederationProvider` for Google OIDC. Backed by `openid-client`; discovers endpoints from `https://accounts.google.com`. Supports multi-tenant usage (e.g. `google` and `google-work` as separate instances via distinct `name` values).
-
----
-
-### `createGithubProvider`
-
-```typescript
-function createGithubProvider(config: {
-  name: string;
-  clientId: string;
-  clientSecret: string;
-  callbackURL: string;
-}): FederationProvider;
-```
-
-Creates a `FederationProvider` for GitHub OAuth 2.0. Backed by `openid-client` with Arctic-style GitHub token endpoint. The default scope is `["read:user", "user:email"]`. The federation token format is `${federationName}:${profile.sub}` where `sub` is the GitHub numeric user ID.
+Creates an empty `FederationProviderFactory` (an `AdapterFactory<FederationProvider>` with no provider types registered). Install provider packages and register them in the composition root, then pass the factory to `sessionModule`.
 
 ---
 
@@ -166,7 +123,9 @@ function supportsLogout(
 ): provider is FederationProvider & SupportsLogout;
 ```
 
-The built-in `"google"` and `"github"` providers **do not** implement `SupportsLogout`: Google has no public OIDC end-session endpoint, and GitHub is OAuth2-only. External integrations (Microsoft Entra ID, Auth0, Okta, …) can add the capability by mixing it into their custom provider.
+Provider packages may implement `SupportsLogout` when the upstream IdP exposes
+an end-session endpoint. External integrations (Microsoft Entra ID, Auth0,
+Okta, etc.) can add the capability by mixing it into their custom provider.
 
 Minimum custom provider example:
 
@@ -252,7 +211,7 @@ function supportsClaimMapping(
 ): provider is FederationProvider & SupportsClaimMapping;
 ```
 
-Providers that implement `SupportsClaimMapping` translate a `FederationProfile` into OIDC-standard claim names. The built-in `"google"` and `"github"` providers implement this capability. Custom providers can add it by exposing a `mapClaims` method:
+Providers that implement `SupportsClaimMapping` translate a `FederationProfile` into OIDC-standard claim names. Custom providers can add it by exposing a `mapClaims` method:
 
 ```ts
 import { supportsClaimMapping } from "@o3co/auth-provider-session";
@@ -288,15 +247,15 @@ Providers implementing `SupportsRefresh` can keep federation tokens alive withou
 
 ---
 
-### Built-in provider notes
+### Provider package notes
 
-**Google provider (`createGoogleProvider`)**
+**`@o3co/auth-provider-federation-google`**
 
 - Requests `openid profile email` scope by default.
-- Discovers endpoints via OIDC discovery at `https://accounts.google.com`.
+- Uses stable Google OAuth/OIDC endpoints.
 - `FederationProfile.sub` is the Google numeric account ID.
 
-**GitHub provider (`createGithubProvider`)**
+**`@o3co/auth-provider-federation-github`**
 
 - Default scope is `["read:user", "user:email"]`.
 - When the primary profile object omits an `email` field, the provider enriches the profile by calling the GitHub `/user/emails` API to retrieve the primary verified email.
@@ -332,7 +291,14 @@ Discriminated union returned by `FederationProvider` methods. Check `ok` before 
 ```typescript
 import express from "express";
 import { createApp } from "@o3co/auth-provider-core";
-import { sessionModule } from "@o3co/auth-provider-session";
+import {
+  createFederationProviderFactory,
+  sessionModule,
+} from "@o3co/auth-provider-session";
+import { registerGoogleFederation } from "@o3co/auth-provider-federation-google";
+
+const federationProviderFactory = createFederationProviderFactory();
+registerGoogleFederation(federationProviderFactory);
 
 const app = createApp(express, {
   config,
@@ -340,13 +306,16 @@ const app = createApp(express, {
   modules: [
     sessionModule({
       userRepository,
+      federationProviderFactory,
     }),
   ],
 });
 await app.init();
 ```
 
-The `sessionModule` reads `config.federations` and wires up providers automatically using `createFederationProviderFactory` + `registerBuiltinFederations` internally.
+The `sessionModule` reads `config.federations` and creates providers using the
+factory supplied by the composition root. If a federation type is enabled in
+config but no package registered that type, boot fails fast.
 
 ### HOCON federation configuration
 
@@ -402,16 +371,13 @@ Mixed shape — top-level fields alongside a nested sub-section — is rejected 
 
 ```typescript
 import {
+  codeChallenge,
   createFederationProviderFactory,
-  registerBuiltinFederations,
   type FederationProvider,
   type FederationProviderFactory,
 } from "@o3co/auth-provider-session";
-import { codeChallenge } from "@o3co/auth-provider-session/federations/pkce.mjs";
 
-// Create factory and register built-ins
 const factory = createFederationProviderFactory();
-registerBuiltinFederations(factory);
 
 // Register a custom provider type
 factory.register("microsoft", async (config) => {
@@ -502,7 +468,7 @@ class CustomProvider implements FederationProviderBase {
 **After (v0.4.0, pure-function interface):**
 
 ```ts
-import { codeChallenge } from "@o3co/auth-provider-session/federations/pkce.mjs";
+import { codeChallenge } from "@o3co/auth-provider-session";
 
 class CustomProvider implements FederationProvider, SupportsClaimMapping {
   readonly name = "custom";

--- a/packages/session/src/__tests__/index.test.mts
+++ b/packages/session/src/__tests__/index.test.mts
@@ -34,18 +34,20 @@ describe("package public surface (@o3co/auth-provider-session)", () => {
 		).toBe("function");
 	});
 
-	it("exports createGoogleProvider as a runtime factory", async () => {
+	it("exports federation helper utilities for provider packages", async () => {
 		const mod = await import("#/index.mjs");
-		expect(typeof (mod as { createGoogleProvider?: unknown }).createGoogleProvider).toBe(
+		expect(typeof (mod as { validateRedirect?: unknown }).validateRedirect).toBe("function");
+		expect(typeof (mod as { resolveCallbackRedirect?: unknown }).resolveCallbackRedirect).toBe(
 			"function",
 		);
+		expect(typeof (mod as { codeChallenge?: unknown }).codeChallenge).toBe("function");
 	});
 
-	it("exports createGithubProvider as a runtime factory", async () => {
+	it("does NOT export concrete Google/GitHub provider factories", async () => {
 		const mod = await import("#/index.mjs");
-		expect(typeof (mod as { createGithubProvider?: unknown }).createGithubProvider).toBe(
-			"function",
-		);
+		expect((mod as Record<string, unknown>).createGoogleProvider).toBeUndefined();
+		expect((mod as Record<string, unknown>).createGithubProvider).toBeUndefined();
+		expect((mod as Record<string, unknown>).registerBuiltinFederations).toBeUndefined();
 	});
 
 	it("does NOT export createPassport (passport-era export removed)", async () => {

--- a/packages/session/src/__tests__/module.test.mts
+++ b/packages/session/src/__tests__/module.test.mts
@@ -15,6 +15,7 @@
  */
 
 import {
+	AdapterFactoryError,
 	type AppConfig,
 	createSymmetricKeyStore,
 	type FederationTokenStoreBase,
@@ -142,6 +143,75 @@ describe("sessionModule", () => {
 		const calls = (routerMock.use as ReturnType<typeof vi.fn>).mock.calls;
 		const sessionCalls = calls.filter((call: unknown[]) => call[0] === "/session");
 		expect(sessionCalls.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("uses the public federationProviderFactory option for enabled federations", async () => {
+		const factory = {
+			create: vi.fn().mockResolvedValue({
+				name: "google",
+				scope: [],
+				validateRedirect: vi.fn(),
+				resolveCallbackRedirect: vi.fn(),
+				buildAuthorizationUrl: vi.fn(),
+				exchangeCode: vi.fn(),
+			}),
+		};
+		const routerMock = { use: vi.fn().mockReturnThis() } as unknown as Router;
+		const config = {
+			...mockConfig,
+			federations: {
+				google: {
+					enabled: true,
+					clientId: "id",
+					clientSecret: "secret",
+					callbackURL: "https://example.com/cb",
+				},
+			},
+		} as unknown as AppConfig;
+		const ctx = makeContext({ router: routerMock, config });
+		const module = sessionModule({
+			userRepository: {
+				authenticate: vi.fn(),
+				authenticateByToken: vi.fn(),
+			} as unknown as UserRepository,
+			federationProviderFactory:
+				factory as unknown as import("#/federations/factory.mjs").FederationProviderFactory,
+		});
+
+		await module.init(ctx);
+
+		expect(factory.create).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "google", name: "google" }),
+		);
+	});
+
+	it("does not register Google/GitHub providers by default", async () => {
+		const routerMock = { use: vi.fn().mockReturnThis() } as unknown as Router;
+		const config = {
+			...mockConfig,
+			federations: {
+				google: {
+					enabled: true,
+					clientId: "id",
+					clientSecret: "secret",
+					callbackURL: "https://example.com/cb",
+				},
+			},
+		} as unknown as AppConfig;
+		const ctx = makeContext({ router: routerMock, config });
+		const module = sessionModule({
+			userRepository: {
+				authenticate: vi.fn(),
+				authenticateByToken: vi.fn(),
+			} as unknown as UserRepository,
+		});
+
+		await expect(module.init(ctx)).rejects.toSatisfy(
+			(err) =>
+				err instanceof AdapterFactoryError &&
+				err.reason === "unknown" &&
+				err.kind === "FederationProvider",
+		);
 	});
 
 	it("skips federations with enabled=false", async () => {

--- a/packages/session/src/__tests__/module.test.mts
+++ b/packages/session/src/__tests__/module.test.mts
@@ -232,7 +232,7 @@ describe("sessionModule", () => {
 				authenticate: vi.fn(),
 				authenticateByToken: vi.fn(),
 			} as unknown as UserRepository,
-			_federationFactory:
+			federationProviderFactory:
 				factory as unknown as import("#/federations/factory.mjs").FederationProviderFactory,
 		});
 
@@ -272,7 +272,7 @@ describe("sessionModule", () => {
 				authenticate: vi.fn(),
 				authenticateByToken: vi.fn(),
 			} as unknown as UserRepository,
-			_federationFactory:
+			federationProviderFactory:
 				factory as unknown as import("#/federations/factory.mjs").FederationProviderFactory,
 		});
 
@@ -313,7 +313,7 @@ describe("sessionModule", () => {
 				authenticate: vi.fn(),
 				authenticateByToken: vi.fn(),
 			} as unknown as UserRepository,
-			_federationFactory:
+			federationProviderFactory:
 				factory as unknown as import("#/federations/factory.mjs").FederationProviderFactory,
 		});
 
@@ -349,7 +349,7 @@ describe("sessionModule", () => {
 				authenticate: vi.fn(),
 				authenticateByToken: vi.fn(),
 			} as unknown as UserRepository,
-			_federationFactory:
+			federationProviderFactory:
 				factory as unknown as import("#/federations/factory.mjs").FederationProviderFactory,
 		});
 
@@ -393,7 +393,7 @@ describe("sessionModule", () => {
 				authenticate: vi.fn(),
 				authenticateByToken: vi.fn(),
 			} as unknown as UserRepository,
-			_federationFactory:
+			federationProviderFactory:
 				factory as unknown as import("#/federations/factory.mjs").FederationProviderFactory,
 		});
 
@@ -434,7 +434,7 @@ describe("sessionModule", () => {
 				authenticate: vi.fn(),
 				authenticateByToken: vi.fn(),
 			} as unknown as UserRepository,
-			_federationFactory:
+			federationProviderFactory:
 				factory as unknown as import("#/federations/factory.mjs").FederationProviderFactory,
 		});
 
@@ -513,7 +513,7 @@ describe("sessionModule", () => {
 				authenticate: vi.fn(),
 				authenticateByToken: vi.fn(),
 			} as unknown as UserRepository,
-			_federationFactory:
+			federationProviderFactory:
 				factory as unknown as import("#/federations/factory.mjs").FederationProviderFactory,
 		});
 
@@ -563,7 +563,7 @@ describe("sessionModule", () => {
 				authenticate: vi.fn(),
 				authenticateByToken: vi.fn(),
 			} as unknown as UserRepository,
-			_federationFactory:
+			federationProviderFactory:
 				factory as unknown as import("#/federations/factory.mjs").FederationProviderFactory,
 			_createFederationRouter:
 				federationRouterSpy as unknown as typeof import("#/routes/Federation.mjs").createRouter,
@@ -610,7 +610,7 @@ describe("sessionModule", () => {
 				authenticate: vi.fn(),
 				authenticateByToken: vi.fn(),
 			} as unknown as UserRepository,
-			_federationFactory:
+			federationProviderFactory:
 				factory as unknown as import("#/federations/factory.mjs").FederationProviderFactory,
 		});
 

--- a/packages/session/src/__tests__/module.test.mts
+++ b/packages/session/src/__tests__/module.test.mts
@@ -220,6 +220,75 @@ describe("sessionModule", () => {
 		});
 	});
 
+	it("rethrows non-AdapterFactoryError failures from factory.create unchanged", async () => {
+		const originalError = new Error("custom provider builder crashed");
+		const factory = {
+			create: vi.fn().mockRejectedValue(originalError),
+		};
+		const routerMock = { use: vi.fn().mockReturnThis() } as unknown as Router;
+		const config = {
+			...mockConfig,
+			federations: {
+				google: {
+					enabled: true,
+					clientId: "id",
+					clientSecret: "secret",
+					callbackURL: "https://example.com/cb",
+				},
+			},
+		} as unknown as AppConfig;
+		const ctx = makeContext({ router: routerMock, config });
+		const module = sessionModule({
+			userRepository: {
+				authenticate: vi.fn(),
+				authenticateByToken: vi.fn(),
+			} as unknown as UserRepository,
+			federationProviderFactory:
+				factory as unknown as import("#/federations/factory.mjs").FederationProviderFactory,
+		});
+
+		// Unknown-type wrapping must only apply to AdapterFactoryError; other failures
+		// from custom builders must surface unchanged so operators see the real cause.
+		await expect(module.init(ctx)).rejects.toBe(originalError);
+	});
+
+	it("rethrows AdapterFactoryError with reason=duplicate unchanged", async () => {
+		const dupErr = new AdapterFactoryError({
+			reason: "duplicate",
+			kind: "FederationProvider",
+			type: "google",
+			registered: ["google"],
+		});
+		const factory = {
+			create: vi.fn().mockRejectedValue(dupErr),
+		};
+		const routerMock = { use: vi.fn().mockReturnThis() } as unknown as Router;
+		const config = {
+			...mockConfig,
+			federations: {
+				google: {
+					enabled: true,
+					clientId: "id",
+					clientSecret: "secret",
+					callbackURL: "https://example.com/cb",
+				},
+			},
+		} as unknown as AppConfig;
+		const ctx = makeContext({ router: routerMock, config });
+		const module = sessionModule({
+			userRepository: {
+				authenticate: vi.fn(),
+				authenticateByToken: vi.fn(),
+			} as unknown as UserRepository,
+			federationProviderFactory:
+				factory as unknown as import("#/federations/factory.mjs").FederationProviderFactory,
+		});
+
+		// Only reason='unknown' gets the install/register hint wrapping; duplicate
+		// (a builder-bug signal) must propagate verbatim.
+		await expect(module.init(ctx)).rejects.toBe(dupErr);
+	});
+
 	it("skips federations with enabled=false", async () => {
 		// Arrange: one federation entry with enabled=false
 		const factory = {

--- a/packages/session/src/__tests__/module.test.mts
+++ b/packages/session/src/__tests__/module.test.mts
@@ -206,12 +206,18 @@ describe("sessionModule", () => {
 			} as unknown as UserRepository,
 		});
 
-		await expect(module.init(ctx)).rejects.toSatisfy(
-			(err) =>
-				err instanceof AdapterFactoryError &&
-				err.reason === "unknown" &&
-				err.kind === "FederationProvider",
-		);
+		await expect(module.init(ctx)).rejects.toSatisfy((err) => {
+			if (!(err instanceof Error)) return false;
+			const cause = (err as Error & { cause?: unknown }).cause;
+			return (
+				/no provider registered for type "google"/.test(err.message) &&
+				/@o3co\/auth-provider-federation-google/.test(err.message) &&
+				/federationProviderFactory/.test(err.message) &&
+				cause instanceof AdapterFactoryError &&
+				cause.reason === "unknown" &&
+				cause.kind === "FederationProvider"
+			);
+		});
 	});
 
 	it("skips federations with enabled=false", async () => {

--- a/packages/session/src/federations/__tests__/factory.test.mts
+++ b/packages/session/src/federations/__tests__/factory.test.mts
@@ -19,7 +19,6 @@ import { describe, expect, it } from "vitest";
 import {
 	createFederationProviderFactory,
 	type FederationProviderFactory,
-	registerBuiltinFederations,
 } from "#/federations/factory.mjs";
 import type { FederationProvider } from "#/federations/types.mjs";
 
@@ -63,77 +62,5 @@ describe("createFederationProviderFactory", () => {
 
 		expect(asBase.name).toBe("stub");
 		expect(created.name).toBe("stub");
-	});
-});
-
-describe("registerBuiltinFederations", () => {
-	it("registers 'google' and 'github' types", () => {
-		const factory = createFederationProviderFactory();
-		registerBuiltinFederations(factory);
-		expect(factory.registeredTypes()).toEqual(expect.arrayContaining(["google", "github"]));
-	});
-
-	it("builds a Google provider via factory.create({ type: 'google', name, clientId, ... })", async () => {
-		const factory = createFederationProviderFactory();
-		registerBuiltinFederations(factory);
-		const provider = await factory.create({
-			type: "google",
-			name: "google",
-			clientId: "id",
-			clientSecret: "secret",
-			callbackURL: "https://example.com/cb",
-		});
-		expect(provider.name).toBe("google");
-		expect(provider.scope).toContain("email");
-	});
-
-	it("builds a GitHub provider via factory.create({ type: 'github', name, ... })", async () => {
-		const factory = createFederationProviderFactory();
-		registerBuiltinFederations(factory);
-		const provider = await factory.create({
-			type: "github",
-			name: "github",
-			clientId: "id",
-			clientSecret: "secret",
-			callbackURL: "https://example.com/cb",
-		});
-		expect(provider.name).toBe("github");
-		expect(provider.scope).toEqual(["read:user", "user:email"]);
-	});
-
-	it("supports multi-tenant instance names (e.g. 'google-work' with type='google')", async () => {
-		const factory = createFederationProviderFactory();
-		registerBuiltinFederations(factory);
-		const provider = await factory.create({
-			type: "google",
-			name: "google-work",
-			clientId: "id",
-			clientSecret: "secret",
-			callbackURL: "https://example.com/cb",
-		});
-		expect(provider.name).toBe("google-work");
-	});
-
-	it("throws when required fields are missing (google)", async () => {
-		const factory = createFederationProviderFactory();
-		registerBuiltinFederations(factory);
-		await expect(
-			factory.create({
-				type: "google",
-				name: "google",
-				// missing clientId, clientSecret, callbackURL
-			}),
-		).rejects.toThrow(/clientId|clientSecret|callbackURL/i);
-	});
-
-	it("throws when required fields are missing (github)", async () => {
-		const factory = createFederationProviderFactory();
-		registerBuiltinFederations(factory);
-		await expect(
-			factory.create({
-				type: "github",
-				name: "github",
-			}),
-		).rejects.toThrow(/clientId|clientSecret|callbackURL/i);
 	});
 });

--- a/packages/session/src/index.mts
+++ b/packages/session/src/index.mts
@@ -15,14 +15,10 @@
  */
 
 export type { FederationProviderFactory } from "./federations/factory.mjs";
-export {
-	createFederationProviderFactory,
-	registerBuiltinFederations,
-} from "./federations/factory.mjs";
-export type { GithubProviderConfig } from "./federations/github.mjs";
-export { createGithubProvider } from "./federations/github.mjs";
-export type { GoogleProviderConfig } from "./federations/google.mjs";
-export { createGoogleProvider } from "./federations/google.mjs";
+export { createFederationProviderFactory } from "./federations/factory.mjs";
+export type { RedirectConfig } from "./federations/helpers.mjs";
+export { resolveCallbackRedirect, validateRedirect } from "./federations/helpers.mjs";
+export { codeChallenge } from "./federations/pkce.mjs";
 export type {
 	EndSessionRequest,
 	EndSessionResult,

--- a/packages/session/src/module.mts
+++ b/packages/session/src/module.mts
@@ -54,8 +54,6 @@ export type SessionModuleOptions = {
 };
 
 type SessionModuleInternalOptions = SessionModuleOptions & {
-	/** For testing only — inject a pre-configured factory to skip registration. */
-	_federationFactory?: FederationProviderFactory;
 	/** For testing only — replace sessionRoutes.createRouter to capture call arguments. */
 	_createSessionRouter?: typeof sessionRoutes.createRouter;
 	/** For testing only — replace federationRoutes.createRouter to capture call arguments. */
@@ -87,9 +85,7 @@ export const _sessionModuleImpl = (params: SessionModuleInternalOptions): Module
 
 		// Build federation provider factory (or use injected stub in tests).
 		const factory: FederationProviderFactory =
-			params.federationProviderFactory ??
-			params._federationFactory ??
-			createFederationProviderFactory();
+			params.federationProviderFactory ?? createFederationProviderFactory();
 
 		// Normalize federation config entries and build the provider Map.
 		const federationProviders = new Map<string, FederationProvider>();

--- a/packages/session/src/module.mts
+++ b/packages/session/src/module.mts
@@ -25,7 +25,6 @@ import type { RequestHandler, Router } from "express";
 import {
 	createFederationProviderFactory,
 	type FederationProviderFactory,
-	registerBuiltinFederations,
 } from "./federations/factory.mjs";
 import type { FederationProvider } from "./federations/types.mjs";
 import * as federationRoutes from "./routes/Federation.mjs";
@@ -50,6 +49,8 @@ export type SessionModuleOptions = {
 	express?: ExpressLike;
 	/** Session TTL in milliseconds for new federation-created UserSessions. Default 24h. */
 	sessionTtlMs?: number;
+	/** Federation provider factory configured by the composition root. Defaults to an empty factory. */
+	federationProviderFactory?: FederationProviderFactory;
 };
 
 type SessionModuleInternalOptions = SessionModuleOptions & {
@@ -86,12 +87,9 @@ export const _sessionModuleImpl = (params: SessionModuleInternalOptions): Module
 
 		// Build federation provider factory (or use injected stub in tests).
 		const factory: FederationProviderFactory =
+			params.federationProviderFactory ??
 			params._federationFactory ??
-			(() => {
-				const f = createFederationProviderFactory();
-				registerBuiltinFederations(f);
-				return f;
-			})();
+			createFederationProviderFactory();
 
 		// Normalize federation config entries and build the provider Map.
 		const federationProviders = new Map<string, FederationProvider>();

--- a/packages/session/src/module.mts
+++ b/packages/session/src/module.mts
@@ -15,6 +15,7 @@
  */
 
 import {
+	AdapterFactoryError,
 	type AppConfig,
 	fullSectionsSchema,
 	type Module,
@@ -148,14 +149,28 @@ export const _sessionModuleImpl = (params: SessionModuleInternalOptions): Module
 				// config.endpoints.client: optional section — fallback URL when no redirectTo in session
 				config.endpoints.client?.url ?? undefined;
 
-			const provider = await factory.create({
-				type,
-				name,
-				...flatConfig,
-				sessionDomain,
-				authCallbackUrl,
-				clientUrl,
-			});
+			let provider: FederationProvider;
+			try {
+				provider = await factory.create({
+					type,
+					name,
+					...flatConfig,
+					sessionDomain,
+					authCallbackUrl,
+					clientUrl,
+				});
+			} catch (err) {
+				if (err instanceof AdapterFactoryError && err.reason === "unknown") {
+					throw new Error(
+						`federations.${name}: no provider registered for type "${type}". ` +
+							`Install @o3co/auth-provider-federation-${type} (or a custom provider package), ` +
+							`call its register*Federation(factory) helper, and pass the factory to sessionModule ` +
+							`via the federationProviderFactory option.`,
+						{ cause: err },
+					);
+				}
+				throw err;
+			}
 
 			// Invariant guard: the provider's name must equal the config key so that
 			// routes/Federation.mts can look up the provider by the :name route param.

--- a/templates/standalone/package.json
+++ b/templates/standalone/package.json
@@ -19,6 +19,7 @@
 	},
 	"dependencies": {
 		"@o3co/auth-provider-core": "workspace:*",
+		"@o3co/auth-provider-federation-google": "workspace:*",
 		"@o3co/auth-provider-oauth": "workspace:*",
 		"@o3co/auth-provider-session": "workspace:*",
 		"@o3co/auth-provider-foundation": "workspace:*",

--- a/templates/standalone/src/app.mts
+++ b/templates/standalone/src/app.mts
@@ -28,6 +28,7 @@ import {
 	registerBuiltinKeyStores,
 	registerBuiltinUserSessionStores,
 } from "@o3co/auth-provider-core";
+import { registerGoogleFederation } from "@o3co/auth-provider-federation-google";
 import { registerBuiltinAdapters } from "@o3co/auth-provider-foundation";
 import {
 	oauthAuthorizationModule,
@@ -35,6 +36,7 @@ import {
 	oauthSessionModule,
 } from "@o3co/auth-provider-oauth";
 import {
+	createFederationProviderFactory,
 	createSessionStoreFactory,
 	registerBuiltinSessionStores,
 	sessionModule,
@@ -162,6 +164,9 @@ await (async (): Promise<void> => {
 		),
 	);
 
+	const federationProviderFactory = createFederationProviderFactory();
+	registerGoogleFederation(federationProviderFactory);
+
 	// Step 8: Compose the OAuth / session modules and build the app router.
 	const { init, router, grantRegistry } = createApp({
 		express,
@@ -172,7 +177,7 @@ await (async (): Promise<void> => {
 		federationTokenStore,
 		modules: [
 			oauthModule({ clientRepository, codeRepository, express }),
-			sessionModule({ userRepository, express }),
+			sessionModule({ userRepository, express, federationProviderFactory }),
 			oauthSessionModule({ clientRepository }),
 			oauthAuthorizationModule({ codeRepository, clientRepository }),
 		],

--- a/templates/standalone/src/app.mts
+++ b/templates/standalone/src/app.mts
@@ -29,6 +29,7 @@ import {
 	registerBuiltinUserSessionStores,
 } from "@o3co/auth-provider-core";
 import { registerGoogleFederation } from "@o3co/auth-provider-federation-google";
+// import { registerGithubFederation } from "@o3co/auth-provider-federation-github";
 import { registerBuiltinAdapters } from "@o3co/auth-provider-foundation";
 import {
 	oauthAuthorizationModule,
@@ -166,6 +167,7 @@ await (async (): Promise<void> => {
 
 	const federationProviderFactory = createFederationProviderFactory();
 	registerGoogleFederation(federationProviderFactory);
+	// registerGithubFederation(federationProviderFactory);
 
 	// Step 8: Compose the OAuth / session modules and build the app router.
 	const { init, router, grantRegistry } = createApp({

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,6 +2,8 @@
 	"entryPoints": [
 		"packages/core",
 		"packages/did",
+		"packages/federation-google",
+		"packages/federation-github",
 		"packages/oauth",
 		"packages/session",
 		"packages/foundation"


### PR DESCRIPTION
## Summary

- Split built-in Google/GitHub federation providers out of `@o3co/auth-provider-session` into per-provider packages (`@o3co/auth-provider-federation-google`, `@o3co/auth-provider-federation-github`) for v0.5.0
- `registerBuiltinFederations` deleted; `sessionModule` now accepts an explicit `federationProviderFactory` option. Session retains only the contract (`FederationProvider` + capability types), route layer, and shared helpers
- `openid-client` dependency moves from session to the provider packages; session is now provider-agnostic

Spec: [`.claude/superpowers/specs/2026-04-23-federation-provider-package-split-design.md`](.claude/superpowers/specs/2026-04-23-federation-provider-package-split-design.md)

## Breaking changes (v0.5.0)

Consumers that previously relied on session's built-in Google/GitHub registration must now explicitly install and register the provider packages:

```ts
import { createFederationProviderFactory, sessionModule } from "@o3co/auth-provider-session";
import { registerGoogleFederation } from "@o3co/auth-provider-federation-google";
import { registerGithubFederation } from "@o3co/auth-provider-federation-github";

const federationProviderFactory = createFederationProviderFactory();
registerGoogleFederation(federationProviderFactory);
registerGithubFederation(federationProviderFactory);

sessionModule({ userRepository, express, federationProviderFactory });
```

Migration guide: `CHANGELOG.md` v0.5.0 section + `packages/session/README.md`.

## Review cycle

Round 1 (multi-agent-review, pre-PR) — 5 findings addressed in `922276b`:

- `_federationFactory` test-only option removed (spec §Registration model)
- `templates/standalone` gets commented GitHub registration example
- `create-app` versions map includes `federation-github`
- `peerDependencies` aligned with repo convention (`^0.0.0`)
- `GoogleProvider` / `GithubProvider` capability-narrowed types exported

## Test plan

- [ ] `pnpm --recursive typecheck` passes
- [ ] `pnpm --recursive build` passes
- [ ] `pnpm --recursive test` passes (session + federation-google + federation-github)
- [ ] `make test-e2e` token-flow + ABAC green
- [ ] Standalone template boots with Google federation registered
- [ ] `packages/session/dist/**/*.d.mts` contains no `GoogleProviderConfig` / `GithubProviderConfig` leak
- [ ] CI vendor-leak guard clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
