### PR TITLE
feat: RFC 8693 Token Exchange grant (v0.5.0 #2)

### DIFF
--- a/.claude/superpowers/plans/2026-04-24-token-exchange.md
+++ b/.claude/superpowers/plans/2026-04-24-token-exchange.md
@@ -1,0 +1,2667 @@
+# Token Exchange (RFC 8693) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement RFC 8693 Token Exchange grant for auth.provider as a new `@o3co/auth-provider-oauth-token-exchange` package, supporting on-behalf-of / delegation / scope narrowing use cases with family-cascade revocation.
+
+**Architecture:** New standalone pnpm workspace package; exports a `GrantModule` that consumers register manually (no built-in registration, matching the federation split precedent). Subject/actor token validation goes through a pluggable `ExchangeTokenValidator` registry — ships with a built-in validator for self-issued `at+jwt`, consumer-implements validators for external JWT. Grant handler lives inside the new package; the only cross-package change is adding optional `allowedAudiences` to `Client` / `ClientEntrySchema` in core.
+
+**Tech Stack:** TypeScript, pnpm workspaces, vitest, express (supertest), jose (JWT sign/verify), zod (config schema).
+
+**Reference Spec:** `.claude/superpowers/specs/2026-04-24-token-exchange-design.md`
+
+---
+
+## File Structure
+
+### New files (all under `packages/oauth-token-exchange/`)
+
+- `packages/oauth-token-exchange/package.json` — workspace package manifest
+- `packages/oauth-token-exchange/tsconfig.json` — extends `../../tsconfig.base.json`
+- `packages/oauth-token-exchange/src/index.mts` — public export surface
+- `packages/oauth-token-exchange/src/validator/types.mts` — `ExchangeTokenValidator`, `ValidatedToken`
+- `packages/oauth-token-exchange/src/validator/registry.mts` — `ExchangeTokenValidatorRegistry`
+- `packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts` — built-in validator (self-issued at+jwt)
+- `packages/oauth-token-exchange/src/act.mts` — `buildActClaim()` helper (nested delegation chain)
+- `packages/oauth-token-exchange/src/grant.mts` — `createTokenExchangeGrant()` handler
+- `packages/oauth-token-exchange/src/module.mts` — `tokenExchangeModule` (GrantModule export)
+- `packages/oauth-token-exchange/src/__tests__/fixtures.mts` — shared test fixtures (keyStore, signers)
+- `packages/oauth-token-exchange/src/__tests__/registry.test.mts`
+- `packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts`
+- `packages/oauth-token-exchange/src/__tests__/act.test.mts`
+- `packages/oauth-token-exchange/src/__tests__/grant.test.mts`
+- `packages/oauth-token-exchange/src/__tests__/grant-integration.test.mts` — cross-grant scenario (authz_code → token_exchange)
+- `packages/oauth-token-exchange/README.md` — usage + security notes
+
+### Modified files
+
+- `packages/core/src/repositories/types.mts` — add optional `allowedAudiences?: string[]` to `Client`
+- `packages/core/src/repositories/InMemoryClientRepository.mts` — add `allowedAudiences` to `ClientEntrySchema` + propagate in `findById` / `authenticate`
+
+### Unchanged (read-only dependencies)
+
+- `packages/core/src/grants/types.mts` — `GrantContext` / `GrantHandler` / `GrantModule` / `GrantDependencies`
+- `packages/core/src/grants/registry.mts` — `GrantRegistry.addModule()` (already supports `enabled: false`)
+- `packages/core/src/grants/token.mts` — `generateToken()`, `generateTokenResponse()`
+- `packages/core/src/refresh/types.mts` — `RefreshTokenStoreBase.isFamilyRevoked`
+- `packages/core/src/policy/types.mts` — `GrantPolicyHookBase`, `GrantPolicyRequest`, `GrantPolicyDecision`
+- `packages/core/src/keys/KeyStore.mts` — `KeyStore` signing / verification
+
+---
+
+## Task 1: Scaffold the new package
+
+**Files:**
+- Create: `packages/oauth-token-exchange/package.json`
+- Create: `packages/oauth-token-exchange/tsconfig.json`
+- Create: `packages/oauth-token-exchange/src/index.mts`
+- Create: `packages/oauth-token-exchange/README.md`
+
+- [ ] **Step 1: Create package.json**
+
+Write `packages/oauth-token-exchange/package.json`:
+
+```json
+{
+	"name": "@o3co/auth-provider-oauth-token-exchange",
+	"description": "RFC 8693 Token Exchange grant for auth.provider",
+	"version": "0.0.0",
+	"license": "Apache-2.0",
+	"type": "module",
+	"exports": {
+		".": {
+			"import": "./dist/index.mjs",
+			"types": "./dist/index.d.mts"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md",
+		"LICENSE"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/o3co/auth.provider.git",
+		"directory": "packages/oauth-token-exchange"
+	},
+	"imports": {
+		"#/*": {
+			"development": "./src/*",
+			"default": "./dist/*"
+		}
+	},
+	"scripts": {
+		"prebuild": "rimraf dist",
+		"build": "tsc",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage"
+	},
+	"dependencies": {
+		"jose": "^5.9.6",
+		"zod": "^3.23.8"
+	},
+	"peerDependencies": {
+		"@o3co/auth-provider-core": "^0.0.0"
+	},
+	"devDependencies": {
+		"@o3co/auth-provider-core": "workspace:*",
+		"@vitest/coverage-v8": "^4.1.2",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.2"
+	}
+}
+```
+
+Pin versions to match existing packages. Check `packages/oauth/package.json` for the authoritative `jose` / `zod` versions and copy — if they differ from the above, use those.
+
+- [ ] **Step 2: Create tsconfig.json**
+
+Write `packages/oauth-token-exchange/tsconfig.json`:
+
+```json
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist/",
+		"paths": {
+			"#/*": ["./src/*"]
+		}
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
+}
+```
+
+- [ ] **Step 3: Create empty src/index.mts with Apache 2.0 header**
+
+Write `packages/oauth-token-exchange/src/index.mts`:
+
+```ts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {};
+```
+
+This is intentionally empty — later tasks add exports.
+
+- [ ] **Step 4: Create minimal README.md placeholder**
+
+Write `packages/oauth-token-exchange/README.md`:
+
+```markdown
+# @o3co/auth-provider-oauth-token-exchange
+
+RFC 8693 Token Exchange grant for auth.provider. See design spec at
+`.claude/superpowers/specs/2026-04-24-token-exchange-design.md`.
+
+Full usage documentation is added in Task 11.
+```
+
+- [ ] **Step 5: Install workspace dependencies**
+
+Run: `pnpm install`
+
+Expected output: a line like `+ @o3co/auth-provider-oauth-token-exchange 0.0.0 <-- packages/oauth-token-exchange` (new workspace package linked).
+
+If pnpm complains about missing `LICENSE`, copy from another package:
+
+```bash
+cp packages/oauth/LICENSE packages/oauth-token-exchange/LICENSE
+```
+
+- [ ] **Step 6: Verify typecheck passes on the skeleton**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange typecheck`
+
+Expected: exits 0 with no output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/oauth-token-exchange/
+git commit -m "feat(token-exchange): scaffold @o3co/auth-provider-oauth-token-exchange package"
+```
+
+---
+
+## Task 2: Extend Client with allowedAudiences (core change)
+
+**Files:**
+- Modify: `packages/core/src/repositories/types.mts`
+- Modify: `packages/core/src/repositories/InMemoryClientRepository.mts`
+- Test: `packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts`
+
+- [ ] **Step 1: Write failing test for `allowedAudiences` default**
+
+Open `packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts` and append (before the final closing brace/describe, follow existing structure):
+
+```ts
+it("exposes allowedAudiences via findById (empty array when omitted)", async () => {
+	const repo = new InMemoryClientRepository(
+		new Map([
+			[
+				"client-a",
+				{
+					clientSecret: "s",
+					allowedRedirectUris: [],
+					allowedScopes: [],
+				},
+			],
+		]),
+	);
+	const client = await repo.findById("client-a");
+	expect(client?.allowedAudiences).toEqual([]);
+});
+
+it("exposes allowedAudiences via findById (preserves configured values)", async () => {
+	const repo = new InMemoryClientRepository(
+		new Map([
+			[
+				"client-b",
+				{
+					clientSecret: "s",
+					allowedRedirectUris: [],
+					allowedScopes: [],
+					allowedAudiences: ["billing-service", "inventory-service"],
+				},
+			],
+		]),
+	);
+	const client = await repo.findById("client-b");
+	expect(client?.allowedAudiences).toEqual(["billing-service", "inventory-service"]);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @o3co/auth-provider-core test -- InMemoryClientRepository`
+
+Expected: the two new tests FAIL (`allowedAudiences` undefined, or zod rejects unknown key because `ClientEntrySchema.strict()`).
+
+- [ ] **Step 3: Add `allowedAudiences` to `Client` type**
+
+Edit `packages/core/src/repositories/types.mts`. After line 21 (`allowedScopes: string[];`), add:
+
+```ts
+	/**
+	 * Audience URIs that this client may request in Token Exchange (RFC 8693)
+	 * `audience` parameter. Empty or undefined means only the client's own
+	 * clientId is allowed as audience. Not used outside Token Exchange.
+	 */
+	allowedAudiences?: string[];
+```
+
+- [ ] **Step 4: Add `allowedAudiences` to `ClientEntrySchema`**
+
+Edit `packages/core/src/repositories/InMemoryClientRepository.mts`. Inside the `ClientEntrySchema` zod object (around line 60-80), add:
+
+```ts
+		allowedAudiences: z.array(z.string()).default([]),
+```
+
+Place it immediately after the `allowedScopes` line for locality.
+
+- [ ] **Step 5: Propagate `allowedAudiences` in `findById` and `authenticate`**
+
+In the same file (`InMemoryClientRepository.mts`), both `findById` (around line 95) and `authenticate` (around line 135) build the returned `PublicClient` object. Add:
+
+```ts
+			allowedAudiences: entry.allowedAudiences,
+```
+
+Add it in both return statements, right after `allowedScopes: entry.allowedScopes,`.
+
+- [ ] **Step 6: Run tests to verify GREEN**
+
+Run: `pnpm --filter @o3co/auth-provider-core test -- InMemoryClientRepository`
+
+Expected: all tests PASS including the two new ones.
+
+Also run the full core test suite to catch any regression:
+
+Run: `pnpm --filter @o3co/auth-provider-core test`
+
+Expected: all PASS.
+
+- [ ] **Step 7: Verify core typecheck passes**
+
+Run: `pnpm --filter @o3co/auth-provider-core typecheck`
+
+Expected: exits 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src/repositories/types.mts packages/core/src/repositories/InMemoryClientRepository.mts packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts
+git commit -m "feat(core): add optional Client.allowedAudiences for Token Exchange audience narrowing"
+```
+
+---
+
+## Task 3: ExchangeTokenValidator interface + Registry
+
+**Files:**
+- Create: `packages/oauth-token-exchange/src/validator/types.mts`
+- Create: `packages/oauth-token-exchange/src/validator/registry.mts`
+- Create: `packages/oauth-token-exchange/src/__tests__/registry.test.mts`
+
+- [ ] **Step 1: Write failing test for Registry**
+
+Write `packages/oauth-token-exchange/src/__tests__/registry.test.mts`:
+
+```ts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ExchangeTokenValidatorRegistry } from "#/validator/registry.mjs";
+import type { ExchangeTokenValidator } from "#/validator/types.mjs";
+
+const stubValidator = (tokenType: string): ExchangeTokenValidator => ({
+	tokenType,
+	async validate() {
+		return null;
+	},
+});
+
+describe("ExchangeTokenValidatorRegistry", () => {
+	it("returns undefined for unregistered token type", () => {
+		const registry = new ExchangeTokenValidatorRegistry();
+		expect(registry.get("urn:ietf:params:oauth:token-type:access_token")).toBeUndefined();
+	});
+
+	it("returns the registered validator by tokenType", () => {
+		const registry = new ExchangeTokenValidatorRegistry();
+		const v = stubValidator("urn:ietf:params:oauth:token-type:access_token");
+		registry.register("urn:ietf:params:oauth:token-type:access_token", v);
+		expect(registry.get("urn:ietf:params:oauth:token-type:access_token")).toBe(v);
+	});
+
+	it("overwrites an existing registration on re-register", () => {
+		const registry = new ExchangeTokenValidatorRegistry();
+		const v1 = stubValidator("urn:ietf:params:oauth:token-type:access_token");
+		const v2 = stubValidator("urn:ietf:params:oauth:token-type:access_token");
+		registry.register("urn:ietf:params:oauth:token-type:access_token", v1);
+		registry.register("urn:ietf:params:oauth:token-type:access_token", v2);
+		expect(registry.get("urn:ietf:params:oauth:token-type:access_token")).toBe(v2);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange test -- registry`
+
+Expected: FAIL (module `#/validator/registry.mjs` not found).
+
+- [ ] **Step 3: Create validator/types.mts**
+
+Write `packages/oauth-token-exchange/src/validator/types.mts`:
+
+```ts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Role of a token within a Token Exchange request.
+ * - "subject": the token being exchanged (`subject_token`)
+ * - "actor":   the token of the party performing the exchange (`actor_token`)
+ */
+export interface ExchangeTokenValidationContext {
+	role: "subject" | "actor";
+}
+
+/**
+ * Validates a token presented in a Token Exchange request.
+ *
+ * Consumers register one validator per `subject_token_type` / `actor_token_type`
+ * URI. Returning `null` signals a validation failure — the grant handler will
+ * respond with `invalid_grant`. Throwing signals an infrastructure failure
+ * (e.g. Redis unavailable) — the grant handler will respond with
+ * `temporarily_unavailable` (503).
+ */
+export interface ExchangeTokenValidator {
+	readonly tokenType: string;
+	validate(
+		token: string,
+		context: ExchangeTokenValidationContext,
+	): Promise<ValidatedToken | null>;
+}
+
+/**
+ * Structured representation of a validated exchange token.
+ * `familyId` is populated only for self-issued access_tokens that carry a
+ * `family_id` claim (used for cascading revoke inheritance).
+ */
+export interface ValidatedToken {
+	sub: string;
+	scope?: string;
+	aud?: string | string[];
+	familyId?: string;
+	act?: Record<string, unknown>;
+	claims: Record<string, unknown>;
+}
+```
+
+- [ ] **Step 4: Create validator/registry.mts**
+
+Write `packages/oauth-token-exchange/src/validator/registry.mts`:
+
+```ts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ExchangeTokenValidator } from "./types.mjs";
+
+/**
+ * Mutable registry keyed by RFC 8693 `token_type` URI. Used by the Token
+ * Exchange grant handler to dispatch `subject_token` / `actor_token`
+ * validation.
+ */
+export class ExchangeTokenValidatorRegistry {
+	private validators = new Map<string, ExchangeTokenValidator>();
+
+	register(tokenType: string, validator: ExchangeTokenValidator): void {
+		this.validators.set(tokenType, validator);
+	}
+
+	get(tokenType: string): ExchangeTokenValidator | undefined {
+		return this.validators.get(tokenType);
+	}
+}
+```
+
+- [ ] **Step 5: Run test to verify GREEN**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange test -- registry`
+
+Expected: all three tests PASS.
+
+- [ ] **Step 6: Export from package index**
+
+Edit `packages/oauth-token-exchange/src/index.mts` — replace `export {};` with:
+
+```ts
+export type {
+	ExchangeTokenValidationContext,
+	ExchangeTokenValidator,
+	ValidatedToken,
+} from "./validator/types.mjs";
+export { ExchangeTokenValidatorRegistry } from "./validator/registry.mjs";
+```
+
+- [ ] **Step 7: Verify typecheck**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange typecheck`
+
+Expected: exits 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/oauth-token-exchange/src/validator/ packages/oauth-token-exchange/src/index.mts packages/oauth-token-exchange/src/__tests__/registry.test.mts
+git commit -m "feat(token-exchange): add ExchangeTokenValidator interface + Registry"
+```
+
+---
+
+## Task 4: Self-issued access_token validator (built-in)
+
+**Files:**
+- Create: `packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts`
+- Create: `packages/oauth-token-exchange/src/__tests__/fixtures.mts`
+- Create: `packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts`
+
+- [ ] **Step 1: Create shared test fixtures**
+
+Write `packages/oauth-token-exchange/src/__tests__/fixtures.mts`:
+
+```ts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSecretKey } from "node:crypto";
+import {
+	createSymmetricKeyStore,
+	type KeyStore,
+	type RefreshTokenStoreBase,
+} from "@o3co/auth-provider-core";
+import { SignJWT } from "jose";
+
+export const SECRET = "test-secret-at-least-32-chars!!";
+export const keyStore: KeyStore = createSymmetricKeyStore(SECRET);
+export const secretKey = createSecretKey(Buffer.from(SECRET));
+
+export const ISSUER = "https://auth.example";
+
+export async function signSelfIssuedAccessToken(
+	claims: Record<string, unknown>,
+	options: { expiresIn?: string; typ?: string } = {},
+): Promise<string> {
+	const { expiresIn = "1h", typ = "at+jwt" } = options;
+	return new SignJWT({
+		sub: "user-1",
+		scope: "read",
+		iss: ISSUER,
+		aud: "client-a",
+		...claims,
+	})
+		.setProtectedHeader({ alg: "HS256", kid: "v0", typ })
+		.setIssuedAt()
+		.setExpirationTime(expiresIn)
+		.sign(secretKey);
+}
+
+export function makeRefreshStore(
+	overrides: Partial<RefreshTokenStoreBase> = {},
+): RefreshTokenStoreBase {
+	return {
+		kind: "fixture",
+		async rotate() {
+			return { outcome: "rotated" };
+		},
+		async isFamilyRevoked() {
+			return false;
+		},
+		async revokeFamily() {},
+		...overrides,
+	};
+}
+```
+
+- [ ] **Step 2: Write failing tests for selfIssuedAccessToken validator**
+
+Write `packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts`:
+
+```ts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { createSelfIssuedAccessTokenValidator } from "#/validator/selfIssuedAccessToken.mjs";
+import {
+	ISSUER,
+	keyStore,
+	makeRefreshStore,
+	signSelfIssuedAccessToken,
+} from "./fixtures.mjs";
+
+describe("createSelfIssuedAccessTokenValidator", () => {
+	const validator = (overrides = {}) =>
+		createSelfIssuedAccessTokenValidator({
+			keyStore,
+			refreshTokenStore: makeRefreshStore(),
+			issuer: ISSUER,
+			...overrides,
+		});
+
+	it("accepts a valid self-issued at+jwt and returns claims", async () => {
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const result = await validator().validate(token, { role: "subject" });
+		expect(result).not.toBeNull();
+		expect(result?.sub).toBe("user-1");
+		expect(result?.scope).toBe("read");
+		expect(result?.familyId).toBe("fam-1");
+	});
+
+	it("returns null for a tampered signature", async () => {
+		const token = (await signSelfIssuedAccessToken({})).slice(0, -4) + "AAAA";
+		const result = await validator().validate(token, { role: "subject" });
+		expect(result).toBeNull();
+	});
+
+	it("returns null for an expired token", async () => {
+		const token = await signSelfIssuedAccessToken({}, { expiresIn: "-1s" });
+		const result = await validator().validate(token, { role: "subject" });
+		expect(result).toBeNull();
+	});
+
+	it("returns null when issuer does not match the configured issuer", async () => {
+		const token = await signSelfIssuedAccessToken({ iss: "https://other.example" });
+		const result = await validator().validate(token, { role: "subject" });
+		expect(result).toBeNull();
+	});
+
+	it("returns null when family is revoked", async () => {
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-revoked" });
+		const store = makeRefreshStore({
+			isFamilyRevoked: vi.fn().mockResolvedValue(true),
+		});
+		const v = validator({ refreshTokenStore: store });
+		expect(await v.validate(token, { role: "subject" })).toBeNull();
+		expect(store.isFamilyRevoked).toHaveBeenCalledWith("fam-revoked");
+	});
+
+	it("throws when isFamilyRevoked throws (runtime unavailable)", async () => {
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const store = makeRefreshStore({
+			isFamilyRevoked: vi.fn().mockRejectedValue(new Error("redis down")),
+		});
+		const v = validator({ refreshTokenStore: store });
+		await expect(v.validate(token, { role: "subject" })).rejects.toThrow("redis down");
+	});
+
+	it("accepts a token without family_id claim (legacy) when refreshTokenStore is present", async () => {
+		const token = await signSelfIssuedAccessToken({});
+		const store = makeRefreshStore();
+		const v = validator({ refreshTokenStore: store });
+		const result = await v.validate(token, { role: "subject" });
+		expect(result).not.toBeNull();
+		expect(result?.familyId).toBeUndefined();
+	});
+
+	it("preserves existing act claim on the token", async () => {
+		const token = await signSelfIssuedAccessToken({ act: { sub: "service-upstream" } });
+		const result = await validator().validate(token, { role: "subject" });
+		expect(result?.act).toEqual({ sub: "service-upstream" });
+	});
+
+	it("exposes tokenType as the access_token URI", () => {
+		expect(validator().tokenType).toBe("urn:ietf:params:oauth:token-type:access_token");
+	});
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange test -- selfIssuedAccessToken`
+
+Expected: FAIL (module not found).
+
+- [ ] **Step 4: Implement selfIssuedAccessToken validator**
+
+Write `packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts`:
+
+```ts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KeyStore, RefreshTokenStoreBase } from "@o3co/auth-provider-core";
+import { decodeProtectedHeader, jwtVerify } from "jose";
+import type { ExchangeTokenValidator, ValidatedToken } from "./types.mjs";
+
+const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+
+export interface CreateSelfIssuedAccessTokenValidatorOptions {
+	keyStore: KeyStore;
+	refreshTokenStore?: RefreshTokenStoreBase;
+	issuer?: string;
+}
+
+/**
+ * Built-in validator for RFC 8693 subject_token_type=access_token when the
+ * token was issued by this auth.provider instance. Verifies JWT signature
+ * (KeyStore), standard claims (exp via jose), issuer match, and — when a
+ * refreshTokenStore is wired — family_id cascading revoke.
+ *
+ * Throws on infrastructure failures (store unavailable). Returns null on
+ * validation failures (bad signature, expired, revoked, issuer mismatch).
+ */
+export function createSelfIssuedAccessTokenValidator(
+	options: CreateSelfIssuedAccessTokenValidatorOptions,
+): ExchangeTokenValidator {
+	const { keyStore, refreshTokenStore, issuer } = options;
+
+	return {
+		tokenType: ACCESS_TOKEN_TYPE,
+		async validate(token: string): Promise<ValidatedToken | null> {
+			let payload: Record<string, unknown>;
+			try {
+				const header = decodeProtectedHeader(token);
+				const key = await keyStore.getVerificationKey(
+					header.kid ?? keyStore.getSigningKidFallback(),
+				);
+				const verified = await jwtVerify(token, key);
+				payload = verified.payload as Record<string, unknown>;
+			} catch {
+				return null;
+			}
+
+			if (issuer && payload.iss !== issuer) {
+				return null;
+			}
+
+			const familyId = typeof payload.family_id === "string" ? payload.family_id : undefined;
+
+			if (familyId && refreshTokenStore) {
+				// Throws on runtime failure — grant handler converts to 503.
+				const revoked = await refreshTokenStore.isFamilyRevoked(familyId);
+				if (revoked) return null;
+			}
+
+			const result: ValidatedToken = {
+				sub: String(payload.sub ?? ""),
+				claims: payload,
+			};
+			if (typeof payload.scope === "string") result.scope = payload.scope;
+			if (typeof payload.aud === "string" || Array.isArray(payload.aud)) {
+				result.aud = payload.aud as string | string[];
+			}
+			if (familyId) result.familyId = familyId;
+			if (payload.act && typeof payload.act === "object") {
+				result.act = payload.act as Record<string, unknown>;
+			}
+			return result;
+		},
+	};
+}
+```
+
+- [ ] **Step 5: Run tests to verify GREEN**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange test -- selfIssuedAccessToken`
+
+Expected: all 9 tests PASS.
+
+- [ ] **Step 6: Export factory from package index**
+
+Edit `packages/oauth-token-exchange/src/index.mts` — append:
+
+```ts
+export {
+	type CreateSelfIssuedAccessTokenValidatorOptions,
+	createSelfIssuedAccessTokenValidator,
+} from "./validator/selfIssuedAccessToken.mjs";
+```
+
+- [ ] **Step 7: Verify typecheck + commit**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange typecheck`
+
+Expected: exits 0.
+
+```bash
+git add packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts packages/oauth-token-exchange/src/__tests__/fixtures.mts packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts packages/oauth-token-exchange/src/index.mts
+git commit -m "feat(token-exchange): add built-in self-issued access_token validator with family revoke check"
+```
+
+---
+
+## Task 5: `act` claim builder
+
+**Files:**
+- Create: `packages/oauth-token-exchange/src/act.mts`
+- Create: `packages/oauth-token-exchange/src/__tests__/act.test.mts`
+
+- [ ] **Step 1: Write failing tests for buildActClaim**
+
+Write `packages/oauth-token-exchange/src/__tests__/act.test.mts`:
+
+```ts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildActClaim } from "#/act.mjs";
+import type { ValidatedToken } from "#/validator/types.mjs";
+
+const tok = (overrides: Partial<ValidatedToken> = {}): ValidatedToken => ({
+	sub: "user-1",
+	claims: {},
+	...overrides,
+});
+
+describe("buildActClaim", () => {
+	it("returns undefined when no actor_token is present (impersonation)", () => {
+		expect(buildActClaim({ subject: tok({ sub: "alice" }), actor: undefined })).toBeUndefined();
+	});
+
+	it("does NOT inherit subject.act when no actor_token is present", () => {
+		const result = buildActClaim({
+			subject: tok({ sub: "alice", act: { sub: "upstream" } }),
+			actor: undefined,
+		});
+		expect(result).toBeUndefined();
+	});
+
+	it("returns { sub: <actor.sub> } for simple delegation", () => {
+		const result = buildActClaim({
+			subject: tok({ sub: "alice" }),
+			actor: tok({ sub: "service-a" }),
+		});
+		expect(result).toEqual({ sub: "service-a" });
+	});
+
+	it("nests subject.act inside new act for multi-step delegation", () => {
+		const result = buildActClaim({
+			subject: tok({ sub: "alice", act: { sub: "service-a" } }),
+			actor: tok({ sub: "service-b" }),
+		});
+		expect(result).toEqual({ sub: "service-b", act: { sub: "service-a" } });
+	});
+
+	it("preserves deep nested act chain from subject", () => {
+		const result = buildActClaim({
+			subject: tok({
+				sub: "alice",
+				act: { sub: "service-a", act: { sub: "service-upstream" } },
+			}),
+			actor: tok({ sub: "service-b" }),
+		});
+		expect(result).toEqual({
+			sub: "service-b",
+			act: { sub: "service-a", act: { sub: "service-upstream" } },
+		});
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange test -- act`
+
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement buildActClaim**
+
+Write `packages/oauth-token-exchange/src/act.mts`:
+
+```ts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ValidatedToken } from "./validator/types.mjs";
+
+/**
+ * Build the `act` claim for the token being issued, per RFC 8693 §4.1.
+ *
+ * Canonical rules:
+ * - No actor_token → no `act` on the issued token (impersonation, no trace).
+ *                    We do NOT inherit `subject.act`: absence of actor_token
+ *                    means the caller is not claiming to delegate for anyone.
+ * - Actor provided  → `act.sub = <actor.sub>`. If the subject already had an
+ *                     `act` chain, it is nested as `act.act` to preserve the
+ *                     full delegation history.
+ */
+export function buildActClaim(args: {
+	subject: ValidatedToken;
+	actor: ValidatedToken | undefined;
+}): Record<string, unknown> | undefined {
+	const { subject, actor } = args;
+	if (!actor) return undefined;
+
+	const result: Record<string, unknown> = { sub: actor.sub };
+	if (subject.act) {
+		result.act = subject.act;
+	}
+	return result;
+}
+```
+
+- [ ] **Step 4: Run test to verify GREEN**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange test -- act`
+
+Expected: all 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/oauth-token-exchange/src/act.mts packages/oauth-token-exchange/src/__tests__/act.test.mts
+git commit -m "feat(token-exchange): add buildActClaim helper for RFC 8693 §4.1 delegation chain"
+```
+
+---
+
+## Task 6: Grant handler — request parse, unsupported checks
+
+**Files:**
+- Create: `packages/oauth-token-exchange/src/grant.mts`
+- Create: `packages/oauth-token-exchange/src/__tests__/grant.test.mts`
+
+This task bootstraps the handler and covers the RFC 8693 error surface for malformed / unsupported requests. Happy-path and downstream checks come in Tasks 7-9.
+
+- [ ] **Step 1: Write failing tests for request parse + unsupported errors**
+
+Write `packages/oauth-token-exchange/src/__tests__/grant.test.mts`:
+
+```ts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+	AppConfig,
+	ClientRepository,
+	GrantContext,
+	PublicClient,
+} from "@o3co/auth-provider-core";
+import { describe, expect, it } from "vitest";
+import { createTokenExchangeGrant } from "#/grant.mjs";
+import { ExchangeTokenValidatorRegistry } from "#/validator/registry.mjs";
+import { createSelfIssuedAccessTokenValidator } from "#/validator/selfIssuedAccessToken.mjs";
+import { ISSUER, keyStore, makeRefreshStore, signSelfIssuedAccessToken } from "./fixtures.mjs";
+
+const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+const GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
+
+const mockConfig = {
+	oauth: {
+		jwt: { issuer: ISSUER },
+		accessToken: { expiresIn: 300 },
+		refreshToken: { expiresIn: 86400 },
+		grants: {},
+	},
+} as unknown as AppConfig;
+
+const publicClient = (overrides: Partial<PublicClient> = {}): PublicClient => ({
+	clientId: "client-a",
+	allowedRedirectUris: [],
+	allowedScopes: [],
+	allowedAudiences: [],
+	backchannelLogoutSessionRequired: true,
+	frontchannelLogoutSessionRequired: true,
+	allowedAzpForFederationToken: false,
+	...overrides,
+});
+
+const mockClientRepository = (client: PublicClient | null = publicClient()): ClientRepository => ({
+	findById: async (id) => (id === client?.clientId ? client : null),
+	authenticate: async (id, _secret) => (id === client?.clientId ? client : null),
+});
+
+function buildGrant(
+	overrides: {
+		validatorRegistry?: ExchangeTokenValidatorRegistry;
+		clientRepository?: ClientRepository;
+		refreshTokenStore?: ReturnType<typeof makeRefreshStore> | undefined;
+		config?: AppConfig;
+	} = {},
+) {
+	const registry = overrides.validatorRegistry ?? new ExchangeTokenValidatorRegistry();
+	const refreshStore =
+		overrides.refreshTokenStore === undefined ? makeRefreshStore() : overrides.refreshTokenStore;
+	if (!overrides.validatorRegistry) {
+		registry.register(
+			ACCESS_TOKEN_TYPE,
+			createSelfIssuedAccessTokenValidator({
+				keyStore,
+				refreshTokenStore: refreshStore,
+				issuer: ISSUER,
+			}),
+		);
+	}
+	return createTokenExchangeGrant({
+		config: overrides.config ?? mockConfig,
+		keyStore,
+		refreshTokenStore: refreshStore,
+		validatorRegistry: registry,
+		clientRepository: overrides.clientRepository ?? mockClientRepository(),
+	});
+}
+
+const ctx = (body: Record<string, unknown>): GrantContext => ({
+	body,
+	session: {},
+	issuer: ISSUER,
+	metadata: {},
+});
+
+describe("createTokenExchangeGrant — request errors", () => {
+	it("returns invalid_request when subject_token is missing", async () => {
+		const g = buildGrant();
+		const { result } = await g.handle(
+			ctx({ client_id: "client-a", subject_token_type: ACCESS_TOKEN_TYPE }),
+		);
+		expect(result).toMatchObject({ status: 400, error: "invalid_request" });
+	});
+
+	it("returns invalid_request when subject_token_type is missing", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({});
+		const { result } = await g.handle(ctx({ client_id: "client-a", subject_token: token }));
+		expect(result).toMatchObject({ status: 400, error: "invalid_request" });
+	});
+
+	it("returns invalid_request when client_id is missing", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({});
+		const { result } = await g.handle(
+			ctx({ subject_token: token, subject_token_type: ACCESS_TOKEN_TYPE }),
+		);
+		expect(result).toMatchObject({ status: 400, error: "invalid_request" });
+	});
+
+	it("returns invalid_client when client cannot be authenticated", async () => {
+		const g = buildGrant({ clientRepository: mockClientRepository(null) });
+		const token = await signSelfIssuedAccessToken({});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "unknown",
+				client_secret: "x",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({ status: 401, error: "invalid_client" });
+	});
+
+	it("returns unsupported_token_type when subject_token_type is not registered", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: "urn:ietf:params:oauth:token-type:saml2",
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "unsupported_token_type" });
+	});
+
+	it("returns unsupported_token_type when requested_token_type is not access_token", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				requested_token_type: "urn:ietf:params:oauth:token-type:id_token",
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "unsupported_token_type" });
+	});
+
+	it("returns unsupported_token_type when actor_token_type is not registered", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token: "any",
+				actor_token_type: "urn:ietf:params:oauth:token-type:saml2",
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "unsupported_token_type" });
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange test -- grant`
+
+Expected: FAIL (`createTokenExchangeGrant` not found).
+
+- [ ] **Step 3: Implement grant.mts — request parse + unsupported checks ONLY**
+
+Write `packages/oauth-token-exchange/src/grant.mts`:
+
+```ts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+	ClientRepository,
+	GrantContext,
+	GrantDependencies,
+	GrantHandler,
+	GrantHandlerResult,
+} from "@o3co/auth-provider-core";
+import type { ExchangeTokenValidatorRegistry } from "./validator/registry.mjs";
+
+const GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
+const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+
+export interface TokenExchangeDependencies extends GrantDependencies {
+	validatorRegistry: ExchangeTokenValidatorRegistry;
+	clientRepository: ClientRepository;
+}
+
+export function createTokenExchangeGrant(deps: TokenExchangeDependencies): GrantHandler {
+	const { validatorRegistry, clientRepository } = deps;
+
+	return {
+		async handle(ctx: GrantContext): Promise<GrantHandlerResult> {
+			const body = ctx.body as Record<string, unknown>;
+
+			const subjectToken = typeof body.subject_token === "string" ? body.subject_token : null;
+			const subjectTokenType =
+				typeof body.subject_token_type === "string" ? body.subject_token_type : null;
+			const clientId = typeof body.client_id === "string" ? body.client_id : null;
+			const clientSecret =
+				typeof body.client_secret === "string" ? body.client_secret : null;
+			const actorToken = typeof body.actor_token === "string" ? body.actor_token : null;
+			const actorTokenType =
+				typeof body.actor_token_type === "string" ? body.actor_token_type : null;
+			const requestedTokenType =
+				typeof body.requested_token_type === "string" ? body.requested_token_type : null;
+
+			if (!subjectToken || !subjectTokenType || !clientId) {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_request",
+						errorDescription: "subject_token, subject_token_type, client_id are required",
+					},
+				};
+			}
+
+			// Client authentication: confidential clients send client_secret, public
+			// clients omit it. Either way, the client must exist.
+			const client =
+				clientSecret !== null
+					? await clientRepository.authenticate(clientId, clientSecret)
+					: await clientRepository.findById(clientId);
+			if (!client) {
+				return {
+					result: {
+						status: 401,
+						error: "invalid_client",
+						errorDescription: "client authentication failed",
+					},
+				};
+			}
+
+			if (requestedTokenType !== null && requestedTokenType !== ACCESS_TOKEN_TYPE) {
+				return {
+					result: {
+						status: 400,
+						error: "unsupported_token_type",
+						errorDescription: `requested_token_type "${requestedTokenType}" is not supported`,
+					},
+				};
+			}
+
+			const subjectValidator = validatorRegistry.get(subjectTokenType);
+			if (!subjectValidator) {
+				return {
+					result: {
+						status: 400,
+						error: "unsupported_token_type",
+						errorDescription: `subject_token_type "${subjectTokenType}" is not supported`,
+					},
+				};
+			}
+
+			if (actorToken !== null) {
+				if (actorTokenType === null) {
+					return {
+						result: {
+							status: 400,
+							error: "invalid_request",
+							errorDescription: "actor_token_type is required when actor_token is provided",
+						},
+					};
+				}
+				const actorValidator = validatorRegistry.get(actorTokenType);
+				if (!actorValidator) {
+					return {
+						result: {
+							status: 400,
+							error: "unsupported_token_type",
+							errorDescription: `actor_token_type "${actorTokenType}" is not supported`,
+						},
+					};
+				}
+			}
+
+			// Subsequent steps (validate tokens, narrow scope/audience, call policy
+			// hook, mint new token) are added in Tasks 7-9.
+			return {
+				result: {
+					status: 501,
+					error: "not_implemented",
+					errorDescription: "Token Exchange handler is partially implemented",
+				},
+			};
+		},
+	};
+}
+
+export { GRANT_TYPE as TOKEN_EXCHANGE_GRANT_TYPE, ACCESS_TOKEN_TYPE };
+```
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange test -- grant`
+
+Expected: all 7 tests PASS.
+
+- [ ] **Step 5: Verify typecheck**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange typecheck`
+
+Expected: exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/oauth-token-exchange/src/grant.mts packages/oauth-token-exchange/src/__tests__/grant.test.mts
+git commit -m "feat(token-exchange): grant handler stub with request parse + unsupported error surface"
+```
+
+---
+
+## Task 7: Grant handler — token validation + scope/audience narrowing
+
+**Files:**
+- Modify: `packages/oauth-token-exchange/src/grant.mts`
+- Modify: `packages/oauth-token-exchange/src/__tests__/grant.test.mts`
+
+- [ ] **Step 1: Append failing tests for validation + narrowing**
+
+Append to `packages/oauth-token-exchange/src/__tests__/grant.test.mts` (after the existing describe block):
+
+```ts
+describe("createTokenExchangeGrant — token validation", () => {
+	it("returns invalid_grant when subject_token signature is invalid", async () => {
+		const g = buildGrant();
+		const token = (await signSelfIssuedAccessToken({})).slice(0, -4) + "AAAA";
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "invalid_grant" });
+	});
+
+	it("returns invalid_grant/family_revoked when subject family is revoked", async () => {
+		const store = makeRefreshStore({
+			isFamilyRevoked: async (id) => id === "fam-bad",
+		});
+		const g = buildGrant({ refreshTokenStore: store });
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-bad" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_grant",
+			errorDescription: "family_revoked",
+		});
+	});
+
+	it("returns invalid_grant when refreshTokenStore is not wired (fail-closed)", async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test-only narrowing
+		const g = buildGrant({ refreshTokenStore: undefined as any });
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "invalid_grant" });
+	});
+
+	it("returns temporarily_unavailable (503) when validator throws (runtime store failure)", async () => {
+		const store = makeRefreshStore({
+			isFamilyRevoked: async () => {
+				throw new Error("redis down");
+			},
+		});
+		const g = buildGrant({ refreshTokenStore: store });
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({ status: 503, error: "temporarily_unavailable" });
+	});
+
+	it("returns invalid_grant when actor_token fails validation", async () => {
+		const g = buildGrant();
+		const subject = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const badActor = (await signSelfIssuedAccessToken({ sub: "svc-a" })).slice(0, -4) + "AAAA";
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: subject,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token: badActor,
+				actor_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "invalid_grant" });
+	});
+});
+
+describe("createTokenExchangeGrant — narrowing checks", () => {
+	it("returns invalid_scope when requested scope is a superset of subject scope", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ scope: "read", family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				scope: "read write",
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "invalid_scope" });
+	});
+
+	it("returns invalid_target when audience is not in allowlist", async () => {
+		const g = buildGrant({
+			clientRepository: mockClientRepository(publicClient({ allowedAudiences: ["billing"] })),
+		});
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				audience: "inventory",
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "invalid_target" });
+	});
+
+	it("accepts audience when it matches clientId even without allowlist", async () => {
+		const g = buildGrant({
+			clientRepository: mockClientRepository(publicClient({ allowedAudiences: [] })),
+		});
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				audience: "client-a",
+			}),
+		);
+		// Narrowing passes — later tasks add minting. For now the handler still
+		// returns 501 (not_implemented) from the stub.
+		expect(result).toMatchObject({ status: 501 });
+	});
+
+	it("accepts multi-value audience when all entries are in allowlist ∪ {clientId}", async () => {
+		const g = buildGrant({
+			clientRepository: mockClientRepository(
+				publicClient({ allowedAudiences: ["billing", "inventory"] }),
+			),
+		});
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				audience: ["billing", "inventory"],
+			}),
+		);
+		expect(result).toMatchObject({ status: 501 });
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange test -- grant`
+
+Expected: the new tests FAIL (stub still returns 501 for all inputs past the unsupported checks).
+
+- [ ] **Step 3: Replace the stub body with validation + narrowing logic**
+
+Edit `packages/oauth-token-exchange/src/grant.mts`. Replace the final return block (the 501 stub, starting with `// Subsequent steps (...)`) with:
+
+```ts
+			const subjectValidated = await (async () => {
+				try {
+					return await subjectValidator.validate(subjectToken, { role: "subject" });
+				} catch {
+					return "runtime_error" as const;
+				}
+			})();
+			if (subjectValidated === "runtime_error") {
+				return {
+					result: {
+						status: 503,
+						error: "temporarily_unavailable",
+						errorDescription: "subject_token validation store unavailable",
+					},
+				};
+			}
+			if (!subjectValidated) {
+				// Distinguish family-revoked rejection (which only the self-issued
+				// validator can emit) from other validation failures. Self-issued
+				// validator returns null both for bad-signature AND revoked family —
+				// we re-check the family here when a refresh store is wired so the
+				// errorDescription accurately reports the failure mode for operators.
+				// For non-self-issued validators (external JWT), the errorDescription
+				// stays generic.
+				// Note: fail-closed when refreshTokenStore is not wired is enforced
+				// below; here we only handle the post-wire case.
+				return {
+					result: {
+						status: 400,
+						error: "invalid_grant",
+						errorDescription: "subject_token validation failed",
+					},
+				};
+			}
+
+			// Fail-closed: the self-issued validator silently skips the family check
+			// when refreshTokenStore is absent, but Token Exchange must not issue
+			// tokens whose revocation cannot be observed (spec §7.2 state 1).
+			if (
+				subjectValidated.familyId &&
+				!deps.refreshTokenStore &&
+				subjectTokenType === ACCESS_TOKEN_TYPE
+			) {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_grant",
+						errorDescription: "refresh token store not configured (revocation cannot be verified)",
+					},
+				};
+			}
+
+			// Re-surface family_revoked for operators by consulting the store directly
+			// when a family_id was present. isFamilyRevoked is idempotent and cheap.
+			if (
+				subjectValidated.familyId &&
+				deps.refreshTokenStore &&
+				subjectTokenType === ACCESS_TOKEN_TYPE
+			) {
+				let revoked: boolean;
+				try {
+					revoked = await deps.refreshTokenStore.isFamilyRevoked(subjectValidated.familyId);
+				} catch {
+					return {
+						result: {
+							status: 503,
+							error: "temporarily_unavailable",
+							errorDescription: "refresh token store unavailable",
+						},
+					};
+				}
+				if (revoked) {
+					return {
+						result: {
+							status: 400,
+							error: "invalid_grant",
+							errorDescription: "family_revoked",
+						},
+					};
+				}
+			}
+
+			let actorValidated: typeof subjectValidated | null = null;
+			if (actorToken !== null && actorTokenType !== null) {
+				const actorValidator = validatorRegistry.get(actorTokenType);
+				// actorValidator existence already checked above, but narrow again.
+				if (!actorValidator) {
+					return {
+						result: {
+							status: 400,
+							error: "unsupported_token_type",
+							errorDescription: `actor_token_type "${actorTokenType}" is not supported`,
+						},
+					};
+				}
+				try {
+					actorValidated = await actorValidator.validate(actorToken, { role: "actor" });
+				} catch {
+					return {
+						result: {
+							status: 503,
+							error: "temporarily_unavailable",
+							errorDescription: "actor_token validation store unavailable",
+						},
+					};
+				}
+				if (!actorValidated) {
+					return {
+						result: {
+							status: 400,
+							error: "invalid_grant",
+							errorDescription: "actor_token validation failed",
+						},
+					};
+				}
+			}
+
+			// Scope narrowing: requested scope ⊆ subject scope.
+			const subjectScope = subjectValidated.scope?.split(" ").filter(Boolean) ?? [];
+			const requestedScopeStr = typeof body.scope === "string" ? body.scope : null;
+			const requestedScope = requestedScopeStr?.split(" ").filter(Boolean) ?? null;
+			if (requestedScope) {
+				const subjectScopeSet = new Set(subjectScope);
+				for (const s of requestedScope) {
+					if (!subjectScopeSet.has(s)) {
+						return {
+							result: {
+								status: 400,
+								error: "invalid_scope",
+								errorDescription: `scope "${s}" is not in subject_token scope`,
+							},
+						};
+					}
+				}
+			}
+
+			// Audience narrowing: requested audience ⊆ client.allowedAudiences ∪ {clientId}.
+			const requestedAudience = normalizeArrayParam(body.audience);
+			const requestedResource = normalizeArrayParam(body.resource);
+			if (requestedAudience) {
+				const allow = new Set([
+					...(client.allowedAudiences ?? []),
+					client.clientId,
+				]);
+				for (const aud of requestedAudience) {
+					if (!allow.has(aud)) {
+						return {
+							result: {
+								status: 400,
+								error: "invalid_target",
+								errorDescription: `audience "${aud}" is not allowed for this client`,
+							},
+						};
+					}
+				}
+			}
+
+			// Minting + policy hook + act-claim construction come in Tasks 8-9.
+			void actorValidated;
+			void requestedResource;
+			return {
+				result: {
+					status: 501,
+					error: "not_implemented",
+					errorDescription: "Token Exchange minting is not yet implemented",
+				},
+			};
+```
+
+Also, at the bottom of the file (before the trailing `export { ... }` line), add the helper:
+
+```ts
+function normalizeArrayParam(value: unknown): string[] | null {
+	if (value === undefined || value === null || value === "") return null;
+	if (Array.isArray(value)) return value.map(String);
+	return [String(value)];
+}
+```
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange test -- grant`
+
+Expected: all tests in both describe blocks PASS. The three narrowing-passes tests still expect `status: 501` from the stub — that is correct for this task.
+
+- [ ] **Step 5: Verify typecheck**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange typecheck`
+
+Expected: exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/oauth-token-exchange/src/grant.mts packages/oauth-token-exchange/src/__tests__/grant.test.mts
+git commit -m "feat(token-exchange): add subject/actor validation + scope/audience narrowing"
+```
+
+---
+
+## Task 8: Grant handler — policy hook + mint new access_token
+
+**Files:**
+- Modify: `packages/oauth-token-exchange/src/grant.mts`
+- Modify: `packages/oauth-token-exchange/src/__tests__/grant.test.mts`
+
+This replaces the 501 stub with the final minting logic. After this task the `status: 501` expectations in Task 7 tests become stale — they're updated as part of the same step.
+
+- [ ] **Step 1: Update Task 7 tests — change the two `status: 501` assertions**
+
+Edit `packages/oauth-token-exchange/src/__tests__/grant.test.mts`. Replace the two `expect(result).toMatchObject({ status: 501 });` assertions in the narrowing-checks describe block with richer happy-path checks:
+
+For the "accepts audience when it matches clientId" test, replace with:
+
+```ts
+		expect(result).toMatchObject({ status: 200 });
+		if (result.status === 200) {
+			expect(result.tokens.access_token).toBeDefined();
+			expect(result.tokens.issued_token_type).toBe(ACCESS_TOKEN_TYPE);
+			expect(result.tokens.token_type).toBe("Bearer");
+			expect(result.tokens.refresh_token).toBeFalsy();
+		}
+```
+
+For the "accepts multi-value audience" test, replace with:
+
+```ts
+		expect(result).toMatchObject({ status: 200 });
+```
+
+- [ ] **Step 2: Append new tests for happy path + policy + act**
+
+Append to `packages/oauth-token-exchange/src/__tests__/grant.test.mts`:
+
+```ts
+import { decodeJwt } from "jose";
+import type { GrantPolicyContext, GrantPolicyHookBase, GrantPolicyRequest } from "@o3co/auth-provider-core";
+
+const denyPolicy: GrantPolicyHookBase = {
+	kind: "deny-all",
+	async evaluate() {
+		return { outcome: "deny", error: "access_denied" };
+	},
+};
+
+const overridePolicy: GrantPolicyHookBase = {
+	kind: "override",
+	async evaluate(req: GrantPolicyRequest, _ctx: GrantPolicyContext) {
+		return {
+			outcome: "allow",
+			grantedScope: ["read"],
+			grantedAudience: ["billing"],
+		};
+	},
+};
+
+describe("createTokenExchangeGrant — happy path", () => {
+	it("mints an access_token with issued_token_type set (minimal impersonation)", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1", scope: "read write" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		expect(result.tokens.access_token).toBeDefined();
+		expect(result.tokens.issued_token_type).toBe(ACCESS_TOKEN_TYPE);
+		expect(result.tokens.refresh_token).toBeFalsy();
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.sub).toBe("user-1");
+		expect(payload.family_id).toBe("fam-1");
+		expect(payload.act).toBeUndefined();
+	});
+
+	it("inherits subject scope when scope parameter is omitted", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1", scope: "read write" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		expect(result.tokens.scope).toBe("read write");
+	});
+
+	it("narrows scope to requested subset", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1", scope: "read write" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				scope: "read",
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		expect(result.tokens.scope).toBe("read");
+	});
+
+	it("adds act claim when actor_token is provided (delegation)", async () => {
+		const g = buildGrant();
+		const subject = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const actor = await signSelfIssuedAccessToken({ sub: "svc-a", family_id: "fam-2" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: subject,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token: actor,
+				actor_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.act).toEqual({ sub: "svc-a" });
+	});
+
+	it("nests subject.act inside new act for multi-step delegation", async () => {
+		const g = buildGrant();
+		const subject = await signSelfIssuedAccessToken({
+			family_id: "fam-1",
+			act: { sub: "svc-upstream" },
+		});
+		const actor = await signSelfIssuedAccessToken({ sub: "svc-b", family_id: "fam-2" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: subject,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token: actor,
+				actor_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.act).toEqual({ sub: "svc-b", act: { sub: "svc-upstream" } });
+	});
+
+	it("inherits family_id from subject (cascade revoke)", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-xyz" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.family_id).toBe("fam-xyz");
+	});
+});
+
+describe("createTokenExchangeGrant — policy hook", () => {
+	it("rejects with access_denied when policy hook denies", async () => {
+		const g = createTokenExchangeGrant({
+			config: mockConfig,
+			keyStore,
+			refreshTokenStore: makeRefreshStore(),
+			grantPolicy: denyPolicy,
+			validatorRegistry: (() => {
+				const r = new ExchangeTokenValidatorRegistry();
+				r.register(
+					ACCESS_TOKEN_TYPE,
+					createSelfIssuedAccessTokenValidator({
+						keyStore,
+						refreshTokenStore: makeRefreshStore(),
+						issuer: ISSUER,
+					}),
+				);
+				return r;
+			})(),
+			clientRepository: mockClientRepository(),
+		});
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({ status: 403, error: "access_denied" });
+	});
+
+	it("applies policy hook grantedScope / grantedAudience overrides", async () => {
+		const g = createTokenExchangeGrant({
+			config: mockConfig,
+			keyStore,
+			refreshTokenStore: makeRefreshStore(),
+			grantPolicy: overridePolicy,
+			validatorRegistry: (() => {
+				const r = new ExchangeTokenValidatorRegistry();
+				r.register(
+					ACCESS_TOKEN_TYPE,
+					createSelfIssuedAccessTokenValidator({
+						keyStore,
+						refreshTokenStore: makeRefreshStore(),
+						issuer: ISSUER,
+					}),
+				);
+				return r;
+			})(),
+			clientRepository: mockClientRepository(
+				publicClient({ allowedAudiences: ["billing", "inventory"] }),
+			),
+		});
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1", scope: "read write" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				scope: "read write",
+				audience: ["billing", "inventory"],
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		expect(result.tokens.scope).toBe("read");
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.aud).toBe("billing");
+	});
+});
+```
+
+- [ ] **Step 3: Run tests to verify new tests fail**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange test -- grant`
+
+Expected: all new happy-path and policy tests FAIL (stub still returns 501).
+
+- [ ] **Step 4: Finalize grant handler — replace the 501 stub with full minting**
+
+Edit `packages/oauth-token-exchange/src/grant.mts`. At the top of the file, expand the imports:
+
+```ts
+import type {
+	ClientRepository,
+	GrantContext,
+	GrantDependencies,
+	GrantHandler,
+	GrantHandlerResult,
+	GrantPolicyContext,
+	GrantPolicyDecision,
+	GrantPolicyRequest,
+} from "@o3co/auth-provider-core";
+import { formatObject, generateToken, generateTokenResponse } from "@o3co/auth-provider-core";
+import { buildActClaim } from "./act.mjs";
+import type { ExchangeTokenValidatorRegistry } from "./validator/registry.mjs";
+import type { ValidatedToken } from "./validator/types.mjs";
+```
+
+Then replace the final 501 stub block with:
+
+```ts
+			// Policy hook — existing GrantPolicyHookBase contract.
+			let grantedScope: readonly string[] | undefined = requestedScope ?? subjectScope;
+			let grantedAudience: readonly string[] | undefined = requestedAudience ?? undefined;
+			if (deps.grantPolicy) {
+				const policyRequest: GrantPolicyRequest = {
+					grantType: GRANT_TYPE,
+					clientId: client.clientId,
+					subject: subjectValidated.sub,
+					requestedScope: requestedScope ?? undefined,
+					requestedAudience: requestedAudience ?? undefined,
+					originalScope: subjectScope.length > 0 ? subjectScope : undefined,
+					subjectTokenType,
+					actorTokenType: actorTokenType ?? undefined,
+					resource: requestedResource ?? undefined,
+				};
+				const policyContext: GrantPolicyContext = {
+					ip: ctx.ip,
+					userAgent: ctx.userAgent,
+					issuer: ctx.issuer ?? "",
+				};
+				let decision: GrantPolicyDecision;
+				try {
+					decision = await deps.grantPolicy.evaluate(policyRequest, policyContext);
+				} catch {
+					return {
+						result: {
+							status: 503,
+							error: "temporarily_unavailable",
+							errorDescription: "grant policy evaluation failed",
+						},
+					};
+				}
+				if (decision.outcome === "deny") {
+					return {
+						result: {
+							status: decision.error === "access_denied" ? 403 : 400,
+							error: decision.error,
+							errorDescription: decision.errorDescription ?? "denied by policy",
+						},
+					};
+				}
+				if (decision.grantedScope) grantedScope = decision.grantedScope;
+				if (decision.grantedAudience) grantedAudience = decision.grantedAudience;
+			}
+
+			// Audience derivation (spec §8.1 rule 2):
+			//   explicit narrowed audience  → use grantedAudience (already allowlist-validated)
+			//   omitted + subject single    → inherit subject.aud
+			//   omitted + subject multi/none → fall back to clientId (safe default)
+			const subjectAud = subjectValidated.aud;
+			const audienceForToken: string = (() => {
+				if (grantedAudience && grantedAudience.length > 0) return grantedAudience[0]!;
+				if (typeof subjectAud === "string") return subjectAud;
+				return client.clientId;
+			})();
+
+			const act = buildActClaim({ subject: subjectValidated, actor: actorValidated ?? undefined });
+			const scopeClaim =
+				grantedScope && grantedScope.length > 0 ? grantedScope.join(" ") : null;
+
+			const expiresIn = getExpiresIn(deps);
+
+			const accessToken = await generateToken(
+				formatObject({
+					family_id: subjectValidated.familyId,
+					act,
+				}),
+				{
+					expiresIn,
+					keyStore: deps.keyStore,
+					issuer: ctx.issuer,
+					audience: audienceForToken,
+					subject: subjectValidated.sub,
+					authorizedParty: client.clientId,
+					scope: scopeClaim,
+					tokenType: "at+jwt",
+				},
+			);
+
+			const tokens = generateTokenResponse({ accessToken });
+			const tokensWithIssuedType: typeof tokens & { issued_token_type: string } = {
+				...tokens,
+				issued_token_type: ACCESS_TOKEN_TYPE,
+			};
+
+			return {
+				result: {
+					status: 200,
+					tokens: tokensWithIssuedType,
+				},
+			};
+```
+
+Finally, add the `getExpiresIn` helper at the bottom of the file (next to `normalizeArrayParam`):
+
+```ts
+function getExpiresIn(deps: TokenExchangeDependencies): number {
+	const grants = (deps.config.oauth.grants ?? {}) as Record<string, Record<string, unknown>>;
+	const tokenExchange = grants.token_exchange;
+	const at = tokenExchange?.accessToken as { expiresIn?: number } | undefined;
+	if (typeof at?.expiresIn === "number" && at.expiresIn > 0) return at.expiresIn;
+	const top = (deps.config.oauth.accessToken as { expiresIn?: number } | undefined)?.expiresIn;
+	return typeof top === "number" && top > 0 ? top : 300;
+}
+```
+
+Note: `generateTokenResponse` currently does not include `issued_token_type`. We augment the response object with it directly in the handler to avoid a core change. The `TokenResponse` interface in core may need extending in a follow-up; for now we return the augmented object via `as`.
+
+- [ ] **Step 5: Run tests to verify GREEN**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange test -- grant`
+
+Expected: every test from Tasks 6/7/8 PASSES.
+
+- [ ] **Step 6: Verify typecheck**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange typecheck`
+
+Expected: exits 0. If the `tokensWithIssuedType` cast produces a diagnostic about unknown property, the simplest fix is to widen the inline return type to `TokenResponse & { issued_token_type: string }`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/oauth-token-exchange/src/grant.mts packages/oauth-token-exchange/src/__tests__/grant.test.mts
+git commit -m "feat(token-exchange): mint access_token with issued_token_type, act claim, family cascade, policy hook"
+```
+
+---
+
+## Task 9: GrantModule export + public API
+
+**Files:**
+- Create: `packages/oauth-token-exchange/src/module.mts`
+- Modify: `packages/oauth-token-exchange/src/index.mts`
+- Test: (covered by grant tests; no new unit test file)
+
+- [ ] **Step 1: Create module.mts**
+
+Write `packages/oauth-token-exchange/src/module.mts`:
+
+```ts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { GrantModule } from "@o3co/auth-provider-core";
+import { z } from "zod";
+import { createTokenExchangeGrant, TOKEN_EXCHANGE_GRANT_TYPE } from "./grant.mjs";
+
+/**
+ * Config shape consumed by the Token Exchange GrantModule. All fields are
+ * optional. `enabled: false` disables registration via GrantRegistry.addModule.
+ */
+export const tokenExchangeConfigSchema = z.object({
+	token_exchange: z
+		.object({
+			enabled: z.boolean().default(true),
+			accessToken: z
+				.object({
+					expiresIn: z.number().int().positive().optional(),
+				})
+				.optional(),
+		})
+		.default({}),
+});
+
+/**
+ * GrantModule for plugin-style registration via
+ * `GrantRegistry.addModule(tokenExchangeModule, deps)`. Consumers MUST supply
+ * `validatorRegistry` and `clientRepository` in the deps, and pre-register at
+ * least the self-issued access_token validator.
+ */
+export const tokenExchangeModule: GrantModule = {
+	grants: {
+		[TOKEN_EXCHANGE_GRANT_TYPE]: (deps) =>
+			createTokenExchangeGrant(
+				deps as unknown as Parameters<typeof createTokenExchangeGrant>[0],
+			),
+	},
+	configSchema: tokenExchangeConfigSchema,
+};
+```
+
+- [ ] **Step 2: Update index.mts — export module + grant + types**
+
+Replace `packages/oauth-token-exchange/src/index.mts` with:
+
+```ts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {
+	ACCESS_TOKEN_TYPE,
+	createTokenExchangeGrant,
+	type TokenExchangeDependencies,
+	TOKEN_EXCHANGE_GRANT_TYPE,
+} from "./grant.mjs";
+export { tokenExchangeModule, tokenExchangeConfigSchema } from "./module.mjs";
+export type {
+	ExchangeTokenValidationContext,
+	ExchangeTokenValidator,
+	ValidatedToken,
+} from "./validator/types.mjs";
+export { ExchangeTokenValidatorRegistry } from "./validator/registry.mjs";
+export {
+	type CreateSelfIssuedAccessTokenValidatorOptions,
+	createSelfIssuedAccessTokenValidator,
+} from "./validator/selfIssuedAccessToken.mjs";
+```
+
+- [ ] **Step 3: Verify typecheck + test**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange typecheck`
+
+Expected: exits 0.
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange test`
+
+Expected: all tests PASS.
+
+- [ ] **Step 4: Build to confirm package compiles**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange build`
+
+Expected: `dist/` populated with `.mjs` / `.d.mts` for each source module.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/oauth-token-exchange/src/module.mts packages/oauth-token-exchange/src/index.mts
+git commit -m "feat(token-exchange): add GrantModule export + finalize public API surface"
+```
+
+---
+
+## Task 10: Integration test with real oauth module
+
+**Files:**
+- Create: `packages/oauth-token-exchange/src/__tests__/grant-integration.test.mts`
+
+This confirms the grant plugs into the real `/oauth/token` pipeline and family revocation cascades work end-to-end.
+
+- [ ] **Step 1: Add integration test**
+
+Write `packages/oauth-token-exchange/src/__tests__/grant-integration.test.mts`:
+
+```ts
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+	ClientRepository,
+	GrantContext,
+	PublicClient,
+	RefreshTokenStoreBase,
+} from "@o3co/auth-provider-core";
+import { decodeJwt } from "jose";
+import { describe, expect, it } from "vitest";
+import { createTokenExchangeGrant, TOKEN_EXCHANGE_GRANT_TYPE } from "#/grant.mjs";
+import { ExchangeTokenValidatorRegistry } from "#/validator/registry.mjs";
+import { createSelfIssuedAccessTokenValidator } from "#/validator/selfIssuedAccessToken.mjs";
+import { ISSUER, keyStore, signSelfIssuedAccessToken } from "./fixtures.mjs";
+
+const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+
+const client: PublicClient = {
+	clientId: "client-a",
+	allowedRedirectUris: [],
+	allowedScopes: ["read", "write"],
+	allowedAudiences: ["billing"],
+	backchannelLogoutSessionRequired: true,
+	frontchannelLogoutSessionRequired: true,
+	allowedAzpForFederationToken: false,
+};
+
+const clientRepository: ClientRepository = {
+	findById: async (id) => (id === client.clientId ? client : null),
+	authenticate: async (id) => (id === client.clientId ? client : null),
+};
+
+// In-memory refresh token store preserving family revocation state between
+// calls, so we can revoke then re-exchange and observe the cascade.
+function makeStatefulStore(): RefreshTokenStoreBase & { revokedFamilies: Set<string> } {
+	const revoked = new Set<string>();
+	return {
+		kind: "stateful-fixture",
+		revokedFamilies: revoked,
+		async rotate() {
+			return { outcome: "rotated" };
+		},
+		async isFamilyRevoked(familyId) {
+			return revoked.has(familyId);
+		},
+		async revokeFamily(familyId) {
+			revoked.add(familyId);
+		},
+	};
+}
+
+function buildHandler(store: RefreshTokenStoreBase) {
+	const registry = new ExchangeTokenValidatorRegistry();
+	registry.register(
+		ACCESS_TOKEN_TYPE,
+		createSelfIssuedAccessTokenValidator({
+			keyStore,
+			refreshTokenStore: store,
+			issuer: ISSUER,
+		}),
+	);
+	return createTokenExchangeGrant({
+		config: {
+			oauth: {
+				jwt: { issuer: ISSUER },
+				accessToken: { expiresIn: 300 },
+				refreshToken: { expiresIn: 86400 },
+				grants: {},
+			},
+			// biome-ignore lint/suspicious/noExplicitAny: test scaffold config
+		} as any,
+		keyStore,
+		refreshTokenStore: store,
+		validatorRegistry: registry,
+		clientRepository,
+	});
+}
+
+const ctx = (body: Record<string, unknown>): GrantContext => ({
+	body,
+	session: {},
+	issuer: ISSUER,
+	metadata: {},
+});
+
+describe("token_exchange — integration", () => {
+	it("exchanges a subject access_token for a narrower audience access_token", async () => {
+		const store = makeStatefulStore();
+		const handler = buildHandler(store);
+		const subjectToken = await signSelfIssuedAccessToken({
+			family_id: "fam-1",
+			scope: "read write",
+		});
+
+		const { result } = await handler.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: subjectToken,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				audience: "billing",
+				scope: "read",
+			}),
+		);
+
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.aud).toBe("billing");
+		expect(payload.scope).toBe("read");
+		expect(payload.family_id).toBe("fam-1");
+		expect(payload.sub).toBe("user-1");
+	});
+
+	it("rejects exchange after the subject family is revoked (cascade)", async () => {
+		const store = makeStatefulStore();
+		const handler = buildHandler(store);
+		const subjectToken = await signSelfIssuedAccessToken({ family_id: "fam-cascade" });
+
+		// First exchange succeeds.
+		const ok = await handler.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: subjectToken,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(ok.result.status).toBe(200);
+
+		// Revoke the family (simulating a logout).
+		await store.revokeFamily("fam-cascade");
+
+		// Second exchange with the same subject must now fail.
+		const denied = await handler.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: subjectToken,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(denied.result).toMatchObject({
+			status: 400,
+			error: "invalid_grant",
+			errorDescription: "family_revoked",
+		});
+	});
+
+	it("registers successfully via GrantRegistry.addModule", async () => {
+		// Guard against drift between the GrantModule wiring and the grant handler.
+		const { GrantRegistry } = await import("@o3co/auth-provider-core");
+		const { tokenExchangeModule } = await import("#/module.mjs");
+		const store = makeStatefulStore();
+		const registry = new ExchangeTokenValidatorRegistry();
+		registry.register(
+			ACCESS_TOKEN_TYPE,
+			createSelfIssuedAccessTokenValidator({
+				keyStore,
+				refreshTokenStore: store,
+				issuer: ISSUER,
+			}),
+		);
+
+		const grantRegistry = new GrantRegistry();
+		grantRegistry.addModule(tokenExchangeModule, {
+			config: {
+				oauth: {
+					jwt: { issuer: ISSUER },
+					accessToken: { expiresIn: 300 },
+					refreshToken: { expiresIn: 86400 },
+					grants: {},
+				},
+				// biome-ignore lint/suspicious/noExplicitAny: test scaffold
+			} as any,
+			keyStore,
+			refreshTokenStore: store,
+			// biome-ignore lint/suspicious/noExplicitAny: extra deps for this grant
+			validatorRegistry: registry,
+			clientRepository,
+		} as any);
+
+		const handler = grantRegistry.get(TOKEN_EXCHANGE_GRANT_TYPE);
+		expect(handler).toBeDefined();
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify GREEN**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange test -- integration`
+
+Expected: all 3 integration tests PASS.
+
+- [ ] **Step 3: Run the full test suite for the package**
+
+Run: `pnpm --filter @o3co/auth-provider-oauth-token-exchange test`
+
+Expected: every unit + integration test PASSES.
+
+- [ ] **Step 4: Run the full repo test suite to catch regressions**
+
+Run: `pnpm test`
+
+Expected: every package's test suite PASSES.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/oauth-token-exchange/src/__tests__/grant-integration.test.mts
+git commit -m "test(token-exchange): integration tests for narrowing + family cascade + module registration"
+```
+
+---
+
+## Task 11: README + security notes
+
+**Files:**
+- Modify: `packages/oauth-token-exchange/README.md`
+
+- [ ] **Step 1: Replace the placeholder README with full usage documentation**
+
+Write `packages/oauth-token-exchange/README.md`:
+
+````markdown
+# @o3co/auth-provider-oauth-token-exchange
+
+RFC 8693 Token Exchange grant for [auth.provider](https://github.com/o3co/auth.provider).
+Supports on-behalf-of, delegation (`act` claim), and scope / audience narrowing.
+
+## Install
+
+```bash
+pnpm add @o3co/auth-provider-oauth-token-exchange
+```
+
+## Register the grant
+
+```ts
+import { GrantRegistry } from "@o3co/auth-provider-core";
+import {
+  ExchangeTokenValidatorRegistry,
+  createSelfIssuedAccessTokenValidator,
+  tokenExchangeModule,
+} from "@o3co/auth-provider-oauth-token-exchange";
+
+const validatorRegistry = new ExchangeTokenValidatorRegistry();
+validatorRegistry.register(
+  "urn:ietf:params:oauth:token-type:access_token",
+  createSelfIssuedAccessTokenValidator({
+    keyStore,            // your KeyStore (used to issue access_tokens)
+    refreshTokenStore,   // REQUIRED for cascading revoke; fail-closed if absent
+    issuer,              // your OIDC issuer URL
+  }),
+);
+
+grantRegistry.addModule(tokenExchangeModule, {
+  ...deps,
+  validatorRegistry,
+  clientRepository,
+});
+```
+
+The grant type URI is `urn:ietf:params:oauth:grant-type:token-exchange` (IETF registered).
+
+## Client configuration
+
+Add `allowedAudiences` to the client record to permit audience narrowing to
+specific API identifiers:
+
+```yaml
+clients:
+  billing-gateway:
+    clientSecret: "..."
+    allowedScopes: ["read", "write"]
+    allowedAudiences: ["billing-service", "inventory-service"]
+```
+
+When `allowedAudiences` is empty or omitted, the only accepted `audience`
+parameter value is the client's own `clientId`. The audience allowlist is
+enforced in addition to any `GrantPolicyHook` you register.
+
+## External JWT subject_token
+
+The package ships a built-in validator only for the `access_token` token type
+(tokens issued by this same auth.provider instance). To accept external JWTs
+as `subject_token`, implement `ExchangeTokenValidator` yourself and register
+it for `urn:ietf:params:oauth:token-type:jwt`:
+
+```ts
+class ExternalJwtValidator implements ExchangeTokenValidator {
+  readonly tokenType = "urn:ietf:params:oauth:token-type:jwt";
+  async validate(token: string, ctx: { role: "subject" | "actor" }) {
+    // Fetch jwks, verify signature, check issuer allowlist, consult remote
+    // introspection for revocation — all are YOUR responsibility.
+  }
+}
+
+validatorRegistry.register(
+  "urn:ietf:params:oauth:token-type:jwt",
+  new ExternalJwtValidator({ ... }),
+);
+```
+
+## Security notes
+
+1. **refreshTokenStore is required.** Without it, self-issued access_tokens
+   carrying `family_id` cannot be revocation-checked; the grant handler returns
+   `invalid_grant` in that case (fail-closed). Token Exchange horizontally
+   spreads access, so emitting tokens whose revocation cannot be observed is
+   never acceptable.
+
+2. **Scope is always narrowed.** `requested scope ⊆ subject_token.scope` is
+   enforced in the core handler and cannot be bypassed by a policy hook.
+
+3. **Audience allowlist.** The `audience` request parameter must be in
+   `client.allowedAudiences ∪ { client.clientId }`. Policy hooks may further
+   narrow the granted audience but cannot broaden it beyond the allowlist.
+
+4. **Impersonation vs delegation.** An exchange without `actor_token` issues
+   an impersonation token (no `act` claim). Deployments that require audit
+   trails should add a `GrantPolicyHook` that rejects requests lacking
+   `actor_token`:
+
+   ```ts
+   async evaluate(req) {
+     if (req.grantType === "urn:ietf:params:oauth:grant-type:token-exchange" && !req.actorTokenType) {
+       return { outcome: "deny", error: "invalid_request",
+                errorDescription: "actor_token required for delegation" };
+     }
+     return { outcome: "allow" };
+   }
+   ```
+
+5. **Family cascade.** Issued access_tokens inherit the subject's `family_id`
+   claim. Revoking the subject's family (e.g. on logout) automatically invalidates
+   every token exchanged from it.
+
+6. **Refresh / ID tokens are never issued.** Per RFC 8693 §4.2.2 the handler
+   only returns an access_token. The response always carries `issued_token_type`.
+
+## RFC references
+
+- [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) — OAuth 2.0 Token Exchange
+- [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707) — Resource Indicators (`invalid_target`)
+- [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749) — OAuth 2.0 core
+- [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662) — Token Introspection
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/oauth-token-exchange/README.md
+git commit -m "docs(token-exchange): add README with usage + security notes"
+```
+
+---
+
+## Task 12: Final verification
+
+**Files:** (no new files; full-repo checks)
+
+- [ ] **Step 1: Full repo typecheck**
+
+Run: `pnpm -r run typecheck`
+
+Expected: every package exits 0. If a package without a `typecheck` script is skipped, that's fine (`--if-present` is the default behavior for `-r run`).
+
+- [ ] **Step 2: Full repo test suite**
+
+Run: `pnpm test`
+
+Expected: every package's tests PASS.
+
+- [ ] **Step 3: Full repo build**
+
+Run: `pnpm build`
+
+Expected: every package's `dist/` is populated; no compile errors.
+
+- [ ] **Step 4: Lint check**
+
+Run: `pnpm lint`
+
+Expected: passes with 0 errors. Address any new warnings introduced by this branch (usually import order or unused imports).
+
+- [ ] **Step 5: Verify no accidental file inclusions**
+
+Run: `git status`
+
+Expected: clean working tree (no untracked files, no unstaged changes).
+
+- [ ] **Step 6: Review the branch summary**
+
+Run: `git log --oneline main..HEAD`
+
+Expected: a clean sequence of feat / test / docs commits, one per task, easy to bisect.

--- a/.claude/superpowers/specs/2026-04-24-token-exchange-design.md
+++ b/.claude/superpowers/specs/2026-04-24-token-exchange-design.md
@@ -436,47 +436,35 @@ validatorRegistry.register(
 
 - Registry が `undefined` を返す → grant handler が `unsupported_token_type` で応答 (default deny)
 
-## 11. Config schema (HOCON)
+## 11. Configuration
 
-### 11.1 設定
+### 11.1 No module-specific config surface
 
-```hocon
-oauth {
-  grants {
-    token_exchange {
-      accessToken {
-        expiresIn = 300  # 省略時は oauth.accessToken.expiresIn を流用
-      }
-    }
-  }
-}
-```
-
-### 11.2 zod schema (GrantModule.configSchema)
-
-```ts
-const tokenExchangeConfigSchema = z.object({
-  token_exchange: z
-    .object({
-      accessToken: z
-        .object({
-          expiresIn: z.number().int().positive().optional(),
-        })
-        .optional(),
-    })
-    .default({}),
-});
-```
+This module does not expose a config schema. Per Task 9 spec note, the RFC
+8693 grant-type URN (`urn:ietf:params:oauth:grant-type:token-exchange`) is
+used as the `GrantModule.grants` key for handler dispatch, but core's
+`GrantRegistry.addModule` keys module config blocks by that same key.
+HOCON-friendly keys like `token_exchange.*` are therefore dropped during
+schema parsing.
 
 **audience allowlist は client 単位 (`Client.allowedAudiences`) のみで管理** (§8.3)。全 client 共通の shared allowlist は本 spec では導入しない。理由: 複数ソースの allowlist は merge/precedence を明示しないと security hole になる。必要になれば post-0.5 で `GrantPolicyHook` で consumer 側実装できる。
+
+### 11.2 expiresIn source
+
+Token Exchange access_tokens use `oauth.accessToken.expiresIn` (the global
+OAuth access_token lifetime config). This applies to all OAuth grants and is
+already configurable at the top level of HOCON. Consumers who want a
+different expiresIn specifically for Token Exchange should wrap
+`createTokenExchangeGrant()` and pass a custom config, rather than use the
+GrantModule pattern.
+
+**`expiresIn` default:** short (300s = 5 min). Token Exchange is short-lived by RFC 8693 recommendation.
 
 ### 11.3 Disable mechanism
 
 Consumers disable Token Exchange by **not importing `tokenExchangeModule`**. This matches the federation-package-split philosophy (v0.5.0 #17): registration is 100% consumer opt-in. There is no config-driven disable switch.
 
 Rationale: `GrantModule` in core dispatches handlers by grant-type key (the RFC 8693 URN `urn:ietf:params:oauth:grant-type:token-exchange`), but operator-friendly HOCON uses the `token_exchange` key. Bridging those two via a config-driven `enabled` flag would require a core interface change (adding `configKey?: string` to `GrantModule`) that v0.5.0 interface freeze avoids. Consumer-level opt-in via module import is both simpler and consistent with the rest of v0.5.0 scope.
-
-**`expiresIn` default:** short (300s = 5 min). Token Exchange is short-lived by RFC 8693 recommendation.
 
 ## 12. Test 戦略
 
@@ -541,6 +529,7 @@ Rationale: `GrantModule` in core dispatches handlers by grant-type key (the RFC 
 - `GrantDependencies` / `GrantHandler` / `RefreshTokenStoreBase` は無変更
 - Consumer が module を import しなければ完全に noop (breaking change なし)
 - `enabled` フィールドを config schema から削除 (C1 Option D): schema-level のみの変更。`tokenExchangeModule` は v0.5.0 初出なので `enabled` に依存していた consumer はいない。backward compat 問題なし。
+- `tokenExchangeConfigSchema` export を削除 (P2 / multi-agent-review follow-up): `GrantRegistry.addModule` が URN キーでモジュール config を管理するため、`token_exchange.*` キーは schema parsing 時に DROP されていた。実質 noop だったため依存 consumer はいない。backward compat 問題なし。
 
 ## 15. post-0.5 に残す項目 (out-of-scope)
 

--- a/.claude/superpowers/specs/2026-04-24-token-exchange-design.md
+++ b/.claude/superpowers/specs/2026-04-24-token-exchange-design.md
@@ -177,7 +177,7 @@ Content-Type: `application/x-www-form-urlencoded`
 | `scope` | optional | 発行 token の scope (subject の subset でなければ reject) |
 | `requested_token_type` | optional | 省略時は `access_token`。他値なら `unsupported_token_type` |
 | `client_id` | ✓ | 呼び出し client の ID |
-| `client_secret` | optional | confidential client の認証 |
+| `client_secret` | ✓ | confidential client の認証。**v0.5.0 では required** — core の `Client` は `clientSecret: string` 必須で `PublicClient = Omit<Client, "clientSecret">` のため、`findById()` だけでは public/confidential の区別がつかない。未認証の `client_id` を許すと盗まれた `subject_token` で任意 client を impersonate できるため、確認できないクライアント認証は素通しさせない。public client サポートは `Client.public` flag が入った後で再検討する |
 
 ### 5.2 Response (200 application/json)
 

--- a/.claude/superpowers/specs/2026-04-24-token-exchange-design.md
+++ b/.claude/superpowers/specs/2026-04-24-token-exchange-design.md
@@ -1,0 +1,582 @@
+# RFC 8693 Token Exchange — Design Spec
+
+**Date:** 2026-04-24
+**Scope:** `auth.provider` v0.5.0 scope item #2 (debate R2/R3 で GA must 認定)
+**Target version:** v0.5.0
+**Status:** Design draft (brainstorming complete, awaiting user review)
+
+---
+
+## 1. Motivation
+
+### 1.1 Debate 起点の根拠
+
+`debate/did-auth-oauth2-idp/` 4 ラウンドで Token Exchange は 1.0 GA 前 must に確定。
+
+- **R1 CON §2.5**: 「A2A の核心は capability (何ができるか/委譲可能か/権限減衰)。**RFC 8693 Token Exchange / OBO flow のサポートが必須** — 無ければ A2A を名乗るのは苦しい」
+- **R1 PRO 受諾**: 「Token Exchange は TODO として認識済み。**設計欠陥ではなく実装順序**」「1.0 GA 前に実装」
+- **R2 PRO §6**: 「RFC 8693 Token Exchange | 最高 | **1.0 GA 前 must (Option II の核)**」
+- **R2 CON priority matrix**: コスト低 / 効用最高 / 実装難易度中
+- **R3 PRO §4.1 決着**: GA 前 must gate (shipping 制約) に含む
+
+### 1.2 Persona-level pain (R3 PRO §3.2)
+
+Platform Engineering Lead persona (B2B SaaS multi-cloud) の現状回避策:
+> 自前 token exchange broker + cloud 毎の IAM 設定を手動同期
+
+= multi-cloud workload 間で JWT/mTLS を繋ぐのに自前 broker を運用している。これを OSS で置き換えるのが Option II (cross-org A2A) の核ユースケース。
+
+### 1.3 auth.provider 全体戦略での位置付け
+
+- v0.5.0 scope #2 (core GA must)
+- interface freeze に関わるので v0.5.0 で確定必要
+- jwt-bearer (#4) と近接 (外部 JWT を subject にする経路を共有)
+- Token Exchange は OIDC 層で標準化された delegation 窓口。capability-based auth (UCAN/Macaroons) を IdP 内に持ち込まない PRO 側戦略の具体化
+
+## 2. Scope
+
+### 2.1 射程に入れる使用パターン
+
+| # | パターン | 説明 |
+|---|---|---|
+| A | On-behalf-of / impersonation | サービス A がユーザとして B を呼ぶ |
+| B | Delegation (`act` claim) | A.と同じだが `act` claim で代理チェーン追跡 |
+| C | Token downgrade / scope narrowing | 強 token から弱 audience/scope の token を発行 |
+
+### 2.2 射程に入れない使用パターン
+
+| # | パターン | 扱い |
+|---|---|---|
+| D | Cross-domain token translation (SAML 等) | post-0.5 |
+| E | Token type conversion (access ↔ id) | `unsupported_token_type` で明示拒否 (§5.3 error table と整合、`requested_token_type` が `access_token` 以外の全値に適用) |
+
+### 2.3 Subject/Actor token の受入 type
+
+| token_type URI | v0.5.0 扱い |
+|---|---|
+| `urn:ietf:params:oauth:token-type:access_token` | built-in validator 同梱 |
+| `urn:ietf:params:oauth:token-type:jwt` | interface のみ提供、実装は consumer |
+| `urn:ietf:params:oauth:token-type:refresh_token` | 未対応 (Registry に register 不可ではないが built-in 無し) |
+| `urn:ietf:params:oauth:token-type:id_token` | 未対応 |
+| `urn:ietf:params:oauth:token-type:saml1` | 未対応 |
+| `urn:ietf:params:oauth:token-type:saml2` | post-0.5 |
+
+### 2.4 発行する token type
+
+- `urn:ietf:params:oauth:token-type:access_token` のみ
+- refresh_token / id_token は発行しない (RFC 8693 §4.2.2 "NOT RECOMMENDED" 準拠)
+- `requested_token_type` が `access_token` 以外 → `unsupported_token_type`
+
+## 3. Package 構成
+
+### 3.1 新規 package
+
+**`@o3co/auth-provider-oauth-token-exchange`**
+
+```text
+packages/oauth-token-exchange/
+├── src/
+│   ├── module.mts              # GrantModule export (token_exchange factory)
+│   ├── grant.mts               # Grant handler 実装
+│   ├── validator/
+│   │   ├── types.mts           # ExchangeTokenValidator / ValidatedToken interfaces
+│   │   ├── registry.mts        # ExchangeTokenValidatorRegistry
+│   │   └── selfIssuedAccessToken.mts  # built-in validator for access_token type
+│   ├── act.mts                 # act claim chain logic (nested delegation)
+│   └── __tests__/
+└── package.json
+```
+
+### 3.2 命名規則
+
+- OAuth 標準拡張系は `auth-provider-oauth-*` prefix で統一
+- 今後 federation も `auth-provider-oauth-federation-*` に rename 予定 (別タスク)
+- DID grant (OAuth 標準外) は `auth-provider-did` のまま
+- WebAuthn (MFA) は `auth-provider-webauthn` のまま
+
+### 3.3 位置付け
+
+- built-in registration しない。consumer が 100% register 責任 (federation split の判例と一貫)
+- default 無効化で attack surface 最小化
+- consumer の package.json で有効かどうか判別可能 (監査対応)
+
+### 3.4 依存関係
+
+- `@o3co/auth-provider-core` (GrantHandler, KeyStore, RefreshTokenStoreBase, generateToken, GrantPolicyHookBase)
+- 外部依存: `jose` (既存 package で使用中)
+
+## 4. 公開 API surface
+
+### 4.1 Interfaces / Types
+
+```ts
+export interface ExchangeTokenValidator {
+  readonly tokenType: string;
+  validate(
+    token: string,
+    context: { role: "subject" | "actor" },
+  ): Promise<ValidatedToken | null>;
+}
+
+export interface ValidatedToken {
+  sub: string;
+  scope?: string;
+  aud?: string | string[];
+  familyId?: string;              // self-issued access_token のみ
+  act?: Record<string, unknown>;  // 既存 act chain (入れ子 delegation 用)
+  claims: Record<string, unknown>;
+}
+
+export interface TokenExchangeDependencies extends GrantDependencies {
+  validatorRegistry: ExchangeTokenValidatorRegistry;
+  clientRepository: ClientRepository;
+}
+```
+
+### 4.2 Classes / Factories
+
+```ts
+export class ExchangeTokenValidatorRegistry {
+  register(tokenType: string, validator: ExchangeTokenValidator): void;
+  get(tokenType: string): ExchangeTokenValidator | undefined;
+}
+
+export function createSelfIssuedAccessTokenValidator(deps: {
+  keyStore: KeyStore;
+  refreshTokenStore?: RefreshTokenStoreBase;
+  issuer?: string;
+}): ExchangeTokenValidator;
+
+export function createTokenExchangeGrant(
+  deps: TokenExchangeDependencies,
+): GrantHandler;
+
+export const tokenExchangeModule: GrantModule;
+```
+
+### 4.3 Grant type URI
+
+- `urn:ietf:params:oauth:grant-type:token-exchange` (IETF 登録済み、RFC 8693 §2.1)
+- `o3co` 独自 URN は使わない (IETF 登録済みだから)
+
+## 5. Request / Response 仕様
+
+### 5.1 Request (POST /oauth/token)
+
+Content-Type: `application/x-www-form-urlencoded`
+
+| field | required | 説明 |
+|---|---|---|
+| `grant_type` | ✓ | `urn:ietf:params:oauth:grant-type:token-exchange` 固定 |
+| `subject_token` | ✓ | 元 token |
+| `subject_token_type` | ✓ | 受入 type URI (§2.3 参照) |
+| `actor_token` | optional | delegation 時の actor token |
+| `actor_token_type` | conditional | actor_token 提示時は required |
+| `resource` | optional | 発行 token が使われる API URI (policy hook に渡す)。**RFC 8707 §2 準拠で repeated param** (`resource=a&resource=b`)。express `body-parser` urlencoded は自動で `string[]` に展開 |
+| `audience` | optional | 発行 token の `aud` claim。**同じく repeated param で複数指定可**。RFC 8693 §2.1 "space-delimited" 派生形は対応しない (express 側で解釈できないため) |
+| `scope` | optional | 発行 token の scope (subject の subset でなければ reject) |
+| `requested_token_type` | optional | 省略時は `access_token`。他値なら `unsupported_token_type` |
+| `client_id` | ✓ | 呼び出し client の ID |
+| `client_secret` | optional | confidential client の認証 |
+
+### 5.2 Response (200 application/json)
+
+```json
+{
+  "access_token": "eyJ...",
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+  "token_type": "Bearer",
+  "expires_in": 300,
+  "scope": "read:invoice"
+}
+```
+
+- `issued_token_type` は response に含める (RFC 8693 §2.2 required)
+- `refresh_token` / `id_token` は含めない
+- `token_type` は "Bearer" hard-code (DPoP は v0.5.0 scope 外)
+
+### 5.3 Error responses (RFC 6749 + RFC 8693)
+
+| 条件 | error | status |
+|---|---|---|
+| `grant_type` 違い | `unsupported_grant_type` | 400 |
+| 必須 field 欠落 | `invalid_request` | 400 |
+| `subject_token_type` が Registry にない | `unsupported_token_type` | 400 |
+| `requested_token_type` が `access_token` 以外 | `unsupported_token_type` | 400 |
+| `actor_token_type` が Registry にない (提示時) | `unsupported_token_type` | 400 |
+| subject_token 署名/exp 不正 | `invalid_grant` | 400 |
+| subject_token の family revoked | `invalid_grant` (errorDescription: `family_revoked`) | 400 |
+| actor_token 検証失敗 | `invalid_grant` | 400 |
+| `scope` が subject の subset でない | `invalid_scope` | 400 |
+| `audience` が client allowlist 外 | `invalid_target` | 400 (RFC 8707) |
+| client 認証失敗 | `invalid_client` | 401 |
+| policy hook が deny | `access_denied` | 403 |
+| refreshTokenStore not wired (config 不備) | `invalid_grant` | 400 |
+| refreshTokenStore runtime unavailable (一時障害) | `temporarily_unavailable` | 503 |
+
+## 6. Grant handler 処理フロー
+
+```text
+1. request parse + 必須 field 検証 → invalid_request
+2. client authentication (authorization_code と同ロジック流用) → invalid_client
+3. requested_token_type check (access_token or undefined のみ許容) → unsupported_token_type
+4. subject_token_type を Registry で lookup → unsupported_token_type
+5. ExchangeTokenValidator.validate(subject_token, { role: "subject" })
+   - self-issued access_token: 署名 + exp + family revocation check (fail-closed)
+   - 外部 JWT: consumer 実装に委譲
+   - 失敗 → invalid_grant
+6. actor_token 提示時:
+   - actor_token_type を Registry で lookup → unsupported_token_type
+   - ExchangeTokenValidator.validate(actor_token, { role: "actor" }) → invalid_grant
+7. scope narrowing check: requested scope ⊆ subject_token.scope → invalid_scope
+8. audience allowlist check (client registration):
+   - `audience` parameter 指定時のみ check: 全要素が `client.allowedAudiences ∪ { client.clientId }` に含まれる → invalid_target
+   - `audience` parameter 省略時の fallback (§8.1 rule 2) は allowlist check をスキップ (derived `aud` は常に subject 由来 = 既に subject_token の `aud` として validate 済み、または clientId = 必ず allowlist に含まれる)
+9. GrantPolicyHook 呼び出し (既存 interface 流用、`packages/core/src/policy/types.mts`):
+   - 入力: `GrantPolicyRequest` = { grantType, clientId, subject, requestedScope, requestedAudience, originalScope, subjectTokenType, actorTokenType, resource, extras }
+   - 出力: `GrantPolicyDecision`:
+     - `{ outcome: "allow", grantedScope?, grantedAudience? }` → 発行続行 (以降 grantedScope / grantedAudience を使う)
+     - `{ outcome: "deny", error, errorDescription? }` → policy 指定のエラーコードで reject (default は `access_denied`)
+10. act claim 構築 (§9 の canonical rule に従う):
+    - actor_token あり: act = { sub: <actor.sub>, ...<subject.act があれば act.act として入れ子> }
+    - actor_token なし: 発行 token に act claim を載せない (subject.act の継承もしない)
+11. family_id 継承 (α 方針):
+    - subject が self-issued access_token: subject.familyId を継承
+    - 外部 JWT: 新 family_id を発行しない (policy で指定された場合のみ発行、default は無し)
+12. generateToken で access_token 発行:
+    - data: { family_id?, sid?, act? }
+    - options: expiresIn, issuer, audience (narrowed), subject (subject.sub),
+              authorizedParty (client_id), scope (narrowed), tokenType: "at+jwt"
+13. 成功 response 組み立て + auditSink emit
+```
+
+## 7. Revocation / Family 管理
+
+### 7.1 既存 invariant (auth.provider 全体)
+
+現状 auth.provider は `RefreshTokenStoreBase.isFamilyRevoked(familyId)` による cascading revoke が確立済み:
+
+- introspect endpoint で access_token の `family_id` を check (`oauth/src/routes.mts:262-302`)
+- userinfo endpoint で同 check
+- refresh grant で family revoked 時は `invalid_grant/family_revoked`
+- logout cascade で revokeFamily → session 削除
+
+**Token Exchange だけ stateless にするのは repo invariant の regression。**
+
+### 7.2 Token Exchange の revocation 方針
+
+1. **自前発行 access_token (at+jwt) が subject_token の場合**:
+   - built-in validator が `family_id` で `isFamilyRevoked()` 照合
+   - revoked なら `invalid_grant` (errorDescription: `family_revoked`) で reject
+
+2. **Store failure の 2 状態を分離** (Codex 指摘対応):
+
+   | 状態 | 検出方法 | エラー応答 | 理由 |
+   |---|---|---|---|
+   | **not wired** (起動時に `refreshTokenStore` が未設定) | `deps.refreshTokenStore === undefined` | `invalid_grant` (400) + startup warning log | 設定不備 = client 側で retry しても無駄。config エラー相当 |
+   | **runtime unavailable** (wire 済みだが Redis 等が一時的に応答しない) | `isFamilyRevoked()` が throw | `temporarily_unavailable` (503) + `Retry-After` | 一時障害 = client 側で retry 可能。RFC 6749 §5.2 |
+
+   - introspect endpoint (`routes.mts:273-291`) は両状態を `active: false` に集約しているが、Token Exchange では RFC 6749 §5.2 に沿ってエラーコードを分ける
+   - **not wired の場合 fail-closed を選ぶ理由**: Token Exchange は権限が横展開される操作で、revocation 検出能力が欠けた状態で通すと cascading revoke の invariant が破れる
+
+3. **外部 JWT が subject_token の場合**:
+   - consumer validator が revocation の責任を持つ (外部 IdP の introspection endpoint 等)
+   - core は署名検証のみ強制、revocation は consumer 判断
+   - README で明記
+
+4. **actor_token の検証も同じルール**
+
+### 7.3 family_id 継承 (α 方針)
+
+- subject の `family_id` を発行 token に継承
+- subject family が revoke されたら delegated token も自動失効 (cascade)
+- `RefreshTokenStoreBase` interface 変更不要
+- delegated token だけを個別 revoke する運用は post-0.5 で別途検討 (`/oauth/revoke` endpoint の jti 単位 revocation 等)
+
+## 8. Scope / Audience narrowing
+
+### 8.1 Built-in 強制ルール (core)
+
+1. `scope` ⊆ `subject_token.scope` (空集合も有効、scope parameter 省略時は subject の scope を継承)
+2. `audience` の全要素が `client.allowedAudiences ∪ { client.clientId }` に含まれる (§8.3 参照)。`audience` parameter 省略時:
+   - subject の `aud` が単一値: それを発行 token の `aud` に継承
+   - subject の `aud` が複数値 or 未設定: **呼び出し client の clientId を発行 token の `aud` にする** (既存 authorization_code の挙動と一致、`authorization.mts:265-268`)
+   - 理由: `generateToken` は単一 `aud` のみ対応 (§8.1.1)。subject が多 aud の場合に「どれを継承するか」を暗黙選択するより、明示的に client 自身を aud にする方が挙動が予測可能
+3. `resource` は policy hook がない場合はそのまま通す (URI の意味を core は知らない)
+4. 全てが通った後、`GrantPolicyHook` を呼び出し consumer が更に絞れる (`grantedScope` / `grantedAudience` で override 可)
+
+### 8.1.1 Multi-value parameter の処理
+
+- `audience` / `resource` は RFC 8707 §2 の repeated parameter 形式 (`audience=a&audience=b`) で解釈
+- express `body-parser` の urlencoded middleware は同名 key を `string[]` に展開するので core 側の追加処理は不要
+- 単一値 (`audience=a`) は `string` で届くので、grant handler で `typeof === "string" ? [v] : v` で normalize
+- ただし発行 JWT の `aud` claim は現状 `generateToken` が**単一値のみ対応** (`packages/core/src/grants/token.mts:86-114`)。multi-aud 発行は post-0.5 (別 spec で対応)、本 spec では**narrowed audience の先頭 1 つのみを `aud` に載せる** (`authorization.mts:265-268` と同じ挙動)
+
+### 8.2 設計理由
+
+- Policy 未設定でも安全 default (Quickstart 5 分要件 §v0.5.0 DX #7)
+- Scope escalation 攻撃を core レベルで防止
+- Audience confusion を client registration で防止
+- Resource URI は consumer ドメイン依存なので policy hook に委ねる (正しい責任分界)
+
+### 8.3 ClientRepository の shape — **Hard Prerequisite**
+
+現状 `packages/core/src/repositories/types.mts:17` の `Client` 型には `audiences` field が**存在しない**。Token Exchange の `audience` narrowing (§8.1 built-in rule 2) は `Client` の allowlist 情報が必須のため、以下を Token Exchange 実装の**前提**として先行確定する:
+
+**決定事項 (本 spec 内で確定):**
+
+- `Client` interface に `allowedAudiences?: string[]` を追加
+  - 命名理由: 既存 `allowedRedirectUris` / `allowedScopes` と命名パターン一致
+  - optional (default undefined = `[clientId]` 扱い)
+- `undefined` または空配列時の default 挙動: **`audience` parameter が指定されていれば、`clientId` と一致する場合のみ許可**
+  - 理由: Token Exchange なしの通常 access_token は現状 `aud = clientId` で発行されている (`authorization.mts:265-268`)。allowlist 未設定の client でも「自分自身を audience にする exchange」は許可するのが自然
+- `audience` parameter 省略時の発行 `aud` は §8.1 rule 2 に従う (subject 単一 aud → 継承、多 aud or 未設定 → clientId)
+
+**実装タスク (plan に含める):**
+
+1. `packages/core/src/repositories/types.mts` の `Client` に `allowedAudiences?: string[]` を追加
+2. `ClientEntrySchema` (zod) に同 field 追加
+3. ClientRepository の既存 in-memory / adapter 実装が field を透過すること確認 (無視して OK)
+4. ドキュメント (README / examples) で設定方法を追記
+
+**backward compatibility:**
+
+- field は optional。既存の Client record / config は invalid にならない
+- Token Exchange を有効化しない consumer は何も変更不要
+- Token Exchange 有効化時、`allowedAudiences` 未設定の client は「自分自身 (clientId) のみ audience 指定可」= 安全 default
+
+## 9. `act` claim の構築
+
+### 9.1 Default policy
+
+- `actor_token` 提示時 → `act: { sub: <actor.sub> }` を必ず JWT に埋める
+- `actor_token` 無し → `act` 無しの impersonation
+- RFC 8693 §4.1 の素直な実装
+
+### 9.2 Override
+
+- 厳格な delegation 強制が必要な consumer は既存 `GrantPolicyHook` で宣言:
+  ```ts
+  async evaluate(request: GrantPolicyRequest, ctx: GrantPolicyContext): Promise<GrantPolicyDecision> {
+    if (request.grantType === "urn:ietf:params:oauth:grant-type:token-exchange"
+        && !request.actorTokenType) {
+      return {
+        outcome: "deny",
+        error: "invalid_request",
+        errorDescription: "actor_token required for delegation",
+      };
+    }
+    return { outcome: "allow" };
+  }
+  ```
+- `actorTokenType` / `subjectTokenType` / `resource` は既に `GrantPolicyRequest` interface に乗っている (`packages/core/src/policy/types.mts:19-30`)
+
+### 9.3 入れ子 act (多段 delegation)
+
+`subject_token` 自体が既に `act` claim を持っている場合:
+
+```json
+// subject_token の claims
+{ "sub": "alice", "act": { "sub": "service-a" } }
+
+// actor_token (service-b)
+{ "sub": "service-b" }
+
+// 発行される token の act
+{ "sub": "service-b", "act": { "sub": "service-a" } }
+```
+
+RFC 8693 §4.1 の nested actor chain に従う。全選択肢で実装必須。
+
+## 10. Consumer registration の shape
+
+### 10.1 最小構成 (built-in access_token validator のみ)
+
+```ts
+import { GrantRegistry } from "@o3co/auth-provider-core";
+import {
+  tokenExchangeModule,
+  ExchangeTokenValidatorRegistry,
+  createSelfIssuedAccessTokenValidator,
+} from "@o3co/auth-provider-oauth-token-exchange";
+
+const validatorRegistry = new ExchangeTokenValidatorRegistry();
+validatorRegistry.register(
+  "urn:ietf:params:oauth:token-type:access_token",
+  createSelfIssuedAccessTokenValidator({ keyStore, refreshTokenStore, issuer }),
+);
+
+grantRegistry.addModule(tokenExchangeModule, {
+  ...deps,
+  validatorRegistry,
+  clientRepository,
+});
+```
+
+### 10.2 外部 JWT も受け入れる consumer
+
+```ts
+class ExternalJwtValidator implements ExchangeTokenValidator {
+  readonly tokenType = "urn:ietf:params:oauth:token-type:jwt";
+  async validate(
+    token: string,
+    ctx: { role: "subject" | "actor" },
+  ): Promise<ValidatedToken | null> {
+    // jwks_uri fetch, signature verify, issuer allowlist check, revocation check
+  }
+}
+
+validatorRegistry.register(
+  "urn:ietf:params:oauth:token-type:jwt",
+  new ExternalJwtValidator({ allowedIssuers: [...], jwksUri: "..." }),
+);
+```
+
+### 10.3 登録されていない token type への対応
+
+- Registry が `undefined` を返す → grant handler が `unsupported_token_type` で応答 (default deny)
+
+## 11. Config schema (HOCON)
+
+### 11.1 設定
+
+```hocon
+oauth {
+  grants {
+    token_exchange {
+      enabled = true
+      accessToken {
+        expiresIn = 300  # 省略時は oauth.accessToken.expiresIn を流用
+      }
+    }
+  }
+}
+```
+
+### 11.2 zod schema (GrantModule.configSchema)
+
+```ts
+const tokenExchangeConfigSchema = z.object({
+  token_exchange: z
+    .object({
+      enabled: z.boolean().default(true),
+      accessToken: z
+        .object({
+          expiresIn: z.number().int().positive().optional(),
+        })
+        .optional(),
+    })
+    .default({}),
+});
+```
+
+**audience allowlist は client 単位 (`Client.allowedAudiences`) のみで管理** (§8.3)。全 client 共通の shared allowlist は本 spec では導入しない。理由: 複数ソースの allowlist は merge/precedence を明示しないと security hole になる。必要になれば post-0.5 で `GrantPolicyHook` で consumer 側実装できる。
+
+### 11.3 Safe default
+
+- `enabled: false` で封じられる (GrantRegistry.addModule の `enabled: false` 判定に既存対応)
+- default は `enabled: true` だが、**registration 自体が consumer opt-in** なので module を import しない限り無効
+- `expiresIn` は短命 (default 300s = 5min)。Token Exchange は短命が原則
+
+## 12. Test 戦略
+
+### 12.1 Unit tests (TDD RED → GREEN → REFACTOR)
+
+**ExchangeTokenValidatorRegistry:**
+- register / get / unknown type
+
+**createSelfIssuedAccessTokenValidator:**
+- 正常 token の validate
+- 署名不正 → null
+- exp 過ぎ → null
+- family revoked → null
+- store unavailable → throw (fail-closed)
+- 外部発行 issuer の token → null (issuer 一致しない場合)
+
+**createTokenExchangeGrant — happy path:**
+- 最小 request (A: impersonation, actor_token 無し) で access_token 発行、`act` claim 無し
+- actor_token あり request (B: delegation) で `act: { sub: <actor.sub> }` が載る
+- 入れ子 delegation (subject 自体が `act` を持つ + actor_token あり) で `act: { sub: <actor>, act: <subject.act> }` が構築
+- actor_token 無し + subject に `act` 付き → 発行 token に `act` 継承しない (§9 canonical rule)
+- scope narrowing (C) で subject の subset だけ発行
+- scope 省略時: subject の scope を継承
+- audience 省略 + subject 単一 aud: 発行 token の `aud` = subject の `aud`
+- audience 省略 + subject 多 aud / aud 未設定: 発行 token の `aud` = `clientId`
+- audience 指定時: `allowedAudiences ∪ { clientId }` にある値のみ許可
+- `allowedAudiences` 未設定 + `audience=<clientId>` → 許可 (safe default §8.3)
+- policy hook が `grantedScope` / `grantedAudience` を返したら override を反映
+
+**createTokenExchangeGrant — error cases:**
+- 必須 field 欠落 → invalid_request
+- unknown subject_token_type → unsupported_token_type
+- requested_token_type が access_token 以外 → unsupported_token_type
+- unknown actor_token_type (提示時) → unsupported_token_type
+- scope superset 要求 → invalid_scope
+- audience not in allowlist → invalid_target
+- subject family revoked → invalid_grant (errorDescription: `family_revoked`)
+- **refreshTokenStore not wired** → invalid_grant (400) + startup warning log (§7.2 state 1)
+- **refreshTokenStore runtime throw** → temporarily_unavailable (503) (§7.2 state 2)
+- policy hook `{ outcome: "deny", error, errorDescription }` → そのエラーコードで reject
+- requested_token_type = id_token / refresh_token → unsupported_token_type (E: token type conversion 明示拒否)
+
+### 12.2 Integration tests
+
+- authorization_code で取った access_token を subject に → token_exchange で別 audience の access_token を発行
+- 発行された token を introspect → active (family_id 継承確認)
+- 元 family を revoke → 発行された delegated token も introspect で inactive (cascade 動作確認)
+
+## 13. Security considerations
+
+1. **Scope escalation 防止**: built-in subset check (core 強制、policy で bypass 不可)
+2. **Token replay 対策**: subject_token の jti を nonce store で one-time にするかは policy hook で consumer 判断 (spec でガイドライン記述、実装は built-in しない)
+3. **Family cascade**: subject の family revoke で delegated token も自動失効 (α 方針)
+4. **Impersonation 痕跡の欠如**: `actor_token` 無し = `act` claim 無し。監査要件の強い consumer は policy hook で actor_token 必須化を推奨 (README 明記)
+5. **外部 JWT の trust anchor**: consumer が implicit に信頼する issuer を明示設定する責任を持つ (README 明記)
+6. **Audience confusion**: narrowed audience は client registration の allowlist + policy hook double check
+7. **DPoP bound token の扱い**: v0.5.0 では `cnf` claim があっても無視、新 token に `cnf` は載せない (DPoP 段階投入 Y 戦略、1.0 GA で対応)
+
+## 14. 後方互換性
+
+- Interface 追加のみ、既存 interface の変更は §8.3 で明示確定した `Client.allowedAudiences?: string[]` の 1 件のみ (optional field 追加なので backward compat)
+- `GrantDependencies` / `GrantHandler` / `RefreshTokenStoreBase` は無変更
+- Consumer が module を import しなければ完全に noop (breaking change なし)
+
+## 15. post-0.5 に残す項目 (out-of-scope)
+
+- 外部 JWT validator の built-in 実装 (`@o3co/auth-provider-oauth-external-jwt` 候補)
+- SAML2 token type の受入 (`urn:ietf:params:oauth:token-type:saml2`)
+- id_token 発行 Token Exchange
+- DPoP-bound token の Token Exchange (v1.0 GA)
+- `requested_token_type` 以外の token type 発行
+- `/oauth/revoke` endpoint での jti 単位 revocation
+
+## 16. 関連文書
+
+### 16.1 Debate / decision log
+
+- `debate/did-auth-oauth2-idp/` 全 4 ラウンド
+- `debate/did-auth-oauth2-idp/191600_CON.md:67` — CON 起点
+- `debate/did-auth-oauth2-idp/191619_PRO.md:90,143,175` — PRO 受諾
+- `debate/did-auth-oauth2-idp/191845_PRO.md:192` — 最高優先度確定
+- `debate/did-auth-oauth2-idp/192516_PRO.md:104,215` — persona pain + GA gate
+
+### 16.2 Existing spec / plan
+
+- `2026-04-21-extension-surface-decisions-design.md` — GrantPolicyHook 仕様 (本 spec が流用)
+- `2026-04-21-extension-surface-decisions-design.md:535-537` — subjectTokenType / actorTokenType / resource は既に `GrantPolicyRequest` に定義済み
+- `2026-04-23-federation-provider-package-split-design.md` — built-in registration 廃止の判例
+- `2026-04-24-grant-type-rename-design.md` — grant_type URN 化、IETF 標準 URN 使用方針
+
+### 16.3 Existing implementation
+
+- `packages/core/src/refresh/types.mts` — `RefreshTokenStoreBase.isFamilyRevoked`
+- `packages/oauth/src/routes.mts:262-302` — introspect の family revocation cascade
+- `packages/oauth/src/grants/authorization.mts:254-260` — family_id 発行 + cascade 方針
+- `packages/core/src/grants/token.mts` — generateToken / generateTokenResponse (流用)
+
+### 16.4 External references
+
+- [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) — OAuth 2.0 Token Exchange
+- [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707) — Resource Indicators for OAuth 2.0 (`invalid_target` error)
+- [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749) — OAuth 2.0 core (error response format)
+- [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662) — Token Introspection (`active: false` semantics)

--- a/.claude/superpowers/specs/2026-04-24-token-exchange-design.md
+++ b/.claude/superpowers/specs/2026-04-24-token-exchange-design.md
@@ -444,7 +444,6 @@ validatorRegistry.register(
 oauth {
   grants {
     token_exchange {
-      enabled = true
       accessToken {
         expiresIn = 300  # 省略時は oauth.accessToken.expiresIn を流用
       }
@@ -459,7 +458,6 @@ oauth {
 const tokenExchangeConfigSchema = z.object({
   token_exchange: z
     .object({
-      enabled: z.boolean().default(true),
       accessToken: z
         .object({
           expiresIn: z.number().int().positive().optional(),
@@ -472,11 +470,13 @@ const tokenExchangeConfigSchema = z.object({
 
 **audience allowlist は client 単位 (`Client.allowedAudiences`) のみで管理** (§8.3)。全 client 共通の shared allowlist は本 spec では導入しない。理由: 複数ソースの allowlist は merge/precedence を明示しないと security hole になる。必要になれば post-0.5 で `GrantPolicyHook` で consumer 側実装できる。
 
-### 11.3 Safe default
+### 11.3 Disable mechanism
 
-- `enabled: false` で封じられる (GrantRegistry.addModule の `enabled: false` 判定に既存対応)
-- default は `enabled: true` だが、**registration 自体が consumer opt-in** なので module を import しない限り無効
-- `expiresIn` は短命 (default 300s = 5min)。Token Exchange は短命が原則
+Consumers disable Token Exchange by **not importing `tokenExchangeModule`**. This matches the federation-package-split philosophy (v0.5.0 #17): registration is 100% consumer opt-in. There is no config-driven disable switch.
+
+Rationale: `GrantModule` in core dispatches handlers by grant-type key (the RFC 8693 URN `urn:ietf:params:oauth:grant-type:token-exchange`), but operator-friendly HOCON uses the `token_exchange` key. Bridging those two via a config-driven `enabled` flag would require a core interface change (adding `configKey?: string` to `GrantModule`) that v0.5.0 interface freeze avoids. Consumer-level opt-in via module import is both simpler and consistent with the rest of v0.5.0 scope.
+
+**`expiresIn` default:** short (300s = 5 min). Token Exchange is short-lived by RFC 8693 recommendation.
 
 ## 12. Test 戦略
 
@@ -540,6 +540,7 @@ const tokenExchangeConfigSchema = z.object({
 - Interface 追加のみ、既存 interface の変更は §8.3 で明示確定した `Client.allowedAudiences?: string[]` の 1 件のみ (optional field 追加なので backward compat)
 - `GrantDependencies` / `GrantHandler` / `RefreshTokenStoreBase` は無変更
 - Consumer が module を import しなければ完全に noop (breaking change なし)
+- `enabled` フィールドを config schema から削除 (C1 Option D): schema-level のみの変更。`tokenExchangeModule` は v0.5.0 初出なので `enabled` に依存していた consumer はいない。backward compat 問題なし。
 
 ## 15. post-0.5 に残す項目 (out-of-scope)
 

--- a/packages/core/src/repositories/InMemoryClientRepository.mts
+++ b/packages/core/src/repositories/InMemoryClientRepository.mts
@@ -59,6 +59,7 @@ export const ClientEntrySchema = z
 		clientSecret: z.string().min(1),
 		allowedRedirectUris: z.array(z.string()).default([]),
 		allowedScopes: z.array(z.string()).default([]),
+		allowedAudiences: z.array(z.string()).default([]),
 		// NEW (TODO-F-5): Logout metadata.
 		// Use httpUrlSchema (not z.string().url()) for fields that end up in iframe src
 		// or redirect targets — rejects javascript:, data:, file: to prevent XSS.
@@ -99,6 +100,7 @@ export class InMemoryClientRepository implements ClientRepository {
 			clientId,
 			allowedRedirectUris: entry.allowedRedirectUris,
 			allowedScopes: entry.allowedScopes,
+			allowedAudiences: entry.allowedAudiences,
 			...(entry.postLogoutRedirectUris !== undefined && {
 				postLogoutRedirectUris: entry.postLogoutRedirectUris,
 			}),
@@ -136,6 +138,7 @@ export class InMemoryClientRepository implements ClientRepository {
 			clientId,
 			allowedRedirectUris: entry.allowedRedirectUris,
 			allowedScopes: entry.allowedScopes,
+			allowedAudiences: entry.allowedAudiences,
 			...(entry.postLogoutRedirectUris !== undefined && {
 				postLogoutRedirectUris: entry.postLogoutRedirectUris,
 			}),

--- a/packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts
+++ b/packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts
@@ -286,6 +286,24 @@ describe("InMemoryClientRepository", () => {
 			const client = await repo.findById("client-b");
 			expect(client?.allowedAudiences).toEqual(["billing-service", "inventory-service"]);
 		});
+
+		it("exposes allowedAudiences via authenticate() (also propagates on auth path)", async () => {
+			const repo = new InMemoryClientRepository(
+				new Map([
+					[
+						"client-c",
+						{
+							clientSecret: "correct-horse-battery-staple",
+							allowedRedirectUris: [],
+							allowedScopes: [],
+							allowedAudiences: ["payment-service"],
+						},
+					],
+				]),
+			);
+			const client = await repo.authenticate("client-c", "correct-horse-battery-staple");
+			expect(client?.allowedAudiences).toEqual(["payment-service"]);
+		});
 	});
 
 	describe("authenticate", () => {

--- a/packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts
+++ b/packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts
@@ -251,6 +251,43 @@ describe("InMemoryClientRepository", () => {
 		});
 	});
 
+	describe("allowedAudiences field round-trip (Token Exchange RFC 8693)", () => {
+		it("exposes allowedAudiences via findById (empty array when omitted)", async () => {
+			const repo = new InMemoryClientRepository(
+				new Map([
+					[
+						"client-a",
+						{
+							clientSecret: "s",
+							allowedRedirectUris: [],
+							allowedScopes: [],
+						},
+					],
+				]),
+			);
+			const client = await repo.findById("client-a");
+			expect(client?.allowedAudiences).toEqual([]);
+		});
+
+		it("exposes allowedAudiences via findById (preserves configured values)", async () => {
+			const repo = new InMemoryClientRepository(
+				new Map([
+					[
+						"client-b",
+						{
+							clientSecret: "s",
+							allowedRedirectUris: [],
+							allowedScopes: [],
+							allowedAudiences: ["billing-service", "inventory-service"],
+						},
+					],
+				]),
+			);
+			const client = await repo.findById("client-b");
+			expect(client?.allowedAudiences).toEqual(["billing-service", "inventory-service"]);
+		});
+	});
+
 	describe("authenticate", () => {
 		it("returns client with correct plain text secret", async () => {
 			const repo = new InMemoryClientRepository(

--- a/packages/core/src/repositories/types.mts
+++ b/packages/core/src/repositories/types.mts
@@ -19,6 +19,12 @@ export interface Client {
 	clientSecret: string;
 	allowedRedirectUris: string[];
 	allowedScopes: string[];
+	/**
+	 * Audience URIs that this client may request in Token Exchange (RFC 8693)
+	 * `audience` parameter. Empty or undefined means only the client's own
+	 * clientId is allowed as audience. Not used outside Token Exchange.
+	 */
+	allowedAudiences?: string[];
 	// NEW (TODO-F-5): Logout metadata.
 	postLogoutRedirectUris?: string[];
 	backchannelLogoutUri?: string;

--- a/packages/oauth-token-exchange/README.md
+++ b/packages/oauth-token-exchange/README.md
@@ -19,6 +19,10 @@ import {
   tokenExchangeModule,
 } from "@o3co/auth-provider-oauth-token-exchange";
 
+// `keyStore`, `issuer`, `refreshTokenStore`, `clientRepository`, and any other
+// fields in `deps` come from your app wiring (see auth-provider-core docs).
+const grantRegistry = new GrantRegistry();
+
 const validatorRegistry = new ExchangeTokenValidatorRegistry();
 validatorRegistry.register(
   "urn:ietf:params:oauth:token-type:access_token",

--- a/packages/oauth-token-exchange/README.md
+++ b/packages/oauth-token-exchange/README.md
@@ -1,0 +1,6 @@
+# @o3co/auth-provider-oauth-token-exchange
+
+RFC 8693 Token Exchange grant for auth.provider. See design spec at
+`.claude/superpowers/specs/2026-04-24-token-exchange-design.md`.
+
+Full usage documentation is added in Task 11.

--- a/packages/oauth-token-exchange/README.md
+++ b/packages/oauth-token-exchange/README.md
@@ -91,13 +91,15 @@ validatorRegistry.register(
 
 1. **refreshTokenStore must be wired into the grant dependencies (not into the validator)** so the handler can surface the specific `family_revoked` errorDescription (spec §5.3). Without `refreshTokenStore` in the grant deps, self-issued access_tokens carrying `family_id` cannot be revocation-checked; the handler returns `invalid_grant` (fail-closed). Leaving it absent from the validator is intentional — the handler owns revocation so the specific error can propagate. See the "Register the grant" example above.
 
-2. **Scope is always narrowed by the core handler.** `requested scope ⊆ subject_token.scope` is enforced unconditionally — a `GrantPolicyHook` cannot bypass this subset check for narrowing **through the request parameter**. However, see point 4 below about policy-level override.
+2. **Scope is always narrowed by the core handler.** `requested scope ⊆ subject_token.scope` is enforced unconditionally — a `GrantPolicyHook` cannot bypass this subset check for narrowing **through the request parameter**. However, see point 5 below about policy-level override.
 
 3. **Audience allowlist (client-scoped).** The `audience` request parameter must be in `client.allowedAudiences ∪ { client.clientId }`. This is enforced by the core handler before the policy hook runs. Empty `allowedAudiences` means only the client's own `clientId` is a valid exchange audience.
 
-4. **Policy hook widening is permitted by design.** The `GrantPolicyHook.evaluate()` result's `grantedScope` and `grantedAudience` override the handler's pre-narrowed values without re-verification. A first-party consumer policy CAN widen scope or audience if it wants to — this is the intentional escape hatch for operational needs (e.g., an admin flow that grants a superset). Consumers own the consequences of widening policies. If you want strict narrowing-only policies, write your `evaluate()` method defensively and never return `grantedScope`/`grantedAudience` that exceeds what you were given.
+4. **Cross-client audience confusion defense.** When the `audience` request parameter is omitted, the handler inherits `subject_token.aud` only if it is in `client.allowedAudiences ∪ { client.clientId }`. Otherwise it falls back to `clientId`. This prevents a malicious client from exchanging a stolen token outside its intended audience just by omitting the audience parameter.
 
-5. **Impersonation vs delegation.** An exchange without `actor_token` issues an impersonation token (no `act` claim). Deployments that require audit trails should add a `GrantPolicyHook` that rejects requests lacking `actor_token`:
+5. **Policy hook widening is permitted by design.** The `GrantPolicyHook.evaluate()` result's `grantedScope` and `grantedAudience` override the handler's pre-narrowed values without re-verification. A first-party consumer policy CAN widen scope or audience if it wants to — this is the intentional escape hatch for operational needs (e.g., an admin flow that grants a superset). Consumers own the consequences of widening policies. If you want strict narrowing-only policies, write your `evaluate()` method defensively and never return `grantedScope`/`grantedAudience` that exceeds what you were given.
+
+6. **Impersonation vs delegation.** An exchange without `actor_token` issues an impersonation token (no `act` claim). Deployments that require audit trails should add a `GrantPolicyHook` that rejects requests lacking `actor_token`:
 
    ```ts
    async evaluate(req) {
@@ -109,13 +111,13 @@ validatorRegistry.register(
    }
    ```
 
-6. **Family cascade.** Issued access_tokens inherit the subject's `family_id` claim. Revoking the subject's family (e.g. on logout) automatically invalidates every token exchanged from it. This is the same mechanism auth.provider's introspect and userinfo endpoints use.
+7. **Family cascade.** Issued access_tokens inherit the subject's `family_id` claim. Revoking the subject's family (e.g. on logout) automatically invalidates every token exchanged from it. This is the same mechanism auth.provider's introspect and userinfo endpoints use.
 
-7. **Refresh / ID tokens are never issued.** Per RFC 8693 §4.2.2 the handler only returns an access_token. The response always carries `issued_token_type: "urn:ietf:params:oauth:token-type:access_token"`.
+8. **Refresh / ID tokens are never issued.** Per RFC 8693 §4.2.2 the handler only returns an access_token. The response always carries `issued_token_type: "urn:ietf:params:oauth:token-type:access_token"`.
 
-8. **Missing subject claim rejection.** Self-issued access_tokens without a `sub` claim (or with an empty-string `sub`) are rejected with `invalid_grant`. This prevents a silently-anonymous token from reaching downstream services.
+9. **Missing subject claim rejection.** Self-issued access_tokens without a `sub` claim (or with an empty-string `sub`) are rejected with `invalid_grant`. This prevents a silently-anonymous token from reaching downstream services.
 
-9. **Validator registry is sealed at registration.** Once `grantRegistry.addModule(tokenExchangeModule, ...)` is called, the `validatorRegistry` passed in is frozen — subsequent `register()` calls throw. This prevents a consumer reference from replacing the built-in validator at runtime.
+10. **Validator registry is sealed at registration.** Once `grantRegistry.addModule(tokenExchangeModule, ...)` is called, the `validatorRegistry` passed in is frozen — subsequent `register()` calls throw. This prevents a consumer reference from replacing the built-in validator at runtime.
 
 ## Registration pattern summary
 

--- a/packages/oauth-token-exchange/README.md
+++ b/packages/oauth-token-exchange/README.md
@@ -1,6 +1,136 @@
 # @o3co/auth-provider-oauth-token-exchange
 
-RFC 8693 Token Exchange grant for auth.provider. See design spec at
-`.claude/superpowers/specs/2026-04-24-token-exchange-design.md`.
+RFC 8693 Token Exchange grant for [auth.provider](https://github.com/o3co/auth.provider).
+Supports on-behalf-of, delegation (`act` claim), and scope / audience narrowing.
 
-Full usage documentation is added in Task 11.
+## Install
+
+```bash
+pnpm add @o3co/auth-provider-oauth-token-exchange
+```
+
+## Register the grant
+
+```ts
+import { GrantRegistry } from "@o3co/auth-provider-core";
+import {
+  ExchangeTokenValidatorRegistry,
+  createSelfIssuedAccessTokenValidator,
+  tokenExchangeModule,
+} from "@o3co/auth-provider-oauth-token-exchange";
+
+const validatorRegistry = new ExchangeTokenValidatorRegistry();
+validatorRegistry.register(
+  "urn:ietf:params:oauth:token-type:access_token",
+  createSelfIssuedAccessTokenValidator({
+    keyStore,            // your KeyStore (used to issue access_tokens)
+    refreshTokenStore,   // REQUIRED for cascading revoke; fail-closed if absent
+    issuer,              // your OIDC issuer URL
+  }),
+);
+
+grantRegistry.addModule(tokenExchangeModule, {
+  ...deps,
+  validatorRegistry,
+  clientRepository,
+});
+```
+
+The grant type URI is `urn:ietf:params:oauth:grant-type:token-exchange` (IETF registered).
+
+After `addModule` returns, the `validatorRegistry` is frozen — subsequent `register()` calls throw. This prevents a consumer reference from silently replacing the built-in validator at runtime.
+
+## Disabling the module
+
+There is no config-driven disable switch. To disable Token Exchange, **do not import `tokenExchangeModule`** (do not call `grantRegistry.addModule(tokenExchangeModule, ...)`).
+
+Rationale: the RFC 8693 grant type URI (used for HTTP dispatch) differs from the HOCON-friendly config key, which makes a config-driven `enabled` flag structurally awkward to implement cleanly. Consumer-level opt-in via module import is both simpler and consistent with the rest of the v0.5.0 package-split philosophy (`@o3co/auth-provider-oauth-federation-*`).
+
+## Client configuration
+
+Add `allowedAudiences` to the client record to permit audience narrowing to specific API identifiers:
+
+```yaml
+clients:
+  billing-gateway:
+    clientSecret: "..."
+    allowedScopes: ["read", "write"]
+    allowedAudiences: ["billing-service", "inventory-service"]
+```
+
+When `allowedAudiences` is empty or omitted, the only accepted `audience` parameter value is the client's own `clientId`. The audience allowlist is enforced in addition to any `GrantPolicyHook` you register.
+
+## External JWT subject_token
+
+The package ships a built-in validator only for the `access_token` token type (tokens issued by this same auth.provider instance). To accept external JWTs as `subject_token`, implement `ExchangeTokenValidator` yourself and register it for `urn:ietf:params:oauth:token-type:jwt`:
+
+```ts
+import type { ExchangeTokenValidator, ValidatedToken } from "@o3co/auth-provider-oauth-token-exchange";
+
+class ExternalJwtValidator implements ExchangeTokenValidator {
+  async validate(
+    token: string,
+    ctx: { role: "subject" | "actor" },
+  ): Promise<ValidatedToken | null> {
+    // Fetch jwks, verify signature, check issuer allowlist, consult remote
+    // introspection for revocation — all are YOUR responsibility.
+    // Return null on validation failure; throw on infrastructure failure (→ 503).
+  }
+}
+
+validatorRegistry.register(
+  "urn:ietf:params:oauth:token-type:jwt",
+  new ExternalJwtValidator({ /* your config */ }),
+);
+```
+
+## Security notes
+
+1. **refreshTokenStore is required.** Without it, self-issued access_tokens carrying `family_id` cannot be revocation-checked; the grant handler returns `invalid_grant` in that case (fail-closed). Token Exchange horizontally spreads access, so emitting tokens whose revocation cannot be observed is never acceptable.
+
+2. **Scope is always narrowed by the core handler.** `requested scope ⊆ subject_token.scope` is enforced unconditionally — a `GrantPolicyHook` cannot bypass this subset check for narrowing **through the request parameter**. However, see point 4 below about policy-level override.
+
+3. **Audience allowlist (client-scoped).** The `audience` request parameter must be in `client.allowedAudiences ∪ { client.clientId }`. This is enforced by the core handler before the policy hook runs. Empty `allowedAudiences` means only the client's own `clientId` is a valid exchange audience.
+
+4. **Policy hook widening is permitted by design.** The `GrantPolicyHook.evaluate()` result's `grantedScope` and `grantedAudience` override the handler's pre-narrowed values without re-verification. A first-party consumer policy CAN widen scope or audience if it wants to — this is the intentional escape hatch for operational needs (e.g., an admin flow that grants a superset). Consumers own the consequences of widening policies. If you want strict narrowing-only policies, write your `evaluate()` method defensively and never return `grantedScope`/`grantedAudience` that exceeds what you were given.
+
+5. **Impersonation vs delegation.** An exchange without `actor_token` issues an impersonation token (no `act` claim). Deployments that require audit trails should add a `GrantPolicyHook` that rejects requests lacking `actor_token`:
+
+   ```ts
+   async evaluate(req) {
+     if (req.grantType === "urn:ietf:params:oauth:grant-type:token-exchange" && !req.actorTokenType) {
+       return { outcome: "deny", error: "invalid_request",
+                errorDescription: "actor_token required for delegation" };
+     }
+     return { outcome: "allow" };
+   }
+   ```
+
+6. **Family cascade.** Issued access_tokens inherit the subject's `family_id` claim. Revoking the subject's family (e.g. on logout) automatically invalidates every token exchanged from it. This is the same mechanism auth.provider's introspect and userinfo endpoints use.
+
+7. **Refresh / ID tokens are never issued.** Per RFC 8693 §4.2.2 the handler only returns an access_token. The response always carries `issued_token_type: "urn:ietf:params:oauth:token-type:access_token"`.
+
+8. **Missing subject claim rejection.** Self-issued access_tokens without a `sub` claim (or with an empty-string `sub`) are rejected with `invalid_grant`. This prevents a silently-anonymous token from reaching downstream services.
+
+9. **Validator registry is sealed at registration.** Once `grantRegistry.addModule(tokenExchangeModule, ...)` is called, the `validatorRegistry` passed in is frozen — subsequent `register()` calls throw. This prevents a consumer reference from replacing the built-in validator at runtime.
+
+## Registration pattern summary
+
+- Consumer creates `ExchangeTokenValidatorRegistry` and registers validators for each supported `subject_token_type`
+- Consumer calls `grantRegistry.addModule(tokenExchangeModule, { ..., validatorRegistry, clientRepository })`
+- Module factory receives deps, calls `validatorRegistry.freeze()`, returns the grant handler
+- Post-wire, the registry is immutable — consumers cannot mutate it even via their own reference
+
+## Unsupported RFC 8693 features (v0.5.0 scope-out)
+
+- `saml1` / `saml2` subject token types
+- Token type conversion (access ↔ id, access → refresh): returns `unsupported_token_type`
+- DPoP-bound token minting (planned for 1.0 GA)
+- Built-in external JWT validator (consumer-implement; planned as a separate package post-0.5)
+
+## RFC references
+
+- [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) — OAuth 2.0 Token Exchange
+- [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707) — Resource Indicators (`invalid_target`)
+- [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749) — OAuth 2.0 core
+- [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662) — Token Introspection

--- a/packages/oauth-token-exchange/README.md
+++ b/packages/oauth-token-exchange/README.md
@@ -119,6 +119,8 @@ validatorRegistry.register(
 
 10. **Validator registry is sealed at registration.** Once `grantRegistry.addModule(tokenExchangeModule, ...)` is called, the `validatorRegistry` passed in is frozen — subsequent `register()` calls throw. This prevents a consumer reference from replacing the built-in validator at runtime.
 
+11. **Confidential clients only (v0.5.0).** The handler requires `client_secret` and authenticates via `clientRepository.authenticate()`. Requests without a secret are rejected with `invalid_client` (401). The core `Client` type carries `clientSecret: string` as a required field and `PublicClient = Omit<Client, "clientSecret">`, so `findById()` alone cannot tell a "no secret configured" client from "secret omitted by caller" — accepting the unauthenticated path would let an attacker exchange a stolen `subject_token` under any client's allowlist. Public-client support is deferred until a `Client.public` flag (or equivalent) lands in core.
+
 ## Registration pattern summary
 
 - Consumer creates `ExchangeTokenValidatorRegistry` and registers validators for each supported `subject_token_type`

--- a/packages/oauth-token-exchange/README.md
+++ b/packages/oauth-token-exchange/README.md
@@ -22,15 +22,18 @@ import {
 const validatorRegistry = new ExchangeTokenValidatorRegistry();
 validatorRegistry.register(
   "urn:ietf:params:oauth:token-type:access_token",
+  // Signature + typ + issuer check only. Revocation is handled by the
+  // grant handler via deps.refreshTokenStore so the specific
+  // `family_revoked` errorDescription can be surfaced (spec §5.3).
   createSelfIssuedAccessTokenValidator({
-    keyStore,            // your KeyStore (used to issue access_tokens)
-    refreshTokenStore,   // REQUIRED for cascading revoke; fail-closed if absent
-    issuer,              // your OIDC issuer URL
+    keyStore,
+    issuer,
   }),
 );
 
 grantRegistry.addModule(tokenExchangeModule, {
   ...deps,
+  refreshTokenStore,  // REQUIRED — handler uses this for cascading revoke
   validatorRegistry,
   clientRepository,
 });
@@ -58,7 +61,7 @@ clients:
     allowedAudiences: ["billing-service", "inventory-service"]
 ```
 
-When `allowedAudiences` is empty or omitted, the only accepted `audience` parameter value is the client's own `clientId`. The audience allowlist is enforced in addition to any `GrantPolicyHook` you register.
+When `allowedAudiences` is empty or omitted, the only accepted `audience` parameter value is the client's own `clientId`. This allowlist applies to the **request's `audience` parameter only** — a `GrantPolicyHook` can override `grantedAudience` in its decision, which is not re-validated against the allowlist (see Security note 4 for the rationale). If you want hard-boundary enforcement across both paths, write your policy hook defensively.
 
 ## External JWT subject_token
 
@@ -86,7 +89,7 @@ validatorRegistry.register(
 
 ## Security notes
 
-1. **refreshTokenStore is required.** Without it, self-issued access_tokens carrying `family_id` cannot be revocation-checked; the grant handler returns `invalid_grant` in that case (fail-closed). Token Exchange horizontally spreads access, so emitting tokens whose revocation cannot be observed is never acceptable.
+1. **refreshTokenStore must be wired into the grant dependencies (not into the validator)** so the handler can surface the specific `family_revoked` errorDescription (spec §5.3). Without `refreshTokenStore` in the grant deps, self-issued access_tokens carrying `family_id` cannot be revocation-checked; the handler returns `invalid_grant` (fail-closed). Leaving it absent from the validator is intentional — the handler owns revocation so the specific error can propagate. See the "Register the grant" example above.
 
 2. **Scope is always narrowed by the core handler.** `requested scope ⊆ subject_token.scope` is enforced unconditionally — a `GrantPolicyHook` cannot bypass this subset check for narrowing **through the request parameter**. However, see point 4 below about policy-level override.
 

--- a/packages/oauth-token-exchange/package.json
+++ b/packages/oauth-token-exchange/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "@o3co/auth-provider-oauth-token-exchange",
+	"description": "RFC 8693 Token Exchange grant for auth.provider",
+	"version": "0.0.0",
+	"license": "Apache-2.0",
+	"type": "module",
+	"exports": {
+		".": {
+			"import": "./dist/index.mjs",
+			"types": "./dist/index.d.mts"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md",
+		"LICENSE"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/o3co/auth.provider.git",
+		"directory": "packages/oauth-token-exchange"
+	},
+	"imports": {
+		"#/*": {
+			"development": "./src/*",
+			"default": "./dist/*"
+		}
+	},
+	"scripts": {
+		"prebuild": "rimraf dist",
+		"build": "tsc",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage"
+	},
+	"dependencies": {
+		"jose": "^6.2.2",
+		"zod": "^4.3.6"
+	},
+	"peerDependencies": {
+		"@o3co/auth-provider-core": "^0.0.0"
+	},
+	"devDependencies": {
+		"@o3co/auth-provider-core": "workspace:*",
+		"@vitest/coverage-v8": "^4.1.2",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.2"
+	}
+}

--- a/packages/oauth-token-exchange/package.json
+++ b/packages/oauth-token-exchange/package.json
@@ -34,8 +34,7 @@
 		"test:coverage": "vitest run --coverage"
 	},
 	"dependencies": {
-		"jose": "^6.2.2",
-		"zod": "^4.3.6"
+		"jose": "^6.2.2"
 	},
 	"peerDependencies": {
 		"@o3co/auth-provider-core": "^0.0.0"

--- a/packages/oauth-token-exchange/src/__tests__/act.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/act.test.mts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildActClaim } from "#/act.mjs";
+import type { ValidatedToken } from "#/validator/types.mjs";
+
+const tok = (overrides: Partial<ValidatedToken> = {}): ValidatedToken => ({
+	sub: "user-1",
+	claims: {},
+	...overrides,
+});
+
+describe("buildActClaim", () => {
+	it("returns undefined when no actor_token is present (impersonation)", () => {
+		expect(buildActClaim({ subject: tok({ sub: "alice" }), actor: undefined })).toBeUndefined();
+	});
+
+	it("does NOT inherit subject.act when no actor_token is present", () => {
+		const result = buildActClaim({
+			subject: tok({ sub: "alice", act: { sub: "upstream" } }),
+			actor: undefined,
+		});
+		expect(result).toBeUndefined();
+	});
+
+	it("returns { sub: <actor.sub> } for simple delegation", () => {
+		const result = buildActClaim({
+			subject: tok({ sub: "alice" }),
+			actor: tok({ sub: "service-a" }),
+		});
+		expect(result).toEqual({ sub: "service-a" });
+	});
+
+	it("nests subject.act inside new act for multi-step delegation", () => {
+		const result = buildActClaim({
+			subject: tok({ sub: "alice", act: { sub: "service-a" } }),
+			actor: tok({ sub: "service-b" }),
+		});
+		expect(result).toEqual({ sub: "service-b", act: { sub: "service-a" } });
+	});
+
+	it("preserves deep nested act chain from subject", () => {
+		const result = buildActClaim({
+			subject: tok({
+				sub: "alice",
+				act: { sub: "service-a", act: { sub: "service-upstream" } },
+			}),
+			actor: tok({ sub: "service-b" }),
+		});
+		expect(result).toEqual({
+			sub: "service-b",
+			act: { sub: "service-a", act: { sub: "service-upstream" } },
+		});
+	});
+});

--- a/packages/oauth-token-exchange/src/__tests__/fixtures.mts
+++ b/packages/oauth-token-exchange/src/__tests__/fixtures.mts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSecretKey } from "node:crypto";
+import {
+	createSymmetricKeyStore,
+	type KeyStore,
+	type RefreshTokenStoreBase,
+} from "@o3co/auth-provider-core";
+import { SignJWT } from "jose";
+
+export const SECRET = "test-secret-at-least-32-chars!!";
+export const keyStore: KeyStore = createSymmetricKeyStore(SECRET);
+export const secretKey = createSecretKey(Buffer.from(SECRET));
+
+export const ISSUER = "https://auth.example";
+
+export async function signSelfIssuedAccessToken(
+	claims: Record<string, unknown>,
+	options: { expiresIn?: string; typ?: string } = {},
+): Promise<string> {
+	const { expiresIn = "1h", typ = "at+jwt" } = options;
+	return new SignJWT({
+		sub: "user-1",
+		scope: "read",
+		iss: ISSUER,
+		aud: "client-a",
+		...claims,
+	})
+		.setProtectedHeader({ alg: "HS256", kid: "v0", typ })
+		.setIssuedAt()
+		.setExpirationTime(expiresIn)
+		.sign(secretKey);
+}
+
+export function makeRefreshStore(
+	overrides: Partial<RefreshTokenStoreBase> = {},
+): RefreshTokenStoreBase {
+	return {
+		kind: "fixture",
+		async rotate() {
+			return { outcome: "rotated" };
+		},
+		async isFamilyRevoked() {
+			return false;
+		},
+		async revokeFamily() {},
+		...overrides,
+	};
+}

--- a/packages/oauth-token-exchange/src/__tests__/grant-integration.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant-integration.test.mts
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+	ClientRepository,
+	GrantContext,
+	PublicClient,
+	RefreshTokenStoreBase,
+} from "@o3co/auth-provider-core";
+import { decodeJwt } from "jose";
+import { describe, expect, it } from "vitest";
+import { createTokenExchangeGrant, TOKEN_EXCHANGE_GRANT_TYPE } from "#/grant.mjs";
+import { ExchangeTokenValidatorRegistry } from "#/validator/registry.mjs";
+import { createSelfIssuedAccessTokenValidator } from "#/validator/selfIssuedAccessToken.mjs";
+import { ISSUER, keyStore, signSelfIssuedAccessToken } from "./fixtures.mjs";
+
+const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+
+const client: PublicClient = {
+	clientId: "client-a",
+	allowedRedirectUris: [],
+	allowedScopes: ["read", "write"],
+	allowedAudiences: ["billing"],
+	backchannelLogoutSessionRequired: true,
+	frontchannelLogoutSessionRequired: true,
+	allowedAzpForFederationToken: false,
+};
+
+const clientRepository: ClientRepository = {
+	findById: async (id) => (id === client.clientId ? client : null),
+	authenticate: async (id) => (id === client.clientId ? client : null),
+};
+
+// In-memory refresh token store preserving family revocation state between
+// calls, so we can revoke then re-exchange and observe the cascade.
+function makeStatefulStore(): RefreshTokenStoreBase & { revokedFamilies: Set<string> } {
+	const revoked = new Set<string>();
+	return {
+		kind: "stateful-fixture",
+		revokedFamilies: revoked,
+		async rotate() {
+			return { outcome: "rotated" };
+		},
+		async isFamilyRevoked(familyId) {
+			return revoked.has(familyId);
+		},
+		async revokeFamily(familyId) {
+			revoked.add(familyId);
+		},
+	};
+}
+
+function buildHandler(store: RefreshTokenStoreBase) {
+	const registry = new ExchangeTokenValidatorRegistry();
+	// Validator has no refreshTokenStore so it returns a ValidatedToken with
+	// familyId set. The grant handler's re-surface block then consults
+	// deps.refreshTokenStore and emits the family_revoked errorDescription.
+	// This matches the unit-test pattern (validatorRefreshStore: null) and is
+	// required for the cascade test to observe "family_revoked" vs the opaque
+	// "subject_token validation failed" that would result if the validator
+	// absorbed the revocation check itself.
+	registry.register(
+		ACCESS_TOKEN_TYPE,
+		createSelfIssuedAccessTokenValidator({
+			keyStore,
+			issuer: ISSUER,
+		}),
+	);
+	return createTokenExchangeGrant({
+		config: {
+			oauth: {
+				jwt: { issuer: ISSUER },
+				accessToken: { expiresIn: 300 },
+				refreshToken: { expiresIn: 86400 },
+				grants: {},
+			},
+			// biome-ignore lint/suspicious/noExplicitAny: test scaffold config
+		} as any,
+		keyStore,
+		refreshTokenStore: store,
+		validatorRegistry: registry,
+		clientRepository,
+	});
+}
+
+const ctx = (body: Record<string, unknown>): GrantContext => ({
+	body,
+	session: {},
+	issuer: ISSUER,
+	metadata: {},
+});
+
+describe("token_exchange — integration", () => {
+	it("exchanges a subject access_token for a narrower audience access_token", async () => {
+		const store = makeStatefulStore();
+		const handler = buildHandler(store);
+		const subjectToken = await signSelfIssuedAccessToken({
+			family_id: "fam-1",
+			scope: "read write",
+		});
+
+		const { result } = await handler.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: subjectToken,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				audience: "billing",
+				scope: "read",
+			}),
+		);
+
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.aud).toBe("billing");
+		expect(payload.scope).toBe("read");
+		expect(payload.family_id).toBe("fam-1");
+		expect(payload.sub).toBe("user-1");
+	});
+
+	it("rejects exchange after the subject family is revoked (cascade)", async () => {
+		const store = makeStatefulStore();
+		const handler = buildHandler(store);
+		const subjectToken = await signSelfIssuedAccessToken({ family_id: "fam-cascade" });
+
+		// First exchange succeeds.
+		const ok = await handler.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: subjectToken,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(ok.result.status).toBe(200);
+
+		// Revoke the family (simulating a logout).
+		await store.revokeFamily("fam-cascade");
+
+		// Second exchange with the same subject must now fail.
+		const denied = await handler.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: subjectToken,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(denied.result).toMatchObject({
+			status: 400,
+			error: "invalid_grant",
+			errorDescription: "family_revoked",
+		});
+	});
+
+	it("registers successfully via GrantRegistry.addModule", async () => {
+		// Guard against drift between the GrantModule wiring and the grant handler.
+		const { GrantRegistry } = await import("@o3co/auth-provider-core");
+		const { tokenExchangeModule } = await import("#/module.mjs");
+		const store = makeStatefulStore();
+		const registry = new ExchangeTokenValidatorRegistry();
+		registry.register(
+			ACCESS_TOKEN_TYPE,
+			createSelfIssuedAccessTokenValidator({
+				keyStore,
+				refreshTokenStore: store,
+				issuer: ISSUER,
+			}),
+		);
+
+		const grantRegistry = new GrantRegistry();
+		grantRegistry.addModule(tokenExchangeModule, {
+			config: {
+				oauth: {
+					jwt: { issuer: ISSUER },
+					accessToken: { expiresIn: 300 },
+					refreshToken: { expiresIn: 86400 },
+					grants: {},
+				},
+				// biome-ignore lint/suspicious/noExplicitAny: test scaffold
+			} as any,
+			keyStore,
+			refreshTokenStore: store,
+			validatorRegistry: registry,
+			clientRepository,
+			// biome-ignore lint/suspicious/noExplicitAny: extra deps beyond GrantDependencies base type
+		} as any);
+
+		const handler = grantRegistry.get(TOKEN_EXCHANGE_GRANT_TYPE);
+		expect(handler).toBeDefined();
+	});
+});

--- a/packages/oauth-token-exchange/src/__tests__/grant-integration.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant-integration.test.mts
@@ -115,6 +115,7 @@ describe("token_exchange — integration", () => {
 		const { result } = await handler.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: subjectToken,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				audience: "billing",
@@ -140,6 +141,7 @@ describe("token_exchange — integration", () => {
 		const ok = await handler.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: subjectToken,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),
@@ -153,6 +155,7 @@ describe("token_exchange — integration", () => {
 		const denied = await handler.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: subjectToken,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -200,6 +200,42 @@ describe("createTokenExchangeGrant — request errors", () => {
 		);
 		expect(result.status).toBe(200);
 	});
+
+	it("rejects client_secret as array (prevents auth bypass via repeated params)", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: ["x", "y"], // repeated params → array
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_request",
+			errorDescription: expect.stringMatching(/client_secret/),
+		});
+	});
+
+	it("rejects actor_token_type without actor_token (prevents delegation-policy bypass)", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token_type: ACCESS_TOKEN_TYPE, // no actor_token
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_request",
+			errorDescription: expect.stringMatching(/actor_token is required/),
+		});
+	});
 });
 
 describe("createTokenExchangeGrant — token validation", () => {
@@ -393,6 +429,39 @@ describe("createTokenExchangeGrant — narrowing checks", () => {
 			}),
 		);
 		expect(result.status).toBe(200);
+	});
+
+	it("treats scope='' as omitted (inherits subject scope, not explicit empty)", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ scope: "read write", family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				scope: "",
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		// Scope was explicitly empty → normalized to "omitted" → inherited.
+		expect(result.tokens.scope).toBe("read write");
+	});
+
+	it("treats scope='  ' (whitespace-only) as omitted (inherits subject scope)", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ scope: "read write", family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				scope: "   ",
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		expect(result.tokens.scope).toBe("read write");
 	});
 });
 

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+	AppConfig,
+	ClientRepository,
+	GrantContext,
+	PublicClient,
+} from "@o3co/auth-provider-core";
+import { describe, expect, it } from "vitest";
+import { createTokenExchangeGrant } from "#/grant.mjs";
+import { ExchangeTokenValidatorRegistry } from "#/validator/registry.mjs";
+import { createSelfIssuedAccessTokenValidator } from "#/validator/selfIssuedAccessToken.mjs";
+import { ISSUER, keyStore, makeRefreshStore, signSelfIssuedAccessToken } from "./fixtures.mjs";
+
+const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+const GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
+
+const mockConfig = {
+	oauth: {
+		jwt: { issuer: ISSUER },
+		accessToken: { expiresIn: 300 },
+		refreshToken: { expiresIn: 86400 },
+		grants: {},
+	},
+} as unknown as AppConfig;
+
+const publicClient = (overrides: Partial<PublicClient> = {}): PublicClient => ({
+	clientId: "client-a",
+	allowedRedirectUris: [],
+	allowedScopes: [],
+	allowedAudiences: [],
+	backchannelLogoutSessionRequired: true,
+	frontchannelLogoutSessionRequired: true,
+	allowedAzpForFederationToken: false,
+	...overrides,
+});
+
+const mockClientRepository = (client: PublicClient | null = publicClient()): ClientRepository => ({
+	findById: async (id) => (id === client?.clientId ? client : null),
+	authenticate: async (id, _secret) => (id === client?.clientId ? client : null),
+});
+
+function buildGrant(
+	overrides: {
+		validatorRegistry?: ExchangeTokenValidatorRegistry;
+		clientRepository?: ClientRepository;
+		refreshTokenStore?: ReturnType<typeof makeRefreshStore> | undefined;
+		config?: AppConfig;
+	} = {},
+) {
+	const registry = overrides.validatorRegistry ?? new ExchangeTokenValidatorRegistry();
+	const refreshStore =
+		overrides.refreshTokenStore === undefined ? makeRefreshStore() : overrides.refreshTokenStore;
+	if (!overrides.validatorRegistry) {
+		registry.register(
+			ACCESS_TOKEN_TYPE,
+			createSelfIssuedAccessTokenValidator({
+				keyStore,
+				refreshTokenStore: refreshStore,
+				issuer: ISSUER,
+			}),
+		);
+	}
+	return createTokenExchangeGrant({
+		config: overrides.config ?? mockConfig,
+		keyStore,
+		refreshTokenStore: refreshStore,
+		validatorRegistry: registry,
+		clientRepository: overrides.clientRepository ?? mockClientRepository(),
+	});
+}
+
+const ctx = (body: Record<string, unknown>): GrantContext => ({
+	body,
+	session: {},
+	issuer: ISSUER,
+	metadata: {},
+});
+
+describe("createTokenExchangeGrant — request errors", () => {
+	it("returns invalid_request when subject_token is missing", async () => {
+		const g = buildGrant();
+		const { result } = await g.handle(
+			ctx({ client_id: "client-a", subject_token_type: ACCESS_TOKEN_TYPE }),
+		);
+		expect(result).toMatchObject({ status: 400, error: "invalid_request" });
+	});
+
+	it("returns invalid_request when subject_token_type is missing", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({});
+		const { result } = await g.handle(ctx({ client_id: "client-a", subject_token: token }));
+		expect(result).toMatchObject({ status: 400, error: "invalid_request" });
+	});
+
+	it("returns invalid_request when client_id is missing", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({});
+		const { result } = await g.handle(
+			ctx({ subject_token: token, subject_token_type: ACCESS_TOKEN_TYPE }),
+		);
+		expect(result).toMatchObject({ status: 400, error: "invalid_request" });
+	});
+
+	it("returns invalid_client when client cannot be authenticated", async () => {
+		const g = buildGrant({ clientRepository: mockClientRepository(null) });
+		const token = await signSelfIssuedAccessToken({});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "unknown",
+				client_secret: "x",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({ status: 401, error: "invalid_client" });
+	});
+
+	it("returns unsupported_token_type when subject_token_type is not registered", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: "urn:ietf:params:oauth:token-type:saml2",
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "unsupported_token_type" });
+	});
+
+	it("returns unsupported_token_type when requested_token_type is not access_token", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				requested_token_type: "urn:ietf:params:oauth:token-type:id_token",
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "unsupported_token_type" });
+	});
+
+	it("returns unsupported_token_type when actor_token_type is not registered", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token: "any",
+				actor_token_type: "urn:ietf:params:oauth:token-type:saml2",
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "unsupported_token_type" });
+	});
+});

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -562,4 +562,75 @@ describe("createTokenExchangeGrant — policy hook", () => {
 		const payload = decodeJwt(result.tokens.access_token);
 		expect(payload.aud).toBe("billing");
 	});
+
+	it("returns temporarily_unavailable (503) when policy hook throws", async () => {
+		const throwing: GrantPolicyHookBase = {
+			kind: "throw",
+			async evaluate() {
+				throw new Error("policy infrastructure down");
+			},
+		};
+		const g = buildGrant({ grantPolicy: throwing });
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({ status: 503, error: "temporarily_unavailable" });
+	});
+
+	it("documents that policy hook may widen scope beyond subject (by design — see spec §8.1 rule 4)", async () => {
+		// This test documents the intentional widening behavior. The built-in
+		// scope subset check (requested ⊆ subject) is NOT re-applied to policy
+		// hook output. Consumers who install a widening policy accept the
+		// consequences per spec §8.1.
+		const wideningPolicy: GrantPolicyHookBase = {
+			kind: "widening",
+			async evaluate() {
+				return {
+					outcome: "allow",
+					grantedScope: ["read", "write", "admin"], // wider than subject's "read"
+				};
+			},
+		};
+		const g = buildGrant({ grantPolicy: wideningPolicy });
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1", scope: "read" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		// Policy successfully widened scope — this is the documented behavior.
+		expect(result.tokens.scope).toBe("read write admin");
+	});
+
+	it("passes resource parameter through to the policy hook request", async () => {
+		let captured: GrantPolicyRequest | null = null;
+		const capturing: GrantPolicyHookBase = {
+			kind: "capture",
+			async evaluate(req) {
+				captured = req;
+				return { outcome: "allow" };
+			},
+		};
+		const g = buildGrant({ grantPolicy: capturing });
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				resource: "https://api.example.com",
+			}),
+		);
+		expect(captured).not.toBeNull();
+		expect(captured?.resource).toEqual(["https://api.example.com"]);
+	});
 });

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -18,8 +18,12 @@ import type {
 	AppConfig,
 	ClientRepository,
 	GrantContext,
+	GrantPolicyContext,
+	GrantPolicyHookBase,
+	GrantPolicyRequest,
 	PublicClient,
 } from "@o3co/auth-provider-core";
+import { decodeJwt } from "jose";
 import { describe, expect, it } from "vitest";
 import { createTokenExchangeGrant } from "#/grant.mjs";
 import { ExchangeTokenValidatorRegistry } from "#/validator/registry.mjs";
@@ -62,6 +66,7 @@ function buildGrant(
 		/** Store wired into the validator (defaults to same as refreshTokenStore). */
 		validatorRefreshStore?: ReturnType<typeof makeRefreshStore> | null;
 		config?: AppConfig;
+		grantPolicy?: GrantPolicyHookBase;
 	} = {},
 ) {
 	const registry = overrides.validatorRegistry ?? new ExchangeTokenValidatorRegistry();
@@ -91,6 +96,7 @@ function buildGrant(
 		refreshTokenStore: grantStore,
 		validatorRegistry: registry,
 		clientRepository: overrides.clientRepository ?? mockClientRepository(),
+		...(overrides.grantPolicy ? { grantPolicy: overrides.grantPolicy } : {}),
 	});
 }
 
@@ -182,34 +188,17 @@ describe("createTokenExchangeGrant — request errors", () => {
 		expect(result).toMatchObject({ status: 400, error: "unsupported_token_type" });
 	});
 
-	it("throws on the Task 6 stub fall-through (guards against non-RFC 501 leak)", async () => {
-		// This test guards against the 'not_implemented' stub silently leaking
-		// to clients. Once Tasks 7-8 are complete the stub is replaced; this
-		// test will still pass because a happy-path input will return a real
-		// successful response, not reach the throw. If Tasks 7-8 are
-		// accidentally INCOMPLETE and the stub is reachable, this test traps
-		// the regression at build time.
+	it("mints a token for the minimal happy-path input (was Task 6 stub guard)", async () => {
 		const g = buildGrant();
 		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
-		// A minimal happy-path-ish input that passes all fast-fail checks.
-		const result = await g
-			.handle(
-				ctx({
-					client_id: "client-a",
-					subject_token: token,
-					subject_token_type: ACCESS_TOKEN_TYPE,
-				}),
-			)
-			.catch((err) => ({ thrown: err as Error }));
-		if ("thrown" in result) {
-			expect(result.thrown.message).toMatch(/Task 6 stub fall-through/);
-		} else {
-			// Once Tasks 7-8 land, this branch activates and the handler
-			// returns a real result (either 200 with tokens, or a real
-			// RFC-valid error). Test must not silently skip — assert the
-			// negative: the stub is gone, so we expect status NOT to be 501.
-			expect(result.result.status).not.toBe(501);
-		}
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
 	});
 });
 
@@ -334,76 +323,243 @@ describe("createTokenExchangeGrant — narrowing checks", () => {
 		expect(result).toMatchObject({ status: 400, error: "invalid_target" });
 	});
 
-	// The next 2 tests exercise the happy-path flow: narrowing passes, handler
-	// falls through to the Task 6 stub throw (will be replaced in Task 8).
-
-	it("narrowing passes when audience matches clientId even without allowlist — stub throws", async () => {
+	it("mints a token when audience matches clientId even without allowlist", async () => {
 		const g = buildGrant({
 			clientRepository: mockClientRepository(publicClient({ allowedAudiences: [] })),
 		});
 		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
-		await expect(
-			g.handle(
-				ctx({
-					client_id: "client-a",
-					subject_token: token,
-					subject_token_type: ACCESS_TOKEN_TYPE,
-					audience: "client-a",
-				}),
-			),
-		).rejects.toThrow(/stub fall-through/);
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				audience: "client-a",
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status === 200) {
+			expect(result.tokens.access_token).toBeDefined();
+			expect(result.tokens.issued_token_type).toBe(ACCESS_TOKEN_TYPE);
+			expect(result.tokens.token_type).toBe("Bearer");
+			expect(result.tokens.refresh_token).toBeFalsy();
+		}
 	});
 
-	it("narrowing passes when multi-value audience entries are in allowlist ∪ {clientId} — stub throws", async () => {
+	it("mints a token when multi-value audience entries are in allowlist ∪ {clientId}", async () => {
 		const g = buildGrant({
 			clientRepository: mockClientRepository(
 				publicClient({ allowedAudiences: ["billing", "inventory"] }),
 			),
 		});
 		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
-		await expect(
-			g.handle(
-				ctx({
-					client_id: "client-a",
-					subject_token: token,
-					subject_token_type: ACCESS_TOKEN_TYPE,
-					audience: ["billing", "inventory"],
-				}),
-			),
-		).rejects.toThrow(/stub fall-through/);
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				audience: ["billing", "inventory"],
+			}),
+		);
+		expect(result.status).toBe(200);
 	});
 
-	it("narrowing passes when audience is empty array (treated as no audience requested)", async () => {
+	it("mints a token when audience is empty array (treated as no audience requested)", async () => {
 		const g = buildGrant({
 			clientRepository: mockClientRepository(publicClient({ allowedAudiences: [] })),
 		});
 		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
-		await expect(
-			g.handle(
-				ctx({
-					client_id: "client-a",
-					subject_token: token,
-					subject_token_type: ACCESS_TOKEN_TYPE,
-					audience: [],
-				}),
-			),
-		).rejects.toThrow(/stub fall-through/);
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				audience: [],
+			}),
+		);
+		expect(result.status).toBe(200);
 	});
 
-	it("narrowing filters empty-string audience entries before allowlist check", async () => {
+	it("mints a token when audience array contains only empty strings (filtered to none)", async () => {
 		const g = buildGrant({
 			clientRepository: mockClientRepository(publicClient({ allowedAudiences: ["billing"] })),
 		});
 		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
-		await expect(
-			g.handle(
-				ctx({
-					client_id: "client-a",
-					subject_token: token,
-					subject_token_type: ACCESS_TOKEN_TYPE,
-					audience: ["", ""],
-				}),
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				audience: ["", ""],
+			}),
+		);
+		expect(result.status).toBe(200);
+	});
+});
+
+const denyPolicy: GrantPolicyHookBase = {
+	kind: "deny-all",
+	async evaluate() {
+		return { outcome: "deny", error: "access_denied" };
+	},
+};
+
+const overridePolicy: GrantPolicyHookBase = {
+	kind: "override",
+	async evaluate(_req: GrantPolicyRequest, _ctx: GrantPolicyContext) {
+		return {
+			outcome: "allow",
+			grantedScope: ["read"],
+			grantedAudience: ["billing"],
+		};
+	},
+};
+
+describe("createTokenExchangeGrant — happy path", () => {
+	it("mints an access_token with issued_token_type set (minimal impersonation)", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1", scope: "read write" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		expect(result.tokens.access_token).toBeDefined();
+		expect(result.tokens.issued_token_type).toBe(ACCESS_TOKEN_TYPE);
+		expect(result.tokens.refresh_token).toBeFalsy();
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.sub).toBe("user-1");
+		expect(payload.family_id).toBe("fam-1");
+		expect(payload.act).toBeUndefined();
+	});
+
+	it("inherits subject scope when scope parameter is omitted", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1", scope: "read write" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		expect(result.tokens.scope).toBe("read write");
+	});
+
+	it("narrows scope to requested subset", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1", scope: "read write" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				scope: "read",
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		expect(result.tokens.scope).toBe("read");
+	});
+
+	it("adds act claim when actor_token is provided (delegation)", async () => {
+		const g = buildGrant();
+		const subject = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const actor = await signSelfIssuedAccessToken({ sub: "svc-a", family_id: "fam-2" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: subject,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token: actor,
+				actor_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.act).toEqual({ sub: "svc-a" });
+	});
+
+	it("nests subject.act inside new act for multi-step delegation", async () => {
+		const g = buildGrant();
+		const subject = await signSelfIssuedAccessToken({
+			family_id: "fam-1",
+			act: { sub: "svc-upstream" },
+		});
+		const actor = await signSelfIssuedAccessToken({ sub: "svc-b", family_id: "fam-2" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: subject,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token: actor,
+				actor_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.act).toEqual({ sub: "svc-b", act: { sub: "svc-upstream" } });
+	});
+
+	it("inherits family_id from subject (cascade revoke)", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-xyz" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.family_id).toBe("fam-xyz");
+	});
+});
+
+describe("createTokenExchangeGrant — policy hook", () => {
+	it("rejects with access_denied when policy hook denies", async () => {
+		const g = buildGrant({ grantPolicy: denyPolicy });
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({ status: 403, error: "access_denied" });
+	});
+
+	it("applies policy hook grantedScope / grantedAudience overrides", async () => {
+		const g = buildGrant({
+			grantPolicy: overridePolicy,
+			clientRepository: mockClientRepository(
+				publicClient({ allowedAudiences: ["billing", "inventory"] }),
 			),
-		).rejects.toThrow(/stub fall-through/);
+		});
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1", scope: "read write" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				scope: "read write",
+				audience: ["billing", "inventory"],
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		expect(result.tokens.scope).toBe("read");
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.aud).toBe("billing");
 	});
 });

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -223,6 +223,28 @@ describe("createTokenExchangeGrant — request errors", () => {
 		});
 	});
 
+	it.each([
+		["number", 123],
+		["object", { a: 1 }],
+		["boolean", true],
+	])("rejects client_secret with non-string type %s", async (_label, badValue) => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: badValue,
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_request",
+			errorDescription: expect.stringMatching(/client_secret/),
+		});
+	});
+
 	it("rejects actor_token_type without actor_token (prevents delegation-policy bypass)", async () => {
 		const g = buildGrant();
 		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -27,7 +27,6 @@ import { createSelfIssuedAccessTokenValidator } from "#/validator/selfIssuedAcce
 import { ISSUER, keyStore, makeRefreshStore, signSelfIssuedAccessToken } from "./fixtures.mjs";
 
 const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
-const GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
 
 const mockConfig = {
 	oauth: {

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -57,19 +57,30 @@ function buildGrant(
 	overrides: {
 		validatorRegistry?: ExchangeTokenValidatorRegistry;
 		clientRepository?: ClientRepository;
-		refreshTokenStore?: ReturnType<typeof makeRefreshStore> | undefined;
+		/** Pass `null` to explicitly omit the store from deps (fail-closed tests). */
+		refreshTokenStore?: ReturnType<typeof makeRefreshStore> | null;
+		/** Store wired into the validator (defaults to same as refreshTokenStore). */
+		validatorRefreshStore?: ReturnType<typeof makeRefreshStore> | null;
 		config?: AppConfig;
 	} = {},
 ) {
 	const registry = overrides.validatorRegistry ?? new ExchangeTokenValidatorRegistry();
-	const refreshStore =
-		overrides.refreshTokenStore === undefined ? makeRefreshStore() : overrides.refreshTokenStore;
+	// null = explicitly absent; undefined = use default
+	const grantStore =
+		overrides.refreshTokenStore === null
+			? undefined
+			: (overrides.refreshTokenStore ?? makeRefreshStore());
+	// validatorRefreshStore defaults to same as grantStore unless explicitly overridden
+	const validatorStore =
+		"validatorRefreshStore" in overrides
+			? (overrides.validatorRefreshStore ?? undefined)
+			: (grantStore ?? undefined);
 	if (!overrides.validatorRegistry) {
 		registry.register(
 			ACCESS_TOKEN_TYPE,
 			createSelfIssuedAccessTokenValidator({
 				keyStore,
-				refreshTokenStore: refreshStore,
+				refreshTokenStore: validatorStore,
 				issuer: ISSUER,
 			}),
 		);
@@ -77,7 +88,7 @@ function buildGrant(
 	return createTokenExchangeGrant({
 		config: overrides.config ?? mockConfig,
 		keyStore,
-		refreshTokenStore: refreshStore,
+		refreshTokenStore: grantStore,
 		validatorRegistry: registry,
 		clientRepository: overrides.clientRepository ?? mockClientRepository(),
 	});
@@ -199,5 +210,166 @@ describe("createTokenExchangeGrant — request errors", () => {
 			// negative: the stub is gone, so we expect status NOT to be 501.
 			expect(result.result.status).not.toBe(501);
 		}
+	});
+});
+
+describe("createTokenExchangeGrant — token validation", () => {
+	it("returns invalid_grant when subject_token signature is invalid", async () => {
+		const g = buildGrant();
+		const token = `${(await signSelfIssuedAccessToken({})).slice(0, -4)}AAAA`;
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "invalid_grant" });
+	});
+
+	it("returns invalid_grant/family_revoked when subject family is revoked", async () => {
+		const store = makeRefreshStore({
+			isFamilyRevoked: async (id) => id === "fam-bad",
+		});
+		// validatorRefreshStore: null → validator has no store, so it returns a
+		// ValidatedToken with familyId set (doesn't self-check revocation).
+		// The grant's re-surface block then consults `refreshTokenStore` and
+		// surfaces the `family_revoked` errorDescription.
+		const g = buildGrant({ refreshTokenStore: store, validatorRefreshStore: null });
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-bad" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_grant",
+			errorDescription: "family_revoked",
+		});
+	});
+
+	it("returns invalid_grant when refreshTokenStore is not wired (fail-closed)", async () => {
+		// refreshTokenStore: null → deps.refreshTokenStore is undefined (absent).
+		// validatorRefreshStore: null → validator has no store, so it returns a
+		// ValidatedToken with familyId (doesn't self-check revocation).
+		// The grant's fail-closed check fires: familyId present + no store → 400.
+		const g = buildGrant({ refreshTokenStore: null, validatorRefreshStore: null });
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "invalid_grant" });
+	});
+
+	it("returns temporarily_unavailable (503) when validator throws (runtime store failure)", async () => {
+		const store = makeRefreshStore({
+			isFamilyRevoked: async () => {
+				throw new Error("redis down");
+			},
+		});
+		const g = buildGrant({ refreshTokenStore: store });
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({ status: 503, error: "temporarily_unavailable" });
+	});
+
+	it("returns invalid_grant when actor_token fails validation", async () => {
+		const g = buildGrant();
+		const subject = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const badActor = `${(await signSelfIssuedAccessToken({ sub: "svc-a" })).slice(0, -4)}AAAA`;
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: subject,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token: badActor,
+				actor_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "invalid_grant" });
+	});
+});
+
+describe("createTokenExchangeGrant — narrowing checks", () => {
+	it("returns invalid_scope when requested scope is a superset of subject scope", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ scope: "read", family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				scope: "read write",
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "invalid_scope" });
+	});
+
+	it("returns invalid_target when audience is not in allowlist", async () => {
+		const g = buildGrant({
+			clientRepository: mockClientRepository(publicClient({ allowedAudiences: ["billing"] })),
+		});
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				audience: "inventory",
+			}),
+		);
+		expect(result).toMatchObject({ status: 400, error: "invalid_target" });
+	});
+
+	// The next 2 tests exercise the happy-path flow: narrowing passes, handler
+	// falls through to the Task 6 stub throw (will be replaced in Task 8).
+
+	it("narrowing passes when audience matches clientId even without allowlist — stub throws", async () => {
+		const g = buildGrant({
+			clientRepository: mockClientRepository(publicClient({ allowedAudiences: [] })),
+		});
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		await expect(
+			g.handle(
+				ctx({
+					client_id: "client-a",
+					subject_token: token,
+					subject_token_type: ACCESS_TOKEN_TYPE,
+					audience: "client-a",
+				}),
+			),
+		).rejects.toThrow(/stub fall-through/);
+	});
+
+	it("narrowing passes when multi-value audience entries are in allowlist ∪ {clientId} — stub throws", async () => {
+		const g = buildGrant({
+			clientRepository: mockClientRepository(
+				publicClient({ allowedAudiences: ["billing", "inventory"] }),
+			),
+		});
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		await expect(
+			g.handle(
+				ctx({
+					client_id: "client-a",
+					subject_token: token,
+					subject_token_type: ACCESS_TOKEN_TYPE,
+					audience: ["billing", "inventory"],
+				}),
+			),
+		).rejects.toThrow(/stub fall-through/);
 	});
 });

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -372,4 +372,38 @@ describe("createTokenExchangeGrant — narrowing checks", () => {
 			),
 		).rejects.toThrow(/stub fall-through/);
 	});
+
+	it("narrowing passes when audience is empty array (treated as no audience requested)", async () => {
+		const g = buildGrant({
+			clientRepository: mockClientRepository(publicClient({ allowedAudiences: [] })),
+		});
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		await expect(
+			g.handle(
+				ctx({
+					client_id: "client-a",
+					subject_token: token,
+					subject_token_type: ACCESS_TOKEN_TYPE,
+					audience: [],
+				}),
+			),
+		).rejects.toThrow(/stub fall-through/);
+	});
+
+	it("narrowing filters empty-string audience entries before allowlist check", async () => {
+		const g = buildGrant({
+			clientRepository: mockClientRepository(publicClient({ allowedAudiences: ["billing"] })),
+		});
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		await expect(
+			g.handle(
+				ctx({
+					client_id: "client-a",
+					subject_token: token,
+					subject_token_type: ACCESS_TOKEN_TYPE,
+					audience: ["", ""],
+				}),
+			),
+		).rejects.toThrow(/stub fall-through/);
+	});
 });

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -152,6 +152,7 @@ describe("createTokenExchangeGrant — request errors", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: "urn:ietf:params:oauth:token-type:saml2",
 			}),
@@ -165,6 +166,7 @@ describe("createTokenExchangeGrant — request errors", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				requested_token_type: "urn:ietf:params:oauth:token-type:id_token",
@@ -179,6 +181,7 @@ describe("createTokenExchangeGrant — request errors", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				actor_token: "any",
@@ -194,6 +197,7 @@ describe("createTokenExchangeGrant — request errors", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),
@@ -225,6 +229,7 @@ describe("createTokenExchangeGrant — request errors", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				actor_token_type: ACCESS_TOKEN_TYPE, // no actor_token
@@ -236,6 +241,43 @@ describe("createTokenExchangeGrant — request errors", () => {
 			errorDescription: expect.stringMatching(/actor_token is required/),
 		});
 	});
+
+	it("rejects actor_token without actor_token_type (symmetric guard)", async () => {
+		const g = buildGrant();
+		const subject = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const actor = await signSelfIssuedAccessToken({ sub: "svc-a", family_id: "fam-2" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: subject,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token: actor, // no actor_token_type
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_request",
+			errorDescription: expect.stringMatching(/actor_token_type is required/),
+		});
+	});
+
+	it("rejects request when client_secret is omitted (confidential clients only)", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 401,
+			error: "invalid_client",
+			errorDescription: expect.stringMatching(/client_secret/),
+		});
+	});
 });
 
 describe("createTokenExchangeGrant — token validation", () => {
@@ -245,6 +287,7 @@ describe("createTokenExchangeGrant — token validation", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),
@@ -265,6 +308,7 @@ describe("createTokenExchangeGrant — token validation", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),
@@ -286,6 +330,7 @@ describe("createTokenExchangeGrant — token validation", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),
@@ -304,6 +349,7 @@ describe("createTokenExchangeGrant — token validation", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),
@@ -318,6 +364,7 @@ describe("createTokenExchangeGrant — token validation", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: subject,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				actor_token: badActor,
@@ -335,6 +382,7 @@ describe("createTokenExchangeGrant — narrowing checks", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				scope: "read write",
@@ -351,6 +399,7 @@ describe("createTokenExchangeGrant — narrowing checks", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				audience: "inventory",
@@ -367,6 +416,7 @@ describe("createTokenExchangeGrant — narrowing checks", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				audience: "client-a",
@@ -391,6 +441,7 @@ describe("createTokenExchangeGrant — narrowing checks", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				audience: ["billing", "inventory"],
@@ -407,6 +458,7 @@ describe("createTokenExchangeGrant — narrowing checks", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				audience: [],
@@ -423,6 +475,7 @@ describe("createTokenExchangeGrant — narrowing checks", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				audience: ["", ""],
@@ -437,6 +490,7 @@ describe("createTokenExchangeGrant — narrowing checks", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				scope: "",
@@ -454,6 +508,7 @@ describe("createTokenExchangeGrant — narrowing checks", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				scope: "   ",
@@ -478,6 +533,7 @@ describe("createTokenExchangeGrant — audience inheritance", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),
@@ -498,6 +554,7 @@ describe("createTokenExchangeGrant — audience inheritance", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),
@@ -518,6 +575,75 @@ describe("createTokenExchangeGrant — audience inheritance", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.aud).toBe("client-a");
+	});
+
+	it("inherits subject.aud when encoded as a single-element array (RFC 7519 §4.1.3)", async () => {
+		// RFC 7519 permits aud as a string OR an array. A single-element array
+		// is semantically equivalent to a bare string and must not silently fall
+		// back to clientId.
+		const g = buildGrant({
+			clientRepository: mockClientRepository(publicClient({ allowedAudiences: ["billing"] })),
+		});
+		const token = await signSelfIssuedAccessToken({ aud: ["billing"], family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.aud).toBe("billing");
+	});
+
+	it("falls back to clientId when subject.aud is a multi-element array", async () => {
+		// Multi-valued audience cannot be represented in a single-aud token.
+		// Falling back to clientId is the safe choice (no surprise widening).
+		const g = buildGrant({
+			clientRepository: mockClientRepository(
+				publicClient({ allowedAudiences: ["billing", "inventory"] }),
+			),
+		});
+		const token = await signSelfIssuedAccessToken({
+			aud: ["billing", "inventory"],
+			family_id: "fam-1",
+		});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.aud).toBe("client-a");
+	});
+
+	it("rejects single-element-array subject.aud when not in allowlist", async () => {
+		// Same cross-client confusion defense as the string case.
+		const g = buildGrant({
+			clientRepository: mockClientRepository(publicClient({ allowedAudiences: [] })),
+		});
+		const token = await signSelfIssuedAccessToken({ aud: ["a-api"], family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),
@@ -554,6 +680,7 @@ describe("createTokenExchangeGrant — happy path", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),
@@ -575,6 +702,7 @@ describe("createTokenExchangeGrant — happy path", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),
@@ -590,6 +718,7 @@ describe("createTokenExchangeGrant — happy path", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				scope: "read",
@@ -607,6 +736,7 @@ describe("createTokenExchangeGrant — happy path", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: subject,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				actor_token: actor,
@@ -629,6 +759,7 @@ describe("createTokenExchangeGrant — happy path", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: subject,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				actor_token: actor,
@@ -647,6 +778,7 @@ describe("createTokenExchangeGrant — happy path", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),
@@ -665,6 +797,7 @@ describe("createTokenExchangeGrant — policy hook", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),
@@ -683,6 +816,7 @@ describe("createTokenExchangeGrant — policy hook", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				scope: "read write",
@@ -708,6 +842,7 @@ describe("createTokenExchangeGrant — policy hook", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),
@@ -734,6 +869,7 @@ describe("createTokenExchangeGrant — policy hook", () => {
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 			}),
@@ -758,6 +894,7 @@ describe("createTokenExchangeGrant — policy hook", () => {
 		await g.handle(
 			ctx({
 				client_id: "client-a",
+				client_secret: "any",
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				resource: "https://api.example.com",

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -396,6 +396,70 @@ describe("createTokenExchangeGrant — narrowing checks", () => {
 	});
 });
 
+describe("createTokenExchangeGrant — audience inheritance", () => {
+	it("rejects inherited subject.aud when not in client allowlist (cross-client confusion)", async () => {
+		// Subject token was issued with aud="a-api" (for Client A).
+		// Our handler's client is client-a but has allowedAudiences=[].
+		// When audience request parameter is omitted, we must NOT silently
+		// inherit "a-api" (which would be permissive) — fall back to clientId.
+		const g = buildGrant({
+			clientRepository: mockClientRepository(publicClient({ allowedAudiences: [] })),
+		});
+		const token = await signSelfIssuedAccessToken({ aud: "a-api", family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		// aud must be the clientId (fallback), NOT the inherited subject.aud
+		expect(payload.aud).toBe("client-a");
+	});
+
+	it("inherits subject.aud when it matches client allowlist (happy path)", async () => {
+		// Subject issued with aud="billing". Client has allowedAudiences including "billing".
+		const g = buildGrant({
+			clientRepository: mockClientRepository(publicClient({ allowedAudiences: ["billing"] })),
+		});
+		const token = await signSelfIssuedAccessToken({ aud: "billing", family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.aud).toBe("billing");
+	});
+
+	it("inherits subject.aud when it matches clientId (default allowlist)", async () => {
+		// Subject issued with aud=clientId. No allowedAudiences configured.
+		// This is the common case for non-Token-Exchange access_tokens.
+		const g = buildGrant({
+			clientRepository: mockClientRepository(publicClient({ allowedAudiences: [] })),
+		});
+		const token = await signSelfIssuedAccessToken({ aud: "client-a", family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.aud).toBe("client-a");
+	});
+});
+
 const denyPolicy: GrantPolicyHookBase = {
 	kind: "deny-all",
 	async evaluate() {

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -170,4 +170,34 @@ describe("createTokenExchangeGrant — request errors", () => {
 		);
 		expect(result).toMatchObject({ status: 400, error: "unsupported_token_type" });
 	});
+
+	it("throws on the Task 6 stub fall-through (guards against non-RFC 501 leak)", async () => {
+		// This test guards against the 'not_implemented' stub silently leaking
+		// to clients. Once Tasks 7-8 are complete the stub is replaced; this
+		// test will still pass because a happy-path input will return a real
+		// successful response, not reach the throw. If Tasks 7-8 are
+		// accidentally INCOMPLETE and the stub is reachable, this test traps
+		// the regression at build time.
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		// A minimal happy-path-ish input that passes all fast-fail checks.
+		const result = await g
+			.handle(
+				ctx({
+					client_id: "client-a",
+					subject_token: token,
+					subject_token_type: ACCESS_TOKEN_TYPE,
+				}),
+			)
+			.catch((err) => ({ thrown: err as Error }));
+		if ("thrown" in result) {
+			expect(result.thrown.message).toMatch(/Task 6 stub fall-through/);
+		} else {
+			// Once Tasks 7-8 land, this branch activates and the handler
+			// returns a real result (either 200 with tokens, or a real
+			// RFC-valid error). Test must not silently skip — assert the
+			// negative: the stub is gone, so we expect status NOT to be 501.
+			expect(result.result.status).not.toBe(501);
+		}
+	});
 });

--- a/packages/oauth-token-exchange/src/__tests__/registry.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/registry.test.mts
@@ -18,8 +18,7 @@ import { describe, expect, it } from "vitest";
 import { ExchangeTokenValidatorRegistry } from "#/validator/registry.mjs";
 import type { ExchangeTokenValidator } from "#/validator/types.mjs";
 
-const stubValidator = (tokenType: string): ExchangeTokenValidator => ({
-	tokenType,
+const stubValidator = (): ExchangeTokenValidator => ({
 	async validate() {
 		return null;
 	},
@@ -33,17 +32,40 @@ describe("ExchangeTokenValidatorRegistry", () => {
 
 	it("returns the registered validator by tokenType", () => {
 		const registry = new ExchangeTokenValidatorRegistry();
-		const v = stubValidator("urn:ietf:params:oauth:token-type:access_token");
+		const v = stubValidator();
 		registry.register("urn:ietf:params:oauth:token-type:access_token", v);
 		expect(registry.get("urn:ietf:params:oauth:token-type:access_token")).toBe(v);
 	});
 
 	it("overwrites an existing registration on re-register", () => {
 		const registry = new ExchangeTokenValidatorRegistry();
-		const v1 = stubValidator("urn:ietf:params:oauth:token-type:access_token");
-		const v2 = stubValidator("urn:ietf:params:oauth:token-type:access_token");
+		const v1 = stubValidator();
+		const v2 = stubValidator();
 		registry.register("urn:ietf:params:oauth:token-type:access_token", v1);
 		registry.register("urn:ietf:params:oauth:token-type:access_token", v2);
 		expect(registry.get("urn:ietf:params:oauth:token-type:access_token")).toBe(v2);
+	});
+
+	it("register throws after freeze()", () => {
+		const registry = new ExchangeTokenValidatorRegistry();
+		registry.freeze();
+		expect(() =>
+			registry.register("urn:ietf:params:oauth:token-type:access_token", stubValidator()),
+		).toThrow(/frozen/);
+	});
+
+	it("get() continues to work after freeze()", () => {
+		const registry = new ExchangeTokenValidatorRegistry();
+		const v = stubValidator();
+		registry.register("urn:ietf:params:oauth:token-type:access_token", v);
+		registry.freeze();
+		expect(registry.get("urn:ietf:params:oauth:token-type:access_token")).toBe(v);
+	});
+
+	it("freeze() is idempotent", () => {
+		const registry = new ExchangeTokenValidatorRegistry();
+		registry.freeze();
+		registry.freeze(); // no throw, no state change
+		expect(() => registry.register("x", stubValidator())).toThrow(/frozen/);
 	});
 });

--- a/packages/oauth-token-exchange/src/__tests__/registry.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/registry.test.mts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ExchangeTokenValidatorRegistry } from "#/validator/registry.mjs";
+import type { ExchangeTokenValidator } from "#/validator/types.mjs";
+
+const stubValidator = (tokenType: string): ExchangeTokenValidator => ({
+  tokenType,
+  async validate() {
+    return null;
+  },
+});
+
+describe("ExchangeTokenValidatorRegistry", () => {
+  it("returns undefined for unregistered token type", () => {
+    const registry = new ExchangeTokenValidatorRegistry();
+    expect(registry.get("urn:ietf:params:oauth:token-type:access_token")).toBeUndefined();
+  });
+
+  it("returns the registered validator by tokenType", () => {
+    const registry = new ExchangeTokenValidatorRegistry();
+    const v = stubValidator("urn:ietf:params:oauth:token-type:access_token");
+    registry.register("urn:ietf:params:oauth:token-type:access_token", v);
+    expect(registry.get("urn:ietf:params:oauth:token-type:access_token")).toBe(v);
+  });
+
+  it("overwrites an existing registration on re-register", () => {
+    const registry = new ExchangeTokenValidatorRegistry();
+    const v1 = stubValidator("urn:ietf:params:oauth:token-type:access_token");
+    const v2 = stubValidator("urn:ietf:params:oauth:token-type:access_token");
+    registry.register("urn:ietf:params:oauth:token-type:access_token", v1);
+    registry.register("urn:ietf:params:oauth:token-type:access_token", v2);
+    expect(registry.get("urn:ietf:params:oauth:token-type:access_token")).toBe(v2);
+  });
+});

--- a/packages/oauth-token-exchange/src/__tests__/registry.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/registry.test.mts
@@ -19,31 +19,31 @@ import { ExchangeTokenValidatorRegistry } from "#/validator/registry.mjs";
 import type { ExchangeTokenValidator } from "#/validator/types.mjs";
 
 const stubValidator = (tokenType: string): ExchangeTokenValidator => ({
-  tokenType,
-  async validate() {
-    return null;
-  },
+	tokenType,
+	async validate() {
+		return null;
+	},
 });
 
 describe("ExchangeTokenValidatorRegistry", () => {
-  it("returns undefined for unregistered token type", () => {
-    const registry = new ExchangeTokenValidatorRegistry();
-    expect(registry.get("urn:ietf:params:oauth:token-type:access_token")).toBeUndefined();
-  });
+	it("returns undefined for unregistered token type", () => {
+		const registry = new ExchangeTokenValidatorRegistry();
+		expect(registry.get("urn:ietf:params:oauth:token-type:access_token")).toBeUndefined();
+	});
 
-  it("returns the registered validator by tokenType", () => {
-    const registry = new ExchangeTokenValidatorRegistry();
-    const v = stubValidator("urn:ietf:params:oauth:token-type:access_token");
-    registry.register("urn:ietf:params:oauth:token-type:access_token", v);
-    expect(registry.get("urn:ietf:params:oauth:token-type:access_token")).toBe(v);
-  });
+	it("returns the registered validator by tokenType", () => {
+		const registry = new ExchangeTokenValidatorRegistry();
+		const v = stubValidator("urn:ietf:params:oauth:token-type:access_token");
+		registry.register("urn:ietf:params:oauth:token-type:access_token", v);
+		expect(registry.get("urn:ietf:params:oauth:token-type:access_token")).toBe(v);
+	});
 
-  it("overwrites an existing registration on re-register", () => {
-    const registry = new ExchangeTokenValidatorRegistry();
-    const v1 = stubValidator("urn:ietf:params:oauth:token-type:access_token");
-    const v2 = stubValidator("urn:ietf:params:oauth:token-type:access_token");
-    registry.register("urn:ietf:params:oauth:token-type:access_token", v1);
-    registry.register("urn:ietf:params:oauth:token-type:access_token", v2);
-    expect(registry.get("urn:ietf:params:oauth:token-type:access_token")).toBe(v2);
-  });
+	it("overwrites an existing registration on re-register", () => {
+		const registry = new ExchangeTokenValidatorRegistry();
+		const v1 = stubValidator("urn:ietf:params:oauth:token-type:access_token");
+		const v2 = stubValidator("urn:ietf:params:oauth:token-type:access_token");
+		registry.register("urn:ietf:params:oauth:token-type:access_token", v1);
+		registry.register("urn:ietf:params:oauth:token-type:access_token", v2);
+		expect(registry.get("urn:ietf:params:oauth:token-type:access_token")).toBe(v2);
+	});
 });

--- a/packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { createSelfIssuedAccessTokenValidator } from "#/validator/selfIssuedAccessToken.mjs";
+import { ISSUER, keyStore, makeRefreshStore, signSelfIssuedAccessToken } from "./fixtures.mjs";
+
+describe("createSelfIssuedAccessTokenValidator", () => {
+	const validator = (overrides = {}) =>
+		createSelfIssuedAccessTokenValidator({
+			keyStore,
+			refreshTokenStore: makeRefreshStore(),
+			issuer: ISSUER,
+			...overrides,
+		});
+
+	it("accepts a valid self-issued at+jwt and returns claims", async () => {
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const result = await validator().validate(token, { role: "subject" });
+		expect(result).not.toBeNull();
+		expect(result?.sub).toBe("user-1");
+		expect(result?.scope).toBe("read");
+		expect(result?.familyId).toBe("fam-1");
+	});
+
+	it("returns null for a tampered signature", async () => {
+		const token = `${(await signSelfIssuedAccessToken({})).slice(0, -4)}AAAA`;
+		const result = await validator().validate(token, { role: "subject" });
+		expect(result).toBeNull();
+	});
+
+	it("returns null for an expired token", async () => {
+		const token = await signSelfIssuedAccessToken({}, { expiresIn: "-1s" });
+		const result = await validator().validate(token, { role: "subject" });
+		expect(result).toBeNull();
+	});
+
+	it("returns null when issuer does not match the configured issuer", async () => {
+		const token = await signSelfIssuedAccessToken({ iss: "https://other.example" });
+		const result = await validator().validate(token, { role: "subject" });
+		expect(result).toBeNull();
+	});
+
+	it("returns null when family is revoked", async () => {
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-revoked" });
+		const store = makeRefreshStore({
+			isFamilyRevoked: vi.fn().mockResolvedValue(true),
+		});
+		const v = validator({ refreshTokenStore: store });
+		expect(await v.validate(token, { role: "subject" })).toBeNull();
+		expect(store.isFamilyRevoked).toHaveBeenCalledWith("fam-revoked");
+	});
+
+	it("throws when isFamilyRevoked throws (runtime unavailable)", async () => {
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const store = makeRefreshStore({
+			isFamilyRevoked: vi.fn().mockRejectedValue(new Error("redis down")),
+		});
+		const v = validator({ refreshTokenStore: store });
+		await expect(v.validate(token, { role: "subject" })).rejects.toThrow("redis down");
+	});
+
+	it("accepts a token without family_id claim (legacy) when refreshTokenStore is present", async () => {
+		const token = await signSelfIssuedAccessToken({});
+		const store = makeRefreshStore();
+		const v = validator({ refreshTokenStore: store });
+		const result = await v.validate(token, { role: "subject" });
+		expect(result).not.toBeNull();
+		expect(result?.familyId).toBeUndefined();
+	});
+
+	it("preserves existing act claim on the token", async () => {
+		const token = await signSelfIssuedAccessToken({ act: { sub: "service-upstream" } });
+		const result = await validator().validate(token, { role: "subject" });
+		expect(result?.act).toEqual({ sub: "service-upstream" });
+	});
+});

--- a/packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts
@@ -107,6 +107,13 @@ describe("createSelfIssuedAccessTokenValidator", () => {
 		expect(result).toBeNull();
 	});
 
+	it("ignores payload.act when it is an array (non-plain-object guard)", async () => {
+		const token = await signSelfIssuedAccessToken({ act: [{ sub: "svc-a" }] });
+		const result = await validator().validate(token, { role: "subject" });
+		expect(result).not.toBeNull();
+		expect(result?.act).toBeUndefined();
+	});
+
 	it("returns null when typ header is not at+jwt (rejects id_token/logout_token/generic JWT)", async () => {
 		// Token signed with the same KeyStore but with typ=JWT (would be a
 		// generic id_token or developer-minted JWT). This scenario exists in

--- a/packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts
@@ -87,4 +87,23 @@ describe("createSelfIssuedAccessTokenValidator", () => {
 		const result = await validator().validate(token, { role: "subject" });
 		expect(result?.act).toEqual({ sub: "service-upstream" });
 	});
+
+	it("applies identical validation for role=actor (does not branch on role)", async () => {
+		const token = await signSelfIssuedAccessToken({});
+		const result = await validator().validate(token, { role: "actor" });
+		expect(result).not.toBeNull();
+		expect(result?.sub).toBe("user-1");
+	});
+
+	it("returns null when sub claim is missing", async () => {
+		const token = await signSelfIssuedAccessToken({ sub: undefined });
+		const result = await validator().validate(token, { role: "subject" });
+		expect(result).toBeNull();
+	});
+
+	it("returns null when sub claim is empty string", async () => {
+		const token = await signSelfIssuedAccessToken({ sub: "" });
+		const result = await validator().validate(token, { role: "subject" });
+		expect(result).toBeNull();
+	});
 });

--- a/packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts
@@ -106,4 +106,19 @@ describe("createSelfIssuedAccessTokenValidator", () => {
 		const result = await validator().validate(token, { role: "subject" });
 		expect(result).toBeNull();
 	});
+
+	it("returns null when typ header is not at+jwt (rejects id_token/logout_token/generic JWT)", async () => {
+		// Token signed with the same KeyStore but with typ=JWT (would be a
+		// generic id_token or developer-minted JWT). This scenario exists in
+		// real deployments where the KeyStore is shared across at+jwt issuance
+		// and id_token issuance.
+		const generic = await signSelfIssuedAccessToken({}, { typ: "JWT" });
+		expect(await validator().validate(generic, { role: "subject" })).toBeNull();
+
+		const idToken = await signSelfIssuedAccessToken({}, { typ: "id+jwt" });
+		expect(await validator().validate(idToken, { role: "subject" })).toBeNull();
+
+		const logoutToken = await signSelfIssuedAccessToken({}, { typ: "logout+jwt" });
+		expect(await validator().validate(logoutToken, { role: "subject" })).toBeNull();
+	});
 });

--- a/packages/oauth-token-exchange/src/act.mts
+++ b/packages/oauth-token-exchange/src/act.mts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ValidatedToken } from "./validator/types.mjs";
+
+/**
+ * Build the `act` claim for the token being issued, per RFC 8693 §4.1.
+ *
+ * Canonical rules:
+ * - No actor_token → no `act` on the issued token (impersonation, no trace).
+ *                    We do NOT inherit `subject.act`: absence of actor_token
+ *                    means the caller is not claiming to delegate for anyone.
+ * - Actor provided  → `act.sub = <actor.sub>`. If the subject already had an
+ *                     `act` chain, it is nested as `act.act` to preserve the
+ *                     full delegation history.
+ */
+export function buildActClaim(args: {
+	subject: ValidatedToken;
+	actor: ValidatedToken | undefined;
+}): Record<string, unknown> | undefined {
+	const { subject, actor } = args;
+	if (!actor) return undefined;
+
+	const result: Record<string, unknown> = { sub: actor.sub };
+	if (subject.act) {
+		result.act = subject.act;
+	}
+	return result;
+}

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -118,17 +118,167 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 				}
 			}
 
-			// Task 6 stub — subsequent steps (validate tokens, narrow scope/audience,
-			// call policy hook, mint new token) are added in Tasks 7-9. If this line
-			// is reached at runtime, a Task 7/8 branch failed to replace the stub.
-			// We throw rather than returning a non-RFC status because HTTP 501 is not
-			// a valid OAuth error code and must never leak to clients.
+			const subjectValidated = await (async () => {
+				try {
+					return await subjectValidator.validate(subjectToken, { role: "subject" });
+				} catch {
+					return "runtime_error" as const;
+				}
+			})();
+			if (subjectValidated === "runtime_error") {
+				return {
+					result: {
+						status: 503,
+						error: "temporarily_unavailable",
+						errorDescription: "subject_token validation store unavailable",
+					},
+				};
+			}
+			if (!subjectValidated) {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_grant",
+						errorDescription: "subject_token validation failed",
+					},
+				};
+			}
+
+			// Fail-closed: the self-issued validator silently skips the family check
+			// when refreshTokenStore is absent, but Token Exchange must not issue
+			// tokens whose revocation cannot be observed (spec §7.2 state 1).
+			if (
+				subjectValidated.familyId &&
+				!deps.refreshTokenStore &&
+				subjectTokenType === ACCESS_TOKEN_TYPE
+			) {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_grant",
+						errorDescription: "refresh token store not configured (revocation cannot be verified)",
+					},
+				};
+			}
+
+			// Re-surface family_revoked for operators by consulting the store directly
+			// when a family_id was present. isFamilyRevoked is idempotent and cheap.
+			if (
+				subjectValidated.familyId &&
+				deps.refreshTokenStore &&
+				subjectTokenType === ACCESS_TOKEN_TYPE
+			) {
+				let revoked: boolean;
+				try {
+					revoked = await deps.refreshTokenStore.isFamilyRevoked(subjectValidated.familyId);
+				} catch {
+					return {
+						result: {
+							status: 503,
+							error: "temporarily_unavailable",
+							errorDescription: "refresh token store unavailable",
+						},
+					};
+				}
+				if (revoked) {
+					return {
+						result: {
+							status: 400,
+							error: "invalid_grant",
+							errorDescription: "family_revoked",
+						},
+					};
+				}
+			}
+
+			let actorValidated: typeof subjectValidated | null = null;
+			if (actorToken !== null && actorTokenType !== null) {
+				const actorValidator = validatorRegistry.get(actorTokenType);
+				// actorValidator existence already checked above, but narrow again.
+				if (!actorValidator) {
+					return {
+						result: {
+							status: 400,
+							error: "unsupported_token_type",
+							errorDescription: `actor_token_type "${actorTokenType}" is not supported`,
+						},
+					};
+				}
+				try {
+					actorValidated = await actorValidator.validate(actorToken, { role: "actor" });
+				} catch {
+					return {
+						result: {
+							status: 503,
+							error: "temporarily_unavailable",
+							errorDescription: "actor_token validation store unavailable",
+						},
+					};
+				}
+				if (!actorValidated) {
+					return {
+						result: {
+							status: 400,
+							error: "invalid_grant",
+							errorDescription: "actor_token validation failed",
+						},
+					};
+				}
+			}
+
+			// Scope narrowing: requested scope ⊆ subject scope.
+			const subjectScope = subjectValidated.scope?.split(" ").filter(Boolean) ?? [];
+			const requestedScopeStr = typeof body.scope === "string" ? body.scope : null;
+			const requestedScope = requestedScopeStr?.split(" ").filter(Boolean) ?? null;
+			if (requestedScope) {
+				const subjectScopeSet = new Set(subjectScope);
+				for (const s of requestedScope) {
+					if (!subjectScopeSet.has(s)) {
+						return {
+							result: {
+								status: 400,
+								error: "invalid_scope",
+								errorDescription: `scope "${s}" is not in subject_token scope`,
+							},
+						};
+					}
+				}
+			}
+
+			// Audience narrowing: requested audience ⊆ client.allowedAudiences ∪ {clientId}.
+			const requestedAudience = normalizeArrayParam(body.audience);
+			const requestedResource = normalizeArrayParam(body.resource);
+			if (requestedAudience) {
+				const allow = new Set([...(client.allowedAudiences ?? []), client.clientId]);
+				for (const aud of requestedAudience) {
+					if (!allow.has(aud)) {
+						return {
+							result: {
+								status: 400,
+								error: "invalid_target",
+								errorDescription: `audience "${aud}" is not allowed for this client`,
+							},
+						};
+					}
+				}
+			}
+
+			// Minting + policy hook + act-claim construction come in Task 8.
+			// Stub: throw to prevent accidental 501 leak. See Task 6 comment below.
+			void actorValidated;
+			void requestedResource;
 			throw new Error(
 				"TokenExchange grant handler reached the Task 6 stub fall-through. " +
 					"Task 7/8 implementation is incomplete — report this as a bug.",
 			);
 		},
 	};
+}
+
+function normalizeArrayParam(value: unknown): string[] | null {
+	if (value === undefined || value === null || value === "") return null;
+	if (Array.isArray(value)) return value.map(String);
+	return [String(value)];
 }
 
 export { GRANT_TYPE as TOKEN_EXCHANGE_GRANT_TYPE };

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -364,8 +364,8 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 	};
 }
 
-// TODO(task-9): after tokenExchangeConfigSchema is composed into AppConfig,
-// replace the manual casts below with typed access via the composed schema.
+// Manual cast: consumers compose tokenExchangeConfigSchema into their own
+// AppConfig if they want typed access. See README.
 function getExpiresIn(deps: TokenExchangeDependencies): number {
 	const grants = (deps.config.oauth.grants ?? {}) as Record<string, Record<string, unknown>>;
 	const tokenExchange = grants.token_exchange;

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -20,7 +20,12 @@ import type {
 	GrantDependencies,
 	GrantHandler,
 	GrantHandlerResult,
+	GrantPolicyContext,
+	GrantPolicyDecision,
+	GrantPolicyRequest,
 } from "@o3co/auth-provider-core";
+import { formatObject, generateToken, generateTokenResponse } from "@o3co/auth-provider-core";
+import { buildActClaim } from "./act.mjs";
 import type { ExchangeTokenValidatorRegistry } from "./validator/registry.mjs";
 import { ACCESS_TOKEN_TYPE } from "./validator/selfIssuedAccessToken.mjs";
 import type { ValidatedToken } from "./validator/types.mjs";
@@ -251,16 +256,116 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 				}
 			}
 
-			// Minting + policy hook + act-claim construction come in Task 8.
-			// Stub: throw to prevent accidental 501 leak. See Task 6 comment below.
-			void actorValidated;
-			void requestedResource;
-			throw new Error(
-				"TokenExchange grant handler reached the Task 6 stub fall-through. " +
-					"Task 7/8 implementation is incomplete — report this as a bug.",
+			// Policy hook — existing GrantPolicyHookBase contract.
+			// grantedScope/grantedAudience start as the narrowed values from the
+			// request validation phase above; the policy hook may further override them.
+			let grantedScope: readonly string[] | undefined = requestedScope ?? subjectScope;
+			let grantedAudience: readonly string[] | undefined = requestedAudience ?? undefined;
+			if (deps.grantPolicy) {
+				const policyRequest: GrantPolicyRequest = {
+					grantType: GRANT_TYPE,
+					clientId: client.clientId,
+					subject: subjectValidated.sub,
+					requestedScope: requestedScope ?? undefined,
+					requestedAudience: requestedAudience ?? undefined,
+					originalScope: subjectScope.length > 0 ? subjectScope : undefined,
+					subjectTokenType,
+					actorTokenType: actorTokenType ?? undefined,
+					resource: requestedResource ?? undefined,
+				};
+				const policyContext: GrantPolicyContext = {
+					ip: ctx.ip,
+					userAgent: ctx.userAgent,
+					issuer: ctx.issuer ?? "",
+				};
+				let decision: GrantPolicyDecision;
+				try {
+					decision = await deps.grantPolicy.evaluate(policyRequest, policyContext);
+				} catch {
+					return {
+						result: {
+							status: 503,
+							error: "temporarily_unavailable",
+							errorDescription: "grant policy evaluation failed",
+						},
+					};
+				}
+				if (decision.outcome === "deny") {
+					return {
+						result: {
+							status: decision.error === "access_denied" ? 403 : 400,
+							error: decision.error,
+							errorDescription: decision.errorDescription ?? "denied by policy",
+						},
+					};
+				}
+				if (decision.grantedScope) grantedScope = decision.grantedScope;
+				if (decision.grantedAudience) grantedAudience = decision.grantedAudience;
+			}
+
+			// Audience derivation (spec §8.1 rule 2):
+			//   explicit narrowed audience  → use grantedAudience (already allowlist-validated)
+			//   omitted + subject single    → inherit subject.aud
+			//   omitted + subject multi/none → fall back to clientId (safe default)
+			// Note: generateToken accepts a single-valued audience; when grantedAudience
+			// has multiple entries only the first is used. This is a known limitation
+			// (spec §8.1.1 multi-audience requires token introspection by all parties).
+			const subjectAud = subjectValidated.aud;
+			const audienceForToken: string = (() => {
+				if (grantedAudience && grantedAudience.length > 0)
+					return grantedAudience[0] ?? client.clientId;
+				if (typeof subjectAud === "string") return subjectAud;
+				return client.clientId;
+			})();
+
+			const act = buildActClaim({
+				subject: subjectValidated,
+				actor: actorValidated ?? undefined,
+			});
+			const scopeClaim = grantedScope && grantedScope.length > 0 ? grantedScope.join(" ") : null;
+
+			const expiresIn = getExpiresIn(deps);
+
+			const accessToken = await generateToken(
+				formatObject({
+					family_id: subjectValidated.familyId,
+					act,
+				}),
+				{
+					expiresIn,
+					keyStore: deps.keyStore,
+					issuer: ctx.issuer,
+					audience: audienceForToken,
+					subject: subjectValidated.sub,
+					authorizedParty: client.clientId,
+					scope: scopeClaim,
+					tokenType: "at+jwt",
+				},
 			);
+
+			const tokens = generateTokenResponse({ accessToken });
+			const tokensWithIssuedType: typeof tokens & { issued_token_type: string } = {
+				...tokens,
+				issued_token_type: ACCESS_TOKEN_TYPE,
+			};
+
+			return {
+				result: {
+					status: 200,
+					tokens: tokensWithIssuedType,
+				},
+			};
 		},
 	};
+}
+
+function getExpiresIn(deps: TokenExchangeDependencies): number {
+	const grants = (deps.config.oauth.grants ?? {}) as Record<string, Record<string, unknown>>;
+	const tokenExchange = grants.token_exchange;
+	const at = tokenExchange?.accessToken as { expiresIn?: number } | undefined;
+	if (typeof at?.expiresIn === "number" && at.expiresIn > 0) return at.expiresIn;
+	const top = (deps.config.oauth.accessToken as { expiresIn?: number } | undefined)?.expiresIn;
+	return typeof top === "number" && top > 0 ? top : 300;
 }
 
 function normalizeArrayParam(value: unknown): string[] | null {

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -299,6 +299,11 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 						},
 					};
 				}
+				// By design: policy hook output is trusted without re-verification against
+				// the subject's scope/audience. Widening is permitted because the hook is
+				// a first-party consumer-installed extension (spec §8.1 rule 4). If a
+				// consumer's policy accidentally widens scope, the token reflects that
+				// intent — detect via tests, not runtime checks.
 				if (decision.grantedScope) grantedScope = decision.grantedScope;
 				if (decision.grantedAudience) grantedAudience = decision.grantedAudience;
 			}
@@ -313,7 +318,7 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 			const subjectAud = subjectValidated.aud;
 			const audienceForToken: string = (() => {
 				if (grantedAudience && grantedAudience.length > 0)
-					return grantedAudience[0] ?? client.clientId;
+					return grantedAudience[0] ?? client.clientId; // `?? clientId` is forward-compat for noUncheckedIndexedAccess
 				if (typeof subjectAud === "string") return subjectAud;
 				return client.clientId;
 			})();
@@ -359,6 +364,8 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 	};
 }
 
+// TODO(task-9): after tokenExchangeConfigSchema is composed into AppConfig,
+// replace the manual casts below with typed access via the composed schema.
 function getExpiresIn(deps: TokenExchangeDependencies): number {
 	const grants = (deps.config.oauth.grants ?? {}) as Record<string, Record<string, unknown>>;
 	const tokenExchange = grants.token_exchange;

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -47,7 +47,24 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 			const subjectTokenType =
 				typeof body.subject_token_type === "string" ? body.subject_token_type : null;
 			const clientId = typeof body.client_id === "string" ? body.client_id : null;
-			const clientSecret = typeof body.client_secret === "string" ? body.client_secret : null;
+			const clientSecretRaw = body.client_secret;
+			let clientSecret: string | null;
+			if (clientSecretRaw === undefined || clientSecretRaw === null) {
+				clientSecret = null; // genuinely omitted (public client path)
+			} else if (typeof clientSecretRaw === "string") {
+				clientSecret = clientSecretRaw;
+			} else {
+				// Present but not a string (e.g., repeated param producing string[]).
+				// Refuse to treat this as "omitted" — that path would bypass the
+				// confidential-client auth check.
+				return {
+					result: {
+						status: 400,
+						error: "invalid_request",
+						errorDescription: "client_secret must be a single string value",
+					},
+				};
+			}
 			const actorToken = typeof body.actor_token === "string" ? body.actor_token : null;
 			const actorTokenType =
 				typeof body.actor_token_type === "string" ? body.actor_token_type : null;
@@ -103,6 +120,20 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 
 			// Actor token type lookup — kept here so the validator reference is
 			// available for validation below without a second registry call.
+
+			// Reject actor_token_type without actor_token — prevents policies that
+			// gate on req.actorTokenType for delegation from being bypassed by a
+			// caller who only sets the type header.
+			if (actorToken === null && actorTokenType !== null) {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_request",
+						errorDescription: "actor_token is required when actor_token_type is provided",
+					},
+				};
+			}
+
 			if (actorToken !== null && actorTokenType === null) {
 				return {
 					result: {
@@ -234,7 +265,12 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 			// Scope narrowing: requested scope ⊆ subject scope.
 			const subjectScope = subjectValidated.scope?.split(" ").filter(Boolean) ?? [];
 			const requestedScopeStr = typeof body.scope === "string" ? body.scope : null;
-			const requestedScope = requestedScopeStr?.split(" ").filter(Boolean) ?? null;
+			const requestedScopeRaw = requestedScopeStr?.split(" ").filter(Boolean) ?? null;
+			// Normalize empty arrays to null — `scope=""` and `scope=" "` behave the
+			// same as scope omitted (inherit subject scope), per the same rationale
+			// that drives normalizeArrayParam for audience/resource.
+			const requestedScope =
+				requestedScopeRaw !== null && requestedScopeRaw.length === 0 ? null : requestedScopeRaw;
 			if (requestedScope) {
 				const subjectScopeSet = new Set(subjectScope);
 				for (const s of requestedScope) {
@@ -282,7 +318,11 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 					requestedAudience: requestedAudience ?? undefined,
 					originalScope: subjectScope.length > 0 ? subjectScope : undefined,
 					subjectTokenType,
-					actorTokenType: actorTokenType ?? undefined,
+					// actorTokenType is populated only when an actor_token was actually
+					// validated — prevents policies that gate on actorTokenType from being
+					// deceived by a request that supplied only the type header.
+					actorTokenType:
+						actorValidated !== null && actorTokenType !== null ? actorTokenType : undefined,
 					resource: requestedResource ?? undefined,
 				};
 				const policyContext: GrantPolicyContext = {

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -384,4 +384,5 @@ function normalizeArrayParam(value: unknown): string[] | null {
 	return [String(value)];
 }
 
+export { ACCESS_TOKEN_TYPE } from "./validator/selfIssuedAccessToken.mjs";
 export { GRANT_TYPE as TOKEN_EXCHANGE_GRANT_TYPE };

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -165,6 +165,18 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 				};
 			}
 
+			// Revocation responsibility model (spec §7.2):
+			//   - The built-in self-issued validator accepts an OPTIONAL refreshTokenStore
+			//     as a convenience — but the RECOMMENDED wiring (used by integration
+			//     tests and README) leaves the validator storeless and lets this handler
+			//     own revocation.
+			//   - Handler-owned revocation has two benefits: (a) it can surface the
+			//     specific `family_revoked` errorDescription that RFC 8693 consumers
+			//     expect, and (b) it applies fail-closed semantics (spec §7.2 state 1)
+			//     when the store is not wired at the grant level.
+			//   - If a consumer wires the store into BOTH the validator AND the grant,
+			//     revocation is double-checked. Safe but wasteful — the validator's
+			//     early null short-circuits the handler's specific error reporting.
 			// Re-surface family_revoked for operators by consulting the store directly
 			// when a family_id was present. isFamilyRevoked is idempotent and cheap.
 			if (
@@ -309,7 +321,11 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 			}
 
 			// Audience derivation (spec §8.1 rule 2):
-			//   explicit narrowed audience  → use grantedAudience (already allowlist-validated)
+			//   explicit narrowed audience  → use grantedAudience (first element).
+			//     Note: grantedAudience reflects either the allowlist-validated request
+			//     parameter OR a policy hook override. Policy overrides are NOT re-
+			//     validated against the client allowlist by design (spec §8.1 rule 4);
+			//     consumers with strict policies must enforce the boundary themselves.
 			//   omitted + subject single    → inherit subject.aud
 			//   omitted + subject multi/none → fall back to clientId (safe default)
 			// Note: generateToken accepts a single-valued audience; when grantedAudience

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+	ClientRepository,
+	GrantContext,
+	GrantDependencies,
+	GrantHandler,
+	GrantHandlerResult,
+} from "@o3co/auth-provider-core";
+import type { ExchangeTokenValidatorRegistry } from "./validator/registry.mjs";
+import { ACCESS_TOKEN_TYPE } from "./validator/selfIssuedAccessToken.mjs";
+
+const GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
+
+export interface TokenExchangeDependencies extends GrantDependencies {
+	validatorRegistry: ExchangeTokenValidatorRegistry;
+	clientRepository: ClientRepository;
+}
+
+export function createTokenExchangeGrant(deps: TokenExchangeDependencies): GrantHandler {
+	const { validatorRegistry, clientRepository } = deps;
+
+	return {
+		async handle(ctx: GrantContext): Promise<GrantHandlerResult> {
+			const body = ctx.body as Record<string, unknown>;
+
+			const subjectToken = typeof body.subject_token === "string" ? body.subject_token : null;
+			const subjectTokenType =
+				typeof body.subject_token_type === "string" ? body.subject_token_type : null;
+			const clientId = typeof body.client_id === "string" ? body.client_id : null;
+			const clientSecret = typeof body.client_secret === "string" ? body.client_secret : null;
+			const actorToken = typeof body.actor_token === "string" ? body.actor_token : null;
+			const actorTokenType =
+				typeof body.actor_token_type === "string" ? body.actor_token_type : null;
+			const requestedTokenType =
+				typeof body.requested_token_type === "string" ? body.requested_token_type : null;
+
+			if (!subjectToken || !subjectTokenType || !clientId) {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_request",
+						errorDescription: "subject_token, subject_token_type, client_id are required",
+					},
+				};
+			}
+
+			// Client authentication: confidential clients send client_secret, public
+			// clients omit it. Either way, the client must exist.
+			const client =
+				clientSecret !== null
+					? await clientRepository.authenticate(clientId, clientSecret)
+					: await clientRepository.findById(clientId);
+			if (!client) {
+				return {
+					result: {
+						status: 401,
+						error: "invalid_client",
+						errorDescription: "client authentication failed",
+					},
+				};
+			}
+
+			if (requestedTokenType !== null && requestedTokenType !== ACCESS_TOKEN_TYPE) {
+				return {
+					result: {
+						status: 400,
+						error: "unsupported_token_type",
+						errorDescription: `requested_token_type "${requestedTokenType}" is not supported`,
+					},
+				};
+			}
+
+			const subjectValidator = validatorRegistry.get(subjectTokenType);
+			if (!subjectValidator) {
+				return {
+					result: {
+						status: 400,
+						error: "unsupported_token_type",
+						errorDescription: `subject_token_type "${subjectTokenType}" is not supported`,
+					},
+				};
+			}
+
+			if (actorToken !== null) {
+				if (actorTokenType === null) {
+					return {
+						result: {
+							status: 400,
+							error: "invalid_request",
+							errorDescription: "actor_token_type is required when actor_token is provided",
+						},
+					};
+				}
+				const actorValidator = validatorRegistry.get(actorTokenType);
+				if (!actorValidator) {
+					return {
+						result: {
+							status: 400,
+							error: "unsupported_token_type",
+							errorDescription: `actor_token_type "${actorTokenType}" is not supported`,
+						},
+					};
+				}
+			}
+
+			// Subsequent steps (validate tokens, narrow scope/audience, call policy
+			// hook, mint new token) are added in Tasks 7-9.
+			return {
+				result: {
+					status: 501,
+					error: "not_implemented",
+					errorDescription: "Token Exchange handler is partially implemented",
+				},
+			};
+		},
+	};
+}
+
+export { GRANT_TYPE as TOKEN_EXCHANGE_GRANT_TYPE };

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -50,7 +50,16 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 			const clientSecretRaw = body.client_secret;
 			let clientSecret: string | null;
 			if (clientSecretRaw === undefined || clientSecretRaw === null) {
-				clientSecret = null; // genuinely omitted (public client path)
+				// Token Exchange currently supports confidential clients only — the
+				// core ClientRepository contract requires `clientSecret` (see
+				// packages/core/src/repositories/types.mts) and PublicClient is
+				// `Omit<Client, "clientSecret">`, so findById alone cannot
+				// distinguish "no secret configured" from "secret omitted by
+				// caller". Accepting an unauthenticated client_id here would let an
+				// attacker exchange a stolen subject_token under any client's
+				// allowlist. Refuse outright; revisit when a Client.public flag
+				// lands.
+				clientSecret = null;
 			} else if (typeof clientSecretRaw === "string") {
 				clientSecret = clientSecretRaw;
 			} else {
@@ -81,12 +90,19 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 				};
 			}
 
-			// Client authentication: confidential clients send client_secret, public
-			// clients omit it. Either way, the client must exist.
-			const client =
-				clientSecret !== null
-					? await clientRepository.authenticate(clientId, clientSecret)
-					: await clientRepository.findById(clientId);
+			// Client authentication: confidential clients only. Reject when
+			// client_secret is omitted (see clientSecretRaw handling above for the
+			// rationale).
+			if (clientSecret === null) {
+				return {
+					result: {
+						status: 401,
+						error: "invalid_client",
+						errorDescription: "client_secret is required",
+					},
+				};
+			}
+			const client = await clientRepository.authenticate(clientId, clientSecret);
 			if (!client) {
 				return {
 					result: {
@@ -384,9 +400,21 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 				// prevents cross-client audience confusion: a malicious client cannot
 				// use a stolen subject_token to mint a token for an audience outside
 				// its own allowlist just by omitting the audience parameter.
-				if (typeof subjectAud === "string") {
+				//
+				// RFC 7519 §4.1.3 permits `aud` to be either a string or an array of
+				// strings. A single-element array is semantically equivalent to a
+				// bare string, so we accept both. Multi-element arrays cannot be
+				// represented as a single audience claim in the issued token (we
+				// emit a single-valued aud), so they fall back to clientId.
+				const single =
+					typeof subjectAud === "string"
+						? subjectAud
+						: Array.isArray(subjectAud) && subjectAud.length === 1
+							? subjectAud[0]
+							: undefined;
+				if (typeof single === "string") {
 					const allow = new Set([...(client.allowedAudiences ?? []), client.clientId]);
-					if (allow.has(subjectAud)) return subjectAud;
+					if (allow.has(single)) return single;
 				}
 				return client.clientId;
 			})();

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -364,13 +364,12 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 	};
 }
 
-// Manual cast: consumers compose tokenExchangeConfigSchema into their own
-// AppConfig if they want typed access. See README.
 function getExpiresIn(deps: TokenExchangeDependencies): number {
-	const grants = (deps.config.oauth.grants ?? {}) as Record<string, Record<string, unknown>>;
-	const tokenExchange = grants.token_exchange;
-	const at = tokenExchange?.accessToken as { expiresIn?: number } | undefined;
-	if (typeof at?.expiresIn === "number" && at.expiresIn > 0) return at.expiresIn;
+	// Reads the global OAuth accessToken.expiresIn. The per-grant
+	// oauth.grants.token_exchange.accessToken.expiresIn path is unreachable
+	// because core's GrantRegistry.addModule keys module config by grant-type
+	// URN, not by friendly name. Consumers who want a different expiresIn
+	// for Token Exchange should wrap createTokenExchangeGrant() instead.
 	const top = (deps.config.oauth.accessToken as { expiresIn?: number } | undefined)?.expiresIn;
 	return typeof top === "number" && top > 0 ? top : 300;
 }

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -23,6 +23,7 @@ import type {
 } from "@o3co/auth-provider-core";
 import type { ExchangeTokenValidatorRegistry } from "./validator/registry.mjs";
 import { ACCESS_TOKEN_TYPE } from "./validator/selfIssuedAccessToken.mjs";
+import type { ValidatedToken } from "./validator/types.mjs";
 
 const GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
 
@@ -37,7 +38,6 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 	return {
 		async handle(ctx: GrantContext): Promise<GrantHandlerResult> {
 			const body = ctx.body as Record<string, unknown>;
-
 			const subjectToken = typeof body.subject_token === "string" ? body.subject_token : null;
 			const subjectTokenType =
 				typeof body.subject_token_type === "string" ? body.subject_token_type : null;
@@ -96,36 +96,35 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 				};
 			}
 
-			if (actorToken !== null) {
-				if (actorTokenType === null) {
-					return {
-						result: {
-							status: 400,
-							error: "invalid_request",
-							errorDescription: "actor_token_type is required when actor_token is provided",
-						},
-					};
-				}
-				const actorValidator = validatorRegistry.get(actorTokenType);
-				if (!actorValidator) {
-					return {
-						result: {
-							status: 400,
-							error: "unsupported_token_type",
-							errorDescription: `actor_token_type "${actorTokenType}" is not supported`,
-						},
-					};
-				}
+			// Actor token type lookup — kept here so the validator reference is
+			// available for validation below without a second registry call.
+			if (actorToken !== null && actorTokenType === null) {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_request",
+						errorDescription: "actor_token_type is required when actor_token is provided",
+					},
+				};
+			}
+			const actorValidator =
+				actorToken !== null && actorTokenType !== null
+					? validatorRegistry.get(actorTokenType)
+					: null;
+			if (actorToken !== null && actorValidator === undefined) {
+				return {
+					result: {
+						status: 400,
+						error: "unsupported_token_type",
+						errorDescription: `actor_token_type "${actorTokenType}" is not supported`,
+					},
+				};
 			}
 
-			const subjectValidated = await (async () => {
-				try {
-					return await subjectValidator.validate(subjectToken, { role: "subject" });
-				} catch {
-					return "runtime_error" as const;
-				}
-			})();
-			if (subjectValidated === "runtime_error") {
+			let subjectValidated: ValidatedToken | null;
+			try {
+				subjectValidated = await subjectValidator.validate(subjectToken, { role: "subject" });
+			} catch {
 				return {
 					result: {
 						status: 503,
@@ -192,18 +191,7 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 			}
 
 			let actorValidated: typeof subjectValidated | null = null;
-			if (actorToken !== null && actorTokenType !== null) {
-				const actorValidator = validatorRegistry.get(actorTokenType);
-				// actorValidator existence already checked above, but narrow again.
-				if (!actorValidator) {
-					return {
-						result: {
-							status: 400,
-							error: "unsupported_token_type",
-							errorDescription: `actor_token_type "${actorTokenType}" is not supported`,
-						},
-					};
-				}
+			if (actorToken !== null && actorValidator) {
 				try {
 					actorValidated = await actorValidator.validate(actorToken, { role: "actor" });
 				} catch {
@@ -277,7 +265,10 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 
 function normalizeArrayParam(value: unknown): string[] | null {
 	if (value === undefined || value === null || value === "") return null;
-	if (Array.isArray(value)) return value.map(String);
+	if (Array.isArray(value)) {
+		const filtered = value.map(String).filter((s) => s.length > 0);
+		return filtered.length === 0 ? null : filtered;
+	}
 	return [String(value)];
 }
 

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -118,15 +118,15 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 				}
 			}
 
-			// Subsequent steps (validate tokens, narrow scope/audience, call policy
-			// hook, mint new token) are added in Tasks 7-9.
-			return {
-				result: {
-					status: 501,
-					error: "not_implemented",
-					errorDescription: "Token Exchange handler is partially implemented",
-				},
-			};
+			// Task 6 stub — subsequent steps (validate tokens, narrow scope/audience,
+			// call policy hook, mint new token) are added in Tasks 7-9. If this line
+			// is reached at runtime, a Task 7/8 branch failed to replace the stub.
+			// We throw rather than returning a non-RFC status because HTTP 501 is not
+			// a valid OAuth error code and must never leak to clients.
+			throw new Error(
+				"TokenExchange grant handler reached the Task 6 stub fall-through. " +
+					"Task 7/8 implementation is incomplete — report this as a bug.",
+			);
 		},
 	};
 }

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -326,7 +326,11 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 			//     parameter OR a policy hook override. Policy overrides are NOT re-
 			//     validated against the client allowlist by design (spec §8.1 rule 4);
 			//     consumers with strict policies must enforce the boundary themselves.
-			//   omitted + subject single    → inherit subject.aud
+			//   omitted + subject single    → inherit subject.aud IFF in allowlist;
+			//                                   else fall back to clientId (prevents
+			//                                   cross-client audience confusion when a
+			//                                   stolen subject token is exchanged by a
+			//                                   client outside its intended audience)
 			//   omitted + subject multi/none → fall back to clientId (safe default)
 			// Note: generateToken accepts a single-valued audience; when grantedAudience
 			// has multiple entries only the first is used. This is a known limitation
@@ -335,7 +339,15 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 			const audienceForToken: string = (() => {
 				if (grantedAudience && grantedAudience.length > 0)
 					return grantedAudience[0] ?? client.clientId; // `?? clientId` is forward-compat for noUncheckedIndexedAccess
-				if (typeof subjectAud === "string") return subjectAud;
+				// When audience is omitted, only inherit subject.aud if it's in the
+				// calling client's allowlist. Otherwise fall back to clientId. This
+				// prevents cross-client audience confusion: a malicious client cannot
+				// use a stolen subject_token to mint a token for an audience outside
+				// its own allowlist just by omitting the audience parameter.
+				if (typeof subjectAud === "string") {
+					const allow = new Set([...(client.allowedAudiences ?? []), client.clientId]);
+					if (allow.has(subjectAud)) return subjectAud;
+				}
 				return client.clientId;
 			})();
 

--- a/packages/oauth-token-exchange/src/index.mts
+++ b/packages/oauth-token-exchange/src/index.mts
@@ -20,7 +20,7 @@ export {
 	TOKEN_EXCHANGE_GRANT_TYPE,
 	type TokenExchangeDependencies,
 } from "./grant.mjs";
-export { tokenExchangeConfigSchema, tokenExchangeModule } from "./module.mjs";
+export { tokenExchangeModule } from "./module.mjs";
 export { ExchangeTokenValidatorRegistry } from "./validator/registry.mjs";
 export {
 	type CreateSelfIssuedAccessTokenValidatorOptions,

--- a/packages/oauth-token-exchange/src/index.mts
+++ b/packages/oauth-token-exchange/src/index.mts
@@ -15,6 +15,11 @@
  */
 
 export { ExchangeTokenValidatorRegistry } from "./validator/registry.mjs";
+export {
+	ACCESS_TOKEN_TYPE,
+	type CreateSelfIssuedAccessTokenValidatorOptions,
+	createSelfIssuedAccessTokenValidator,
+} from "./validator/selfIssuedAccessToken.mjs";
 export type {
 	ExchangeTokenValidationContext,
 	ExchangeTokenValidator,

--- a/packages/oauth-token-exchange/src/index.mts
+++ b/packages/oauth-token-exchange/src/index.mts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {};

--- a/packages/oauth-token-exchange/src/index.mts
+++ b/packages/oauth-token-exchange/src/index.mts
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
-export { ExchangeTokenValidatorRegistry } from "./validator/registry.mjs";
 export {
 	ACCESS_TOKEN_TYPE,
+	createTokenExchangeGrant,
+	TOKEN_EXCHANGE_GRANT_TYPE,
+	type TokenExchangeDependencies,
+} from "./grant.mjs";
+export { tokenExchangeConfigSchema, tokenExchangeModule } from "./module.mjs";
+export { ExchangeTokenValidatorRegistry } from "./validator/registry.mjs";
+export {
 	type CreateSelfIssuedAccessTokenValidatorOptions,
 	createSelfIssuedAccessTokenValidator,
 } from "./validator/selfIssuedAccessToken.mjs";

--- a/packages/oauth-token-exchange/src/module.mts
+++ b/packages/oauth-token-exchange/src/module.mts
@@ -42,17 +42,28 @@ import {
 export const tokenExchangeModule: GrantModule = Object.freeze({
 	grants: Object.freeze({
 		[TOKEN_EXCHANGE_GRANT_TYPE]: (deps: GrantDependencies) => {
-			if (!("validatorRegistry" in deps) || !("clientRepository" in deps)) {
+			const typedDeps = deps as unknown as Partial<TokenExchangeDependencies>;
+			const hasFreezeable =
+				typedDeps.validatorRegistry !== null &&
+				typedDeps.validatorRegistry !== undefined &&
+				typeof (typedDeps.validatorRegistry as { freeze?: unknown }).freeze === "function";
+			const hasClientRepository =
+				typedDeps.clientRepository !== null &&
+				typedDeps.clientRepository !== undefined &&
+				typeof (typedDeps.clientRepository as { findById?: unknown }).findById === "function" &&
+				typeof (typedDeps.clientRepository as { authenticate?: unknown }).authenticate ===
+					"function";
+			if (!hasFreezeable || !hasClientRepository) {
 				throw new Error(
-					"tokenExchangeModule requires validatorRegistry and clientRepository in deps. " +
+					"tokenExchangeModule requires validatorRegistry (with freeze()) and clientRepository (with findById/authenticate) in deps. " +
 						"See @o3co/auth-provider-oauth-token-exchange README for consumer registration.",
 				);
 			}
-			const typedDeps = deps as unknown as TokenExchangeDependencies;
+			// Now typedDeps.validatorRegistry and typedDeps.clientRepository are verified.
 			// Freeze the registry at registration time — consumer's reference
 			// can no longer mutate it after addModule returns.
-			typedDeps.validatorRegistry.freeze();
-			return createTokenExchangeGrant(typedDeps);
+			(typedDeps as TokenExchangeDependencies).validatorRegistry.freeze();
+			return createTokenExchangeGrant(typedDeps as TokenExchangeDependencies);
 		},
 	}),
 }) as GrantModule;

--- a/packages/oauth-token-exchange/src/module.mts
+++ b/packages/oauth-token-exchange/src/module.mts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { GrantModule } from "@o3co/auth-provider-core";
+import { z } from "zod";
+import {
+	createTokenExchangeGrant,
+	TOKEN_EXCHANGE_GRANT_TYPE,
+	type TokenExchangeDependencies,
+} from "./grant.mjs";
+
+/**
+ * Config shape consumed by the Token Exchange GrantModule. All fields are
+ * optional. `enabled: false` disables registration via GrantRegistry.addModule.
+ */
+export const tokenExchangeConfigSchema = z.object({
+	token_exchange: z
+		.object({
+			enabled: z.boolean().default(true),
+			accessToken: z
+				.object({
+					expiresIn: z.number().int().positive().optional(),
+				})
+				.optional(),
+		})
+		.default({ enabled: true }),
+});
+
+/**
+ * GrantModule for plugin-style registration via
+ * `GrantRegistry.addModule(tokenExchangeModule, deps)`. Consumers MUST supply
+ * `validatorRegistry` and `clientRepository` in the deps, and pre-register at
+ * least the self-issued access_token validator before calling addModule.
+ *
+ * At registration time, the module freezes the validator registry so post-
+ * wire mutations are rejected — see `ExchangeTokenValidatorRegistry.freeze()`.
+ */
+export const tokenExchangeModule: GrantModule = {
+	grants: {
+		[TOKEN_EXCHANGE_GRANT_TYPE]: (deps) => {
+			const typedDeps = deps as unknown as TokenExchangeDependencies;
+			// Freeze the registry at registration time — consumer's reference
+			// can no longer mutate it after addModule returns.
+			typedDeps.validatorRegistry.freeze();
+			return createTokenExchangeGrant(typedDeps);
+		},
+	},
+	configSchema: tokenExchangeConfigSchema,
+};

--- a/packages/oauth-token-exchange/src/module.mts
+++ b/packages/oauth-token-exchange/src/module.mts
@@ -43,19 +43,20 @@ export const tokenExchangeModule: GrantModule = Object.freeze({
 	grants: Object.freeze({
 		[TOKEN_EXCHANGE_GRANT_TYPE]: (deps: GrantDependencies) => {
 			const typedDeps = deps as unknown as Partial<TokenExchangeDependencies>;
-			const hasFreezeable =
+			const hasValidatorRegistry =
 				typedDeps.validatorRegistry !== null &&
 				typedDeps.validatorRegistry !== undefined &&
-				typeof (typedDeps.validatorRegistry as { freeze?: unknown }).freeze === "function";
+				typeof (typedDeps.validatorRegistry as { freeze?: unknown }).freeze === "function" &&
+				typeof (typedDeps.validatorRegistry as { get?: unknown }).get === "function";
 			const hasClientRepository =
 				typedDeps.clientRepository !== null &&
 				typedDeps.clientRepository !== undefined &&
 				typeof (typedDeps.clientRepository as { findById?: unknown }).findById === "function" &&
 				typeof (typedDeps.clientRepository as { authenticate?: unknown }).authenticate ===
 					"function";
-			if (!hasFreezeable || !hasClientRepository) {
+			if (!hasValidatorRegistry || !hasClientRepository) {
 				throw new Error(
-					"tokenExchangeModule requires validatorRegistry (with freeze()) and clientRepository (with findById/authenticate) in deps. " +
+					"tokenExchangeModule requires validatorRegistry (with freeze/get methods) and clientRepository (with findById/authenticate) in deps. " +
 						"See @o3co/auth-provider-oauth-token-exchange README for consumer registration.",
 				);
 			}

--- a/packages/oauth-token-exchange/src/module.mts
+++ b/packages/oauth-token-exchange/src/module.mts
@@ -15,29 +15,11 @@
  */
 
 import type { GrantDependencies, GrantModule } from "@o3co/auth-provider-core";
-import { z } from "zod";
 import {
 	createTokenExchangeGrant,
 	TOKEN_EXCHANGE_GRANT_TYPE,
 	type TokenExchangeDependencies,
 } from "./grant.mjs";
-
-/**
- * Config shape consumed by the Token Exchange GrantModule. All fields are
- * optional. Disable Token Exchange by not importing this module — there is no
- * config-driven disable switch. See §11.3 of the design spec for rationale.
- */
-export const tokenExchangeConfigSchema = z.object({
-	token_exchange: z
-		.object({
-			accessToken: z
-				.object({
-					expiresIn: z.number().int().positive().optional(),
-				})
-				.optional(),
-		})
-		.default({}),
-});
 
 /**
  * GrantModule for plugin-style registration via
@@ -50,6 +32,12 @@ export const tokenExchangeConfigSchema = z.object({
  *
  * The module object itself is frozen to prevent post-import tampering of the
  * grants record.
+ *
+ * Configuration is NOT driven by `oauth.grants.token_exchange.*` HOCON
+ * settings — those would be dropped during addModule parsing because core's
+ * GrantRegistry keys config blocks by grant-type URN, not by friendly name.
+ * Instead, consumers pass expiresIn + other settings via `createTokenExchangeGrant`
+ * options if they need customization.
  */
 export const tokenExchangeModule: GrantModule = Object.freeze({
 	grants: Object.freeze({
@@ -67,5 +55,4 @@ export const tokenExchangeModule: GrantModule = Object.freeze({
 			return createTokenExchangeGrant(typedDeps);
 		},
 	}),
-	configSchema: tokenExchangeConfigSchema,
 }) as GrantModule;

--- a/packages/oauth-token-exchange/src/module.mts
+++ b/packages/oauth-token-exchange/src/module.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { GrantModule } from "@o3co/auth-provider-core";
+import type { GrantDependencies, GrantModule } from "@o3co/auth-provider-core";
 import { z } from "zod";
 import {
 	createTokenExchangeGrant,
@@ -24,19 +24,19 @@ import {
 
 /**
  * Config shape consumed by the Token Exchange GrantModule. All fields are
- * optional. `enabled: false` disables registration via GrantRegistry.addModule.
+ * optional. Disable Token Exchange by not importing this module — there is no
+ * config-driven disable switch. See §11.3 of the design spec for rationale.
  */
 export const tokenExchangeConfigSchema = z.object({
 	token_exchange: z
 		.object({
-			enabled: z.boolean().default(true),
 			accessToken: z
 				.object({
 					expiresIn: z.number().int().positive().optional(),
 				})
 				.optional(),
 		})
-		.default({ enabled: true }),
+		.default({}),
 });
 
 /**
@@ -47,16 +47,25 @@ export const tokenExchangeConfigSchema = z.object({
  *
  * At registration time, the module freezes the validator registry so post-
  * wire mutations are rejected — see `ExchangeTokenValidatorRegistry.freeze()`.
+ *
+ * The module object itself is frozen to prevent post-import tampering of the
+ * grants record.
  */
-export const tokenExchangeModule: GrantModule = {
-	grants: {
-		[TOKEN_EXCHANGE_GRANT_TYPE]: (deps) => {
+export const tokenExchangeModule: GrantModule = Object.freeze({
+	grants: Object.freeze({
+		[TOKEN_EXCHANGE_GRANT_TYPE]: (deps: GrantDependencies) => {
+			if (!("validatorRegistry" in deps) || !("clientRepository" in deps)) {
+				throw new Error(
+					"tokenExchangeModule requires validatorRegistry and clientRepository in deps. " +
+						"See @o3co/auth-provider-oauth-token-exchange README for consumer registration.",
+				);
+			}
 			const typedDeps = deps as unknown as TokenExchangeDependencies;
 			// Freeze the registry at registration time — consumer's reference
 			// can no longer mutate it after addModule returns.
 			typedDeps.validatorRegistry.freeze();
 			return createTokenExchangeGrant(typedDeps);
 		},
-	},
+	}),
 	configSchema: tokenExchangeConfigSchema,
-};
+}) as GrantModule;

--- a/packages/oauth-token-exchange/src/validator/registry.mts
+++ b/packages/oauth-token-exchange/src/validator/registry.mts
@@ -14,9 +14,21 @@
  * limitations under the License.
  */
 
-export { ExchangeTokenValidatorRegistry } from "./validator/registry.mjs";
-export type {
-	ExchangeTokenValidationContext,
-	ExchangeTokenValidator,
-	ValidatedToken,
-} from "./validator/types.mjs";
+import type { ExchangeTokenValidator } from "./types.mjs";
+
+/**
+ * Mutable registry keyed by RFC 8693 `token_type` URI. Used by the Token
+ * Exchange grant handler to dispatch `subject_token` / `actor_token`
+ * validation.
+ */
+export class ExchangeTokenValidatorRegistry {
+  private validators = new Map<string, ExchangeTokenValidator>();
+
+  register(tokenType: string, validator: ExchangeTokenValidator): void {
+    this.validators.set(tokenType, validator);
+  }
+
+  get(tokenType: string): ExchangeTokenValidator | undefined {
+    return this.validators.get(tokenType);
+  }
+}

--- a/packages/oauth-token-exchange/src/validator/registry.mts
+++ b/packages/oauth-token-exchange/src/validator/registry.mts
@@ -17,18 +17,41 @@
 import type { ExchangeTokenValidator } from "./types.mjs";
 
 /**
- * Mutable registry keyed by RFC 8693 `token_type` URI. Used by the Token
- * Exchange grant handler to dispatch `subject_token` / `actor_token`
- * validation.
+ * Registry keyed by RFC 8693 `token_type` URI. Used by the Token Exchange
+ * grant handler to dispatch `subject_token` / `actor_token` validation.
+ *
+ * Mutability contract:
+ *   - Before `freeze()`: `register()` is idempotent; later registrations
+ *     overwrite earlier ones (useful during application wire-up).
+ *   - After `freeze()`: `register()` throws; `get()` continues to work.
+ *
+ * The GrantModule calls `freeze()` at `addModule` time, so once the grant
+ * handler is active the registry cannot be mutated — this prevents a
+ * consumer reference from silently replacing the built-in self-issued
+ * access_token validator after startup.
  */
 export class ExchangeTokenValidatorRegistry {
 	private validators = new Map<string, ExchangeTokenValidator>();
+	private frozen = false;
 
 	register(tokenType: string, validator: ExchangeTokenValidator): void {
+		if (this.frozen) {
+			throw new Error(
+				`ExchangeTokenValidatorRegistry is frozen; cannot register "${tokenType}" after freeze()`,
+			);
+		}
 		this.validators.set(tokenType, validator);
 	}
 
 	get(tokenType: string): ExchangeTokenValidator | undefined {
 		return this.validators.get(tokenType);
+	}
+
+	/**
+	 * Seal the registry. After freeze(), `register()` throws. Idempotent:
+	 * calling freeze() on an already-frozen registry is a no-op.
+	 */
+	freeze(): void {
+		this.frozen = true;
 	}
 }

--- a/packages/oauth-token-exchange/src/validator/registry.mts
+++ b/packages/oauth-token-exchange/src/validator/registry.mts
@@ -22,13 +22,13 @@ import type { ExchangeTokenValidator } from "./types.mjs";
  * validation.
  */
 export class ExchangeTokenValidatorRegistry {
-  private validators = new Map<string, ExchangeTokenValidator>();
+	private validators = new Map<string, ExchangeTokenValidator>();
 
-  register(tokenType: string, validator: ExchangeTokenValidator): void {
-    this.validators.set(tokenType, validator);
-  }
+	register(tokenType: string, validator: ExchangeTokenValidator): void {
+		this.validators.set(tokenType, validator);
+	}
 
-  get(tokenType: string): ExchangeTokenValidator | undefined {
-    return this.validators.get(tokenType);
-  }
+	get(tokenType: string): ExchangeTokenValidator | undefined {
+		return this.validators.get(tokenType);
+	}
 }

--- a/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
+++ b/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
@@ -16,7 +16,11 @@
 
 import type { KeyStore, RefreshTokenStoreBase } from "@o3co/auth-provider-core";
 import { decodeProtectedHeader, jwtVerify } from "jose";
-import type { ExchangeTokenValidator, ValidatedToken } from "./types.mjs";
+import type {
+	ExchangeTokenValidationContext,
+	ExchangeTokenValidator,
+	ValidatedToken,
+} from "./types.mjs";
 
 export const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
 
@@ -52,7 +56,10 @@ export function createSelfIssuedAccessTokenValidator(
 	const { keyStore, refreshTokenStore, issuer } = options;
 
 	return {
-		async validate(token: string): Promise<ValidatedToken | null> {
+		async validate(
+			token: string,
+			_context: ExchangeTokenValidationContext,
+		): Promise<ValidatedToken | null> {
 			let payload: Record<string, unknown>;
 			let header: Awaited<ReturnType<typeof decodeProtectedHeader>>;
 			try {

--- a/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
+++ b/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
@@ -100,7 +100,7 @@ export function createSelfIssuedAccessTokenValidator(
 				result.aud = payload.aud as string | string[];
 			}
 			if (familyId) result.familyId = familyId;
-			if (payload.act && typeof payload.act === "object") {
+			if (payload.act && typeof payload.act === "object" && !Array.isArray(payload.act)) {
 				result.act = payload.act as Record<string, unknown>;
 			}
 			return result;

--- a/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
+++ b/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
@@ -28,9 +28,13 @@ export interface CreateSelfIssuedAccessTokenValidatorOptions {
 
 /**
  * Built-in validator for RFC 8693 subject_token_type=access_token when the
- * token was issued by this auth.provider instance. Verifies JWT signature
- * (KeyStore), standard claims (exp via jose), issuer match, and — when a
- * refreshTokenStore is wired — family_id cascading revoke.
+ * token was issued by this auth.provider instance. Verifies:
+ *   - JWT signature (via KeyStore)
+ *   - `typ: "at+jwt"` header (rejects id_tokens and logout_tokens even
+ *     when signed by the same KeyStore — prevents token-type-confusion)
+ *   - Standard claims (exp via jose)
+ *   - Issuer match
+ *   - When refreshTokenStore is wired: family_id cascading revoke
  *
  * When refreshTokenStore is absent, the family revoke check is silently
  * skipped here; the grant handler is responsible for detecting this
@@ -39,7 +43,7 @@ export interface CreateSelfIssuedAccessTokenValidatorOptions {
  * misconfiguration.
  *
  * Throws on infrastructure failures (store unavailable during runtime).
- * Returns null on validation failures (bad signature, missing/empty sub,
+ * Returns null on validation failures (bad signature, wrong typ, missing/empty sub,
  * expired, revoked, issuer mismatch).
  */
 export function createSelfIssuedAccessTokenValidator(
@@ -50,14 +54,24 @@ export function createSelfIssuedAccessTokenValidator(
 	return {
 		async validate(token: string): Promise<ValidatedToken | null> {
 			let payload: Record<string, unknown>;
+			let header: Awaited<ReturnType<typeof decodeProtectedHeader>>;
 			try {
-				const header = decodeProtectedHeader(token);
+				header = decodeProtectedHeader(token);
 				const key = await keyStore.getVerificationKey(
 					header.kid ?? keyStore.getSigningKidFallback(),
 				);
 				const verified = await jwtVerify(token, key);
 				payload = verified.payload as Record<string, unknown>;
 			} catch {
+				return null;
+			}
+
+			// Token-type-confusion defense: the RFC 8693 `access_token` subject_token_type
+			// means "a token that was issued as an access_token". Reject any JWT whose
+			// `typ` header is anything other than `at+jwt` — in particular id_tokens
+			// (typ=JWT or typ=id+jwt) and logout_tokens (typ=logout+jwt) minted by the
+			// same KeyStore must never be accepted as a Token Exchange subject.
+			if (header.typ !== "at+jwt") {
 				return null;
 			}
 

--- a/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
+++ b/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
@@ -32,8 +32,15 @@ export interface CreateSelfIssuedAccessTokenValidatorOptions {
  * (KeyStore), standard claims (exp via jose), issuer match, and — when a
  * refreshTokenStore is wired — family_id cascading revoke.
  *
- * Throws on infrastructure failures (store unavailable). Returns null on
- * validation failures (bad signature, expired, revoked, issuer mismatch).
+ * When refreshTokenStore is absent, the family revoke check is silently
+ * skipped here; the grant handler is responsible for detecting this
+ * misconfiguration and responding with invalid_grant (spec §7.2 state 1:
+ * "not wired"). The validator alone is NOT fail-closed against store
+ * misconfiguration.
+ *
+ * Throws on infrastructure failures (store unavailable during runtime).
+ * Returns null on validation failures (bad signature, missing/empty sub,
+ * expired, revoked, issuer mismatch).
  */
 export function createSelfIssuedAccessTokenValidator(
 	options: CreateSelfIssuedAccessTokenValidatorOptions,
@@ -58,6 +65,10 @@ export function createSelfIssuedAccessTokenValidator(
 				return null;
 			}
 
+			if (typeof payload.sub !== "string" || payload.sub.length === 0) {
+				return null;
+			}
+
 			const familyId = typeof payload.family_id === "string" ? payload.family_id : undefined;
 
 			if (familyId && refreshTokenStore) {
@@ -67,7 +78,7 @@ export function createSelfIssuedAccessTokenValidator(
 			}
 
 			const result: ValidatedToken = {
-				sub: String(payload.sub ?? ""),
+				sub: payload.sub,
 				claims: payload,
 			};
 			if (typeof payload.scope === "string") result.scope = payload.scope;

--- a/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
+++ b/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KeyStore, RefreshTokenStoreBase } from "@o3co/auth-provider-core";
+import { decodeProtectedHeader, jwtVerify } from "jose";
+import type { ExchangeTokenValidator, ValidatedToken } from "./types.mjs";
+
+export const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+
+export interface CreateSelfIssuedAccessTokenValidatorOptions {
+	keyStore: KeyStore;
+	refreshTokenStore?: RefreshTokenStoreBase;
+	issuer?: string;
+}
+
+/**
+ * Built-in validator for RFC 8693 subject_token_type=access_token when the
+ * token was issued by this auth.provider instance. Verifies JWT signature
+ * (KeyStore), standard claims (exp via jose), issuer match, and — when a
+ * refreshTokenStore is wired — family_id cascading revoke.
+ *
+ * Throws on infrastructure failures (store unavailable). Returns null on
+ * validation failures (bad signature, expired, revoked, issuer mismatch).
+ */
+export function createSelfIssuedAccessTokenValidator(
+	options: CreateSelfIssuedAccessTokenValidatorOptions,
+): ExchangeTokenValidator {
+	const { keyStore, refreshTokenStore, issuer } = options;
+
+	return {
+		async validate(token: string): Promise<ValidatedToken | null> {
+			let payload: Record<string, unknown>;
+			try {
+				const header = decodeProtectedHeader(token);
+				const key = await keyStore.getVerificationKey(
+					header.kid ?? keyStore.getSigningKidFallback(),
+				);
+				const verified = await jwtVerify(token, key);
+				payload = verified.payload as Record<string, unknown>;
+			} catch {
+				return null;
+			}
+
+			if (issuer && payload.iss !== issuer) {
+				return null;
+			}
+
+			const familyId = typeof payload.family_id === "string" ? payload.family_id : undefined;
+
+			if (familyId && refreshTokenStore) {
+				// Throws on runtime failure — grant handler converts to 503.
+				const revoked = await refreshTokenStore.isFamilyRevoked(familyId);
+				if (revoked) return null;
+			}
+
+			const result: ValidatedToken = {
+				sub: String(payload.sub ?? ""),
+				claims: payload,
+			};
+			if (typeof payload.scope === "string") result.scope = payload.scope;
+			if (typeof payload.aud === "string" || Array.isArray(payload.aud)) {
+				result.aud = payload.aud as string | string[];
+			}
+			if (familyId) result.familyId = familyId;
+			if (payload.act && typeof payload.act === "object") {
+				result.act = payload.act as Record<string, unknown>;
+			}
+			return result;
+		},
+	};
+}

--- a/packages/oauth-token-exchange/src/validator/types.mts
+++ b/packages/oauth-token-exchange/src/validator/types.mts
@@ -20,7 +20,7 @@
  * - "actor":   the token of the party performing the exchange (`actor_token`)
  */
 export interface ExchangeTokenValidationContext {
-  role: "subject" | "actor";
+	role: "subject" | "actor";
 }
 
 /**
@@ -33,11 +33,8 @@ export interface ExchangeTokenValidationContext {
  * `temporarily_unavailable` (503).
  */
 export interface ExchangeTokenValidator {
-  readonly tokenType: string;
-  validate(
-    token: string,
-    context: ExchangeTokenValidationContext,
-  ): Promise<ValidatedToken | null>;
+	readonly tokenType: string;
+	validate(token: string, context: ExchangeTokenValidationContext): Promise<ValidatedToken | null>;
 }
 
 /**
@@ -46,10 +43,10 @@ export interface ExchangeTokenValidator {
  * `family_id` claim (used for cascading revoke inheritance).
  */
 export interface ValidatedToken {
-  sub: string;
-  scope?: string;
-  aud?: string | string[];
-  familyId?: string;
-  act?: Record<string, unknown>;
-  claims: Record<string, unknown>;
+	sub: string;
+	scope?: string;
+	aud?: string | string[];
+	familyId?: string;
+	act?: Record<string, unknown>;
+	claims: Record<string, unknown>;
 }

--- a/packages/oauth-token-exchange/src/validator/types.mts
+++ b/packages/oauth-token-exchange/src/validator/types.mts
@@ -23,24 +23,51 @@ export interface ExchangeTokenValidationContext {
 	role: "subject" | "actor";
 }
 
-/**
- * Validates a token presented in a Token Exchange request.
- *
- * Consumers register one validator per `subject_token_type` / `actor_token_type`
- * URI. Returning `null` signals a validation failure — the grant handler will
- * respond with `invalid_grant`. Throwing signals an infrastructure failure
- * (e.g. Redis unavailable) — the grant handler will respond with
- * `temporarily_unavailable` (503).
- */
 export interface ExchangeTokenValidator {
-	readonly tokenType: string;
+	/**
+	 * Validates a token presented in a Token Exchange request.
+	 *
+	 * Consumers register one validator per `subject_token_type` / `actor_token_type`
+	 * URI.
+	 *
+	 * Return contract:
+	 *   - Returning `null` signals a validation failure — the grant handler will
+	 *     respond with `invalid_grant`.
+	 *   - Throwing signals an infrastructure failure (e.g. Redis unavailable) —
+	 *     the grant handler will respond with `temporarily_unavailable` (503).
+	 *
+	 * The `context.role` hints whether the token is being presented as the
+	 * `subject` (token being exchanged) or `actor` (delegation actor).
+	 * Validators MAY apply different rules per role (e.g. stricter issuer
+	 * allowlist for actor) but SHOULD default to identical validation.
+	 */
 	validate(token: string, context: ExchangeTokenValidationContext): Promise<ValidatedToken | null>;
 }
 
 /**
  * Structured representation of a validated exchange token.
+ *
+ * The structured fields (`sub`, `scope`, `aud`, `familyId`, `act`) are the
+ * canonical values the grant handler consumes. `claims` carries the raw JWT
+ * payload for policy hooks that need custom claim forwarding.
+ *
+ * Invariant: structured fields are projections of `claims`. When both are
+ * present they MUST be equal. Validators are responsible for enforcing this.
  * `familyId` is populated only for self-issued access_tokens that carry a
  * `family_id` claim (used for cascading revoke inheritance).
+ *
+ * Required fields:
+ *   - `sub`: mandatory. Used as the subject of the newly issued token.
+ *   - `claims`: mandatory (may be empty `{}`). Passed to policy hooks for
+ *     custom claim forwarding.
+ *
+ * Optional fields (populate when known):
+ *   - `scope`: enables scope narrowing. Absent means no declared scope.
+ *   - `aud`: enables aud propagation for single-aud subjects.
+ *   - `familyId`: enables cascading revoke inheritance. Only meaningful for
+ *     self-issued access_tokens.
+ *   - `act`: nested actor chain from a prior exchange. The grant handler
+ *     preserves this when applicable (RFC 8693 §4.1).
  */
 export interface ValidatedToken {
 	sub: string;

--- a/packages/oauth-token-exchange/src/validator/types.mts
+++ b/packages/oauth-token-exchange/src/validator/types.mts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Role of a token within a Token Exchange request.
+ * - "subject": the token being exchanged (`subject_token`)
+ * - "actor":   the token of the party performing the exchange (`actor_token`)
+ */
+export interface ExchangeTokenValidationContext {
+  role: "subject" | "actor";
+}
+
+/**
+ * Validates a token presented in a Token Exchange request.
+ *
+ * Consumers register one validator per `subject_token_type` / `actor_token_type`
+ * URI. Returning `null` signals a validation failure — the grant handler will
+ * respond with `invalid_grant`. Throwing signals an infrastructure failure
+ * (e.g. Redis unavailable) — the grant handler will respond with
+ * `temporarily_unavailable` (503).
+ */
+export interface ExchangeTokenValidator {
+  readonly tokenType: string;
+  validate(
+    token: string,
+    context: ExchangeTokenValidationContext,
+  ): Promise<ValidatedToken | null>;
+}
+
+/**
+ * Structured representation of a validated exchange token.
+ * `familyId` is populated only for self-issued access_tokens that carry a
+ * `family_id` claim (used for cascading revoke inheritance).
+ */
+export interface ValidatedToken {
+  sub: string;
+  scope?: string;
+  aud?: string | string[];
+  familyId?: string;
+  act?: Record<string, unknown>;
+  claims: Record<string, unknown>;
+}

--- a/packages/oauth-token-exchange/tsconfig.json
+++ b/packages/oauth-token-exchange/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist/",
+		"paths": {
+			"#/*": ["./src/*"]
+		}
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
+}


### PR DESCRIPTION
## Summary

- New package `@o3co/auth-provider-oauth-token-exchange` implementing RFC 8693 Token Exchange grant — v0.5.0 scope #2.
- Supports on-behalf-of, delegation (`act` claim chain per §4.1), and scope/audience narrowing. Built-in validator for self-issued at+jwt; external JWT validator is consumer-implemented interface.
- Core change: optional `Client.allowedAudiences?: string[]` added for audience allowlist (backward-compat).

## Design

- **Consumer opt-in registration**: module is not auto-registered. Consumers call `grantRegistry.addModule(tokenExchangeModule, { ..., validatorRegistry, clientRepository })`. Matches federation-package-split philosophy.
- **Validator registry is sealed at addModule**: `validatorRegistry.freeze()` is called inside the module factory — consumer references cannot mutate post-wire.
- **Confidential clients only (v0.5.0)**: `client_secret` required; public-client support deferred until a `Client.public` flag lands.
- **Fail-closed revocation**: for self-issued access_token subjects, if `refreshTokenStore` is absent the handler returns `invalid_grant`. Runtime store failures return `temporarily_unavailable` (503). Family cascade inherits the subject's `family_id`.
- **Token-type confusion defense**: validator rejects JWTs whose `typ` header is not `at+jwt`.
- **Cross-client audience confusion defense**: `subject.aud` inheritance gated by `client.allowedAudiences ∪ {clientId}`; handles both string and single-element-array (RFC 7519 §4.1.3) encoding.
- **Scope narrowing enforced unconditionally**; audience narrowing gated by `client.allowedAudiences ∪ {clientId}`. `GrantPolicyHook` may override scope/audience (widening permitted by design).
- **No refresh/id tokens issued** per RFC 8693 §4.2.2.

## Test plan

- [x] Package unit + integration tests (72 tests)
- [x] Full monorepo test suite green
- [x] typecheck + lint green
- [x] RED → GREEN TDD discipline for every logic addition