### PR TITLE
feat!: grant_type RFC compliance + URN-ification (v0.5.0 #3)

### DIFF
--- a/.claude/superpowers/plans/2026-04-24-grant-type-rename.md
+++ b/.claude/superpowers/plans/2026-04-24-grant-type-rename.md
@@ -1,0 +1,878 @@
+# Grant Type Rename Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename OAuth grant values to RFC 6749 / RFC 6755 compliant forms: `authorization` → `authorization_code`, `did` → `urn:o3co:oauth:grant-type:did`. Align HOCON config keys and env vars accordingly.
+
+**Architecture:** Hard break (no dual-accept). Wire values, HOCON config keys, policy input, and standalone template all change in one release. DID grant URN is fixed to `urn:o3co:oauth:grant-type:did` (owned by auth.provider as wire protocol definer). Audit event schema unchanged (`details.grant_type`), only values flow through automatically.
+
+**Tech Stack:** TypeScript (Node.js), Vitest, Zod, Express, HOCON (`@o3co/hocon`).
+
+**Spec:** `.claude/superpowers/specs/2026-04-24-grant-type-rename-design.md`
+
+---
+
+## File Structure
+
+Files to modify (in execution order):
+
+| File | Purpose | Change |
+| --- | --- | --- |
+| `packages/oauth/src/__tests__/oauthAuthorization.test.mts` | Module init registration test | Rename grant key assertions |
+| `packages/oauth/src/oauthAuthorization.mts` | Grant registration + config lookup | Rename config key + registry key |
+| `packages/oauth/src/__tests__/hooks.test.mts` | Policy/audit flow tests | Update policy grantType expectation |
+| `packages/oauth/src/routes.mts` | Policy input hardcoded value | Update `grantType: "authorization"` |
+| `packages/core/config/application.conf` | Core default HOCON | Rename `authorization` section + env var |
+| `templates/standalone/config/application.conf` | Standalone default HOCON | Rename section + env vars |
+| `packages/did/src/__tests__/did.test.mts` | DID grant unit tests | Update mock config key (internal only) |
+| `packages/did/src/module.mts` | DID grant registration | Register fixed URN |
+| `packages/did/src/__tests__/module.test.mts` | NEW — module init test for URN | Create |
+| `templates/standalone/tests/index.test.js` | Standalone integration tests | Update `grant_type=authorization` wire values |
+| `templates/standalone/tests/did-grant.test.js` | Standalone DID integration tests | Update all 8 `grant_type: "did"` to URN |
+| `templates/standalone/src/__tests__/smoke.test.mts` | Standalone smoke tests | Update if any `authorization` references |
+| `templates/standalone/README.md` / `.ja.md` | Standalone env var docs | Update table entries |
+| `README.md` | Root README | Update ASCII diagram + env var |
+| `packages/oauth/README.md` | OAuth package docs | Scan + update any remaining references |
+| `packages/did/README.md` | DID package docs | Add URN fixed-value section + rationale |
+| `CHANGELOG.md` | Root changelog | Add v0.5.0 Unreleased breaking entry |
+
+**Constants introduced:**
+
+- `DID_GRANT_TYPE = "urn:o3co:oauth:grant-type:did"` in `packages/did/src/module.mts` (module-scoped const)
+
+---
+
+## Task 1: Rename `authorization` grant registry key + config key
+
+**Files:**
+
+- Test: `packages/oauth/src/__tests__/oauthAuthorization.test.mts`
+- Modify: `packages/oauth/src/oauthAuthorization.mts`
+
+- [ ] **Step 1: Read the existing test file to understand current shape**
+
+Run: `sed -n '140,170p;255,315p' packages/oauth/src/__tests__/oauthAuthorization.test.mts`
+Note the lines that assert `ctx.grantRegistry.get("authorization")` and the test name strings referencing "authorization".
+
+- [ ] **Step 2: Update test expectations to `authorization_code` (RED)**
+
+In `packages/oauth/src/__tests__/oauthAuthorization.test.mts`, replace every occurrence of the string literal `"authorization"` that is used as a grant registry key with `"authorization_code"`. Do NOT change occurrences where the word is part of a longer identifier (e.g. `authorizationCode`, `Authorization`, or comments not about the grant).
+
+Expected replacements (approximate):
+
+- Line 146: `ctx.grantRegistry.get("authorization")` → `ctx.grantRegistry.get("authorization_code")`
+- Line 169: `ctx.grantRegistry.get("authorization")` → `ctx.grantRegistry.get("authorization_code")`
+- Line 260: `const handler = ctx.grantRegistry.get("authorization");` → `const handler = ctx.grantRegistry.get("authorization_code");`
+- Line 294: `ctx.grantRegistry.get("authorization")` → `ctx.grantRegistry.get("authorization_code")`
+- Line 311: `const handler = ctx.grantRegistry.get("authorization");` → `const handler = ctx.grantRegistry.get("authorization_code");`
+
+Also update any inline mock config object in this test file that uses `authorization: {...}` as a config key to `authorization_code: {...}`.
+
+- [ ] **Step 3: Run the tests to confirm they fail**
+
+Run: `cd packages/oauth && pnpm exec vitest run src/__tests__/oauthAuthorization.test.mts`
+Expected: several failures. Each failure should be either "registry.get returned undefined" or assertion about `authorization_code` mismatching registered `authorization`.
+
+- [ ] **Step 4: Update implementation to register under new key**
+
+Modify `packages/oauth/src/oauthAuthorization.mts`:
+
+- Line 35: `if (grantsConfig.authorization?.enabled !== false) {` → `if (grantsConfig.authorization_code?.enabled !== false) {`
+- Line 45: `context.grantRegistry.register("authorization", handler);` → `context.grantRegistry.register("authorization_code", handler);`
+
+Keep all other lines (config / createAuthorizationGrant call / refresh_token branch) unchanged.
+
+- [ ] **Step 5: Run the tests to confirm they pass**
+
+Run: `cd packages/oauth && pnpm exec vitest run src/__tests__/oauthAuthorization.test.mts`
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/oauth/src/oauthAuthorization.mts packages/oauth/src/__tests__/oauthAuthorization.test.mts
+git commit -m "$(cat <<'EOF'
+feat(oauth)!: rename authorization grant to authorization_code (RFC 6749)
+
+- Registry key: "authorization" → "authorization_code"
+- Config key: oauth.grants.authorization → oauth.grants.authorization_code
+- Wire value: grant_type=authorization → grant_type=authorization_code
+
+RFC 6749 §4.1.3 compliance. Hard break — legacy "authorization" value now
+returns unsupported_grant_type.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Update policy input hardcoded value in routes
+
+**Files:**
+
+- Test: `packages/oauth/src/__tests__/hooks.test.mts`
+- Modify: `packages/oauth/src/routes.mts`
+
+- [ ] **Step 1: Inspect current policy input test**
+
+Run: `sed -n '330,350p' packages/oauth/src/__tests__/hooks.test.mts`
+Confirm line 339 is `expect(request.grantType).toBe("authorization");` (the spec item we need to rename).
+
+- [ ] **Step 2: Update test expectation (RED)**
+
+In `packages/oauth/src/__tests__/hooks.test.mts`, change line 339 from:
+
+```typescript
+expect(request.grantType).toBe("authorization");
+```
+
+to:
+
+```typescript
+expect(request.grantType).toBe("authorization_code");
+```
+
+- [ ] **Step 3: Run the tests to confirm failure**
+
+Run: `cd packages/oauth && pnpm exec vitest run src/__tests__/hooks.test.mts`
+Expected: the policy-input test fails, showing `received: "authorization"`.
+
+- [ ] **Step 4: Update `routes.mts:466`**
+
+Modify `packages/oauth/src/routes.mts` line 466 (inside the `grantPolicy.evaluate` call on the `/oauth/authorize` path):
+
+```typescript
+// Before
+grantType: "authorization",
+// After
+grantType: "authorization_code",
+```
+
+- [ ] **Step 5: Run the tests to confirm pass**
+
+Run: `cd packages/oauth && pnpm exec vitest run src/__tests__/hooks.test.mts`
+Expected: all tests PASS.
+
+- [ ] **Step 6: Run full oauth package tests to ensure no regression**
+
+Run: `cd packages/oauth && pnpm test`
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/oauth/src/routes.mts packages/oauth/src/__tests__/hooks.test.mts
+git commit -m "$(cat <<'EOF'
+feat(oauth)!: pass authorization_code to grantPolicy on /authorize
+
+GrantPolicyRequest.grantType for the authorize phase was hardcoded to
+"authorization" at routes.mts:466. Update to match the RFC 6749 wire
+value "authorization_code".
+
+Breaking for consumers implementing GrantPolicyHookBase and branching
+on `case "authorization":` — rename to `case "authorization_code":`.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Rename HOCON config sections + env vars
+
+**Files:**
+
+- Modify: `packages/core/config/application.conf`
+- Modify: `templates/standalone/config/application.conf`
+
+- [ ] **Step 1: Update `packages/core/config/application.conf`**
+
+Locate line 38:
+
+```hocon
+authorization { enabled = true, enabled = ${?OAUTH_GRANTS_AUTHORIZATION_ENABLED} }
+```
+
+Replace with:
+
+```hocon
+authorization_code { enabled = true, enabled = ${?OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED} }
+```
+
+- [ ] **Step 2: Update `templates/standalone/config/application.conf`**
+
+Locate lines 38-45:
+
+```hocon
+authorization {
+  enabled = true
+  enabled = ${?OAUTH_GRANTS_AUTHORIZATION_ENABLED}
+  pkce {
+    requireS256 = false
+    requireS256 = ${?OAUTH_GRANTS_AUTHORIZATION_PKCE_REQUIRE_S256}
+  }
+}
+```
+
+Replace with:
+
+```hocon
+authorization_code {
+  enabled = true
+  enabled = ${?OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED}
+  pkce {
+    requireS256 = false
+    requireS256 = ${?OAUTH_GRANTS_AUTHORIZATION_CODE_PKCE_REQUIRE_S256}
+  }
+}
+```
+
+- [ ] **Step 3: Verify no other config files reference the old key**
+
+Run: `grep -rn "grants\.authorization\b\|authorization {\s*enabled\|OAUTH_GRANTS_AUTHORIZATION_ENABLED\|OAUTH_GRANTS_AUTHORIZATION_PKCE" packages templates --include="*.conf" 2>/dev/null`
+Expected output: empty (all occurrences updated).
+
+- [ ] **Step 4: Run standalone smoke tests**
+
+Run: `cd templates/standalone && pnpm test`
+Expected: PASS (smoke test reads config and may exercise the rename).
+
+If smoke test fails because the test itself references old config key, capture failures — they'll be fixed in Task 6.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/config/application.conf templates/standalone/config/application.conf
+git commit -m "$(cat <<'EOF'
+feat(config)!: rename oauth.grants.authorization to authorization_code
+
+Align HOCON config section and env var names with RFC 6749 wire value.
+
+- oauth.grants.authorization → oauth.grants.authorization_code
+- OAUTH_GRANTS_AUTHORIZATION_ENABLED → OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED
+- OAUTH_GRANTS_AUTHORIZATION_PKCE_REQUIRE_S256 → OAUTH_GRANTS_AUTHORIZATION_CODE_PKCE_REQUIRE_S256
+
+Hard break. Consumers must update HOCON files and environment variables.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Rename DID grant to URN (registry key)
+
+**Files:**
+
+- Test: `packages/did/src/__tests__/did.test.mts`
+- Create: `packages/did/src/__tests__/module.test.mts`
+- Modify: `packages/did/src/module.mts`
+
+- [ ] **Step 1: Update `did.test.mts` mock config**
+
+The `did.test.mts` file uses a mock config with a sibling `authorization: { enabled: true }` key (not `authorization_code`). Since `createDidGrant` does not read this key (only `oauth.grants.did`), the test is not directly affected by our rename — but to keep the mock internally consistent with the rest of the codebase, update it.
+
+In `packages/did/src/__tests__/did.test.mts`, find the `mockConfig` object (around line 33-46) and update the sibling key:
+
+```typescript
+// Before
+grants: {
+  session: { enabled: true },
+  authorization: { enabled: true },
+  refresh_token: { enabled: true },
+  did: { enabled: true, algorithm: "ed25519_raw", messageMaxAgeSec: 300 },
+},
+// After
+grants: {
+  session: { enabled: true },
+  authorization_code: { enabled: true },
+  refresh_token: { enabled: true },
+  did: { enabled: true, algorithm: "ed25519_raw", messageMaxAgeSec: 300 },
+},
+```
+
+- [ ] **Step 2: Run DID unit tests to confirm they still pass**
+
+Run: `cd packages/did && pnpm exec vitest run src/__tests__/did.test.mts`
+Expected: PASS (the change is internal mock consistency, no behavior change).
+
+- [ ] **Step 3: Create a new module-level test file (RED)**
+
+Create `packages/did/src/__tests__/module.test.mts` with the following content:
+
+```typescript
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+	GrantRegistry,
+	createSymmetricKeyStore,
+	type ModuleContext,
+} from "@o3co/auth-provider-core";
+import type { Router } from "express";
+import { describe, expect, it } from "vitest";
+import { oauthDidModule } from "../module.mjs";
+import type { DidDocument, DidDocumentResolver } from "../resolver/types.mjs";
+
+const DID_URN = "urn:o3co:oauth:grant-type:did";
+
+const mockResolver: DidDocumentResolver = {
+	async resolve(_did: string): Promise<DidDocument> {
+		throw new Error("not expected to be called in this test");
+	},
+};
+
+const buildContext = (
+	didConfig: Record<string, unknown> | undefined,
+): ModuleContext => ({
+	pathResolver: (s: string) => s,
+	config: {
+		oauth: {
+			jwt: { secret: "test-secret" },
+			accessToken: { expiresIn: 3600 },
+			refreshToken: { expiresIn: 86400 },
+			grants: { did: didConfig },
+		},
+	} as unknown as ModuleContext["config"],
+	keyStore: createSymmetricKeyStore("test-secret"),
+	grantRegistry: new GrantRegistry(),
+	router: {} as Router,
+});
+
+describe("oauthDidModule", () => {
+	it("registers DID grant under urn:o3co:oauth:grant-type:did when enabled", async () => {
+		const ctx = buildContext({ enabled: true, supportedAlgorithms: ["ed25519_raw"] });
+		await oauthDidModule({ resolver: mockResolver }).init(ctx);
+
+		expect(ctx.grantRegistry.get(DID_URN)).toBeDefined();
+	});
+
+	it("does NOT register the bare 'did' string (URN-only policy)", async () => {
+		const ctx = buildContext({ enabled: true, supportedAlgorithms: ["ed25519_raw"] });
+		await oauthDidModule({ resolver: mockResolver }).init(ctx);
+
+		expect(ctx.grantRegistry.get("did")).toBeUndefined();
+	});
+
+	it("is a no-op when did.enabled is false", async () => {
+		const ctx = buildContext({ enabled: false });
+		await oauthDidModule({ resolver: mockResolver }).init(ctx);
+
+		expect(ctx.grantRegistry.get(DID_URN)).toBeUndefined();
+		expect(ctx.grantRegistry.get("did")).toBeUndefined();
+	});
+
+	it("registers when did config is missing (enabled defaults to true)", async () => {
+		const ctx = buildContext(undefined);
+		await oauthDidModule({ resolver: mockResolver }).init(ctx);
+
+		// Current behavior: undefined config → enabled !== false, so registered
+		expect(ctx.grantRegistry.get(DID_URN)).toBeDefined();
+	});
+});
+```
+
+- [ ] **Step 4: Run the new test to confirm failure**
+
+Run: `cd packages/did && pnpm exec vitest run src/__tests__/module.test.mts`
+Expected: failures. The current `module.mts` registers under `"did"`, so:
+
+- "registers DID grant under urn:o3co:oauth:grant-type:did when enabled" → FAIL (returned undefined)
+- "does NOT register the bare 'did' string" → FAIL (handler IS registered under "did")
+- "is a no-op when did.enabled is false" → may already pass
+- "registers when did config is missing" → FAIL
+
+- [ ] **Step 5: Update `module.mts` to register under fixed URN**
+
+Modify `packages/did/src/module.mts`:
+
+```typescript
+// At module top (after imports, before the oauthDidModule export)
+const DID_GRANT_TYPE = "urn:o3co:oauth:grant-type:did" as const;
+```
+
+Change line 76 from:
+
+```typescript
+context.grantRegistry.register("did", handler);
+```
+
+to:
+
+```typescript
+context.grantRegistry.register(DID_GRANT_TYPE, handler);
+```
+
+- [ ] **Step 6: Run module.test.mts + did.test.mts to confirm pass**
+
+Run: `cd packages/did && pnpm test`
+Expected: all DID tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/did/src/module.mts packages/did/src/__tests__/module.test.mts packages/did/src/__tests__/did.test.mts
+git commit -m "$(cat <<'EOF'
+feat(did)!: register DID grant under urn:o3co:oauth:grant-type:did
+
+Fixed URN owned by auth.provider (wire protocol definer). Bare "did"
+grant_type is no longer registered and returns unsupported_grant_type.
+
+Add module-level tests verifying URN registration, bare-string non-
+registration, and enabled=false no-op.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Update standalone integration tests (wire values)
+
+**Files:**
+
+- Modify: `templates/standalone/tests/index.test.js`
+- Modify: `templates/standalone/tests/did-grant.test.js`
+- Modify: `templates/standalone/src/__tests__/smoke.test.mts` (if needed)
+
+- [ ] **Step 1: Inspect `index.test.js` for authorization wire values**
+
+Run: `grep -n "grant_type=authorization\b\|grant_type: \"authorization\"" templates/standalone/tests/index.test.js`
+Expected: finds lines around 161-176 using `grant_type=session` / `grant_type=authorization` / etc.
+
+- [ ] **Step 2: Update wire values in `index.test.js`**
+
+In `templates/standalone/tests/index.test.js`, replace `grant_type=authorization` with `grant_type=authorization_code` (URL-encoded form body).
+
+Specifically the test "returns 400 for grant_type=authorization without a code" at line 175-176 becomes:
+
+```javascript
+it("returns 400 for grant_type=authorization_code without a code", async () => {
+  const res = await client.post("/oauth/token", "grant_type=authorization_code", {
+```
+
+(The surrounding lines should stay intact — only rename the literal `authorization` within grant_type assertions and test names.)
+
+- [ ] **Step 3: Update `did-grant.test.js` — all 8 occurrences**
+
+In `templates/standalone/tests/did-grant.test.js`, replace every occurrence of `grant_type: "did"` with `grant_type: "urn:o3co:oauth:grant-type:did"` (8 locations per grep from Task 1 of this plan, lines 44, 95, 124, 133, 141, 150, 162, 185).
+
+Also update the describe/it strings that mention "grant_type=did" (e.g. line 57) to reflect the URN.
+
+- [ ] **Step 4: Inspect smoke test for authorization references**
+
+Run: `grep -n "authorization\|\"did\"" templates/standalone/src/__tests__/smoke.test.mts`
+Note any lines that assert specific grant_type registration or config.
+
+- [ ] **Step 5: Update smoke test if it references old grant values**
+
+If step 4 found literal `"authorization"` as grant key or config key, update to `"authorization_code"`.
+If it references `"did"` as grant key, update to `"urn:o3co:oauth:grant-type:did"`.
+
+(Wire-value test assertions like "`grant_type: 'unsupported'` returns 400" can remain as-is since they use fake values.)
+
+- [ ] **Step 6: Run standalone tests**
+
+Run: `cd templates/standalone && pnpm test`
+Expected: PASS.
+
+If tests fail because they depend on a running server instance (integration tests), accept failures that require external services (auth.provider server). Unit-style and smoke tests that don't require a live server should PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add templates/standalone/tests/index.test.js templates/standalone/tests/did-grant.test.js templates/standalone/src/__tests__/smoke.test.mts
+git commit -m "$(cat <<'EOF'
+test(standalone): update integration tests for new grant_type values
+
+- grant_type=authorization → authorization_code
+- grant_type=did → urn:o3co:oauth:grant-type:did (all 8 sites)
+
+Aligns standalone template tests with RFC 6749 compliance + URN-ification
+of the DID grant.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Update documentation (README + env var tables)
+
+**Files:**
+
+- Modify: `templates/standalone/README.md`
+- Modify: `templates/standalone/README.ja.md`
+- Modify: `README.md` (root)
+- Modify: `packages/oauth/README.md` (scan + update if needed)
+- Modify: `packages/did/README.md` (add URN rationale section)
+
+- [ ] **Step 1: Update standalone README env var tables**
+
+In `templates/standalone/README.md` line 72:
+
+```markdown
+# Before
+| `OAUTH_GRANTS_AUTHORIZATION_ENABLED` | `true` | Enable the authorization code grant type |
+
+# After
+| `OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED` | `true` | Enable the authorization code grant type |
+```
+
+Same for `templates/standalone/README.ja.md` line 72:
+
+```markdown
+# Before
+| `OAUTH_GRANTS_AUTHORIZATION_ENABLED` | `true` | authorization code グラントタイプを有効化 |
+
+# After
+| `OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED` | `true` | authorization code グラントタイプを有効化 |
+```
+
+Also scan both files for `OAUTH_GRANTS_AUTHORIZATION_PKCE_REQUIRE_S256` and rename to `OAUTH_GRANTS_AUTHORIZATION_CODE_PKCE_REQUIRE_S256` if present.
+
+- [ ] **Step 2: Update root `README.md`**
+
+Run: `grep -n "OAUTH_GRANTS_AUTHORIZATION\|grant_type=did\b" README.md`
+Note the lines.
+
+For each line:
+
+- `OAUTH_GRANTS_AUTHORIZATION_PKCE_REQUIRE_S256` → `OAUTH_GRANTS_AUTHORIZATION_CODE_PKCE_REQUIRE_S256`
+- ASCII diagram / examples using `grant_type=did` → `grant_type=urn:o3co:oauth:grant-type:did` (prefer full URN in examples so readers understand the actual wire value; if the diagram has line-length constraints, wrap as appropriate)
+
+- [ ] **Step 3: Scan `packages/oauth/README.md`**
+
+Run: `grep -n "\"authorization\"\|grant_type=authorization\b\|OAUTH_GRANTS_AUTHORIZATION\b" packages/oauth/README.md`
+
+For any match that is about the grant wire value or config (not about the English word "authorization"), update per previous tasks. Most existing text should already say "authorization_code" per prior F-series work; just confirm and fix if any stragglers exist.
+
+- [ ] **Step 4: Update `packages/did/README.md` — add URN section**
+
+At an appropriate place in `packages/did/README.md` (typically after the intro / before "Installation"), add:
+
+```markdown
+## Grant Type URN
+
+The DID grant is registered under the fixed URN:
+
+```
+
+```text
+urn:o3co:oauth:grant-type:did
+```
+
+```markdown
+Clients must send this exact string as the `grant_type` parameter. The
+bare string `"did"` is not supported.
+
+### Why `urn:o3co:...`?
+
+The DID wire protocol (`did` + `message` + `signature` form parameters)
+is defined by auth.provider. Under the RFC 6755 sub-namespace ownership
+model, the URN should be owned by the wire protocol definer. Here, the
+`o3co` segment acts as a **wire protocol version identifier**, not a
+vendor identifier — comparable to how IETF-registered grant URNs live
+under `urn:ietf:params:oauth:grant-type:*`.
+
+Consumer deployments that extend the wire protocol (e.g. to embed a
+Verifiable Presentation) should define a new grant under their own URN
+sub-namespace (e.g. `urn:example.com:oauth:grant-type:did-vp`) rather
+than overriding this one.
+```
+
+- [ ] **Step 5: Sanity-check the markdown builds / renders**
+
+Run: `grep -rn "\"authorization\"\|grant_type=authorization\b\|grant_type: \"did\"\|grant_type=did\b\|OAUTH_GRANTS_AUTHORIZATION[^_]" README.md templates/standalone/README.md templates/standalone/README.ja.md packages/*/README.md 2>/dev/null`
+Expected: empty (all documentation references updated). If any remain, review them manually — some may be intentional (e.g. a migration note explicitly listing the old name).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md templates/standalone/README.md templates/standalone/README.ja.md packages/oauth/README.md packages/did/README.md
+git commit -m "$(cat <<'EOF'
+docs: update env var names + grant_type wire values
+
+- OAUTH_GRANTS_AUTHORIZATION_* → OAUTH_GRANTS_AUTHORIZATION_CODE_*
+- grant_type=authorization → authorization_code in examples
+- grant_type=did → urn:o3co:oauth:grant-type:did in examples
+- packages/did/README.md: add URN fixed-value section + rationale
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Update CHANGELOG
+
+**Files:**
+
+- Modify: `CHANGELOG.md` (root)
+
+- [ ] **Step 1: Read current Unreleased section header**
+
+Run: `sed -n '1,40p' CHANGELOG.md`
+Identify where the `[Unreleased]` or `[0.5.0]` section begins.
+
+- [ ] **Step 2: Add breaking change entry**
+
+Under the Unreleased (or equivalent pre-0.5.0) section, add a new subsection `### Breaking Changes` if not already present, with these entries:
+
+```markdown
+### Breaking Changes
+
+- **`grant_type` wire values (RFC compliance + URN-ification):**
+  - `grant_type=authorization` → `grant_type=authorization_code` (RFC 6749 §4.1.3)
+  - `grant_type=did` → `grant_type=urn:o3co:oauth:grant-type:did` (RFC 6755
+    sub-namespace owned by auth.provider as the wire protocol definer)
+  - `grant_type=session` unchanged
+- **HOCON config keys + env vars:**
+  - `oauth.grants.authorization { ... }` → `oauth.grants.authorization_code { ... }`
+  - `OAUTH_GRANTS_AUTHORIZATION_ENABLED` → `OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED`
+  - `OAUTH_GRANTS_AUTHORIZATION_PKCE_REQUIRE_S256` → `OAUTH_GRANTS_AUTHORIZATION_CODE_PKCE_REQUIRE_S256`
+- **Grant policy interface (`GrantPolicyRequest.grantType`):**
+  - `/oauth/authorize` flow now passes `"authorization_code"` (was `"authorization"`)
+    to `grantPolicy.evaluate()`
+  - `refresh_token` path unchanged
+  - DID grant does not currently invoke `grantPolicy.evaluate()`; if consumers
+    add policy logic for DID in the future, use the full URN
+    (`"urn:o3co:oauth:grant-type:did"`) as the match value
+
+**Migration checklist:**
+
+1. Update client requests:
+   - `grant_type=authorization` → `authorization_code`
+   - `grant_type=did` → `urn:o3co:oauth:grant-type:did`
+2. Update HOCON config / environment:
+   - Rename `oauth.grants.authorization` → `oauth.grants.authorization_code`
+   - Rename `OAUTH_GRANTS_AUTHORIZATION_*` → `OAUTH_GRANTS_AUTHORIZATION_CODE_*`
+3. If implementing `GrantPolicyHookBase`:
+   - Rename `case "authorization":` → `case "authorization_code":` in
+     policy dispatch logic
+```
+
+- [ ] **Step 3: Verify markdown renders correctly**
+
+Run: `sed -n '1,80p' CHANGELOG.md`
+Scan visually for well-formed markdown (list indentation, code fences closed, no accidental blank lines breaking lists).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+docs(changelog): document grant_type rename + config rename breaking changes
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Full test suite + lint + typecheck
+
+**Files:** (no new modifications — verification only)
+
+- [ ] **Step 1: Typecheck all packages**
+
+Run: `pnpm -r typecheck`
+Expected: no errors.
+
+If errors surface, they will likely be in test files or consumer-facing examples that reference the old values. Fix inline and re-run.
+
+- [ ] **Step 2: Lint all packages**
+
+Run: `pnpm -r lint` (or whatever root-level lint command is defined; check `package.json` scripts)
+Expected: no new lint issues introduced by this work.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `pnpm -r test`
+Expected: PASS for all workspaces.
+
+- [ ] **Step 4: Build all packages**
+
+Run: `pnpm -r build`
+Expected: all packages build cleanly.
+
+- [ ] **Step 5: Verify grep finds no stragglers**
+
+Run these commands and expect empty output (except where intentionally documenting the migration):
+
+```bash
+# Wire value stragglers
+grep -rn "grant_type=authorization\b\|grant_type: \"authorization\"" packages/ templates/ --include="*.mts" --include="*.ts" --include="*.js" 2>/dev/null | grep -v __tests__ | grep -v dist | grep -v node_modules
+
+# Registry key stragglers
+grep -rn 'register("authorization",\|get("authorization")\|register("did",\|get("did")' packages/ --include="*.mts" 2>/dev/null | grep -v __tests__ | grep -v dist | grep -v node_modules
+
+# Config key stragglers
+grep -rn "grants\.authorization\b\|authorization { enabled" packages/ templates/ --include="*.mts" --include="*.ts" --include="*.conf" 2>/dev/null | grep -v node_modules | grep -v dist
+
+# Env var stragglers
+grep -rn "OAUTH_GRANTS_AUTHORIZATION_ENABLED\|OAUTH_GRANTS_AUTHORIZATION_PKCE_REQUIRE_S256" . --include="*.conf" --include="*.md" --include="*.mts" --include="*.ts" 2>/dev/null | grep -v node_modules | grep -v dist | grep -v \.pnpm
+```
+
+Any hit should either (a) be fixed, or (b) be an intentional reference in CHANGELOG.md migration notes.
+
+- [ ] **Step 6: Commit no-op marker if any fixes were needed**
+
+If Step 5 surfaced stragglers that needed fixing, commit them:
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+chore: clean up remaining references to old grant_type values
+
+Stragglers found during final grep sweep after primary rename commits.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If no stragglers, skip this step.
+
+---
+
+## Task 9: Run /multi-agent-review
+
+**Files:** (no modifications — review only)
+
+- [ ] **Step 1: Invoke the multi-agent-review skill**
+
+Trigger the `/multi-agent-review` skill on the branch `feat/grant-type-rename`.
+
+Wait for the dual review (Claude code-reviewer + Codex) to complete.
+
+- [ ] **Step 2: Address must-fix findings**
+
+For each finding categorized as **must** (per the priority rule: must > should > can):
+
+1. Fix inline in the relevant file.
+2. Re-run the relevant test file to confirm the fix.
+3. Commit with a descriptive message referencing the review finding.
+
+Do not batch all fixes into a single commit — one commit per logical fix so the review trail is legible.
+
+- [ ] **Step 3: For `should` / `can` findings**
+
+Evaluate each against the dismiss-regime from CLAUDE.md:
+
+- **Dismiss** only with Contract-based or Verified-empirical rationale + explicit "overturn condition"
+- Otherwise, treat as must-fix
+
+Record any dismiss decisions as a comment in the PR or as a brief note in a follow-up CHANGELOG entry.
+
+- [ ] **Step 4: Final full test run after review fixes**
+
+Run: `pnpm -r test && pnpm -r typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: (No commit needed if no review fixes were required)**
+
+---
+
+## Task 10: Open PR to develop
+
+**Files:** (no modifications — PR creation only)
+
+- [ ] **Step 1: Push branch to remote**
+
+```bash
+git push -u origin feat/grant-type-rename
+```
+
+- [ ] **Step 2: Create PR with `gh pr create`**
+
+```bash
+gh pr create --base develop --title "feat!: grant_type RFC compliance + URN-ification (v0.5.0 #3)" --body "$(cat <<'EOF'
+## Summary
+
+- `grant_type=authorization` → `authorization_code` (RFC 6749 §4.1.3)
+- `grant_type=did` → `urn:o3co:oauth:grant-type:did` (fixed URN owned by wire protocol definer)
+- HOCON `oauth.grants.authorization` → `authorization_code` + env var rename
+- Grant policy input value aligned with wire value at `routes.mts:466`
+- Spec: `.claude/superpowers/specs/2026-04-24-grant-type-rename-design.md`
+
+v0.5.0 Core GA must #3. Interface-freeze preparatory work. Hard break — no dual-accept.
+
+## Test plan
+
+- [ ] `pnpm -r test` all green
+- [ ] `pnpm -r typecheck` clean
+- [ ] `pnpm -r build` clean
+- [ ] /multi-agent-review addressed (1 round)
+- [ ] Copilot review addressed (if any)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Run `gh pr view`**
+
+```bash
+gh pr view
+```
+
+Confirm the PR is created and linked to the correct base branch.
+
+- [ ] **Step 4: Await Copilot review**
+
+Wait for Copilot's automated review to post comments (typical delay: 1-5 minutes after PR creation).
+
+For each Copilot comment:
+
+1. Evaluate per CLAUDE.md dismiss regime (must > should > can).
+2. Fix must-fix items inline.
+3. Reply + resolve threads using the `superpowers:github-pr-resolve` skill.
+
+- [ ] **Step 5: Final state check**
+
+Run: `gh pr view && gh pr checks`
+Expected: PR is open, CI is green, all review threads resolved (or explicitly dismissed with rationale).
+
+Do NOT merge — wait for the user's merge decision.
+
+---
+
+## Task 11: Update memory after merge
+
+**Files:** (memory-only, no repo changes)
+
+- [ ] **Step 1: After PR merges, update `project_v050_scope.md`**
+
+In `/Volumes/Workspace/.claude/projects/-Volumes-Workspace-o3co-agentscopes-auth/memory/project_v050_scope.md`, mark item #3 (grant_type RFC compliance + URN-ification) as **DONE** with the merge commit SHA, merged date, and a one-line summary.
+
+- [ ] **Step 2: Update `project_todo_next_steps.md`**
+
+Add an entry under "Recently Completed" with merge SHA + one-line summary.
+Update item 4 (v0.5.0) counter: "17 items, 2 completed" (was 1 completed).
+
+- [ ] **Step 3: Verify `project_did_grant_migration.md` still accurate**
+
+That memory already notes "v0.5.0 grant_type rename uses `urn:o3co:` as interim URN." No changes needed, but confirm the wording still matches reality after merge.
+
+---

--- a/.claude/superpowers/plans/2026-04-24-grant-type-rename.md
+++ b/.claude/superpowers/plans/2026-04-24-grant-type-rename.md
@@ -325,7 +325,6 @@ import {
 	createSymmetricKeyStore,
 	type ModuleContext,
 } from "@o3co/auth-provider-core";
-import type { Router } from "express";
 import { describe, expect, it } from "vitest";
 import { oauthDidModule } from "../module.mjs";
 import type { DidDocument, DidDocumentResolver } from "../resolver/types.mjs";
@@ -352,7 +351,9 @@ const buildContext = (
 	} as unknown as ModuleContext["config"],
 	keyStore: createSymmetricKeyStore("test-secret"),
 	grantRegistry: new GrantRegistry(),
-	router: {} as Router,
+	// Use ModuleContext["router"] to avoid coupling this package's tests
+	// to the `express` type dependency (not declared in packages/did).
+	router: {} as ModuleContext["router"],
 });
 
 describe("oauthDidModule", () => {
@@ -378,11 +379,12 @@ describe("oauthDidModule", () => {
 		expect(ctx.grantRegistry.get("did")).toBeUndefined();
 	});
 
-	it("registers when did config is missing (enabled defaults to true)", async () => {
+	it("registers when did config is undefined (no explicit disable)", async () => {
 		const ctx = buildContext(undefined);
 		await oauthDidModule({ resolver: mockResolver }).init(ctx);
 
-		// Current behavior: undefined config → enabled !== false, so registered
+		// Current behavior: undefined config → enabled !== false, so registered.
+		// Note: init() does not run the zod schema; it only checks `enabled === false`.
 		expect(ctx.grantRegistry.get(DID_URN)).toBeDefined();
 	});
 });

--- a/.claude/superpowers/specs/2026-04-24-grant-type-rename-design.md
+++ b/.claude/superpowers/specs/2026-04-24-grant-type-rename-design.md
@@ -12,37 +12,72 @@
   - §4.3 updated to note `routes.mts:466` is grant-policy input (breaking for policy adapters)
   - §3.9 new section: "Grant Registration Skip — No Logger" decision + rationale
   - §4.1 Module init sketch updated to match §3.9 (no-log approach)
+- 2026-04-24 design revision (post brainstorming):
+  - URN 方針を「consumer が prefix を所有する config」から「wire protocol 定義者 (o3co) が
+    URN を所有する固定値」に転換
+  - `urnCustomGrantTypePrefix` config を撤回
+  - §1.1 新設: 現状 `did` grant の位置付け (「認証 → 認可変換 grant」)
+  - §3.2-§3.3 の URN 設計を固定値設計に刷新
+  - §4.1 Module init を簡素化 (prefix check 不要)
 
 ## 1. Background & Motivation
 
 v0.5.0 の Core GA must 項目のうち、interface freeze に直結する grant_type 整理を行う。現状の grant_type 値には以下の問題がある:
 
 1. **RFC 違反:** `grant_type=authorization` は RFC 6749 §4.1.3 違反。正式値は `authorization_code`。
-2. **DID grant の URN 化未実施:** 独自 grant `did` は裸の文字列で登録されているが、RFC 6755 に倣い独自 grant は URN 形式で識別すべき。
-3. **Namespace の vendor leak 懸念:** URN 化するときライブラリ側が `o3co` 等の namespace を押し付けると、consumer に library owner のアイデンティティが残留する。
+2. **独自 grant の URN 化未実施:** 独自 grant `did` は裸の文字列で登録されているが、RFC 6755 に倣い非 IETF grant は URN 形式で識別すべき。
+3. **Grant の所有者明示:** URN 化の際、`did` grant の wire protocol 定義者を URN sub-namespace で明示する必要がある (§1.1 参照)。
 
 v0.5.0 は 1.0 GA 前の最後の interface 調整ラウンド。ここで RFC 準拠形に倒しきり、1.0 で freeze する。
+
+### 1.1 現状の `did` grant の位置付け
+
+現状の `did` grant は、DID/VC による identity verification を OAuth 2.0 の token envelope に変換する **auth.provider 固有の wire protocol 拡張** である。OAuth 本来の認証 grant (RFC 6749 `password` / `client_credentials` 等) や RFC 7521/7523 の assertion framework とは異なり、以下の構造を持つ:
+
+- **Wire protocol**: `did` + `message` + `signature` の 3 パラメータで DID-signed assertion を表現
+- **Authentication**: DID 秘密鍵の占有確認 (秘密鍵で署名された message の検証) は OAuth token endpoint が実施。DID document resolver で公開鍵を取得するため、pre-established trust relationship (client_id による事前登録) を要求しない
+- **Identity semantics**: DID subject が誰で、信頼できるかの判断は OAuth の外側 (allow-list / policy layer) に委ねる
+- **能力・権限検証**: VC による能力・権限の検証は access_token 発行後、resource server 側 (auth.policy-verifier 等) に委譲する
+- **結果**: DID 認証と OAuth 認可レイヤーの接続点として機能する「認証 → 認可変換 grant」
+
+**論文的位置付け:**
+
+- 03-data-sovereignty ch4 原理 3 (DID 認証接続制御) はパイプライン間ハンドシェークの設計
+- 00-integrated ch5.5 は「OAuth 2.0 フローの認証主体として DID を使用する」提案を行い、同時に「この DID 統合は現行 MCP 仕様に含まれておらず、提案される拡張パス」「future specification work」と明記している
+
+現状 `did` grant はこの未標準化領域を埋める **実装例の一つ** であり、IETF 登録値に収まらない。ゆえに independent URN sub-namespace で識別するのが適切である。
+
+### 1.2 Wire protocol の所有者と URN sub-namespace
+
+RFC 6755 §3 は URN sub-namespace が grant の定義主体によって所有されることを定めている (IETF sub-namespace が IANA-registered grant の定義権を持つのと同じ構造)。
+
+現状の `did` grant wire protocol の定義者は **o3co/auth.provider** であり、consumer (dPLaaS など) は wire の利用者 (deployer) にすぎない。複数 deployment が同じ wire を使う場合、それらの grant_type URN は統一されているべきで、consumer ごとに異なる URN で表現すると client SDK / Agent 側の interop が破綻する。
+
+よって本 spec は `did` grant の URN を **`urn:o3co:oauth:grant-type:did` 固定** とする。ここでの `o3co` は library owner の vendor identifier ではなく、**wire protocol version の identifier** として機能する。IETF registry 値が IETF 固有値として consumer に変更不可であるのと同じ扱い。
+
+Consumer が将来 wire protocol を拡張する (VC Presentation を request に含める等) 場合、それは **consumer 固有の別 grant** として consumer 所有 URN (`urn:dplaas.io:oauth:grant-type:did-vp` 等) を別途定義すべきであり、既存の `urn:o3co:oauth:grant-type:did` を置き換えるべきではない。
 
 ## 2. Scope
 
 ### In Scope
 
 - `authorization` → `authorization_code` の rename (RFC 6749 準拠)
-- DID grant の URN 化 + `urnCustomGrantTypePrefix` config 新設
-- Audit event の grant_type 表記統一 (wire 値を記録)
+- `did` grant の URN 化 (`urn:o3co:oauth:grant-type:did` 固定)
+- Grant policy input + Audit event の grant_type 表記統一 (wire 値を記録)
 - Standalone template / README / CHANGELOG の追従
 
 ### Out of Scope
 
-本 spec は **rename と URN 設計のみ**。以下は別 spec で扱う:
+本 spec は **rename と URN 化のみ**。以下は別 spec で扱う:
 
 - Token Exchange (RFC 8693) 実装 — v0.5.0 #2
 - jwt-bearer (RFC 7523) 実装 — v0.5.0 #4
 - NonceStore interface — v0.5.0 #5
+- VC Presentation abstract interface — v0.5.0 #6
 - DPoP interface 予約 — v0.5.0 #19
 - dplaas.auth 追従 — v0.5.0 publish 完了後に一括
 
-ただし Token Exchange と jwt-bearer の URN は IETF 登録済み値なので、本 spec で URN 設計時に「IETF 標準 URN は `urnCustomGrantTypePrefix` の適用外、固定値で register」という棲み分けルールだけ確定させる。実装箇所は別 spec。
+Token Exchange と jwt-bearer の URN は IETF 登録済み値なので、本 spec で URN 設計時に「IETF 標準 URN は consumer 固有 URN と独立、固定値で register」という棲み分けルールだけ確定させる。
 
 ## 3. Design Decisions
 
@@ -58,65 +93,45 @@ v0.5.0 は 1.0 GA 前の最後の interface 調整ラウンド。ここで RFC �
 - v0.4.0 → v0.5.0 間で breaking は他にも複数発生 (passport 脱出済 / Token Exchange / jwt-bearer 等)。grant_type だけ dual-accept しても consumer の総移行コストは下がらない
 - 内製 consumer (dplaas.auth) は v0.5.0 publish 完了後に一括追従する方針 (Option X) が既に決定済み
 
-### 3.2 URN Structure — Consumer Owns the Prefix Granularity
+### 3.2 DID Grant URN — Fixed Value
 
-URN 形式の grant_type 値は以下で組み立てる:
-
-```text
-urn:${urnCustomGrantTypePrefix}:did
-```
-
-- `urn:` prefix と `:did` suffix はライブラリが付与
-- 中間部分 `urnCustomGrantTypePrefix` は **consumer が任意粒度で指定**
-- ライブラリは namespace 粒度を強制しない (RFC 6755 の `params:oauth:grant-type` 構造を押し付けない)
-
-**Examples:**
-
-| `urnCustomGrantTypePrefix` | Resulting `grant_type` |
-| --- | --- |
-| `o3co:oauth:grant-type` | `urn:o3co:oauth:grant-type:did` |
-| `acme:oauth:grant-type` | `urn:acme:oauth:grant-type:did` |
-| `example.com:grants` | `urn:example.com:grants:did` |
-| `acme` | `urn:acme:did` |
+- DID grant の URN は **`urn:o3co:oauth:grant-type:did` 固定**
+- Consumer config 不要、override 不可
+- `did.enabled` config のみで on/off を切り替える (`enabled = false` なら DID grant module は no-op)
 
 **Rationale:**
 
-- `ns` の粒度はライブラリではなく consumer が決めるべき (branding / governance 観点)
-- RFC 6755 の `params:oauth:grant-type:*` は IETF が自分の URN namespace 内で IANA parameter registry を指す含意を持つ規約であり、IETF 以外 (consumer 独自 namespace) に `params` を入れる必然性はない
-- Consumer が RFC 互換の見た目を望めば `ietf:params:oauth:grant-type` (ただし IETF registry 未登録値を流すのは規約違反なので通常しない) も書ける柔軟性を持たせる
+§1.2 の wire protocol 所有権モデルに従う:
 
-### 3.3 No Default — Omission Disables DID Grant (Pattern β)
+- Wire protocol を定義したのは o3co/auth.provider。dPLaaS や他 consumer は wire の利用者
+- 同じ wire を使う複数 deployment で URN が統一されていないと Agent/client SDK 側の interop が成立しない
+- `o3co` は vendor identifier ではなく **wire protocol version identifier** として機能。IETF registry 値が consumer に変更不可であるのと同じ扱い
+- Consumer が wire protocol を拡張する場合、それは consumer 固有の別 grant として別 URN で定義する (既存 URN を書き換えない)
 
-- `urnCustomGrantTypePrefix` は **Zod schema で optional、default なし**
-- 未指定なら:
-  - DID grant module は **register を skip**
-  - 起動は成功する
-  - Client が DID grant を使おうとすると `unsupported_grant_type` エラーが返る
+### 3.3 `did.enabled` Semantics
 
-通知方針 (ログ出力の有無) は §3.9 で詳述。
+- `did.enabled = true` (default): `oauthDidModule` の init で `urn:o3co:oauth:grant-type:did` を grant registry に register
+- `did.enabled = false`: init は no-op、何も register しない
+- `oauthDidModule` を `createApp` の `modules` 配列に含めない場合は当然 register されない (既存挙動、variation なし)
 
 **Rationale:**
 
-- デフォルト値 (`o3co` 等) を設定すると、そのまま使う consumer が必ず出て vendor leak が発生する
-- `did.enabled = true` と `urnCustomGrantTypePrefix` 未指定を config error にする (Pattern α) 案もあるが、Quickstart で DID を試さない consumer (OAuth のみの利用者) に起動障壁を課すことになる
-- Pattern β (silent skip) なら:
-  - OAuth のみ利用する consumer は config 不要で起動できる
-  - DID を使おうとした consumer は `unsupported_grant_type` で即座に気付く
+- §3.2 で config を URN から排除したため、「DID grant を有効化しつつ URN だけ未設定」という曖昧な状態がなくなる
+- `enabled` flag は引き続き明示的な on/off スイッチとして機能
 
-### 3.4 IETF-Registered URN Grants — Fixed Values, Not Customizable
+### 3.4 IETF-Registered URN Grants — Fixed Values, Independent
 
 Token Exchange (RFC 8693) / jwt-bearer (RFC 7523) は IETF 登録済み URN:
 
 - `urn:ietf:params:oauth:grant-type:token-exchange`
 - `urn:ietf:params:oauth:grant-type:jwt-bearer`
 
-これらは **config 不要の固定値として register** する。`urnCustomGrantTypePrefix` の影響を受けない。
+これらは **config 不要の固定値として register** する。`urn:o3co:` sub-namespace とは独立。
 
 **Rationale:**
 
-- IETF registry 値は RFC 6755 §3 により IETF URN namespace (`urn:ietf:params:*`) に固定される。consumer が prefix を変える余地がない
-- 仮に consumer が `ietf:params:oauth:grant-type` を `urnCustomGrantTypePrefix` に指定しても無視する (IETF 規約準拠側が優先)
-- 実装時は URN 文字列を const で持ち、comment で "IETF-registered URN per RFC 7523/8693, not customizable" を明示
+- IETF registry 値は RFC 6755 §3 により IETF URN namespace (`urn:ietf:params:*`) に固定される。auth.provider 側で prefix を変える余地がない
+- 実装時は URN 文字列を const で持ち、comment で "IETF-registered URN per RFC 7523/8693" を明示
 
 ### 3.5 `session` Grant — Unchanged
 
@@ -129,135 +144,83 @@ Token Exchange (RFC 8693) / jwt-bearer (RFC 7523) は IETF 登録済み URN:
 
 ### 3.6 Grant Policy Input + Audit Event — Wire Value
 
-`GrantPolicyRequest.grantType` (policy hook 入力) と audit event の `grantType` field の両方に **client が送った wire 値そのまま** を入れる:
+**異なる 2 つの surface に対する扱いを明示する:**
 
-- `grant_type=authorization_code` → `grantType: "authorization_code"`
-- `grant_type=urn:acme:oauth:grant-type:did` → `grantType: "urn:acme:oauth:grant-type:did"`
-- `grant_type=refresh_token` → `grantType: "refresh_token"` (変更なし、既に正しい)
-- `grant_type=session` → `grantType: "session"` (変更なし)
+#### 3.6.1 Grant Policy Input (`GrantPolicyRequest.grantType`)
 
-**Breaking surface — Grant Policy:**
+- Field 名: `grantType` (camelCase、TypeScript interface `GrantPolicyRequest`)
+- 現状 `packages/oauth/src/routes.mts:466` で authorize フェーズ時に `grantPolicy.evaluate()` に hardcoded `"authorization"` を渡している
+- これを `"authorization_code"` に修正 (wire 値に合わせる)
+- **変更箇所**: `routes.mts:466` のみ (`refreshToken.mts:161` の `"refresh_token"` は既に RFC 準拠、変更不要)
+- DID grant / session grant は現状 `grantPolicy.evaluate()` を呼び出していない。本 spec の scope 内では DID への policy 統合は行わない
 
-`GrantPolicyRequest.grantType` は public interface のパラメータ。Consumer が `grantPolicy.evaluate()` を実装して `switch (req.grantType) { case "authorization": ... }` のように分岐している場合、本 rename で **policy アダプタが破綻する**。
+**Breaking surface:**
 
-具体的には `packages/oauth/src/routes.mts:466` の `grantType: "authorization"` → `"authorization_code"` 変更により、authorization code flow 中の `/oauth/authorize` フェーズで policy に渡される値が変わる。
+Consumer が `grantPolicy.evaluate()` を実装して `switch (req.grantType) { case "authorization": ... }` のように分岐している場合、本 rename で policy アダプタが破綻する。Migration は `case "authorization":` → `case "authorization_code":` にリネーム。
 
-影響範囲:
+#### 3.6.2 Audit Event (`details.grant_type`)
 
-- `GrantPolicyRequest.grantType = "authorization"` → `"authorization_code"` (authorize フェーズ)
-- `GrantPolicyRequest.grantType = "refresh_token"` (変更なし、既に RFC 準拠)
-- DID grant / session grant は `grantPolicy.evaluate()` を呼び出していない (影響なし)
+- Field 名: `grant_type` (snake_case、`details` object の nested field)
+- 現状 `routes.mts:169`, `205`, `220` などで `details: { grant_type }` の形で audit event に出力される
+- 値は request body の `grant_type` wire 値をそのまま入れている (既存挙動)
+- **本 spec の影響**: schema (field 名) は変更しない。値が client wire と連動して自動的に変わるのみ
+  - `grant_type=authorization_code` → `details: { grant_type: "authorization_code" }`
+  - `grant_type=urn:o3co:oauth:grant-type:did` → `details: { grant_type: "urn:o3co:oauth:grant-type:did" }`
+  - `grant_type=refresh_token` / `session` は変更なし
 
-**Migration (consumers implementing `GrantPolicyHookBase`):**
+**Audit schema contract:**
 
-- `case "authorization":` を `case "authorization_code":` にリネーム
-- URN 形式の grant (例えば DID) を policy で判定する場合、文字列完全一致ではなく URN suffix パターン (`:did` で終わる等) で判定する設計に変更
+本 spec は audit event の schema (field 名 / 構造) を変更しない。`details.grant_type` field は snake_case のまま維持。値の変化は client が送る wire 値の rename に連動する自動変化であり、ライブラリ側の implementation 変更は不要 (dynamic lookup で wire 値をそのまま記録しているため)。
 
-**Rationale:**
+#### 3.6.3 Rationale
 
-- Audit log / policy input は「実際に何が起きたか」を記録するもの。wire 値を入れるのが最も正直
+- Policy 入力と audit event は **別の interface** であり、field 命名規約も異なる (前者 camelCase TypeScript interface、後者 snake_case wire-like)
+- Audit event は「実際に何が起きたか」を記録するもので、wire 値を入れるのが最も正直
 - 短縮 symbolic name (`did` 等) を別途持たせると audit に嘘が記録される (client は URN を送ったのに audit は裸 `did`) ことになり、監査目的に反する
-- Policy input で consumer が「意味論的な grant type 区別」を必要とする場合、本ライブラリは wire 値を渡すに留め、consumer 側でパターン判定を行う責務分担とする
-- 集計・正規化の都合は consumer 側の監査・policy システムで対応
+- Policy 入力も同じ理由で wire 値を渡す
 
-### 3.7 URN Prefix Validation
+### 3.7 DID Grant Registration — URN Only
 
-`urnCustomGrantTypePrefix` の構文制約:
-
-```typescript
-z.string()
-  .min(1)
-  .regex(
-    /^(?!urn:)[A-Za-z0-9][A-Za-z0-9:._-]*$/,
-    "invalid urn prefix (must not start with 'urn:')"
-  )
-  .optional()
-```
-
-- 先頭英数、以降は英数 + `:` `.` `_` `-` を許容
-- `urn:` で始まる値を reject (`urn:urn:acme:did` のような二重 `urn:` を防止)
-- 厳密な RFC 8141 準拠ではないが実用上十分
-- 違反時は起動時 Zod error で失敗
-
-### 3.8 DID Grant Registration — URN Only
-
-- DID grant は **URN 形式でのみ registry に登録** される
-- 裸の `did` は (URN prefix 設定の有無に関わらず) **一切登録されない**
+- DID grant は **`urn:o3co:oauth:grant-type:did` でのみ registry に登録** される
+- 裸の `did` は一切登録されない
 - よって `grant_type=did` (裸) は常に `unsupported_grant_type` エラー
-- この挙動は §3.3 (未設定時 skip) と合わせて grant registration の完全な仕様を定義する
-
-### 3.9 Grant Registration Skip — No Logger Call
-
-DID grant が `urnCustomGrantTypePrefix` 未指定により register されない場合の通知方針:
-
-- **採用: ログ出力を行わない (no-op skip)**
-- README (`packages/did/README.md`) で明示: 「`did.enabled = true` でも `urnCustomGrantTypePrefix` 未指定なら DID grant は登録されない」
-- Consumer が DID grant を使用しようとすると `unsupported_grant_type` エラーが返るので、その時点で設定不備に気付ける
-
-**Rationale:**
-
-- 現状 `Logger` capability (`packages/core/src/logging/Logger.mts:26`) は `warn(message, ...args)` のみ定義で、`info` は未実装
-- `ModuleContext` に `logger` field も未登録 (`packages/core/src/modules/types.mts:56-90`)
-- `info` 追加 + `ModuleContext.logger` 追加は 2 点の surface 変更を招き、本 spec (grant_type rename の整理) の scope を超える
-- `console.warn` 直接呼び出しは consumer のログ集約パイプラインと切り離れるため避ける
-- DID grant が無効化される状況は「consumer が明示的に DID を有効化せず未設定のまま動かす」ケースのため、**silent が問題になるのは DID grant を使おうとした時のみ**。`unsupported_grant_type` エラーで即座に気付けるので UX 上の実害は小さい
-
-**Alternatives considered:**
-
-1. `Logger.info` を追加 + `ModuleContext.logger` 追加 + `context.logger?.info(...)` 呼び出し — v0.5.0 の surface 変更を 2 点増やす。将来的に採用する場合は別 spec
-2. `console.warn` 直接 — consumer ログ集約と非連携で避ける
-3. `throw` で起動を失敗させる (Pattern α) — `did.enabled=true` が残る consumer の既存 config を壊すため回避
 
 ## 4. File-Level Changes
 
 ### 4.1 `packages/did/src/module.mts`
 
-**Schema extension:**
+**Module init (simplified — fixed URN):**
 
 ```typescript
-export const didConfigSchema = z.object({
-  did: z.object({
-    enabled: z.boolean().default(true),
-    urnCustomGrantTypePrefix: z
-      .string()
-      .min(1)
-      .regex(
-        /^(?!urn:)[A-Za-z0-9][A-Za-z0-9:._-]*$/,
-        "invalid urn prefix (must not start with 'urn:')"
-      )
-      .optional(),
-    // existing fields unchanged (algorithm deprecated, supportedAlgorithms, messageMaxAgeSec, allowedAudiences)
-  }).default({
-    // existing default preserved; urnCustomGrantTypePrefix is intentionally absent (no default)
-    enabled: true,
-    supportedAlgorithms: ["ed25519_raw"],
-    messageMaxAgeSec: 300,
-    allowedAudiences: [],
-  }),
+const DID_GRANT_TYPE = "urn:o3co:oauth:grant-type:did" as const;
+
+export const oauthDidModule = (options: DidModuleOptions): Module => ({
+  name: "oauth-did",
+  async init(context: ModuleContext): Promise<void> {
+    const grantConfig = (
+      context.config.oauth.grants as Record<string, Record<string, unknown> | undefined>
+    ).did;
+    if (grantConfig?.enabled === false) return;
+
+    const resolver =
+      "resolver" in options ? options.resolver : options.resolverFactory(grantConfig ?? {});
+
+    const handler = createDidGrant(
+      {
+        config: context.config,
+        keyStore: context.keyStore,
+        pathResolver: context.pathResolver,
+      },
+      { resolver, verifierRegistry: options.verifierRegistry },
+    );
+    context.grantRegistry.register(DID_GRANT_TYPE, handler);
+  },
 });
 ```
 
-**Module init (per §3.9 decision: no logger call):**
+**Schema (unchanged):**
 
-```typescript
-async init(context: ModuleContext): Promise<void> {
-  const grantConfig = (context.config.oauth.grants as Record<string, ...>).did;
-  if (grantConfig?.enabled === false) return;
-
-  const prefix = grantConfig?.urnCustomGrantTypePrefix;
-  if (!prefix) {
-    // Silent skip. See §3.9 rationale. Consumer is notified via README + the
-    // `unsupported_grant_type` error that surfaces when a DID grant request
-    // arrives without URN prefix configured.
-    return;
-  }
-
-  const resolver = /* existing */;
-  const handler = createDidGrant(/* existing */);
-  const grantType = `urn:${prefix}:did`;
-  context.grantRegistry.register(grantType, handler);
-}
-```
+`didConfigSchema` は既存のまま維持。`urnCustomGrantTypePrefix` のような新規 field は追加しない。
 
 ### 4.2 `packages/oauth/src/oauthAuthorization.mts`
 
@@ -292,18 +255,17 @@ grantType: "authorization_code",
 
 ### 4.6 Standalone template
 
-- `templates/standalone/config/application.conf`
-  - `did.urnCustomGrantTypePrefix = "example:oauth:grant-type"` を追加
-  - コメント: `# Override with your organization's URN namespace (e.g. "acme:oauth:grant-type")`
 - `templates/standalone/tests/did-grant.test.js`
-  - `grant_type: "did"` → `grant_type: "urn:example:oauth:grant-type:did"` (全 8 箇所)
+  - `grant_type: "did"` → `grant_type: "urn:o3co:oauth:grant-type:did"` (全 8 箇所)
 - `templates/standalone/tests/index.test.js`
   - `grant_type=authorization` → `grant_type=authorization_code`
 - `README.md` の ASCII 図 (`grant_type=did`) を URN 形式に更新
 
 ### 4.7 Docs
 
-- `packages/did/README.md`: URN 設計セクション + migration note
+- `packages/did/README.md`:
+  - URN 固定値の記載 (`urn:o3co:oauth:grant-type:did`)
+  - Migration note (裸 `did` → URN)
 - `packages/oauth/README.md`: `authorization_code` で既に記載済み、念のため全スキャン
 - Root `CHANGELOG.md` v0.5.0 Unreleased セクションに breaking change entry
 
@@ -314,22 +276,22 @@ grantType: "authorization_code",
 
 - **Wire value (`grant_type`):**
   - `grant_type=authorization` → `grant_type=authorization_code` (RFC 6749 §4.1.3 compliance)
-  - `grant_type=did` → `grant_type=urn:${did.urnCustomGrantTypePrefix}:did`
+  - `grant_type=did` → `grant_type=urn:o3co:oauth:grant-type:did`
   - `grant_type=session` unchanged
 - **Grant policy interface (`GrantPolicyRequest.grantType`):**
   - Authorize flow now passes `"authorization_code"` (was `"authorization"`) to `grantPolicy.evaluate()`
-  - DID grant now passes the full URN string (e.g. `"urn:acme:oauth:grant-type:did"`) to any policy — but note that the built-in DID grant handler does not invoke `grantPolicy.evaluate()` today, so this is a forward-looking interface note
+  - DID grant handler does not currently invoke `grantPolicy.evaluate()`, but if consumers
+    add policy logic for DID grants in the future, use the full URN string
+    (`"urn:o3co:oauth:grant-type:did"`) as the match value
   - `refresh_token` unchanged
-- **New required config for DID grant consumers:**
-  - `did.urnCustomGrantTypePrefix` must be set to register the DID grant handler
-  - Omitting the config silently disables DID grant registration; client requests to the DID URN grant receive `unsupported_grant_type`
 
 Migration:
 
-1. Update client requests: `grant_type=authorization` → `authorization_code`
-2. If implementing `GrantPolicyHookBase`: rename `case "authorization":` → `case "authorization_code":` in policy dispatch logic
-3. If using DID grant: add `did.urnCustomGrantTypePrefix = "<your-namespace>"` to config
-4. Update DID client requests: `grant_type=did` → `grant_type=urn:<your-namespace>:did`
+1. Update client requests:
+   - `grant_type=authorization` → `authorization_code`
+   - `grant_type=did` → `urn:o3co:oauth:grant-type:did`
+2. If implementing `GrantPolicyHookBase`: rename `case "authorization":` →
+   `case "authorization_code":` in policy dispatch logic
 ```
 
 ## 6. Test Plan (TDD outline)
@@ -344,41 +306,31 @@ Migration:
 
 ### 6.2 DID URN 化
 
-- **RED case A:** `urnCustomGrantTypePrefix = "test:oauth:grant-type"` で起動 → `grant_type=urn:test:oauth:grant-type:did` リクエストが通るテスト → registry lookup miss で fail
-- **GREEN A:** `module.mts` を URN 構築ロジックに修正 → pass
-- **RED case B:** `urnCustomGrantTypePrefix` 未指定で起動 → DID grant が register されないテスト (registry に URN も裸 `did` も存在しないことを assert)
-- **GREEN B:** Skip ロジック実装 → pass (ログ出力なし、§3.9 決定に整合)
-- **Negative side-effect test:** `urnCustomGrantTypePrefix` 未指定時、init が `console` に一切の出力を行わないことを確認 (`console.warn` / `console.info` / `console.log` spy の call count 0)。§3.9 で「`ModuleContext.logger` は未導入」と決定しているため logger stub のテストは対象外
-- **NEW RED → GREEN:** 裸の `grant_type=did` が `unsupported_grant_type` を返すテスト (URN prefix 設定時・未設定時の両ケース)
+- **RED:** `grant_type=urn:o3co:oauth:grant-type:did` リクエストが通るテスト → registry lookup miss で fail
+- **GREEN:** `module.mts` を固定 URN register に修正 → pass
+- **NEW RED → GREEN:** 裸の `grant_type=did` が `unsupported_grant_type` を返すテスト
+- **Config test:** `did.enabled = false` で module init が no-op になり、URN が registry に存在しないテスト
 
 ### 6.3 Grant Policy Input + Audit Event
 
-- **Grant Policy (`GrantPolicyRequest.grantType`):**
+- **Grant Policy Input (`GrantPolicyRequest.grantType`, camelCase):**
   - `/oauth/authorize` flow で `grantType: "authorization_code"` が `grantPolicy.evaluate()` に渡されるテスト (routes.mts:466 path)
   - `/oauth/token` (refresh_token grant) で `grantType: "refresh_token"` が渡されるテスト (回帰確認)
   - Policy hook の記録値は wire 値と一致すること
-- **Audit Event:**
-  - `grantType: "authorization_code"` が audit event に記録されるテスト
-  - URN DID grant の audit event に `grantType: "urn:test:oauth:grant-type:did"` (wire 値そのまま) が記録されるテスト
-  - 実装確認ポイント: `routes.mts` / grant handler の audit 発火箇所は registry lookup に使った `grant_type` 文字列を直接利用するため、`line 466` の hardcoded `"authorization"` 以外は追加修正不要のはず。実装時に全 audit 発火箇所を走査して確認する
-
-### 6.4 Schema validation
-
-- `urnCustomGrantTypePrefix = ""` (空文字) で起動 → Zod error で fail
-- `urnCustomGrantTypePrefix = "invalid chars!"` で起動 → Zod regex error で fail
-- `urnCustomGrantTypePrefix = "urn:acme"` (先頭 `urn:`) で起動 → Zod regex error で fail
-- `urnCustomGrantTypePrefix = "example.com:grants"` (dot 含む) で起動 → pass
-- `urnCustomGrantTypePrefix = "valid:prefix-123"` で起動 → pass
+  - DID grant は現状 `grantPolicy.evaluate()` を呼び出していないため policy input テストの対象外 (§3.6.1 参照)
+- **Audit Event (`details.grant_type`, snake_case nested):**
+  - `grant_type=authorization_code` wire 送信時、audit event の `details.grant_type` に `"authorization_code"` が記録されるテスト
+  - `grant_type=urn:o3co:oauth:grant-type:did` wire 送信時、audit event の `details.grant_type` に URN 値そのままが記録されるテスト
+  - 実装確認ポイント: `routes.mts:169/205/220` の audit 発火箇所は `details: { grant_type }` の dynamic destructuring で wire 値を直接記録しているため、schema / field 名の修正は不要。値のみが client wire の rename に連動して変化することを確認するテスト
 
 ## 7. Risks & Mitigations
 
 | Risk | Mitigation |
 | --- | --- |
-| Consumer が `urnCustomGrantTypePrefix` 未設定で DID を使おうとして混乱 | README で明記 + `unsupported_grant_type` エラー時に原因を推測しやすくする (§3.9 rationale: silent skip は DID grant 未使用 consumer への UX を優先) |
+| `urn:o3co:` が vendor lock-in と見られる | §1.2 で「wire protocol version identifier」としての意味を明文化 + README で理由説明 + RFC 6755 sub-namespace 所有権モデルに準拠していることを示す |
 | Audit log / policy input の grant_type が URN で肥大化 | 設計判断として受け入れる (§3.6 rationale)。consumer 側で正規化は可能 |
 | 既存 v0.4.x consumer への breaking impact | v0.5.0 全体が breaking ラウンドなので CHANGELOG で明示 + dplaas.auth は Option X で一括追従 |
-| `urnCustomGrantTypePrefix` に `urn:` を含めて指定された場合 (例: `urn:acme`) → `urn:urn:acme:did` になる | §3.7 の regex で `urn:` prefix を reject。起動時 Zod error で早期発見 |
-| Consumer が `urnCustomGrantTypePrefix = "ietf:params:oauth:grant-type"` を設定し、IETF 未登録値を流す | 本ライブラリは「IETF 値を consumer が自前で流す」シナリオには介入しない (§3.4 rationale)。CHANGELOG + README で「IETF 登録値以外に IETF namespace を使うのは RFC 6755 違反」と警告のみ |
+| Consumer が wire protocol を拡張したい (VC Presentation 追加等) が URN 固定で困る | 拡張は既存 URN の上書きではなく別 grant として扱う (consumer 所有 URN で新規定義)。本 spec で migration path を明示 |
 | Consumer 実装 `GrantPolicyHookBase` が `case "authorization":` で分岐していて v0.5.0 で機能停止 | §3.6 Migration で rename 手順を明示 + CHANGELOG で breaking surface として強調 + dplaas.auth Option X 一括追従で内製 consumer は同期 |
 
 ## 8. Acceptance Criteria
@@ -386,12 +338,11 @@ Migration:
 - [ ] `grant_type=authorization` が `unsupported_grant_type` を返す
 - [ ] `grant_type=authorization_code` が正常に token 発行する
 - [ ] `grant_type=did` (裸) が常に `unsupported_grant_type` を返す
-- [ ] `urnCustomGrantTypePrefix` 未指定時、DID grant module が silent skip (ログ出力なし、起動成功)
-- [ ] `urnCustomGrantTypePrefix` 設定時、`grant_type=urn:${prefix}:did` が正常に token 発行する
-- [ ] `GrantPolicyRequest.grantType` に wire 値 (`authorization_code` / URN / `refresh_token`) がそのまま渡される
-- [ ] Audit event の `grantType` field に wire 値がそのまま記録される
+- [ ] `grant_type=urn:o3co:oauth:grant-type:did` が正常に token 発行する
+- [ ] `did.enabled = false` 時、URN が registry に register されない
+- [ ] `GrantPolicyRequest.grantType` に authorization code / refresh_token path で wire 値がそのまま渡される (DID は現状 policy 呼び出さないため対象外)
+- [ ] Audit event の `details.grant_type` field に wire 値がそのまま記録される (既存 schema 維持、値のみ連動変化)
 - [ ] Standalone template が新 URN 形式で動作する
-- [ ] Zod schema が不正 prefix 値 (空文字 / 不正文字 / `urn:` prefix) を起動時に reject する
 - [ ] CHANGELOG に wire 値・policy interface 両方の migration note が記載される
-- [ ] `packages/did/README.md` に「prefix 未指定時は silent skip」が明記される
+- [ ] `packages/did/README.md` に URN 固定値とその rationale が明記される
 - [ ] 全パッケージのテストが pass する

--- a/.claude/superpowers/specs/2026-04-24-grant-type-rename-design.md
+++ b/.claude/superpowers/specs/2026-04-24-grant-type-rename-design.md
@@ -19,6 +19,11 @@
   - §1.1 新設: 現状 `did` grant の位置付け (「認証 → 認可変換 grant」)
   - §3.2-§3.3 の URN 設計を固定値設計に刷新
   - §4.1 Module init を簡素化 (prefix check 不要)
+- 2026-04-24 scope addition (pre plan writing):
+  - §3.8 新設: HOCON config key rename (`oauth.grants.authorization` → `oauth.grants.authorization_code`)
+  - §4.2 拡張: `oauthAuthorization.mts:35` の `grantsConfig.authorization` → `grantsConfig.authorization_code`
+  - §4.6 拡張: `packages/core/config/application.conf` と `templates/standalone/config/application.conf`
+    の HOCON section rename + env var rename (`OAUTH_GRANTS_AUTHORIZATION_*` → `OAUTH_GRANTS_AUTHORIZATION_CODE_*`)
 
 ## 1. Background & Motivation
 
@@ -185,6 +190,36 @@ Consumer が `grantPolicy.evaluate()` を実装して `switch (req.grantType) { 
 - 裸の `did` は一切登録されない
 - よって `grant_type=did` (裸) は常に `unsupported_grant_type` エラー
 
+### 3.8 HOCON Config Key Rename — `authorization` → `authorization_code`
+
+Wire 値 rename に合わせて、HOCON config section の key も rename する。
+
+| Before | After |
+| --- | --- |
+| `oauth.grants.authorization { ... }` | `oauth.grants.authorization_code { ... }` |
+| `oauth.grants.authorization.enabled` | `oauth.grants.authorization_code.enabled` |
+| `oauth.grants.authorization.pkce.requireS256` | `oauth.grants.authorization_code.pkce.requireS256` |
+| env `OAUTH_GRANTS_AUTHORIZATION_ENABLED` | env `OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED` |
+| env `OAUTH_GRANTS_AUTHORIZATION_PKCE_REQUIRE_S256` | env `OAUTH_GRANTS_AUTHORIZATION_CODE_PKCE_REQUIRE_S256` |
+
+**変更理由:**
+
+- Wire 値 (`grant_type=authorization_code`) と config key (`grants.authorization`) がズレると、README / example / consumer コードで「どちらの名前で呼ぶのか」が混乱する
+- v0.5.0 は interface freeze ラウンド。中途半端な整合を残すと 1.0 GA まで引きずる
+- v0.5.0 は元々 breaking 集中ラウンドなので、追加の breaking でもトータルコストは変わらない
+
+**変更対象ファイル:**
+
+- `packages/oauth/src/oauthAuthorization.mts:33-35` (`grantsConfig.authorization` → `grantsConfig.authorization_code`)
+- `packages/core/config/application.conf:38` (grants block 内の key rename + env var rename)
+- `templates/standalone/config/application.conf:38-45` (grants block 内の key rename + env var rename)
+- `templates/standalone/README.md:72` / `templates/standalone/README.ja.md:72` (env var 表記更新)
+- `README.md:207` (env var 表記更新)
+
+**互換性方針:** Hard break (§3.1 と同じ方針)。旧 key / 旧 env var は一切 fallback しない。Consumer は HOCON ファイルを更新する。
+
+**備考:** `refresh_token` config key は RFC 値と既に一致 (snake_case)、`session` は §3.5 方針で変更なし、DID は `oauth.grants.did.*` (method 名) のまま維持 (URN を config key にすると HOCON syntax 上クォートが必要で扱いにくいため、method 名ベースで参照する現状を維持する)。
+
 ## 4. File-Level Changes
 
 ### 4.1 `packages/did/src/module.mts`
@@ -224,7 +259,16 @@ export const oauthDidModule = (options: DidModuleOptions): Module => ({
 
 ### 4.2 `packages/oauth/src/oauthAuthorization.mts`
 
+2 箇所修正:
+
 ```typescript
+// Line 35 — config key lookup (§3.8)
+// Before
+if (grantsConfig.authorization?.enabled !== false) {
+// After
+if (grantsConfig.authorization_code?.enabled !== false) {
+
+// Line 45 — grant registry key (§3.1)
 // Before
 context.grantRegistry.register("authorization", handler);
 // After
@@ -253,13 +297,56 @@ grantType: "authorization_code",
 
 変更なし (既に `"refresh_token"` で RFC 準拠)。
 
-### 4.6 Standalone template
+### 4.6 Standalone template / HOCON / README
+
+**Standalone template (tests):**
 
 - `templates/standalone/tests/did-grant.test.js`
   - `grant_type: "did"` → `grant_type: "urn:o3co:oauth:grant-type:did"` (全 8 箇所)
 - `templates/standalone/tests/index.test.js`
   - `grant_type=authorization` → `grant_type=authorization_code`
-- `README.md` の ASCII 図 (`grant_type=did`) を URN 形式に更新
+
+**HOCON config files (§3.8):**
+
+- `packages/core/config/application.conf:38`
+
+  ```hocon
+  # Before
+  authorization { enabled = true, enabled = ${?OAUTH_GRANTS_AUTHORIZATION_ENABLED} }
+  # After
+  authorization_code { enabled = true, enabled = ${?OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED} }
+  ```
+
+- `templates/standalone/config/application.conf:38-45`
+
+  ```hocon
+  # Before
+  authorization {
+    enabled = true
+    enabled = ${?OAUTH_GRANTS_AUTHORIZATION_ENABLED}
+    pkce {
+      requireS256 = false
+      requireS256 = ${?OAUTH_GRANTS_AUTHORIZATION_PKCE_REQUIRE_S256}
+    }
+  }
+  # After
+  authorization_code {
+    enabled = true
+    enabled = ${?OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED}
+    pkce {
+      requireS256 = false
+      requireS256 = ${?OAUTH_GRANTS_AUTHORIZATION_CODE_PKCE_REQUIRE_S256}
+    }
+  }
+  ```
+
+**Documentation env var tables:**
+
+- `templates/standalone/README.md:72` / `templates/standalone/README.ja.md:72`
+  - `OAUTH_GRANTS_AUTHORIZATION_ENABLED` → `OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED`
+- `README.md:207`
+  - `OAUTH_GRANTS_AUTHORIZATION_PKCE_REQUIRE_S256` → `OAUTH_GRANTS_AUTHORIZATION_CODE_PKCE_REQUIRE_S256`
+- Root `README.md` の ASCII 図 (`grant_type=did`) を URN 形式に更新
 
 ### 4.7 Docs
 
@@ -290,7 +377,11 @@ Migration:
 1. Update client requests:
    - `grant_type=authorization` → `authorization_code`
    - `grant_type=did` → `urn:o3co:oauth:grant-type:did`
-2. If implementing `GrantPolicyHookBase`: rename `case "authorization":` →
+2. Update HOCON config files:
+   - `oauth.grants.authorization { ... }` → `oauth.grants.authorization_code { ... }`
+   - env var `OAUTH_GRANTS_AUTHORIZATION_ENABLED` → `OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED`
+   - env var `OAUTH_GRANTS_AUTHORIZATION_PKCE_REQUIRE_S256` → `OAUTH_GRANTS_AUTHORIZATION_CODE_PKCE_REQUIRE_S256`
+3. If implementing `GrantPolicyHookBase`: rename `case "authorization":` →
    `case "authorization_code":` in policy dispatch logic
 ```
 
@@ -340,9 +431,12 @@ Migration:
 - [ ] `grant_type=did` (裸) が常に `unsupported_grant_type` を返す
 - [ ] `grant_type=urn:o3co:oauth:grant-type:did` が正常に token 発行する
 - [ ] `did.enabled = false` 時、URN が registry に register されない
+- [ ] `oauth.grants.authorization_code.enabled = false` 時、`authorization_code` grant が register されない
+- [ ] 旧 config key `oauth.grants.authorization` を含む HOCON ファイルで起動しても新 grant が有効化されない (旧 key は silently 無視される)
+- [ ] 新 env var (`OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED` / `_PKCE_REQUIRE_S256`) が正しく適用される
 - [ ] `GrantPolicyRequest.grantType` に authorization code / refresh_token path で wire 値がそのまま渡される (DID は現状 policy 呼び出さないため対象外)
 - [ ] Audit event の `details.grant_type` field に wire 値がそのまま記録される (既存 schema 維持、値のみ連動変化)
-- [ ] Standalone template が新 URN 形式で動作する
-- [ ] CHANGELOG に wire 値・policy interface 両方の migration note が記載される
+- [ ] Standalone template が新 URN 形式・新 config key で動作する
+- [ ] CHANGELOG に wire 値・config key・env var・policy interface の migration note が記載される
 - [ ] `packages/did/README.md` に URN 固定値とその rationale が明記される
 - [ ] 全パッケージのテストが pass する

--- a/.claude/superpowers/specs/2026-04-24-grant-type-rename-design.md
+++ b/.claude/superpowers/specs/2026-04-24-grant-type-rename-design.md
@@ -275,6 +275,24 @@ context.grantRegistry.register("authorization", handler);
 context.grantRegistry.register("authorization_code", handler);
 ```
 
+### 4.2a Additional config-read sites (caught in post-PR review)
+
+These sites also read `grantsConfig.authorization` internally and must be renamed
+together with the module-init site (§4.2) to avoid silent PKCE config regression:
+
+- `packages/oauth/src/grants/authorization.mts:39` —
+  `grantsConfig?.authorization` → `grantsConfig?.authorization_code`
+- `packages/oauth/src/routes.mts:415` —
+  `grantsConfig?.authorization` → `grantsConfig?.authorization_code`
+
+**Lesson:** when renaming a config key, grep for ALL consumer-side reads, not
+just the registration site. Add pre-merge grep to verification step:
+
+```bash
+grep -rn 'grantsConfig?\.authorization\b\|grants\.authorization\b' packages/ \
+  --include='*.mts' --include='*.ts'
+```
+
 ### 4.3 `packages/oauth/src/routes.mts`
 
 **Grant policy input** (`line 466`) — これは `grantPolicy.evaluate()` の入力 (`GrantPolicyRequest.grantType`) であり、audit event ではない。Consumer 実装 policy アダプタへの breaking 影響は §3.6 で詳述。

--- a/.claude/superpowers/specs/2026-04-24-grant-type-rename-design.md
+++ b/.claude/superpowers/specs/2026-04-24-grant-type-rename-design.md
@@ -1,0 +1,397 @@
+# Grant Type Rename — Design Spec
+
+**Date:** 2026-04-24
+**Scope:** auth.provider v0.5.0 — Core GA must #3 (`grant_type` RFC 準拠 + URN 化)
+**Status:** Draft → pending user review
+
+**Revision history:**
+
+- 2026-04-24 initial draft
+- 2026-04-24 Codex review round 1 fixes:
+  - §3.6 renamed "Audit Event" → "Grant Policy + Audit Event" to include policy interface impact
+  - §4.3 updated to note `routes.mts:466` is grant-policy input (breaking for policy adapters)
+  - §3.9 new section: "Grant Registration Skip — No Logger" decision + rationale
+  - §4.1 Module init sketch updated to match §3.9 (no-log approach)
+
+## 1. Background & Motivation
+
+v0.5.0 の Core GA must 項目のうち、interface freeze に直結する grant_type 整理を行う。現状の grant_type 値には以下の問題がある:
+
+1. **RFC 違反:** `grant_type=authorization` は RFC 6749 §4.1.3 違反。正式値は `authorization_code`。
+2. **DID grant の URN 化未実施:** 独自 grant `did` は裸の文字列で登録されているが、RFC 6755 に倣い独自 grant は URN 形式で識別すべき。
+3. **Namespace の vendor leak 懸念:** URN 化するときライブラリ側が `o3co` 等の namespace を押し付けると、consumer に library owner のアイデンティティが残留する。
+
+v0.5.0 は 1.0 GA 前の最後の interface 調整ラウンド。ここで RFC 準拠形に倒しきり、1.0 で freeze する。
+
+## 2. Scope
+
+### In Scope
+
+- `authorization` → `authorization_code` の rename (RFC 6749 準拠)
+- DID grant の URN 化 + `urnCustomGrantTypePrefix` config 新設
+- Audit event の grant_type 表記統一 (wire 値を記録)
+- Standalone template / README / CHANGELOG の追従
+
+### Out of Scope
+
+本 spec は **rename と URN 設計のみ**。以下は別 spec で扱う:
+
+- Token Exchange (RFC 8693) 実装 — v0.5.0 #2
+- jwt-bearer (RFC 7523) 実装 — v0.5.0 #4
+- NonceStore interface — v0.5.0 #5
+- DPoP interface 予約 — v0.5.0 #19
+- dplaas.auth 追従 — v0.5.0 publish 完了後に一括
+
+ただし Token Exchange と jwt-bearer の URN は IETF 登録済み値なので、本 spec で URN 設計時に「IETF 標準 URN は `urnCustomGrantTypePrefix` の適用外、固定値で register」という棲み分けルールだけ確定させる。実装箇所は別 spec。
+
+## 3. Design Decisions
+
+### 3.1 Compatibility Strategy — Hard Break
+
+- v0.5.0 で旧値 (`authorization` / `did`) を **即座に拒否** する
+- Registry lookup が見つからないので既存フロー (`routes.mts:157-173`) で `unsupported_grant_type` を返す
+- Dual-accept や legacy alias flag は導入しない
+
+**Rationale:**
+
+- `authorization` は RFC 6749 違反。互換維持はそれ自体が spec 違反の継続
+- v0.4.0 → v0.5.0 間で breaking は他にも複数発生 (passport 脱出済 / Token Exchange / jwt-bearer 等)。grant_type だけ dual-accept しても consumer の総移行コストは下がらない
+- 内製 consumer (dplaas.auth) は v0.5.0 publish 完了後に一括追従する方針 (Option X) が既に決定済み
+
+### 3.2 URN Structure — Consumer Owns the Prefix Granularity
+
+URN 形式の grant_type 値は以下で組み立てる:
+
+```text
+urn:${urnCustomGrantTypePrefix}:did
+```
+
+- `urn:` prefix と `:did` suffix はライブラリが付与
+- 中間部分 `urnCustomGrantTypePrefix` は **consumer が任意粒度で指定**
+- ライブラリは namespace 粒度を強制しない (RFC 6755 の `params:oauth:grant-type` 構造を押し付けない)
+
+**Examples:**
+
+| `urnCustomGrantTypePrefix` | Resulting `grant_type` |
+| --- | --- |
+| `o3co:oauth:grant-type` | `urn:o3co:oauth:grant-type:did` |
+| `acme:oauth:grant-type` | `urn:acme:oauth:grant-type:did` |
+| `example.com:grants` | `urn:example.com:grants:did` |
+| `acme` | `urn:acme:did` |
+
+**Rationale:**
+
+- `ns` の粒度はライブラリではなく consumer が決めるべき (branding / governance 観点)
+- RFC 6755 の `params:oauth:grant-type:*` は IETF が自分の URN namespace 内で IANA parameter registry を指す含意を持つ規約であり、IETF 以外 (consumer 独自 namespace) に `params` を入れる必然性はない
+- Consumer が RFC 互換の見た目を望めば `ietf:params:oauth:grant-type` (ただし IETF registry 未登録値を流すのは規約違反なので通常しない) も書ける柔軟性を持たせる
+
+### 3.3 No Default — Omission Disables DID Grant (Pattern β)
+
+- `urnCustomGrantTypePrefix` は **Zod schema で optional、default なし**
+- 未指定なら:
+  - DID grant module は **register を skip**
+  - 起動は成功する
+  - Client が DID grant を使おうとすると `unsupported_grant_type` エラーが返る
+
+通知方針 (ログ出力の有無) は §3.9 で詳述。
+
+**Rationale:**
+
+- デフォルト値 (`o3co` 等) を設定すると、そのまま使う consumer が必ず出て vendor leak が発生する
+- `did.enabled = true` と `urnCustomGrantTypePrefix` 未指定を config error にする (Pattern α) 案もあるが、Quickstart で DID を試さない consumer (OAuth のみの利用者) に起動障壁を課すことになる
+- Pattern β (silent skip) なら:
+  - OAuth のみ利用する consumer は config 不要で起動できる
+  - DID を使おうとした consumer は `unsupported_grant_type` で即座に気付く
+
+### 3.4 IETF-Registered URN Grants — Fixed Values, Not Customizable
+
+Token Exchange (RFC 8693) / jwt-bearer (RFC 7523) は IETF 登録済み URN:
+
+- `urn:ietf:params:oauth:grant-type:token-exchange`
+- `urn:ietf:params:oauth:grant-type:jwt-bearer`
+
+これらは **config 不要の固定値として register** する。`urnCustomGrantTypePrefix` の影響を受けない。
+
+**Rationale:**
+
+- IETF registry 値は RFC 6755 §3 により IETF URN namespace (`urn:ietf:params:*`) に固定される。consumer が prefix を変える余地がない
+- 仮に consumer が `ietf:params:oauth:grant-type` を `urnCustomGrantTypePrefix` に指定しても無視する (IETF 規約準拠側が優先)
+- 実装時は URN 文字列を const で持ち、comment で "IETF-registered URN per RFC 7523/8693, not customizable" を明示
+
+### 3.5 `session` Grant — Unchanged
+
+- `grant_type=session` はそのまま維持
+- Rationale:
+  - First-party BFF 固有で、外部 client が呼ばない
+  - `session` という既存 OAuth 名称との conflict がない
+  - URN 化しても実益がなく、変更コストのみが発生
+- RFC 非準拠の独自 grant という事実は変わらないが、使用者が限定的で実害なし
+
+### 3.6 Grant Policy Input + Audit Event — Wire Value
+
+`GrantPolicyRequest.grantType` (policy hook 入力) と audit event の `grantType` field の両方に **client が送った wire 値そのまま** を入れる:
+
+- `grant_type=authorization_code` → `grantType: "authorization_code"`
+- `grant_type=urn:acme:oauth:grant-type:did` → `grantType: "urn:acme:oauth:grant-type:did"`
+- `grant_type=refresh_token` → `grantType: "refresh_token"` (変更なし、既に正しい)
+- `grant_type=session` → `grantType: "session"` (変更なし)
+
+**Breaking surface — Grant Policy:**
+
+`GrantPolicyRequest.grantType` は public interface のパラメータ。Consumer が `grantPolicy.evaluate()` を実装して `switch (req.grantType) { case "authorization": ... }` のように分岐している場合、本 rename で **policy アダプタが破綻する**。
+
+具体的には `packages/oauth/src/routes.mts:466` の `grantType: "authorization"` → `"authorization_code"` 変更により、authorization code flow 中の `/oauth/authorize` フェーズで policy に渡される値が変わる。
+
+影響範囲:
+
+- `GrantPolicyRequest.grantType = "authorization"` → `"authorization_code"` (authorize フェーズ)
+- `GrantPolicyRequest.grantType = "refresh_token"` (変更なし、既に RFC 準拠)
+- DID grant / session grant は `grantPolicy.evaluate()` を呼び出していない (影響なし)
+
+**Migration (consumers implementing `GrantPolicyHookBase`):**
+
+- `case "authorization":` を `case "authorization_code":` にリネーム
+- URN 形式の grant (例えば DID) を policy で判定する場合、文字列完全一致ではなく URN suffix パターン (`:did` で終わる等) で判定する設計に変更
+
+**Rationale:**
+
+- Audit log / policy input は「実際に何が起きたか」を記録するもの。wire 値を入れるのが最も正直
+- 短縮 symbolic name (`did` 等) を別途持たせると audit に嘘が記録される (client は URN を送ったのに audit は裸 `did`) ことになり、監査目的に反する
+- Policy input で consumer が「意味論的な grant type 区別」を必要とする場合、本ライブラリは wire 値を渡すに留め、consumer 側でパターン判定を行う責務分担とする
+- 集計・正規化の都合は consumer 側の監査・policy システムで対応
+
+### 3.7 URN Prefix Validation
+
+`urnCustomGrantTypePrefix` の構文制約:
+
+```typescript
+z.string()
+  .min(1)
+  .regex(
+    /^(?!urn:)[A-Za-z0-9][A-Za-z0-9:._-]*$/,
+    "invalid urn prefix (must not start with 'urn:')"
+  )
+  .optional()
+```
+
+- 先頭英数、以降は英数 + `:` `.` `_` `-` を許容
+- `urn:` で始まる値を reject (`urn:urn:acme:did` のような二重 `urn:` を防止)
+- 厳密な RFC 8141 準拠ではないが実用上十分
+- 違反時は起動時 Zod error で失敗
+
+### 3.8 DID Grant Registration — URN Only
+
+- DID grant は **URN 形式でのみ registry に登録** される
+- 裸の `did` は (URN prefix 設定の有無に関わらず) **一切登録されない**
+- よって `grant_type=did` (裸) は常に `unsupported_grant_type` エラー
+- この挙動は §3.3 (未設定時 skip) と合わせて grant registration の完全な仕様を定義する
+
+### 3.9 Grant Registration Skip — No Logger Call
+
+DID grant が `urnCustomGrantTypePrefix` 未指定により register されない場合の通知方針:
+
+- **採用: ログ出力を行わない (no-op skip)**
+- README (`packages/did/README.md`) で明示: 「`did.enabled = true` でも `urnCustomGrantTypePrefix` 未指定なら DID grant は登録されない」
+- Consumer が DID grant を使用しようとすると `unsupported_grant_type` エラーが返るので、その時点で設定不備に気付ける
+
+**Rationale:**
+
+- 現状 `Logger` capability (`packages/core/src/logging/Logger.mts:26`) は `warn(message, ...args)` のみ定義で、`info` は未実装
+- `ModuleContext` に `logger` field も未登録 (`packages/core/src/modules/types.mts:56-90`)
+- `info` 追加 + `ModuleContext.logger` 追加は 2 点の surface 変更を招き、本 spec (grant_type rename の整理) の scope を超える
+- `console.warn` 直接呼び出しは consumer のログ集約パイプラインと切り離れるため避ける
+- DID grant が無効化される状況は「consumer が明示的に DID を有効化せず未設定のまま動かす」ケースのため、**silent が問題になるのは DID grant を使おうとした時のみ**。`unsupported_grant_type` エラーで即座に気付けるので UX 上の実害は小さい
+
+**Alternatives considered:**
+
+1. `Logger.info` を追加 + `ModuleContext.logger` 追加 + `context.logger?.info(...)` 呼び出し — v0.5.0 の surface 変更を 2 点増やす。将来的に採用する場合は別 spec
+2. `console.warn` 直接 — consumer ログ集約と非連携で避ける
+3. `throw` で起動を失敗させる (Pattern α) — `did.enabled=true` が残る consumer の既存 config を壊すため回避
+
+## 4. File-Level Changes
+
+### 4.1 `packages/did/src/module.mts`
+
+**Schema extension:**
+
+```typescript
+export const didConfigSchema = z.object({
+  did: z.object({
+    enabled: z.boolean().default(true),
+    urnCustomGrantTypePrefix: z
+      .string()
+      .min(1)
+      .regex(
+        /^(?!urn:)[A-Za-z0-9][A-Za-z0-9:._-]*$/,
+        "invalid urn prefix (must not start with 'urn:')"
+      )
+      .optional(),
+    // existing fields unchanged (algorithm deprecated, supportedAlgorithms, messageMaxAgeSec, allowedAudiences)
+  }).default({
+    // existing default preserved; urnCustomGrantTypePrefix is intentionally absent (no default)
+    enabled: true,
+    supportedAlgorithms: ["ed25519_raw"],
+    messageMaxAgeSec: 300,
+    allowedAudiences: [],
+  }),
+});
+```
+
+**Module init (per §3.9 decision: no logger call):**
+
+```typescript
+async init(context: ModuleContext): Promise<void> {
+  const grantConfig = (context.config.oauth.grants as Record<string, ...>).did;
+  if (grantConfig?.enabled === false) return;
+
+  const prefix = grantConfig?.urnCustomGrantTypePrefix;
+  if (!prefix) {
+    // Silent skip. See §3.9 rationale. Consumer is notified via README + the
+    // `unsupported_grant_type` error that surfaces when a DID grant request
+    // arrives without URN prefix configured.
+    return;
+  }
+
+  const resolver = /* existing */;
+  const handler = createDidGrant(/* existing */);
+  const grantType = `urn:${prefix}:did`;
+  context.grantRegistry.register(grantType, handler);
+}
+```
+
+### 4.2 `packages/oauth/src/oauthAuthorization.mts`
+
+```typescript
+// Before
+context.grantRegistry.register("authorization", handler);
+// After
+context.grantRegistry.register("authorization_code", handler);
+```
+
+### 4.3 `packages/oauth/src/routes.mts`
+
+**Grant policy input** (`line 466`) — これは `grantPolicy.evaluate()` の入力 (`GrantPolicyRequest.grantType`) であり、audit event ではない。Consumer 実装 policy アダプタへの breaking 影響は §3.6 で詳述。
+
+```typescript
+// Line 466 — authorize phase, GrantPolicyRequest.grantType
+// Before
+grantType: "authorization",
+// After
+grantType: "authorization_code",
+```
+
+(他の箇所は `registry.get(grant_type)` 経由の dynamic lookup なので変更不要。`packages/oauth/src/grants/refreshToken.mts:161` の `grantType: "refresh_token"` も既に RFC 準拠で変更不要)
+
+### 4.4 `packages/oauth/src/oauthSession.mts`
+
+変更なし (`"session"` のまま)。
+
+### 4.5 `packages/oauth/src/grants/refreshToken.mts`
+
+変更なし (既に `"refresh_token"` で RFC 準拠)。
+
+### 4.6 Standalone template
+
+- `templates/standalone/config/application.conf`
+  - `did.urnCustomGrantTypePrefix = "example:oauth:grant-type"` を追加
+  - コメント: `# Override with your organization's URN namespace (e.g. "acme:oauth:grant-type")`
+- `templates/standalone/tests/did-grant.test.js`
+  - `grant_type: "did"` → `grant_type: "urn:example:oauth:grant-type:did"` (全 8 箇所)
+- `templates/standalone/tests/index.test.js`
+  - `grant_type=authorization` → `grant_type=authorization_code`
+- `README.md` の ASCII 図 (`grant_type=did`) を URN 形式に更新
+
+### 4.7 Docs
+
+- `packages/did/README.md`: URN 設計セクション + migration note
+- `packages/oauth/README.md`: `authorization_code` で既に記載済み、念のため全スキャン
+- Root `CHANGELOG.md` v0.5.0 Unreleased セクションに breaking change entry
+
+## 5. Migration Notes (for CHANGELOG)
+
+```markdown
+### Breaking Changes
+
+- **Wire value (`grant_type`):**
+  - `grant_type=authorization` → `grant_type=authorization_code` (RFC 6749 §4.1.3 compliance)
+  - `grant_type=did` → `grant_type=urn:${did.urnCustomGrantTypePrefix}:did`
+  - `grant_type=session` unchanged
+- **Grant policy interface (`GrantPolicyRequest.grantType`):**
+  - Authorize flow now passes `"authorization_code"` (was `"authorization"`) to `grantPolicy.evaluate()`
+  - DID grant now passes the full URN string (e.g. `"urn:acme:oauth:grant-type:did"`) to any policy — but note that the built-in DID grant handler does not invoke `grantPolicy.evaluate()` today, so this is a forward-looking interface note
+  - `refresh_token` unchanged
+- **New required config for DID grant consumers:**
+  - `did.urnCustomGrantTypePrefix` must be set to register the DID grant handler
+  - Omitting the config silently disables DID grant registration; client requests to the DID URN grant receive `unsupported_grant_type`
+
+Migration:
+
+1. Update client requests: `grant_type=authorization` → `authorization_code`
+2. If implementing `GrantPolicyHookBase`: rename `case "authorization":` → `case "authorization_code":` in policy dispatch logic
+3. If using DID grant: add `did.urnCustomGrantTypePrefix = "<your-namespace>"` to config
+4. Update DID client requests: `grant_type=did` → `grant_type=urn:<your-namespace>:did`
+```
+
+## 6. Test Plan (TDD outline)
+
+各 rename ごとに RED → GREEN → REFACTOR サイクル:
+
+### 6.1 `authorization_code` rename
+
+- **RED:** 既存 `grant_type=authorization` テスト群を `authorization_code` にリネーム → registry lookup 失敗で unsupported → fail
+- **GREEN:** `oauthAuthorization.mts:45` + `routes.mts:466` を `authorization_code` に修正 → pass
+- **NEW RED → GREEN:** `grant_type=authorization` (legacy) が `unsupported_grant_type` を返すことを明示的にテスト
+
+### 6.2 DID URN 化
+
+- **RED case A:** `urnCustomGrantTypePrefix = "test:oauth:grant-type"` で起動 → `grant_type=urn:test:oauth:grant-type:did` リクエストが通るテスト → registry lookup miss で fail
+- **GREEN A:** `module.mts` を URN 構築ロジックに修正 → pass
+- **RED case B:** `urnCustomGrantTypePrefix` 未指定で起動 → DID grant が register されないテスト (registry に URN も裸 `did` も存在しないことを assert)
+- **GREEN B:** Skip ロジック実装 → pass (ログ出力なし、§3.9 決定に整合)
+- **Negative side-effect test:** `urnCustomGrantTypePrefix` 未指定時、init が `console` に一切の出力を行わないことを確認 (`console.warn` / `console.info` / `console.log` spy の call count 0)。§3.9 で「`ModuleContext.logger` は未導入」と決定しているため logger stub のテストは対象外
+- **NEW RED → GREEN:** 裸の `grant_type=did` が `unsupported_grant_type` を返すテスト (URN prefix 設定時・未設定時の両ケース)
+
+### 6.3 Grant Policy Input + Audit Event
+
+- **Grant Policy (`GrantPolicyRequest.grantType`):**
+  - `/oauth/authorize` flow で `grantType: "authorization_code"` が `grantPolicy.evaluate()` に渡されるテスト (routes.mts:466 path)
+  - `/oauth/token` (refresh_token grant) で `grantType: "refresh_token"` が渡されるテスト (回帰確認)
+  - Policy hook の記録値は wire 値と一致すること
+- **Audit Event:**
+  - `grantType: "authorization_code"` が audit event に記録されるテスト
+  - URN DID grant の audit event に `grantType: "urn:test:oauth:grant-type:did"` (wire 値そのまま) が記録されるテスト
+  - 実装確認ポイント: `routes.mts` / grant handler の audit 発火箇所は registry lookup に使った `grant_type` 文字列を直接利用するため、`line 466` の hardcoded `"authorization"` 以外は追加修正不要のはず。実装時に全 audit 発火箇所を走査して確認する
+
+### 6.4 Schema validation
+
+- `urnCustomGrantTypePrefix = ""` (空文字) で起動 → Zod error で fail
+- `urnCustomGrantTypePrefix = "invalid chars!"` で起動 → Zod regex error で fail
+- `urnCustomGrantTypePrefix = "urn:acme"` (先頭 `urn:`) で起動 → Zod regex error で fail
+- `urnCustomGrantTypePrefix = "example.com:grants"` (dot 含む) で起動 → pass
+- `urnCustomGrantTypePrefix = "valid:prefix-123"` で起動 → pass
+
+## 7. Risks & Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Consumer が `urnCustomGrantTypePrefix` 未設定で DID を使おうとして混乱 | README で明記 + `unsupported_grant_type` エラー時に原因を推測しやすくする (§3.9 rationale: silent skip は DID grant 未使用 consumer への UX を優先) |
+| Audit log / policy input の grant_type が URN で肥大化 | 設計判断として受け入れる (§3.6 rationale)。consumer 側で正規化は可能 |
+| 既存 v0.4.x consumer への breaking impact | v0.5.0 全体が breaking ラウンドなので CHANGELOG で明示 + dplaas.auth は Option X で一括追従 |
+| `urnCustomGrantTypePrefix` に `urn:` を含めて指定された場合 (例: `urn:acme`) → `urn:urn:acme:did` になる | §3.7 の regex で `urn:` prefix を reject。起動時 Zod error で早期発見 |
+| Consumer が `urnCustomGrantTypePrefix = "ietf:params:oauth:grant-type"` を設定し、IETF 未登録値を流す | 本ライブラリは「IETF 値を consumer が自前で流す」シナリオには介入しない (§3.4 rationale)。CHANGELOG + README で「IETF 登録値以外に IETF namespace を使うのは RFC 6755 違反」と警告のみ |
+| Consumer 実装 `GrantPolicyHookBase` が `case "authorization":` で分岐していて v0.5.0 で機能停止 | §3.6 Migration で rename 手順を明示 + CHANGELOG で breaking surface として強調 + dplaas.auth Option X 一括追従で内製 consumer は同期 |
+
+## 8. Acceptance Criteria
+
+- [ ] `grant_type=authorization` が `unsupported_grant_type` を返す
+- [ ] `grant_type=authorization_code` が正常に token 発行する
+- [ ] `grant_type=did` (裸) が常に `unsupported_grant_type` を返す
+- [ ] `urnCustomGrantTypePrefix` 未指定時、DID grant module が silent skip (ログ出力なし、起動成功)
+- [ ] `urnCustomGrantTypePrefix` 設定時、`grant_type=urn:${prefix}:did` が正常に token 発行する
+- [ ] `GrantPolicyRequest.grantType` に wire 値 (`authorization_code` / URN / `refresh_token`) がそのまま渡される
+- [ ] Audit event の `grantType` field に wire 値がそのまま記録される
+- [ ] Standalone template が新 URN 形式で動作する
+- [ ] Zod schema が不正 prefix 値 (空文字 / 不正文字 / `urn:` prefix) を起動時に reject する
+- [ ] CHANGELOG に wire 値・policy interface 両方の migration note が記載される
+- [ ] `packages/did/README.md` に「prefix 未指定時は silent skip」が明記される
+- [ ] 全パッケージのテストが pass する

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Breaking**: `registerBuiltinFederations`, `createGoogleProvider`, and `createGithubProvider` are removed from `@o3co/auth-provider-session`.
 - `openid-client` is no longer a runtime dependency of `@o3co/auth-provider-session`; it belongs to the concrete provider packages.
 
+### Breaking Changes
+
+- **`grant_type` wire values (RFC compliance + URN-ification):**
+  - `grant_type=authorization` → `grant_type=authorization_code` (RFC 6749 §4.1.3)
+  - `grant_type=did` → `grant_type=urn:o3co:oauth:grant-type:did` (RFC 6755
+    sub-namespace owned by auth.provider as the wire protocol definer)
+  - `grant_type=session` unchanged
+- **HOCON config keys + env vars:**
+  - `oauth.grants.authorization { ... }` → `oauth.grants.authorization_code { ... }`
+  - `OAUTH_GRANTS_AUTHORIZATION_ENABLED` → `OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED`
+  - `OAUTH_GRANTS_AUTHORIZATION_PKCE_REQUIRE_S256` → `OAUTH_GRANTS_AUTHORIZATION_CODE_PKCE_REQUIRE_S256`
+- **Grant policy interface (`GrantPolicyRequest.grantType`):**
+  - `/oauth/authorize` flow now passes `"authorization_code"` (was `"authorization"`)
+    to `grantPolicy.evaluate()`
+  - `refresh_token` path unchanged
+  - DID grant does not currently invoke `grantPolicy.evaluate()`; if consumers
+    add policy logic for DID in the future, use the full URN
+    (`"urn:o3co:oauth:grant-type:did"`) as the match value
+
+**Migration checklist:**
+
+1. Update client requests:
+   - `grant_type=authorization` → `authorization_code`
+   - `grant_type=did` → `urn:o3co:oauth:grant-type:did`
+2. Update HOCON config / environment:
+   - Rename `oauth.grants.authorization` → `oauth.grants.authorization_code`
+   - Rename `OAUTH_GRANTS_AUTHORIZATION_*` → `OAUTH_GRANTS_AUTHORIZATION_CODE_*`
+3. If implementing `GrantPolicyHookBase`:
+   - Rename `case "authorization":` → `case "authorization_code":` in
+     policy dispatch logic
+
 ## [0.4.1] - 2026-04-22
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -9,20 +9,20 @@ DID (分散型識別子) 認証対応の OAuth 2.0 プロバイダー。従来�
 DID 認証を使うと、クライアントは [Decentralized Identifier](https://www.w3.org/TR/did-core/) に紐づく暗号鍵ペアで身元を証明できる。パスワードも事前共有シークレットも不要。サーバーがクライアントの DID Document を resolve し、公開鍵を取り出して署名を検証する。
 
 ```text
-Client                              auth.provider
-  │                                      │
-  │  POST /oauth/token                   │
-  │  grant_type=did                      │
-  │  did=did:example:org:abc123          │
-  │  message={"did":"...","nonce":"..."}  │
-  │  signature=<Ed25519 署名>            │
-  │ ──────────────────────────────────►  │
-  │                                      │  1. DID Document を resolve
-  │                                      │  2. 公開鍵を取得
-  │                                      │  3. 署名を検証
-  │                                      │  4. JWT を発行
-  │  ◄──────────────────────────────────  │
-  │  { access_token: "eyJ...", ... }     │
+Client                                    auth.provider
+  │                                            │
+  │  POST /oauth/token                         │
+  │  grant_type=urn:o3co:oauth:grant-type:did  │
+  │  did=did:example:org:abc123                │
+  │  message={"did":"...","nonce":"..."}       │
+  │  signature=<Ed25519 署名>                  │
+  │ ────────────────────────────────────────►  │
+  │                                            │  1. DID Document を resolve
+  │                                            │  2. 公開鍵を取得
+  │                                            │  3. 署名を検証
+  │                                            │  4. JWT を発行
+  │  ◄───────────────────────────────────────  │
+  │  { access_token: "eyJ...", ... }           │
 ```
 
 `DidDocumentResolver` インターフェースはプラグイン可能。自分の DID method (`did:web`, `did:key`, `did:ion`, その他任意) 向けの resolver を実装して起動時に注入する。

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ oauth.grants.did {
 **Authorization code grant (when `oauthAuthorizationModule` is registered):**
 
 ```hocon
-oauth.grants.authorization {
+oauth.grants.authorization_code {
   pkce {
     requireS256 = false   # Set to true to reject plain code_challenge_method (S256 only)
     requireS256 = ${?OAUTH_GRANTS_AUTHORIZATION_CODE_PKCE_REQUIRE_S256}

--- a/README.md
+++ b/README.md
@@ -15,20 +15,20 @@ OAuth 2.0 provider with DID (Decentralized Identifier) authentication. Issue JWT
 DID authentication lets clients prove identity using cryptographic key pairs tied to a [Decentralized Identifier](https://www.w3.org/TR/did-core/), without passwords or pre-shared secrets. The server resolves the client's DID Document, extracts the public key, and verifies the signature.
 
 ```text
-Client                              auth.provider
-  │                                      │
-  │  POST /oauth/token                   │
-  │  grant_type=urn:o3co:oauth:grant-type:did    │
-  │  did=did:example:org:abc123          │
-  │  message={"did":"...","nonce":"..."}  │
-  │  signature=<Ed25519 signature>       │
-  │ ──────────────────────────────────►  │
-  │                                      │  1. Resolve DID Document
-  │                                      │  2. Extract public key
-  │                                      │  3. Verify signature
-  │                                      │  4. Issue JWT
-  │  ◄──────────────────────────────────  │
-  │  { access_token: "eyJ...", ... }     │
+Client                                    auth.provider
+  │                                            │
+  │  POST /oauth/token                         │
+  │  grant_type=urn:o3co:oauth:grant-type:did  │
+  │  did=did:example:org:abc123                │
+  │  message={"did":"...","nonce":"..."}       │
+  │  signature=<Ed25519 signature>             │
+  │ ────────────────────────────────────────►  │
+  │                                            │  1. Resolve DID Document
+  │                                            │  2. Extract public key
+  │                                            │  3. Verify signature
+  │                                            │  4. Issue JWT
+  │  ◄───────────────────────────────────────  │
+  │  { access_token: "eyJ...", ... }           │
 ```
 
 The `DidDocumentResolver` interface is pluggable — implement it for your DID method (`did:web`, `did:key`, `did:ion`, or any custom method) and inject it at startup.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ DID authentication lets clients prove identity using cryptographic key pairs tie
 Client                              auth.provider
   │                                      │
   │  POST /oauth/token                   │
-  │  grant_type=did                      │
+  │  grant_type=urn:o3co:oauth:grant-type:did    │
   │  did=did:example:org:abc123          │
   │  message={"did":"...","nonce":"..."}  │
   │  signature=<Ed25519 signature>       │
@@ -204,7 +204,7 @@ oauth.grants.did {
 oauth.grants.authorization {
   pkce {
     requireS256 = false   # Set to true to reject plain code_challenge_method (S256 only)
-    requireS256 = ${?OAUTH_GRANTS_AUTHORIZATION_PKCE_REQUIRE_S256}
+    requireS256 = ${?OAUTH_GRANTS_AUTHORIZATION_CODE_PKCE_REQUIRE_S256}
   }
 }
 ```

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -35,7 +35,7 @@ oauth {
   }
   grants {
     session { enabled = true, enabled = ${?OAUTH_GRANTS_SESSION_ENABLED} }
-    authorization { enabled = true, enabled = ${?OAUTH_GRANTS_AUTHORIZATION_ENABLED} }
+    authorization_code { enabled = true, enabled = ${?OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED} }
     refresh_token { enabled = true, enabled = ${?OAUTH_GRANTS_REFRESH_TOKEN_ENABLED} }
     did {
       enabled = true

--- a/packages/core/src/__tests__/config-composition.test.mts
+++ b/packages/core/src/__tests__/config-composition.test.mts
@@ -206,7 +206,7 @@ describe("AppConfigSchema backward compatibility", () => {
 				refreshToken: { expiresIn: 86400 },
 				grants: {
 					session: { enabled: true },
-					authorization: { enabled: true },
+					authorization_code: { enabled: true },
 					refresh_token: { enabled: true },
 				},
 			},

--- a/packages/core/src/config/__tests__/schema-open-type.test.mts
+++ b/packages/core/src/config/__tests__/schema-open-type.test.mts
@@ -93,7 +93,7 @@ describe("schema open type", () => {
 				refreshToken: { expiresIn: 86400 },
 				grants: {
 					session: { enabled: true },
-					authorization: { enabled: true, pkce: { requireS256: false } },
+					authorization_code: { enabled: true, pkce: { requireS256: false } },
 					refresh_token: { enabled: true },
 				},
 			},

--- a/packages/did/README.ja.md
+++ b/packages/did/README.ja.md
@@ -4,6 +4,28 @@
 
 OAuth 2.0 の `"did"` grant type を追加する。クライアントは DID と署名済みメッセージを提示し、サーバーは DID ドキュメントから解決した公開鍵で署名を検証する。4 種類の署名アルゴリズムをサポートする。
 
+## Grant Type URN
+
+DID grant は固定の URN で登録されている:
+
+```text
+urn:o3co:oauth:grant-type:did
+```
+
+クライアントはこの文字列を `grant_type` パラメータとして送信しなければならない。
+短縮形の `"did"` はワイヤー値としてはサポートされていない。
+
+注意: 内部的には grant は `GrantRegistry` 内で短縮識別子 `"did"` のまま登録されており、
+設定キーも `oauth.grants.did` のままである。クライアント側の*ワイヤー値*のみが URN になる。
+以下の API リファレンスで `"did"` と表記されている箇所は、内部レジストリ識別子を指しており、
+ワイヤー値ではない。
+
+### なぜ `urn:o3co:...` なのか？
+
+DID ワイヤープロトコル（`did` + `message` + `signature` のフォームパラメータ）は auth.provider が定義している。RFC 6755 のサブ名前空間所有モデルの下では、URN はワイヤープロトコルの定義者が所有すべきである。ここで `o3co` セグメントは**ワイヤープロトコルのバージョン識別子**として機能しており、ベンダー識別子ではない。IETF 登録の grant URN が `urn:ietf:params:oauth:grant-type:*` 配下にあるのと同様の位置づけである。
+
+ワイヤープロトコルを拡張したい（例: Verifiable Presentation を埋め込む）コンシューマーのデプロイメントは、この URN をオーバーライドするのではなく、自分の URN サブ名前空間（例: `urn:example.com:oauth:grant-type:did-vp`）で新しい grant を定義すること。
+
 ## インストール
 
 このパッケージは **private** です。npm には公開されておらず、`auth.provider` モノリポ内でのみ利用できます。

--- a/packages/did/README.ja.md
+++ b/packages/did/README.ja.md
@@ -15,10 +15,12 @@ urn:o3co:oauth:grant-type:did
 クライアントはこの文字列を `grant_type` パラメータとして送信しなければならない。
 短縮形の `"did"` はワイヤー値としてはサポートされていない。
 
-注意: 内部的には grant は `GrantRegistry` 内で短縮識別子 `"did"` のまま登録されており、
-設定キーも `oauth.grants.did` のままである。クライアント側の*ワイヤー値*のみが URN になる。
-以下の API リファレンスで `"did"` と表記されている箇所は、内部レジストリ識別子を指しており、
-ワイヤー値ではない。
+注意: grant は `GrantRegistry` に完全な URN `urn:o3co:oauth:grant-type:did`
+でのみ登録される。短縮形の `"did"` は登録されず、`unsupported_grant_type`
+を返す。**設定キー**は `oauth.grants.did` のまま（メソッド名ベースで、
+URN ベースではない。HOCON のキーにコロンが含まれるとクォートが必要になり
+扱いにくいため）。以下の API リファレンスで `"did"` と表記されている箇所は
+この設定キーを指しており、ワイヤー値やレジストリ識別子ではない。
 
 ### なぜ `urn:o3co:...` なのか？
 

--- a/packages/did/README.ja.md
+++ b/packages/did/README.ja.md
@@ -55,7 +55,7 @@ peer dependencies（ワークスペースルートに別途インストール）
 function oauthDidModule(options: DidModuleOptions): Module;
 ```
 
-モジュール（name: `"oauth-did"`）を返すファクトリ関数。`config.oauth.grants.did.enabled` が `true` のとき、grant レジストリに `"did"` grant type を登録する。DID 認証を有効化するには、戻り値を `createApp` の modules に渡すこと。
+モジュール（name: `"oauth-did"`）を返すファクトリ関数。`config.oauth.grants.did.enabled` が `true` のとき（`oauth.grants.did` は**設定キー**であり、ワイヤー値やレジストリキーではない）、grant レジストリに URN `urn:o3co:oauth:grant-type:did` で登録する。DID 認証を有効化するには、戻り値を `createApp` の modules に渡すこと。
 
 `DidModuleOptions` には DID ドキュメントリゾルバーを以下のいずれかの形式で渡す:
 
@@ -76,7 +76,7 @@ type DidModuleOptions =
 function createDidGrant(deps: GrantDependencies): GrantHandler;
 ```
 
-`"did"` grant ハンドラーを生成するファクトリ関数。ハンドラーが期待するリクエストボディフィールド:
+DID grant ハンドラー（URN `urn:o3co:oauth:grant-type:did` で登録される）を生成するファクトリ関数。ハンドラーが期待するリクエストボディフィールド:
 
 | フィールド           | 説明                                               |
 |---------------------|---------------------------------------------------|

--- a/packages/did/README.md
+++ b/packages/did/README.md
@@ -2,7 +2,32 @@
 
 DID (Decentralized Identifier) authentication grant for [auth.provider](../../README.md).
 
-Adds a `"did"` OAuth 2.0 grant type. Clients present a DID and a signed message; the server verifies the signature using the public key resolved from the DID document. Supports four signature algorithms.
+Adds the DID OAuth 2.0 grant type. Clients present a DID and a signed message; the server verifies the signature using the public key resolved from the DID document. Supports four signature algorithms.
+
+## Grant Type URN
+
+The DID grant is registered under the fixed URN:
+
+```text
+urn:o3co:oauth:grant-type:did
+```
+
+Clients must send this exact string as the `grant_type` parameter. The
+bare string `"did"` is not supported.
+
+### Why `urn:o3co:...`?
+
+The DID wire protocol (`did` + `message` + `signature` form parameters)
+is defined by auth.provider. Under the RFC 6755 sub-namespace ownership
+model, the URN should be owned by the wire protocol definer. Here, the
+`o3co` segment acts as a **wire protocol version identifier**, not a
+vendor identifier — comparable to how IETF-registered grant URNs live
+under `urn:ietf:params:oauth:grant-type:*`.
+
+Consumer deployments that extend the wire protocol (e.g. to embed a
+Verifiable Presentation) should define a new grant under their own URN
+sub-namespace (e.g. `urn:example.com:oauth:grant-type:did-vp`) rather
+than overriding this one.
 
 ## Install
 

--- a/packages/did/README.md
+++ b/packages/did/README.md
@@ -64,7 +64,7 @@ Peer dependencies (install separately in the workspace root):
 function oauthDidModule(options: DidModuleOptions): Module;
 ```
 
-Factory that returns a module (name: `"oauth-did"`). Registers the `"did"` grant type in the grant registry when `config.oauth.grants.did.enabled` is `true`. Pass the result to `createApp` as a module to enable DID authentication.
+Factory that returns a module (name: `"oauth-did"`). Registers the DID grant under the URN `urn:o3co:oauth:grant-type:did` in the grant registry when `config.oauth.grants.did.enabled` is `true` (note: `oauth.grants.did` is the **config key**, not the wire value or registry key). Pass the result to `createApp` as a module to enable DID authentication.
 
 `DidModuleOptions` must supply a DID document resolver in one of two forms:
 
@@ -85,7 +85,7 @@ type DidModuleOptions =
 function createDidGrant(deps: GrantDependencies): GrantHandler;
 ```
 
-Factory that creates the `"did"` grant handler. The handler expects the following request body fields:
+Factory that creates the DID grant handler (registered under the URN `urn:o3co:oauth:grant-type:did`). The handler expects the following request body fields:
 
 | Field                 | Description                                        |
 |-----------------------|----------------------------------------------------|

--- a/packages/did/README.md
+++ b/packages/did/README.md
@@ -15,11 +15,13 @@ urn:o3co:oauth:grant-type:did
 Clients must send this exact string as the `grant_type` parameter. The
 bare string `"did"` is not supported.
 
-Note: internally the grant is still registered under the short identifier
-`"did"` in the `GrantRegistry`, and the config key remains
-`oauth.grants.did`. Only the client-facing *wire value* is the URN.
-References to `"did"` in the API reference below refer to the internal
-registry identifier, not a wire value.
+Note: the grant is registered in the `GrantRegistry` under the full URN
+`urn:o3co:oauth:grant-type:did`; the bare string `"did"` is not
+registered and returns `unsupported_grant_type`. The **config key**
+remains `oauth.grants.did` (method-name based, not URN based, because
+HOCON keys with colons require quoting). References to `"did"` in the
+API reference below refer to that config key only, not to a wire value
+or registry identifier.
 
 ### Why `urn:o3co:...`?
 

--- a/packages/did/README.md
+++ b/packages/did/README.md
@@ -15,6 +15,12 @@ urn:o3co:oauth:grant-type:did
 Clients must send this exact string as the `grant_type` parameter. The
 bare string `"did"` is not supported.
 
+Note: internally the grant is still registered under the short identifier
+`"did"` in the `GrantRegistry`, and the config key remains
+`oauth.grants.did`. Only the client-facing *wire value* is the URN.
+References to `"did"` in the API reference below refer to the internal
+registry identifier, not a wire value.
+
 ### Why `urn:o3co:...`?
 
 The DID wire protocol (`did` + `message` + `signature` form parameters)

--- a/packages/did/src/__tests__/did.test.mts
+++ b/packages/did/src/__tests__/did.test.mts
@@ -38,7 +38,7 @@ const mockConfig = {
 		refreshToken: { expiresIn: 86400 },
 		grants: {
 			session: { enabled: true },
-			authorization: { enabled: true },
+			authorization_code: { enabled: true },
 			refresh_token: { enabled: true },
 			did: { enabled: true, algorithm: "ed25519_raw", messageMaxAgeSec: 300 },
 		},
@@ -721,7 +721,7 @@ describe("createDidGrant", () => {
 					refreshToken: { expiresIn: 86400 },
 					grants: {
 						session: { enabled: true },
-						authorization: { enabled: true },
+						authorization_code: { enabled: true },
 						refresh_token: { enabled: true },
 						did: {
 							enabled: true,

--- a/packages/did/src/__tests__/module.test.mts
+++ b/packages/did/src/__tests__/module.test.mts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+	GrantRegistry,
+	createSymmetricKeyStore,
+	type ModuleContext,
+} from "@o3co/auth-provider-core";
+import type { Router } from "express";
+import { describe, expect, it } from "vitest";
+import { oauthDidModule } from "../module.mjs";
+import type { DidDocument, DidDocumentResolver } from "../resolver/types.mjs";
+
+const DID_URN = "urn:o3co:oauth:grant-type:did";
+
+const mockResolver: DidDocumentResolver = {
+	async resolve(_did: string): Promise<DidDocument> {
+		throw new Error("not expected to be called in this test");
+	},
+};
+
+const buildContext = (
+	didConfig: Record<string, unknown> | undefined,
+): ModuleContext => ({
+	pathResolver: (s: string) => s,
+	config: {
+		oauth: {
+			jwt: { secret: "test-secret" },
+			accessToken: { expiresIn: 3600 },
+			refreshToken: { expiresIn: 86400 },
+			grants: { did: didConfig },
+		},
+	} as unknown as ModuleContext["config"],
+	keyStore: createSymmetricKeyStore("test-secret"),
+	grantRegistry: new GrantRegistry(),
+	router: {} as Router,
+});
+
+describe("oauthDidModule", () => {
+	it("registers DID grant under urn:o3co:oauth:grant-type:did when enabled", async () => {
+		const ctx = buildContext({ enabled: true, supportedAlgorithms: ["ed25519_raw"] });
+		await oauthDidModule({ resolver: mockResolver }).init(ctx);
+
+		expect(ctx.grantRegistry.get(DID_URN)).toBeDefined();
+	});
+
+	it("does NOT register the bare 'did' string (URN-only policy)", async () => {
+		const ctx = buildContext({ enabled: true, supportedAlgorithms: ["ed25519_raw"] });
+		await oauthDidModule({ resolver: mockResolver }).init(ctx);
+
+		expect(ctx.grantRegistry.get("did")).toBeUndefined();
+	});
+
+	it("is a no-op when did.enabled is false", async () => {
+		const ctx = buildContext({ enabled: false });
+		await oauthDidModule({ resolver: mockResolver }).init(ctx);
+
+		expect(ctx.grantRegistry.get(DID_URN)).toBeUndefined();
+		expect(ctx.grantRegistry.get("did")).toBeUndefined();
+	});
+
+	it("registers when did config is missing (enabled defaults to true)", async () => {
+		const ctx = buildContext(undefined);
+		await oauthDidModule({ resolver: mockResolver }).init(ctx);
+
+		// Current behavior: undefined config → enabled !== false, so registered
+		expect(ctx.grantRegistry.get(DID_URN)).toBeDefined();
+	});
+});

--- a/packages/did/src/__tests__/module.test.mts
+++ b/packages/did/src/__tests__/module.test.mts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import {
-	GrantRegistry,
 	createSymmetricKeyStore,
+	GrantRegistry,
 	type ModuleContext,
 } from "@o3co/auth-provider-core";
 import { describe, expect, it } from "vitest";
@@ -30,9 +30,7 @@ const mockResolver: DidDocumentResolver = {
 	},
 };
 
-const buildContext = (
-	didConfig: Record<string, unknown> | undefined,
-): ModuleContext => ({
+const buildContext = (didConfig: Record<string, unknown> | undefined): ModuleContext => ({
 	pathResolver: (s: string) => s,
 	config: {
 		oauth: {

--- a/packages/did/src/__tests__/module.test.mts
+++ b/packages/did/src/__tests__/module.test.mts
@@ -18,7 +18,6 @@ import {
 	createSymmetricKeyStore,
 	type ModuleContext,
 } from "@o3co/auth-provider-core";
-import type { Router } from "express";
 import { describe, expect, it } from "vitest";
 import { oauthDidModule } from "../module.mjs";
 import type { DidDocument, DidDocumentResolver } from "../resolver/types.mjs";
@@ -45,7 +44,7 @@ const buildContext = (
 	} as unknown as ModuleContext["config"],
 	keyStore: createSymmetricKeyStore("test-secret"),
 	grantRegistry: new GrantRegistry(),
-	router: {} as Router,
+	router: {} as ModuleContext["router"],
 });
 
 describe("oauthDidModule", () => {
@@ -71,7 +70,7 @@ describe("oauthDidModule", () => {
 		expect(ctx.grantRegistry.get("did")).toBeUndefined();
 	});
 
-	it("registers when did config is missing (enabled defaults to true)", async () => {
+	it("registers when did config is undefined (no explicit disable)", async () => {
 		const ctx = buildContext(undefined);
 		await oauthDidModule({ resolver: mockResolver }).init(ctx);
 

--- a/packages/did/src/module.mts
+++ b/packages/did/src/module.mts
@@ -20,6 +20,8 @@ import { createDidGrant } from "./did.mjs";
 import type { DidDocumentResolver } from "./resolver/types.mjs";
 import type { VerifierRegistry } from "./verifiers/registry.mjs";
 
+const DID_GRANT_TYPE = "urn:o3co:oauth:grant-type:did" as const;
+
 export const didConfigSchema = z.object({
 	did: z
 		.object({
@@ -73,6 +75,6 @@ export const oauthDidModule = (options: DidModuleOptions): Module => ({
 			},
 			{ resolver, verifierRegistry: options.verifierRegistry },
 		);
-		context.grantRegistry.register("did", handler);
+		context.grantRegistry.register(DID_GRANT_TYPE, handler);
 	},
 });

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -32,7 +32,7 @@ const mockConfig = {
 		refreshToken: { expiresIn: 86400 },
 		grants: {
 			session: { enabled: true },
-			authorization: { enabled: true },
+			authorization_code: { enabled: true },
 			refresh_token: { enabled: true },
 			did: { enabled: true, messageMaxAgeSec: 300 },
 		},
@@ -461,7 +461,7 @@ describe("createAuthorizationGrant", () => {
 					refreshToken: { expiresIn: 86400 },
 					grants: {
 						session: { enabled: true },
-						authorization: {
+						authorization_code: {
 							enabled: true,
 							pkce: { requireS256: true },
 						},
@@ -726,7 +726,7 @@ describe("createAuthorizationGrant", () => {
 						accessToken: { expiresIn: 3600 },
 						refreshToken: { expiresIn: 86400 },
 						grants: {
-							authorization: {
+							authorization_code: {
 								enabled: true,
 								pkce,
 							},
@@ -839,7 +839,7 @@ describe("createAuthorizationGrant", () => {
 					refreshToken: { expiresIn: 86400 },
 					grants: {
 						session: { enabled: true },
-						authorization: { enabled: true },
+						authorization_code: { enabled: true },
 						refresh_token: { enabled: true },
 						did: { enabled: true, messageMaxAgeSec: 300 },
 					},

--- a/packages/oauth/src/__tests__/hooks.test.mts
+++ b/packages/oauth/src/__tests__/hooks.test.mts
@@ -336,7 +336,7 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 			const grantPolicy: GrantPolicyHookBase = {
 				kind: "spy",
 				async evaluate(request) {
-					expect(request.grantType).toBe("authorization");
+					expect(request.grantType).toBe("authorization_code");
 					expect(request.clientId).toBe("client-1");
 					expect(request.subject).toBe("user-1");
 					return {

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -110,7 +110,7 @@ const mockConfig = {
 		accessToken: { expiresIn: 3600 },
 		refreshToken: { expiresIn: 86400 },
 		grants: {
-			authorization: { enabled: true },
+			authorization_code: { enabled: true },
 			refresh_token: { enabled: true },
 		},
 	},
@@ -143,7 +143,7 @@ describe("oauthAuthorizationModule", () => {
 
 		await module.init(ctx);
 
-		expect(ctx.grantRegistry.get("authorization")).toBeDefined();
+		expect(ctx.grantRegistry.get("authorization_code")).toBeDefined();
 		expect(ctx.grantRegistry.get("refresh_token")).toBeDefined();
 	});
 
@@ -153,7 +153,7 @@ describe("oauthAuthorizationModule", () => {
 			oauth: {
 				...mockConfig.oauth,
 				grants: {
-					authorization: { enabled: false },
+					authorization_code: { enabled: false },
 					refresh_token: { enabled: true },
 				},
 			},
@@ -166,7 +166,7 @@ describe("oauthAuthorizationModule", () => {
 
 		await module.init(ctx);
 
-		expect(ctx.grantRegistry.get("authorization")).toBeUndefined();
+		expect(ctx.grantRegistry.get("authorization_code")).toBeUndefined();
 		expect(ctx.grantRegistry.get("refresh_token")).toBeDefined();
 	});
 
@@ -257,7 +257,7 @@ describe("oauthAuthorizationModule", () => {
 
 		await module.init(ctx);
 
-		const handler = ctx.grantRegistry.get("authorization");
+		const handler = ctx.grantRegistry.get("authorization_code");
 		expect(handler).toBeDefined();
 		if (!handler) return;
 
@@ -291,7 +291,7 @@ describe("oauthAuthorizationModule", () => {
 
 		await module.init(ctx);
 
-		expect(ctx.grantRegistry.get("authorization")).toBeDefined();
+		expect(ctx.grantRegistry.get("authorization_code")).toBeDefined();
 		expect(ctx.grantRegistry.get("refresh_token")).toBeDefined();
 	});
 
@@ -308,7 +308,7 @@ describe("oauthAuthorizationModule", () => {
 
 		await module.init(ctx);
 
-		const handler = ctx.grantRegistry.get("authorization");
+		const handler = ctx.grantRegistry.get("authorization_code");
 		expect(handler).toBeDefined();
 		if (!handler) return;
 

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -38,7 +38,7 @@ const mockConfig = {
 		refreshToken: { expiresIn: 86400 },
 		grants: {
 			session: { enabled: true },
-			authorization: { enabled: true },
+			authorization_code: { enabled: true },
 			refresh_token: { enabled: true },
 			did: { enabled: true, messageMaxAgeSec: 300 },
 		},

--- a/packages/oauth/src/__tests__/session.test.mts
+++ b/packages/oauth/src/__tests__/session.test.mts
@@ -31,7 +31,7 @@ const mockConfig = {
 		refreshToken: { expiresIn: 86400 },
 		grants: {
 			session: { enabled: true },
-			authorization: { enabled: true },
+			authorization_code: { enabled: true },
 			refresh_token: { enabled: true },
 			did: { enabled: true, messageMaxAgeSec: 300 },
 		},

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -36,7 +36,9 @@ export const createAuthorizationGrant = (
 	const { config, codeRepository, clientRepository, keyStore } = deps;
 
 	const grantsConfig = config.oauth.grants as Record<string, Record<string, unknown>> | undefined;
-	const authorizationConfig = grantsConfig?.authorization as Record<string, unknown> | undefined;
+	const authorizationConfig = grantsConfig?.authorization_code as
+		| Record<string, unknown>
+		| undefined;
 	const pkceConfig = authorizationConfig?.pkce as Record<string, unknown> | undefined;
 
 	// TODO-F-4: id_token issuance requires a configured issuer URL. We read it

--- a/packages/oauth/src/oauthAuthorization.mts
+++ b/packages/oauth/src/oauthAuthorization.mts
@@ -32,7 +32,7 @@ export const oauthAuthorizationModule = (params: {
 		const config = context.config as AppConfig;
 		const grantsConfig = config.oauth.grants as Record<string, { enabled?: boolean }>;
 
-		if (grantsConfig.authorization?.enabled !== false) {
+		if (grantsConfig.authorization_code?.enabled !== false) {
 			const handler = createAuthorizationGrant({
 				config,
 				keyStore: context.keyStore,
@@ -42,7 +42,7 @@ export const oauthAuthorizationModule = (params: {
 				userSessionStore: context.userSessionStore,
 				grantPolicy: context.grantPolicy,
 			});
-			context.grantRegistry.register("authorization", handler);
+			context.grantRegistry.register("authorization_code", handler);
 		}
 
 		if (grantsConfig.refresh_token?.enabled !== false) {

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -463,7 +463,7 @@ export const createOAuthRouter = async (
 					try {
 						decision = await grantPolicy.evaluate(
 							{
-								grantType: "authorization",
+								grantType: "authorization_code",
 								clientId: client_id,
 								subject: subjectForPolicy,
 								requestedScope: requestedScopes.length > 0 ? requestedScopes : undefined,

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -412,7 +412,7 @@ export const createOAuthRouter = async (
 				const grantsConfig = config.oauth.grants as
 					| Record<string, Record<string, unknown>>
 					| undefined;
-				const authorizationConfig = grantsConfig?.authorization as
+				const authorizationConfig = grantsConfig?.authorization_code as
 					| Record<string, unknown>
 					| undefined;
 				const pkceConfig = authorizationConfig?.pkce as Record<string, unknown> | undefined;

--- a/templates/standalone/README.ja.md
+++ b/templates/standalone/README.ja.md
@@ -69,7 +69,7 @@ overlay の値は `application.conf` を上書きします。scaffold には
 | 変数 | デフォルト | 説明 |
 |---|---|---|
 | `OAUTH_GRANTS_SESSION_ENABLED` | `true` | session グラントタイプを有効化 |
-| `OAUTH_GRANTS_AUTHORIZATION_ENABLED` | `true` | authorization code グラントタイプを有効化 |
+| `OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED` | `true` | authorization code グラントタイプを有効化 |
 | `OAUTH_GRANTS_REFRESH_TOKEN_ENABLED` | `true` | refresh token グラントタイプを有効化 |
 
 ### Session

--- a/templates/standalone/README.md
+++ b/templates/standalone/README.md
@@ -69,7 +69,7 @@ fail fast rather than silently falling back to defaults.
 | Variable | Default | Description |
 |---|---|---|
 | `OAUTH_GRANTS_SESSION_ENABLED` | `true` | Enable the session grant type |
-| `OAUTH_GRANTS_AUTHORIZATION_ENABLED` | `true` | Enable the authorization code grant type |
+| `OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED` | `true` | Enable the authorization code grant type |
 | `OAUTH_GRANTS_REFRESH_TOKEN_ENABLED` | `true` | Enable the refresh token grant type |
 
 ### Session

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -35,12 +35,12 @@ oauth {
   }
   grants {
     session { enabled = true, enabled = ${?OAUTH_GRANTS_SESSION_ENABLED} }
-    authorization {
+    authorization_code {
       enabled = true
-      enabled = ${?OAUTH_GRANTS_AUTHORIZATION_ENABLED}
+      enabled = ${?OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED}
       pkce {
         requireS256 = false
-        requireS256 = ${?OAUTH_GRANTS_AUTHORIZATION_PKCE_REQUIRE_S256}
+        requireS256 = ${?OAUTH_GRANTS_AUTHORIZATION_CODE_PKCE_REQUIRE_S256}
       }
     }
     refresh_token { enabled = true, enabled = ${?OAUTH_GRANTS_REFRESH_TOKEN_ENABLED} }

--- a/templates/standalone/tests/did-grant.test.js
+++ b/templates/standalone/tests/did-grant.test.js
@@ -41,7 +41,7 @@ const createDidAuthRequest = async (overrides = {}) => {
 	const signature = await ed.signAsync(messageBytes, privateKey);
 
 	return {
-		grant_type: "did",
+		grant_type: "urn:o3co:oauth:grant-type:did",
 		did,
 		signature: Buffer.from(signature).toString("base64"),
 		message,
@@ -54,7 +54,7 @@ const createDidAuthRequest = async (overrides = {}) => {
 	};
 };
 
-describe("POST /oauth/token grant_type=did", () => {
+describe("POST /oauth/token grant_type=urn:o3co:oauth:grant-type:did", () => {
 	it("returns a JWT access token for a valid DID authentication", async () => {
 		const body = await createDidAuthRequest();
 		const res = await client.post("/oauth/token", body);
@@ -92,7 +92,7 @@ describe("POST /oauth/token grant_type=did", () => {
 		const signature = await ed.signAsync(messageBytes, privateKey);
 
 		const res = await client.post("/oauth/token", {
-			grant_type: "did",
+			grant_type: "urn:o3co:oauth:grant-type:did",
 			did,
 			signature: Buffer.from(signature).toString("base64"),
 			message,
@@ -121,7 +121,7 @@ describe("POST /oauth/token grant_type=did", () => {
 	it("returns 400 when required fields are missing", async () => {
 		// Missing did
 		const res1 = await client.post("/oauth/token", {
-			grant_type: "did",
+			grant_type: "urn:o3co:oauth:grant-type:did",
 			signature: "abc",
 			message: "{}",
 		});
@@ -130,7 +130,7 @@ describe("POST /oauth/token grant_type=did", () => {
 
 		// Missing signature
 		const res2 = await client.post("/oauth/token", {
-			grant_type: "did",
+			grant_type: "urn:o3co:oauth:grant-type:did",
 			did: "did:example:test",
 			message: "{}",
 		});
@@ -138,7 +138,7 @@ describe("POST /oauth/token grant_type=did", () => {
 
 		// Missing message
 		const res3 = await client.post("/oauth/token", {
-			grant_type: "did",
+			grant_type: "urn:o3co:oauth:grant-type:did",
 			did: "did:example:test",
 			signature: "abc",
 		});
@@ -147,7 +147,7 @@ describe("POST /oauth/token grant_type=did", () => {
 
 	it("returns 400 when message is not valid JSON", async () => {
 		const res = await client.post("/oauth/token", {
-			grant_type: "did",
+			grant_type: "urn:o3co:oauth:grant-type:did",
 			did: "did:example:test",
 			signature: "abc",
 			message: "not-json",
@@ -159,7 +159,7 @@ describe("POST /oauth/token grant_type=did", () => {
 
 	it("returns 400 when message.did does not match top-level did", async () => {
 		const res = await client.post("/oauth/token", {
-			grant_type: "did",
+			grant_type: "urn:o3co:oauth:grant-type:did",
 			did: "did:example:one",
 			signature: "abc",
 			message: JSON.stringify({
@@ -182,7 +182,7 @@ describe("POST /oauth/token grant_type=did", () => {
 		});
 
 		const res = await client.post("/oauth/token", {
-			grant_type: "did",
+			grant_type: "urn:o3co:oauth:grant-type:did",
 			did,
 			signature: "abc",
 			message,

--- a/templates/standalone/tests/did-grant.test.js
+++ b/templates/standalone/tests/did-grant.test.js
@@ -21,6 +21,11 @@ import { describe, expect, it } from "vitest";
 
 const BASE_URL = process.env.API_BASE_URL || "http://localhost:3000";
 
+// Wire value for the DID grant. Mirrors `DID_GRANT_TYPE` in
+// `packages/did/src/module.mts`. A future rename of the URN should
+// only touch the constant, not every test site.
+const DID_GRANT_TYPE = "urn:o3co:oauth:grant-type:did";
+
 const client = axios.create({
 	baseURL: BASE_URL,
 	validateStatus: () => true,
@@ -41,7 +46,7 @@ const createDidAuthRequest = async (overrides = {}) => {
 	const signature = await ed.signAsync(messageBytes, privateKey);
 
 	return {
-		grant_type: "urn:o3co:oauth:grant-type:did",
+		grant_type: DID_GRANT_TYPE,
 		did,
 		signature: Buffer.from(signature).toString("base64"),
 		message,
@@ -92,7 +97,7 @@ describe("POST /oauth/token grant_type=urn:o3co:oauth:grant-type:did", () => {
 		const signature = await ed.signAsync(messageBytes, privateKey);
 
 		const res = await client.post("/oauth/token", {
-			grant_type: "urn:o3co:oauth:grant-type:did",
+			grant_type: DID_GRANT_TYPE,
 			did,
 			signature: Buffer.from(signature).toString("base64"),
 			message,
@@ -121,7 +126,7 @@ describe("POST /oauth/token grant_type=urn:o3co:oauth:grant-type:did", () => {
 	it("returns 400 when required fields are missing", async () => {
 		// Missing did
 		const res1 = await client.post("/oauth/token", {
-			grant_type: "urn:o3co:oauth:grant-type:did",
+			grant_type: DID_GRANT_TYPE,
 			signature: "abc",
 			message: "{}",
 		});
@@ -130,7 +135,7 @@ describe("POST /oauth/token grant_type=urn:o3co:oauth:grant-type:did", () => {
 
 		// Missing signature
 		const res2 = await client.post("/oauth/token", {
-			grant_type: "urn:o3co:oauth:grant-type:did",
+			grant_type: DID_GRANT_TYPE,
 			did: "did:example:test",
 			message: "{}",
 		});
@@ -138,7 +143,7 @@ describe("POST /oauth/token grant_type=urn:o3co:oauth:grant-type:did", () => {
 
 		// Missing message
 		const res3 = await client.post("/oauth/token", {
-			grant_type: "urn:o3co:oauth:grant-type:did",
+			grant_type: DID_GRANT_TYPE,
 			did: "did:example:test",
 			signature: "abc",
 		});
@@ -147,7 +152,7 @@ describe("POST /oauth/token grant_type=urn:o3co:oauth:grant-type:did", () => {
 
 	it("returns 400 when message is not valid JSON", async () => {
 		const res = await client.post("/oauth/token", {
-			grant_type: "urn:o3co:oauth:grant-type:did",
+			grant_type: DID_GRANT_TYPE,
 			did: "did:example:test",
 			signature: "abc",
 			message: "not-json",
@@ -159,7 +164,7 @@ describe("POST /oauth/token grant_type=urn:o3co:oauth:grant-type:did", () => {
 
 	it("returns 400 when message.did does not match top-level did", async () => {
 		const res = await client.post("/oauth/token", {
-			grant_type: "urn:o3co:oauth:grant-type:did",
+			grant_type: DID_GRANT_TYPE,
 			did: "did:example:one",
 			signature: "abc",
 			message: JSON.stringify({
@@ -182,7 +187,7 @@ describe("POST /oauth/token grant_type=urn:o3co:oauth:grant-type:did", () => {
 		});
 
 		const res = await client.post("/oauth/token", {
-			grant_type: "urn:o3co:oauth:grant-type:did",
+			grant_type: DID_GRANT_TYPE,
 			did,
 			signature: "abc",
 			message,

--- a/templates/standalone/tests/index.test.js
+++ b/templates/standalone/tests/index.test.js
@@ -172,8 +172,8 @@ describe("POST /oauth/token", () => {
 		expect(res.status).toBe(400);
 	});
 
-	it("returns 400 for grant_type=authorization without a code", async () => {
-		const res = await client.post("/oauth/token", "grant_type=authorization", {
+	it("returns 400 for grant_type=authorization_code without a code", async () => {
+		const res = await client.post("/oauth/token", "grant_type=authorization_code", {
 			headers: { "Content-Type": "application/x-www-form-urlencoded" },
 		});
 		expect(res.status).toBe(400);


### PR DESCRIPTION
## Summary

v0.5.0 Core GA must #3: grant_type RFC compliance + URN-ification. Interface-freeze preparation work ahead of 1.0 GA.

**Wire value changes:**

- `grant_type=authorization` → `grant_type=authorization_code` (RFC 6749 §4.1.3 compliance)
- `grant_type=did` → `grant_type=urn:o3co:oauth:grant-type:did` (fixed URN owned by auth.provider as the wire protocol definer, per RFC 6755 §3)
- `grant_type=session` unchanged

**Aligned surfaces:**

- HOCON config section key `oauth.grants.authorization` → `authorization_code`
- Env vars `OAUTH_GRANTS_AUTHORIZATION_*` → `OAUTH_GRANTS_AUTHORIZATION_CODE_*`
- `GrantPolicyRequest.grantType` (policy input at `/oauth/authorize`) now carries `"authorization_code"`
- `details.grant_type` (audit event field) schema unchanged, values follow wire automatically

Hard break — no dual-accept legacy. dplaas.auth will follow Option X (bulk migration after v0.5.0 publish).

**Design rationale for fixed `urn:o3co:` URN:** the DID wire protocol (`did` + `message` + `signature` form parameters) is defined by auth.provider. Under RFC 6755 §3 sub-namespace ownership, the URN is owned by the wire protocol definer — `o3co` here is a wire-protocol-version identifier, not a vendor lock-in marker. Consumers extending the wire protocol (e.g. VC Presentation embedding) should define a new grant under their own URN namespace, not override this one. Full rationale in [`packages/did/README.md`](packages/did/README.md#grant-type-urn).

**Spec:** [.claude/superpowers/specs/2026-04-24-grant-type-rename-design.md](.claude/superpowers/specs/2026-04-24-grant-type-rename-design.md)
**Plan:** [.claude/superpowers/plans/2026-04-24-grant-type-rename.md](.claude/superpowers/plans/2026-04-24-grant-type-rename.md)

15 commits across 11 tasks (TDD discipline, per-task subagent-driven review with 2-stage spec + code-quality gate).

## Test plan

- [x] `pnpm -r typecheck` clean (all packages)
- [x] `pnpm -r test` green (488 tests + 2 todos across 8 packages)
- [x] `pnpm -r build` clean
- [x] `pnpm lint` 0 errors (17 pre-existing warnings maintained, no new lint regressions)
- [x] Straggler grep clean on runtime code / config / README
- [ ] `/multi-agent-review` (user-triggered)
- [ ] Copilot review resolved

## Migration guide

See [CHANGELOG.md](CHANGELOG.md) `### Breaking Changes` section under `[Unreleased]` for client migration, HOCON update, and `GrantPolicyHookBase` adapter update steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)