### PR TITLE
chore: scrub orphan DID refs + extend cross-project gate to commit messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,32 @@ jobs:
             fi
           done
           echo "OK: no cross-project references in scanned paths"
+      - name: No cross-project references in PR commit messages
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Scan PR commit messages for the same forbidden pattern.
+          # File-content scan misses leaks that only live in commit bodies
+          # (e.g. "moved to project X" lines), and squash-merge promotes those
+          # bodies into the merge commit which becomes immutable history.
+          # The pattern is assembled from parts so this workflow does not match itself.
+          PAT="$(printf '%s' 'dpla' 'as|@dpla' 'asio')"
+          if [ -z "${BASE_SHA:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            echo "PR base or head SHA missing; skipping commit-message scan."
+            exit 0
+          fi
+          # actions/checkout uses fetch-depth:1 by default; deepen so the BASE..HEAD walk works.
+          git fetch --no-tags --prune --depth=200 origin "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true
+          MATCHES="$(git log --format='%H%n%B%n---' "$BASE_SHA..$HEAD_SHA" | grep -E "$PAT" || true)"
+          if [ -n "$MATCHES" ]; then
+            echo "ERROR: prohibited cross-project reference in PR commit messages:"
+            echo "$MATCHES"
+            exit 1
+          fi
+          echo "OK: no cross-project references in PR commit messages"
       - run: pnpm -r --if-present run typecheck
       - run: pnpm run test
       - run: pnpm run test:coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history needed by the "No cross-project references in PR commit
+          # messages" step below (it walks BASE..HEAD on the PR branch). Other
+          # steps don't depend on history depth.
+          fetch-depth: 0
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -83,8 +88,15 @@ jobs:
             echo "PR base or head SHA missing; skipping commit-message scan."
             exit 0
           fi
-          # actions/checkout uses fetch-depth:1 by default; deepen so the BASE..HEAD walk works.
-          git fetch --no-tags --prune --depth=200 origin "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true
+          # Full history is fetched via actions/checkout fetch-depth:0 above,
+          # so both SHAs are reachable. Verify defensively — if either is
+          # missing, fail loudly rather than silently passing.
+          for sha in "$BASE_SHA" "$HEAD_SHA"; do
+            if ! git cat-file -e "$sha^{commit}" 2>/dev/null; then
+              echo "ERROR: commit $sha not present in checkout; cannot scan PR commit messages."
+              exit 1
+            fi
+          done
           MATCHES="$(git log --format='%H%n%B%n---' "$BASE_SHA..$HEAD_SHA" | grep -E "$PAT" || true)"
           if [ -n "$MATCHES" ]; then
             echo "ERROR: prohibited cross-project reference in PR commit messages:"

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -537,7 +537,7 @@ v0.4.0 で追加された 5 つの拡張ポイント (詳細:
 
 - `GrantPolicyHookBase.evaluate(request, ctx)` は allow (narrowing 可) / deny を返す
 - `/oauth/authorize` で 1 回だけ評価、`/oauth/token` は Code record に persist された `grantedScope` / `grantedAudience` を再利用 (authorization_code flow では再評価しない)
-- その他 grant (refresh / client_credentials / did / token-exchange) は token endpoint で評価
+- その他 grant (refresh / client_credentials / token-exchange) は token endpoint で評価
 
 全 adapter は optional — 未設定時は no-op default。
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -538,7 +538,7 @@ Five extension points introduced in v0.4.0 (see
 
 - `GrantPolicyHookBase.evaluate(request, ctx)` returns allow (with optional narrowing) or deny
 - `/oauth/authorize` evaluates once; `/oauth/token` re-uses `grantedScope` / `grantedAudience` persisted on the Code record (no re-evaluation for `authorization_code`)
-- Other grants (refresh / client_credentials / did / token-exchange) evaluate at the token endpoint
+- Other grants (refresh / client_credentials / token-exchange) evaluate at the token endpoint
 
 All five adapters are optional — absence = no-op default.
 

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -37,12 +37,6 @@ oauth {
     session { enabled = true, enabled = ${?OAUTH_GRANTS_SESSION_ENABLED} }
     authorization_code { enabled = true, enabled = ${?OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED} }
     refresh_token { enabled = true, enabled = ${?OAUTH_GRANTS_REFRESH_TOKEN_ENABLED} }
-    did {
-      enabled = true
-      enabled = ${?OAUTH_GRANTS_DID_ENABLED}
-      messageMaxAgeSec = 300
-      messageMaxAgeSec = ${?OAUTH_GRANTS_DID_MESSAGE_MAX_AGE_SEC}
-    }
   }
 }
 

--- a/packages/core/src/__tests__/config-composition.test.mts
+++ b/packages/core/src/__tests__/config-composition.test.mts
@@ -24,7 +24,7 @@ import {
 } from "#/config/application.schema.mjs";
 import { createKeyStoreFactory, registerBuiltinKeyStores } from "#/keys/factory.mjs";
 
-const minimalDIDConfig = {
+const minimalCoreConfig = {
 	http: { port: 3000, trustProxy: false },
 	oauth: {
 		jwt: {
@@ -40,13 +40,13 @@ const minimalDIDConfig = {
 };
 
 describe("CoreConfigSchema", () => {
-	it("validates minimal DID-only config (just http + oauth)", () => {
-		const result = CoreConfigSchema.safeParse(minimalDIDConfig);
+	it("validates minimal core config (just http + oauth)", () => {
+		const result = CoreConfigSchema.safeParse(minimalCoreConfig);
 		expect(result.success).toBe(true);
 	});
 
 	it("does not require session", () => {
-		const result = CoreConfigSchema.safeParse(minimalDIDConfig);
+		const result = CoreConfigSchema.safeParse(minimalCoreConfig);
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect((result.data as Record<string, unknown>).session).toBeUndefined();
@@ -54,7 +54,7 @@ describe("CoreConfigSchema", () => {
 	});
 
 	it("does not require federations", () => {
-		const result = CoreConfigSchema.safeParse(minimalDIDConfig);
+		const result = CoreConfigSchema.safeParse(minimalCoreConfig);
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect((result.data as Record<string, unknown>).federations).toBeUndefined();
@@ -62,7 +62,7 @@ describe("CoreConfigSchema", () => {
 	});
 
 	it("does not require endpoints", () => {
-		const result = CoreConfigSchema.safeParse(minimalDIDConfig);
+		const result = CoreConfigSchema.safeParse(minimalCoreConfig);
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect((result.data as Record<string, unknown>).endpoints).toBeUndefined();
@@ -70,7 +70,7 @@ describe("CoreConfigSchema", () => {
 	});
 
 	it("does not require cors", () => {
-		const result = CoreConfigSchema.safeParse(minimalDIDConfig);
+		const result = CoreConfigSchema.safeParse(minimalCoreConfig);
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect((result.data as Record<string, unknown>).cors).toBeUndefined();
@@ -78,7 +78,7 @@ describe("CoreConfigSchema", () => {
 	});
 
 	it("does not require repositories", () => {
-		const result = CoreConfigSchema.safeParse(minimalDIDConfig);
+		const result = CoreConfigSchema.safeParse(minimalCoreConfig);
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect((result.data as Record<string, unknown>).repositories).toBeUndefined();
@@ -89,9 +89,9 @@ describe("CoreConfigSchema", () => {
 		// Schema no longer rejects this shape — the superRefine moved to the local builder.
 		// Verify that CoreConfigSchema parses successfully, then that the builder throws.
 		const result = CoreConfigSchema.safeParse({
-			...minimalDIDConfig,
+			...minimalCoreConfig,
 			oauth: {
-				...minimalDIDConfig.oauth,
+				...minimalCoreConfig.oauth,
 				jwt: { signingKey: { provider: "local", local: { algorithm: "HS256" } } },
 			},
 		});
@@ -113,7 +113,7 @@ describe("composeConfigSchema", () => {
 		});
 		const composed = composeConfigSchema([moduleSchema]);
 		const result = composed.safeParse({
-			...minimalDIDConfig,
+			...minimalCoreConfig,
 			myModule: { enabled: true },
 		});
 		expect(result.success).toBe(true);
@@ -125,7 +125,7 @@ describe("composeConfigSchema", () => {
 		});
 		const composed = composeConfigSchema([moduleSchema]);
 		// Missing myModule
-		const result = composed.safeParse(minimalDIDConfig);
+		const result = composed.safeParse(minimalCoreConfig);
 		expect(result.success).toBe(false);
 	});
 
@@ -134,7 +134,7 @@ describe("composeConfigSchema", () => {
 		const moduleB = z.object({ moduleB: z.object({ count: z.number() }) });
 		const composed = composeConfigSchema([moduleA, moduleB]);
 		const result = composed.safeParse({
-			...minimalDIDConfig,
+			...minimalCoreConfig,
 			moduleA: { value: "hello" },
 			moduleB: { count: 42 },
 		});
@@ -143,7 +143,7 @@ describe("composeConfigSchema", () => {
 
 	it("returns CoreConfigSchema when no modules are provided", () => {
 		const composed = composeConfigSchema([]);
-		const result = composed.safeParse(minimalDIDConfig);
+		const result = composed.safeParse(minimalCoreConfig);
 		expect(result.success).toBe(true);
 	});
 });

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -93,7 +93,7 @@ const jwtSchema = z.preprocess((raw, ctx) => {
 
 /**
  * Minimal always-required config for the auth provider core.
- * DID-only deployments only need these sections.
+ * Token-only deployments (no session, no federation) only need these sections.
  */
 export const CoreConfigSchema = z.object({
 	http: z.object({

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -34,7 +34,6 @@ const mockConfig = {
 			session: { enabled: true },
 			authorization_code: { enabled: true },
 			refresh_token: { enabled: true },
-			did: { enabled: true, messageMaxAgeSec: 300 },
 		},
 	},
 } as unknown as GrantDependencies["config"];
@@ -466,7 +465,6 @@ describe("createAuthorizationGrant", () => {
 							pkce: { requireS256: true },
 						},
 						refresh_token: { enabled: true },
-						did: { enabled: true, messageMaxAgeSec: 300 },
 					},
 				},
 			} as unknown as GrantDependencies["config"];
@@ -841,7 +839,6 @@ describe("createAuthorizationGrant", () => {
 						session: { enabled: true },
 						authorization_code: { enabled: true },
 						refresh_token: { enabled: true },
-						did: { enabled: true, messageMaxAgeSec: 300 },
 					},
 				},
 			} as unknown as GrantDependencies["config"];

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -40,7 +40,6 @@ const mockConfig = {
 			session: { enabled: true },
 			authorization_code: { enabled: true },
 			refresh_token: { enabled: true },
-			did: { enabled: true, messageMaxAgeSec: 300 },
 		},
 	},
 } as unknown as GrantDependencies["config"];

--- a/packages/oauth/src/__tests__/session.test.mts
+++ b/packages/oauth/src/__tests__/session.test.mts
@@ -33,7 +33,6 @@ const mockConfig = {
 			session: { enabled: true },
 			authorization_code: { enabled: true },
 			refresh_token: { enabled: true },
-			did: { enabled: true, messageMaxAgeSec: 300 },
 		},
 	},
 } as unknown as GrantDependencies["config"];


### PR DESCRIPTION
## Summary

Two cleanup tasks left over from PR #94 (the `@o3co/auth-provider-did` removal). Both target the same goal: leave no DID-shaped residue and prevent the same class of leak from recurring.

### Commit 1 — Orphan DID refs scrub

References that survived the package deletion because nothing wired them and `oauth.grants`'s `passthrough()` schema let them ride through:

- `packages/core/config/application.conf` — drop `oauth.grants.did` block + `OAUTH_GRANTS_DID_*` env vars
- `packages/core/README.md` / `README.ja.md` — remove `did` from the example list of token-endpoint-evaluated grants
- `packages/core/src/config/application.schema.mts` — change "DID-only deployments" comment to "Token-only deployments"
- `packages/core/src/__tests__/config-composition.test.mts` — rename `minimalDIDConfig` fixture to `minimalCoreConfig` and update the matching test name
- `packages/oauth/src/__tests__/{authorization,refreshToken,session}.test.mts` — drop `did: { enabled: true, messageMaxAgeSec: 300 }` from inline mock configs (5 sites)

### Commit 2 — CI gate extension

The existing "No cross-project references" step scans tracked file content but not commit messages. Squash merge promotes commit bodies into the merge commit body, which becomes immutable history. PR #94 itself shipped one such leak in a commit body that the file-content scan did not catch.

The new step:

- runs only on `pull_request` events (skipped on direct push to `develop`)
- deepens the shallow checkout via `git fetch` so `BASE..HEAD` walks work
- uses the same split-pattern trick so this workflow does not match itself
- exits 0 cleanly when SHAs are missing (defensive, no false-fail)

## Test plan

- [ ] CI green: build, test, lint, vendor-leak guard, both cross-project gates
- [ ] Workspace-wide tests pass (900 across 7 packages locally)
- [ ] No `oauth.grants.did` references remain in source/templates/READMEs
- [ ] New commit-message gate fails on a hand-crafted leak (proven by the gate firing if any of these commit messages contained the forbidden pattern — verified locally)