### PR TITLE
feat(core): SingleUseTokenStore extension point (v0.5.0 #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `sessionModule({ federationProviderFactory })` option for composition roots that explicitly register federation provider packages.
 - `validateRedirect` and `resolveCallbackRedirect` exports from `@o3co/auth-provider-session` for provider package implementations. (`codeChallenge` was already exported since v0.4.0.)
 - `@o3co/create-auth-provider` scoped scaffolder package. Replaces the unscoped `create-o3co-auth-provider` so the scaffolder lives under the `@o3co` npm org alongside the runtime packages. Consumers should switch to `npx @o3co/create-auth-provider my-auth-app`. The old `create-o3co-auth-provider` package on npm is deprecated.
+- `SingleUseTokenStore` interface in `@o3co/auth-provider-core` for replay
+  protection: server-issued challenge consume (`issue` / `consume`, used by
+  WebAuthn `ChallengeStore` and future MFA challenges) plus client-supplied
+  JWT `jti` replay detection (`markSeen`, used by jwt-bearer / DPoP).
+  Builtin `memory` + `redis` adapters; the redis adapter uses Hash +
+  `HSETNX consumed=<ts>` for atomic state transition (no Lua), aligned with
+  the dominant Node.js auth ecosystem pattern. `consumed` marker is retained
+  as a hash field until the key TTL elapses, which preserves the
+  replay-vs-unknown distinction. Wired as optional
+  `AppOptions.singleUseTokenStore`. (v0.5.0 #5)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `HSETNX consumed=<ts>` for atomic state transition (no Lua), aligned with
   the dominant Node.js auth ecosystem pattern. `consumed` marker is retained
   as a hash field until the key TTL elapses, which preserves the
-  replay-vs-unknown distinction. Wired as optional
-  `AppOptions.singleUseTokenStore`. (v0.5.0 #5)
+  replay-vs-unknown distinction. Redis `consume` includes
+  poisoning-attack mitigation (cleanup of stray hash residue when an
+  attacker calls `consume` on a never-issued key) and `PEXPIRE` failure
+  handling on `issue`. Wired as optional `AppOptions.singleUseTokenStore`.
+  (v0.5.0 #5)
 
 ### Changed
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -558,6 +558,56 @@ Both stores are consumed by upcoming TODO-F-3 (cascading revocation), F-4 (id_to
 
 The `CodeRepository.createCode` params and `InMemoryCodeRepository` accept `nonce`, `sid`, and `grantedScope` in the same call. Consumers (the `authorization_code` grant) read `codeData.grantedScope` (set by `GrantPolicyHook` at `/oauth/authorize`) as the authoritative scope for token minting instead of `session.granted_scopes`.
 
+### `SingleUseTokenStore` (v0.5.0 #5)
+
+Server-issued challenge consume + client-supplied JWT `jti` replay protection.
+One interface, two op shapes:
+
+- `issue(scope, key, expiresAt)` — register a server-issued single-use token (e.g. WebAuthn challenge).
+- `consume(scope, key)` — atomically consume a previously-issued token. Returns `consumed` / `replayed` / `unknown`.
+- `markSeen(scope, key, expiresAt)` — record a client-supplied identifier (e.g. JWT `jti`). Returns `fresh` / `replayed`.
+
+Builtin adapters: `memory` (single-process / dev), `redis` (production multi-instance).
+
+Throws `SingleUseTokenError({ reason: "duplicate" | "expired-at-issue" })` for invalid inputs.
+
+The redis adapter uses Hash + `HSETNX consumed=<ts>` for atomic state transition (no Lua), aligned with the dominant Node.js auth ecosystem pattern (`node-oidc-provider`, Ory `fosite`). The "consumed" marker is retained as a hash field until the key's TTL elapses, which is what enables replay-vs-unknown distinction.
+
+```typescript
+import { createSingleUseTokenStoreFactory, registerBuiltinSingleUseTokenStores } from "@o3co/auth-provider-core";
+import { createClient } from "redis";
+
+const factory = createSingleUseTokenStoreFactory();
+registerBuiltinSingleUseTokenStores(factory);
+
+const redisClient = createClient({ url: process.env.REDIS_URL });
+await redisClient.connect();
+const store = await factory.create({ type: "redis", client: redisClient });
+
+// Server-issued challenge ceremony (e.g. WebAuthn registration)
+const challenge = crypto.randomBytes(32).toString("base64url");
+await store.issue("webauthn:register", challenge, new Date(Date.now() + 5 * 60_000));
+// ... client echoes the challenge back ...
+const result = await store.consume("webauthn:register", challenge);
+if (result.outcome !== "consumed") throw new Error("invalid challenge");
+
+// Client-supplied JWT jti (e.g. RFC 7523 jwt-bearer)
+const seen = await store.markSeen(`jwt-bearer:${decoded.iss}`, decoded.jti, new Date(decoded.exp * 1000));
+if (seen.outcome === "replayed") throw new Error("assertion replay detected");
+```
+
+Recommended `scope` conventions:
+
+| use case | scope | op |
+| --- | --- | --- |
+| WebAuthn registration challenge | `"webauthn:register"` | `issue` / `consume` |
+| WebAuthn authentication challenge | `"webauthn:auth"` | `issue` / `consume` |
+| MFA challenge (future) | `"mfa:<provider>"` | `issue` / `consume` |
+| jwt-bearer assertion jti | `"jwt-bearer:<issuer>"` | `markSeen` |
+| DPoP jti (post-1.0) | `"dpop:<htm>:<encoded-htu>"` | `markSeen` |
+
+Consumers MUST keep `scope` namespaces disjoint between `issue/consume` (Hash key) and `markSeen` (string key) — mismatching produces a `WRONGTYPE` error from Redis. See spec Section 3.2.
+
 ### OIDC id_token + claim filter (TODO-F-4)
 
 Two low-level helpers used by the `authorization_code` grant and the `/oauth/userinfo` endpoint.

--- a/packages/core/src/__tests__/app.test.mts
+++ b/packages/core/src/__tests__/app.test.mts
@@ -193,3 +193,46 @@ describe("createApp", () => {
 		);
 	});
 });
+
+describe("AppOptions.singleUseTokenStore", () => {
+	it("is forwarded to ModuleContext when provided", async () => {
+		const { createInMemorySingleUseTokenStore } = await import(
+			"#/single-use-tokens/adapters/memory.mjs"
+		);
+		const singleUseTokenStore = createInMemorySingleUseTokenStore();
+		let captured: unknown = "not-touched";
+		const captureModule: Module = {
+			name: "capture-single-use",
+			async init(ctx) {
+				captured = (ctx as unknown as { singleUseTokenStore?: unknown }).singleUseTokenStore;
+			},
+		};
+		const { init } = createApp({
+			express: mockExpress,
+			config: mockConfig,
+			keyStore: createSymmetricKeyStore("test-secret"),
+			modules: [captureModule],
+			singleUseTokenStore,
+		});
+		await init();
+		expect(captured).toBe(singleUseTokenStore);
+	});
+
+	it("is undefined on ModuleContext when AppOptions does not supply one", async () => {
+		let captured: unknown = "not-touched";
+		const captureModule: Module = {
+			name: "capture-single-use",
+			async init(ctx) {
+				captured = (ctx as unknown as { singleUseTokenStore?: unknown }).singleUseTokenStore;
+			},
+		};
+		const { init } = createApp({
+			express: mockExpress,
+			config: mockConfig,
+			keyStore: createSymmetricKeyStore("test-secret"),
+			modules: [captureModule],
+		});
+		await init();
+		expect(captured).toBeUndefined();
+	});
+});

--- a/packages/core/src/app.mts
+++ b/packages/core/src/app.mts
@@ -28,6 +28,7 @@ import type { RateLimiterBase } from "./ratelimit/types.mjs";
 import type { RefreshTokenStoreBase } from "./refresh/types.mjs";
 import * as healthcheck from "./routes/Healthcheck.mjs";
 import * as jwks from "./routes/Jwks.mjs";
+import type { SingleUseTokenStoreBase } from "./single-use-tokens/types.mjs";
 import type { UserSessionStoreBase } from "./user-sessions/types.mjs";
 
 type ExpressLike = {
@@ -49,6 +50,7 @@ export interface AppOptions {
 	rateLimiter?: RateLimiterBase;
 	refreshTokenStore?: RefreshTokenStoreBase;
 	grantPolicy?: GrantPolicyHookBase;
+	singleUseTokenStore?: SingleUseTokenStoreBase;
 	userSessionStore?: UserSessionStoreBase;
 	federationTokenStore?: FederationTokenStoreBase;
 }
@@ -155,6 +157,7 @@ export function createApp(options: AppOptions): AppResult {
 		rateLimiter: options.rateLimiter,
 		refreshTokenStore: options.refreshTokenStore,
 		grantPolicy: options.grantPolicy,
+		singleUseTokenStore: options.singleUseTokenStore,
 		userSessionStore: options.userSessionStore,
 		federationTokenStore: options.federationTokenStore,
 	};

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -183,6 +183,18 @@ export { loadYamlMap } from "./repositories/loadYamlMap.mjs";
 export { createDefaultFactories } from "./repositories/RepositoryFactory.mjs";
 export type { Client, Code, CodeData, User } from "./repositories/types.mjs";
 export type { UserRepository } from "./repositories/UserRepository.mjs";
+// SingleUseTokenStore — v0.5.0 #5
+export {
+	createSingleUseTokenStoreFactory,
+	registerBuiltinSingleUseTokenStores,
+} from "./single-use-tokens/factory.mjs";
+export type {
+	SingleUseConsumeOutcome,
+	SingleUseMarkSeenOutcome,
+	SingleUseTokenStoreBase,
+	SingleUseTokenStoreFactory,
+} from "./single-use-tokens/types.mjs";
+export { SingleUseTokenError } from "./single-use-tokens/types.mjs";
 export { extractUserClaims } from "./user-sessions/claims.mjs";
 export {
 	createUserSessionStoreFactory,

--- a/packages/core/src/modules/types.mts
+++ b/packages/core/src/modules/types.mts
@@ -25,6 +25,7 @@ import type { MfaCoordinator, MfaProviderFactory, MfaTransactionStore } from "..
 import type { GrantPolicyHookBase } from "../policy/types.mjs";
 import type { RateLimiterBase } from "../ratelimit/types.mjs";
 import type { RefreshTokenStoreBase } from "../refresh/types.mjs";
+import type { SingleUseTokenStoreBase } from "../single-use-tokens/types.mjs";
 import type { UserSessionStoreBase } from "../user-sessions/types.mjs";
 
 /**
@@ -66,6 +67,7 @@ export interface ModuleContext {
 	rateLimiter?: RateLimiterBase;
 	refreshTokenStore?: RefreshTokenStoreBase;
 	grantPolicy?: GrantPolicyHookBase;
+	singleUseTokenStore?: SingleUseTokenStoreBase;
 	userSessionStore?: UserSessionStoreBase;
 	federationTokenStore?: FederationTokenStoreBase;
 	/**

--- a/packages/core/src/single-use-tokens/__tests__/factory.test.mts
+++ b/packages/core/src/single-use-tokens/__tests__/factory.test.mts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	createSingleUseTokenStoreFactory,
+	registerBuiltinSingleUseTokenStores,
+} from "#/single-use-tokens/factory.mjs";
+import { createFakeRedis } from "./fakeRedis.mjs";
+
+describe("createSingleUseTokenStoreFactory", () => {
+	it("creates a factory with no adapters registered initially", () => {
+		const factory = createSingleUseTokenStoreFactory();
+		expect(factory.registeredTypes()).toEqual([]);
+	});
+
+	it("registerBuiltinSingleUseTokenStores adds memory + redis", () => {
+		const factory = createSingleUseTokenStoreFactory();
+		registerBuiltinSingleUseTokenStores(factory);
+		expect(factory.registeredTypes().sort()).toEqual(["memory", "redis"]);
+	});
+
+	it("can resolve the memory adapter", async () => {
+		const factory = createSingleUseTokenStoreFactory();
+		registerBuiltinSingleUseTokenStores(factory);
+		const store = await factory.create({ type: "memory" });
+		expect(store.kind).toBe("memory");
+	});
+
+	it("can resolve the redis adapter when a client is provided", async () => {
+		const factory = createSingleUseTokenStoreFactory();
+		registerBuiltinSingleUseTokenStores(factory);
+		const store = await factory.create({ type: "redis", client: createFakeRedis() });
+		expect(store.kind).toBe("redis");
+	});
+
+	it("redis adapter rejects when client is missing", async () => {
+		const factory = createSingleUseTokenStoreFactory();
+		registerBuiltinSingleUseTokenStores(factory);
+		await expect(factory.create({ type: "redis" })).rejects.toThrow(/client/);
+	});
+
+	it("supports consumer-registered adapters", async () => {
+		const factory = createSingleUseTokenStoreFactory();
+		registerBuiltinSingleUseTokenStores(factory);
+		factory.register("custom", () => ({
+			kind: "custom",
+			async issue() {},
+			async consume() {
+				return { outcome: "unknown" } as const;
+			},
+			async markSeen() {
+				return { outcome: "fresh" } as const;
+			},
+		}));
+		const store = await factory.create({ type: "custom" });
+		expect(store.kind).toBe("custom");
+	});
+});

--- a/packages/core/src/single-use-tokens/__tests__/fakeRedis.mts
+++ b/packages/core/src/single-use-tokens/__tests__/fakeRedis.mts
@@ -92,5 +92,9 @@ export function createFakeRedis(): RedisLikeClient & { _store: Map<string, Slot>
 			slot.expiresAtMs = Date.now() + ms;
 			return 1;
 		},
+
+		async del(key) {
+			return store.delete(key) ? 1 : 0;
+		},
 	};
 }

--- a/packages/core/src/single-use-tokens/__tests__/fakeRedis.mts
+++ b/packages/core/src/single-use-tokens/__tests__/fakeRedis.mts
@@ -16,19 +16,21 @@
 
 import type { RedisLikeClient } from "#/single-use-tokens/adapters/redis.mjs";
 
-interface Slot {
-	value: string;
-	expiresAtMs: number;
-}
+type Slot =
+	| { kind: "string"; value: string; expiresAtMs: number }
+	| { kind: "hash"; fields: Map<string, string>; expiresAtMs: number };
 
 /**
- * Hand-rolled fake redis client that supports just the four ops the
- * SingleUseTokenStore redis adapter calls: `set` (with NX/PX), `get`,
- * `pTTL`, and `eval` (executing the inlined Lua-equivalent JavaScript).
+ * Hand-rolled fake redis client supporting the four ops the SingleUseTokenStore
+ * redis adapter calls: `set` (with NX/PX), `hSetNX`, `hGet`, `pExpire`.
  *
- * Intentionally minimal — production Redis behaviour is the contract
- * the adapter targets; this fake just lets contract tests run without
- * a network dependency.
+ * Internally distinguishes string keys (used by `markSeen`) from hash keys
+ * (used by `issue`/`consume`). Mismatching the type produces a `WRONGTYPE`
+ * error matching real Redis.
+ *
+ * Intentionally minimal — production Redis behaviour is the contract the
+ * adapter targets; this fake just lets contract tests run without a network
+ * dependency.
  */
 export function createFakeRedis(): RedisLikeClient & { _store: Map<string, Slot> } {
 	const store = new Map<string, Slot>();
@@ -47,50 +49,48 @@ export function createFakeRedis(): RedisLikeClient & { _store: Map<string, Slot>
 			if (opts?.NX === true && store.has(key)) return null;
 			const ttl = opts?.PX;
 			if (ttl !== undefined && ttl <= 0) {
-				// Match real redis behaviour: SET with non-positive PX errors.
 				throw new Error("ERR invalid expire time in 'set' command");
 			}
 			const expiresAtMs = ttl === undefined ? Number.POSITIVE_INFINITY : nowMs + ttl;
-			store.set(key, { value, expiresAtMs });
+			store.set(key, { kind: "string", value, expiresAtMs });
 			return "OK";
 		},
 
-		async get(key) {
+		async hSetNX(key, field, value) {
+			const nowMs = Date.now();
+			gc(key, nowMs);
+			const slot = store.get(key);
+			if (slot === undefined) {
+				const fields = new Map<string, string>();
+				fields.set(field, value);
+				// Default TTL: never expires until pExpire is called.
+				store.set(key, { kind: "hash", fields, expiresAtMs: Number.POSITIVE_INFINITY });
+				return 1;
+			}
+			if (slot.kind !== "hash") {
+				throw new Error("WRONGTYPE Operation against a key holding the wrong kind of value");
+			}
+			if (slot.fields.has(field)) return 0;
+			slot.fields.set(field, value);
+			return 1;
+		},
+
+		async hGet(key, field) {
 			gc(key, Date.now());
-			return store.get(key)?.value ?? null;
+			const slot = store.get(key);
+			if (slot === undefined) return null;
+			if (slot.kind !== "hash") {
+				throw new Error("WRONGTYPE Operation against a key holding the wrong kind of value");
+			}
+			return slot.fields.get(field) ?? null;
 		},
 
-		async pTTL(key) {
-			const nowMs = Date.now();
-			gc(key, nowMs);
+		async pExpire(key, ms) {
+			gc(key, Date.now());
 			const slot = store.get(key);
-			if (slot === undefined) return -2;
-			if (slot.expiresAtMs === Number.POSITIVE_INFINITY) return -1;
-			return Math.max(0, slot.expiresAtMs - nowMs);
-		},
-
-		async eval(script, opts) {
-			// We accept ONLY the consume Lua script our adapter ships. Any other
-			// script means a test wrote a Lua we don't know — fail loudly so we
-			// notice at adapter changes.
-			if (!script.includes("issued") || !script.includes("consumed")) {
-				throw new Error("fakeRedis.eval: unrecognised script");
-			}
-			const key = opts.keys[0];
-			if (key === undefined) throw new Error("fakeRedis.eval: missing key");
-			const nowMs = Date.now();
-			gc(key, nowMs);
-			const slot = store.get(key);
-			if (slot === undefined) return "unknown";
-			if (slot.value === "consumed") return "replayed";
-			// issued -> consumed, preserving remaining TTL
-			const pttl = slot.expiresAtMs - nowMs;
-			if (pttl < 0) {
-				store.delete(key);
-				return "unknown";
-			}
-			store.set(key, { value: "consumed", expiresAtMs: slot.expiresAtMs });
-			return "consumed";
+			if (slot === undefined) return 0;
+			slot.expiresAtMs = Date.now() + ms;
+			return 1;
 		},
 	};
 }

--- a/packages/core/src/single-use-tokens/__tests__/fakeRedis.mts
+++ b/packages/core/src/single-use-tokens/__tests__/fakeRedis.mts
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { RedisLikeClient } from "#/single-use-tokens/adapters/redis.mjs";
+
+interface Slot {
+	value: string;
+	expiresAtMs: number;
+}
+
+/**
+ * Hand-rolled fake redis client that supports just the four ops the
+ * SingleUseTokenStore redis adapter calls: `set` (with NX/PX), `get`,
+ * `pTTL`, and `eval` (executing the inlined Lua-equivalent JavaScript).
+ *
+ * Intentionally minimal — production Redis behaviour is the contract
+ * the adapter targets; this fake just lets contract tests run without
+ * a network dependency.
+ */
+export function createFakeRedis(): RedisLikeClient & { _store: Map<string, Slot> } {
+	const store = new Map<string, Slot>();
+
+	const gc = (k: string, nowMs: number): void => {
+		const v = store.get(k);
+		if (v !== undefined && v.expiresAtMs <= nowMs) store.delete(k);
+	};
+
+	return {
+		_store: store,
+
+		async set(key, value, opts) {
+			const nowMs = Date.now();
+			gc(key, nowMs);
+			if (opts?.NX === true && store.has(key)) return null;
+			const ttl = opts?.PX;
+			if (ttl !== undefined && ttl <= 0) {
+				// Match real redis behaviour: SET with non-positive PX errors.
+				throw new Error("ERR invalid expire time in 'set' command");
+			}
+			const expiresAtMs = ttl === undefined ? Number.POSITIVE_INFINITY : nowMs + ttl;
+			store.set(key, { value, expiresAtMs });
+			return "OK";
+		},
+
+		async get(key) {
+			gc(key, Date.now());
+			return store.get(key)?.value ?? null;
+		},
+
+		async pTTL(key) {
+			const nowMs = Date.now();
+			gc(key, nowMs);
+			const slot = store.get(key);
+			if (slot === undefined) return -2;
+			if (slot.expiresAtMs === Number.POSITIVE_INFINITY) return -1;
+			return Math.max(0, slot.expiresAtMs - nowMs);
+		},
+
+		async eval(script, opts) {
+			// We accept ONLY the consume Lua script our adapter ships. Any other
+			// script means a test wrote a Lua we don't know — fail loudly so we
+			// notice at adapter changes.
+			if (!script.includes("issued") || !script.includes("consumed")) {
+				throw new Error("fakeRedis.eval: unrecognised script");
+			}
+			const key = opts.keys[0];
+			if (key === undefined) throw new Error("fakeRedis.eval: missing key");
+			const nowMs = Date.now();
+			gc(key, nowMs);
+			const slot = store.get(key);
+			if (slot === undefined) return "unknown";
+			if (slot.value === "consumed") return "replayed";
+			// issued -> consumed, preserving remaining TTL
+			const pttl = slot.expiresAtMs - nowMs;
+			if (pttl < 0) {
+				store.delete(key);
+				return "unknown";
+			}
+			store.set(key, { value: "consumed", expiresAtMs: slot.expiresAtMs });
+			return "consumed";
+		},
+	};
+}

--- a/packages/core/src/single-use-tokens/__tests__/keyEncoding.test.mts
+++ b/packages/core/src/single-use-tokens/__tests__/keyEncoding.test.mts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { canonicalKey } from "#/single-use-tokens/keyEncoding.mjs";
+
+describe("canonicalKey", () => {
+	it("encodes scope and key with length prefixes and a delimiter", () => {
+		expect(canonicalKey("webauthn:auth", "abc")).toBe("13:webauthn:auth|3:abc");
+	});
+
+	it("is deterministic", () => {
+		expect(canonicalKey("a", "b")).toBe(canonicalKey("a", "b"));
+	});
+
+	it("produces distinct keys for shape-collision pairs (length-prefix property)", () => {
+		// Without length prefixes, "ab" + ":" + "cd" and "abcd" + "" share the same
+		// concatenation. Length-prefixed encoding MUST keep them distinct.
+		const a = canonicalKey("ab", ":cd");
+		const b = canonicalKey("abcd", "");
+		expect(a).not.toBe(b);
+	});
+
+	it("produces distinct keys for delimiter-collision pairs", () => {
+		// "::" delimiter naive: ("a", ":b") and ("a:", "b") collide via "a:::b" vs
+		// "a:::b". With length-prefix encoding they MUST be distinct.
+		const a = canonicalKey("a", ":b");
+		const b = canonicalKey("a:", "b");
+		expect(a).not.toBe(b);
+	});
+
+	it("handles empty scope and empty key", () => {
+		expect(canonicalKey("", "")).toBe("0:|0:");
+		expect(canonicalKey("", "x")).toBe("0:|1:x");
+		expect(canonicalKey("x", "")).toBe("1:x|0:");
+	});
+
+	it("uses JS string length (UTF-16 code units), not byte length", () => {
+		// "🦀" is one codepoint U+1F980, two UTF-16 code units, four UTF-8 bytes.
+		// We document and assert UTF-16 code units (String.prototype.length).
+		const s = "🦀";
+		expect(s.length).toBe(2); // sanity: confirm UTF-16 length
+		expect(canonicalKey(s, "")).toBe("2:🦀|0:");
+	});
+});

--- a/packages/core/src/single-use-tokens/__tests__/memory.test.mts
+++ b/packages/core/src/single-use-tokens/__tests__/memory.test.mts
@@ -76,3 +76,66 @@ describe("InMemorySingleUseTokenStore — issue", () => {
 		}
 	});
 });
+
+describe("InMemorySingleUseTokenStore — consume", () => {
+	it("returns 'unknown' when nothing was issued", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		const r = await s.consume("webauthn:reg", "never");
+		expect(r).toEqual({ outcome: "unknown" });
+	});
+
+	it("returns 'consumed' on first consume of an issued token", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		await s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000));
+		const r = await s.consume("webauthn:reg", "k1");
+		expect(r).toEqual({ outcome: "consumed" });
+	});
+
+	it("returns 'replayed' on second consume of an already-consumed token (within TTL)", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		await s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000));
+		await s.consume("webauthn:reg", "k1");
+		const r = await s.consume("webauthn:reg", "k1");
+		expect(r).toEqual({ outcome: "replayed" });
+	});
+
+	it("keeps returning 'replayed' until expiresAt elapses, then returns 'unknown'", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		await s.issue("webauthn:reg", "k1", new Date(Date.now() + 30));
+		expect((await s.consume("webauthn:reg", "k1")).outcome).toBe("consumed");
+		expect((await s.consume("webauthn:reg", "k1")).outcome).toBe("replayed");
+		await new Promise((r) => setTimeout(r, 50));
+		expect((await s.consume("webauthn:reg", "k1")).outcome).toBe("unknown");
+	});
+
+	it("issue throws 'duplicate' for a (scope, key) that is consumed but not yet expired", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		await s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000));
+		await s.consume("webauthn:reg", "k1");
+		await expect(
+			s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000)),
+		).rejects.toMatchObject({ reason: "duplicate" });
+	});
+
+	it("concurrent consume calls for the same issued token yield exactly one 'consumed' and N-1 'replayed' (N=100)", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		await s.issue("webauthn:reg", "race", new Date(Date.now() + 60_000));
+		const calls = await Promise.all(
+			Array.from({ length: 100 }, () => s.consume("webauthn:reg", "race")),
+		);
+		const counts = calls.reduce<Record<string, number>>((acc, r) => {
+			acc[r.outcome] = (acc[r.outcome] ?? 0) + 1;
+			return acc;
+		}, {});
+		expect(counts.consumed).toBe(1);
+		expect(counts.replayed).toBe(99);
+		expect(counts.unknown).toBeUndefined();
+	});
+
+	it("scope isolation: same key under different scopes do not collide", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		await s.issue("scope:a", "k", new Date(Date.now() + 60_000));
+		const r = await s.consume("scope:b", "k");
+		expect(r).toEqual({ outcome: "unknown" });
+	});
+});

--- a/packages/core/src/single-use-tokens/__tests__/memory.test.mts
+++ b/packages/core/src/single-use-tokens/__tests__/memory.test.mts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createInMemorySingleUseTokenStore } from "#/single-use-tokens/adapters/memory.mjs";
+import { SingleUseTokenError } from "#/single-use-tokens/types.mjs";
+
+describe("InMemorySingleUseTokenStore — issue", () => {
+	it("kind is 'memory'", () => {
+		const s = createInMemorySingleUseTokenStore();
+		expect(s.kind).toBe("memory");
+	});
+
+	it("issue stores a fresh (scope, key) without throwing", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		await expect(
+			s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000)),
+		).resolves.toBeUndefined();
+	});
+
+	it("issue rejects expiresAt <= now with reason 'expired-at-issue'", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		const past = new Date(Date.now() - 1);
+		await expect(s.issue("webauthn:reg", "k1", past)).rejects.toMatchObject({
+			name: "SingleUseTokenError",
+			reason: "expired-at-issue",
+		});
+	});
+
+	it("issue rejects exactly at expiresAt === now with 'expired-at-issue'", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		const now = new Date(Date.now());
+		await expect(s.issue("webauthn:reg", "k1", now)).rejects.toMatchObject({
+			reason: "expired-at-issue",
+		});
+	});
+
+	it("issue throws 'duplicate' when (scope, key) is already issued and not expired", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		await s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000));
+		await expect(
+			s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000)),
+		).rejects.toMatchObject({ name: "SingleUseTokenError", reason: "duplicate" });
+	});
+
+	it("issue accepts re-use of (scope, key) after expiresAt has passed", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		const justExpired = new Date(Date.now() + 5);
+		await s.issue("webauthn:reg", "k1", justExpired);
+		await new Promise((r) => setTimeout(r, 10));
+		await expect(
+			s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000)),
+		).resolves.toBeUndefined();
+	});
+
+	it("issue throws SingleUseTokenError instances (not generic Error)", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		try {
+			await s.issue("a", "b", new Date(0));
+			expect.fail("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(SingleUseTokenError);
+		}
+	});
+});

--- a/packages/core/src/single-use-tokens/__tests__/memory.test.mts
+++ b/packages/core/src/single-use-tokens/__tests__/memory.test.mts
@@ -139,3 +139,55 @@ describe("InMemorySingleUseTokenStore — consume", () => {
 		expect(r).toEqual({ outcome: "unknown" });
 	});
 });
+
+describe("InMemorySingleUseTokenStore — markSeen", () => {
+	it("returns 'fresh' on first observation of (scope, key)", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		const r = await s.markSeen("jwt-bearer:iss", "jti-1", new Date(Date.now() + 60_000));
+		expect(r).toEqual({ outcome: "fresh" });
+	});
+
+	it("returns 'replayed' on second observation within TTL", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		await s.markSeen("jwt-bearer:iss", "jti-1", new Date(Date.now() + 60_000));
+		const r = await s.markSeen("jwt-bearer:iss", "jti-1", new Date(Date.now() + 60_000));
+		expect(r).toEqual({ outcome: "replayed" });
+	});
+
+	it("returns 'fresh' again after the recorded expiresAt has passed", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		await s.markSeen("jwt-bearer:iss", "jti-1", new Date(Date.now() + 30));
+		await new Promise((r) => setTimeout(r, 50));
+		const r = await s.markSeen("jwt-bearer:iss", "jti-1", new Date(Date.now() + 60_000));
+		expect(r).toEqual({ outcome: "fresh" });
+	});
+
+	it("rejects expiresAt <= now with 'expired-at-issue'", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		await expect(
+			s.markSeen("jwt-bearer:iss", "jti-1", new Date(Date.now() - 1)),
+		).rejects.toMatchObject({ reason: "expired-at-issue" });
+	});
+
+	it("scope isolation: same jti under different issuers does not collide", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		await s.markSeen("jwt-bearer:a", "jti", new Date(Date.now() + 60_000));
+		const r = await s.markSeen("jwt-bearer:b", "jti", new Date(Date.now() + 60_000));
+		expect(r).toEqual({ outcome: "fresh" });
+	});
+
+	it("concurrent markSeen for the same key yields exactly one 'fresh' and N-1 'replayed'", async () => {
+		const s = createInMemorySingleUseTokenStore();
+		const calls = await Promise.all(
+			Array.from({ length: 100 }, () =>
+				s.markSeen("jwt-bearer:iss", "race", new Date(Date.now() + 60_000)),
+			),
+		);
+		const counts = calls.reduce<Record<string, number>>((acc, r) => {
+			acc[r.outcome] = (acc[r.outcome] ?? 0) + 1;
+			return acc;
+		}, {});
+		expect(counts.fresh).toBe(1);
+		expect(counts.replayed).toBe(99);
+	});
+});

--- a/packages/core/src/single-use-tokens/__tests__/redis.test.mts
+++ b/packages/core/src/single-use-tokens/__tests__/redis.test.mts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createRedisSingleUseTokenStore } from "#/single-use-tokens/adapters/redis.mjs";
+import { SingleUseTokenError } from "#/single-use-tokens/types.mjs";
+import { createFakeRedis } from "./fakeRedis.mjs";
+
+describe("RedisSingleUseTokenStore — issue", () => {
+	it("kind is 'redis'", () => {
+		const s = createRedisSingleUseTokenStore({ client: createFakeRedis() });
+		expect(s.kind).toBe("redis");
+	});
+
+	it("issue stores an issued marker that survives until expiresAt", async () => {
+		const client = createFakeRedis();
+		const s = createRedisSingleUseTokenStore({ client });
+		await s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000));
+		// The issued marker is the value `"issued"` under the prefixed canonical key.
+		const slots = [...client._store.values()];
+		expect(slots).toHaveLength(1);
+		expect(slots[0]?.value).toBe("issued");
+	});
+
+	it("issue rejects expiresAt <= now with 'expired-at-issue' (no SET to redis)", async () => {
+		const client = createFakeRedis();
+		const s = createRedisSingleUseTokenStore({ client });
+		await expect(
+			s.issue("webauthn:reg", "k1", new Date(Date.now() - 1)),
+		).rejects.toMatchObject({ reason: "expired-at-issue" });
+		expect(client._store.size).toBe(0);
+	});
+
+	it("issue throws 'duplicate' when (scope, key) already exists (issued marker)", async () => {
+		const s = createRedisSingleUseTokenStore({ client: createFakeRedis() });
+		await s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000));
+		await expect(
+			s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000)),
+		).rejects.toMatchObject({ name: "SingleUseTokenError", reason: "duplicate" });
+	});
+
+	it("uses keyPrefix when supplied", async () => {
+		const client = createFakeRedis();
+		const s = createRedisSingleUseTokenStore({ client, keyPrefix: "myapp:stk:" });
+		await s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000));
+		const keys = [...client._store.keys()];
+		expect(keys[0]?.startsWith("myapp:stk:")).toBe(true);
+	});
+});
+
+describe("RedisSingleUseTokenStore — markSeen", () => {
+	it("returns 'fresh' on first call", async () => {
+		const s = createRedisSingleUseTokenStore({ client: createFakeRedis() });
+		const r = await s.markSeen("jwt-bearer:iss", "j1", new Date(Date.now() + 60_000));
+		expect(r).toEqual({ outcome: "fresh" });
+	});
+
+	it("returns 'replayed' on second call within TTL", async () => {
+		const s = createRedisSingleUseTokenStore({ client: createFakeRedis() });
+		await s.markSeen("jwt-bearer:iss", "j1", new Date(Date.now() + 60_000));
+		const r = await s.markSeen("jwt-bearer:iss", "j1", new Date(Date.now() + 60_000));
+		expect(r).toEqual({ outcome: "replayed" });
+	});
+
+	it("rejects expiresAt <= now with 'expired-at-issue'", async () => {
+		const s = createRedisSingleUseTokenStore({ client: createFakeRedis() });
+		await expect(
+			s.markSeen("jwt-bearer:iss", "j1", new Date(Date.now() - 1)),
+		).rejects.toBeInstanceOf(SingleUseTokenError);
+	});
+});

--- a/packages/core/src/single-use-tokens/__tests__/redis.test.mts
+++ b/packages/core/src/single-use-tokens/__tests__/redis.test.mts
@@ -25,22 +25,25 @@ describe("RedisSingleUseTokenStore — issue", () => {
 		expect(s.kind).toBe("redis");
 	});
 
-	it("issue stores an issued marker that survives until expiresAt", async () => {
+	it("issue stores an issued marker as a hash field that survives until expiresAt", async () => {
 		const client = createFakeRedis();
 		const s = createRedisSingleUseTokenStore({ client });
 		await s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000));
-		// The issued marker is the value `"issued"` under the prefixed canonical key.
 		const slots = [...client._store.values()];
 		expect(slots).toHaveLength(1);
-		expect(slots[0]?.value).toBe("issued");
+		const slot = slots[0];
+		expect(slot?.kind).toBe("hash");
+		if (slot?.kind === "hash") {
+			expect(slot.fields.get("issued")).toBe("1");
+		}
 	});
 
 	it("issue rejects expiresAt <= now with 'expired-at-issue' (no SET to redis)", async () => {
 		const client = createFakeRedis();
 		const s = createRedisSingleUseTokenStore({ client });
-		await expect(
-			s.issue("webauthn:reg", "k1", new Date(Date.now() - 1)),
-		).rejects.toMatchObject({ reason: "expired-at-issue" });
+		await expect(s.issue("webauthn:reg", "k1", new Date(Date.now() - 1))).rejects.toMatchObject({
+			reason: "expired-at-issue",
+		});
 		expect(client._store.size).toBe(0);
 	});
 
@@ -80,5 +83,55 @@ describe("RedisSingleUseTokenStore — markSeen", () => {
 		await expect(
 			s.markSeen("jwt-bearer:iss", "j1", new Date(Date.now() - 1)),
 		).rejects.toBeInstanceOf(SingleUseTokenError);
+	});
+});
+
+describe("RedisSingleUseTokenStore — consume", () => {
+	it("returns 'unknown' when nothing was issued", async () => {
+		const s = createRedisSingleUseTokenStore({ client: createFakeRedis() });
+		const r = await s.consume("webauthn:reg", "never");
+		expect(r).toEqual({ outcome: "unknown" });
+	});
+
+	it("returns 'consumed' on first consume of an issued token", async () => {
+		const s = createRedisSingleUseTokenStore({ client: createFakeRedis() });
+		await s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000));
+		const r = await s.consume("webauthn:reg", "k1");
+		expect(r).toEqual({ outcome: "consumed" });
+	});
+
+	it("returns 'replayed' on subsequent consume calls within TTL", async () => {
+		const s = createRedisSingleUseTokenStore({ client: createFakeRedis() });
+		await s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000));
+		await s.consume("webauthn:reg", "k1");
+		const r = await s.consume("webauthn:reg", "k1");
+		expect(r).toEqual({ outcome: "replayed" });
+	});
+
+	it("writes a 'consumed' field with a timestamp, preserving the 'issued' field and TTL", async () => {
+		const client = createFakeRedis();
+		const s = createRedisSingleUseTokenStore({ client });
+		await s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000));
+		const keyName = [...client._store.keys()][0] ?? "";
+		const slot = client._store.get(keyName);
+		const beforeExp = slot?.expiresAtMs ?? 0;
+		await s.consume("webauthn:reg", "k1");
+		const after = client._store.get(keyName);
+		expect(after?.kind).toBe("hash");
+		if (after?.kind === "hash") {
+			expect(after.fields.get("issued")).toBe("1");
+			expect(after.fields.get("consumed")).toMatch(/^\d+$/);
+		}
+		// TTL preserved (PEXPIRE was called only on issue).
+		expect(after?.expiresAtMs).toBe(beforeExp);
+	});
+
+	it("issue throws 'duplicate' for a (scope, key) that is consumed but not yet expired", async () => {
+		const s = createRedisSingleUseTokenStore({ client: createFakeRedis() });
+		await s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000));
+		await s.consume("webauthn:reg", "k1");
+		await expect(
+			s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000)),
+		).rejects.toMatchObject({ reason: "duplicate" });
 	});
 });

--- a/packages/core/src/single-use-tokens/__tests__/redis.test.mts
+++ b/packages/core/src/single-use-tokens/__tests__/redis.test.mts
@@ -167,6 +167,34 @@ describe("RedisSingleUseTokenStore — poisoning resistance", () => {
 		// All 10 consume calls should have cleaned up after themselves.
 		expect(client._store.size).toBe(0);
 	});
+
+	it("consume on a never-issued key is non-mutating (no hSetNX, no del invocation)", async () => {
+		// Stronger property than the previous tests: consume on unknown MUST NOT
+		// write anything to redis. This is what makes poisoning resistance robust
+		// to partial failures (crash / netsplit between hSetNX and del).
+		const inner = createFakeRedis();
+		let hSetNXCalls = 0;
+		let delCalls = 0;
+		const client = {
+			...inner,
+			async hSetNX(k: string, f: string, v: string) {
+				hSetNXCalls++;
+				return inner.hSetNX(k, f, v);
+			},
+			async del(k: string) {
+				delCalls++;
+				return inner.del(k);
+			},
+		};
+
+		const s = createRedisSingleUseTokenStore({ client });
+		const r = await s.consume("webauthn:reg", "never-issued");
+
+		expect(r).toEqual({ outcome: "unknown" });
+		expect(hSetNXCalls).toBe(0);
+		expect(delCalls).toBe(0);
+		expect(inner._store.size).toBe(0);
+	});
 });
 
 describe("RedisSingleUseTokenStore — issue PEXPIRE failure handling", () => {

--- a/packages/core/src/single-use-tokens/__tests__/redis.test.mts
+++ b/packages/core/src/single-use-tokens/__tests__/redis.test.mts
@@ -135,3 +135,66 @@ describe("RedisSingleUseTokenStore — consume", () => {
 		).rejects.toMatchObject({ reason: "duplicate" });
 	});
 });
+
+describe("RedisSingleUseTokenStore — poisoning resistance", () => {
+	it("attacker pre-consume followed by legit issue → consume returns 'consumed' (not false 'replayed')", async () => {
+		const client = createFakeRedis();
+		const s = createRedisSingleUseTokenStore({ client });
+
+		// Attacker pre-poisons the (scope, key) by calling consume on a never-issued key.
+		const attackerOutcome = await s.consume("webauthn:reg", "guessable-key");
+		expect(attackerOutcome).toEqual({ outcome: "unknown" });
+
+		// The poison residue should have been cleaned up — verify by inspecting the store.
+		expect(client._store.size).toBe(0);
+
+		// Legitimate user issues + consumes the same (scope, key).
+		await s.issue("webauthn:reg", "guessable-key", new Date(Date.now() + 60_000));
+		const legitOutcome = await s.consume("webauthn:reg", "guessable-key");
+
+		// MUST return 'consumed', NOT 'replayed'. If this asserts 'replayed',
+		// the poisoning vulnerability has regressed.
+		expect(legitOutcome).toEqual({ outcome: "consumed" });
+	});
+
+	it("attacker spamming consume on random keys does not accumulate TTL-less hashes", async () => {
+		const client = createFakeRedis();
+		const s = createRedisSingleUseTokenStore({ client });
+
+		for (let i = 0; i < 10; i++) {
+			await s.consume("webauthn:reg", `attacker-${i}`);
+		}
+		// All 10 consume calls should have cleaned up after themselves.
+		expect(client._store.size).toBe(0);
+	});
+});
+
+describe("RedisSingleUseTokenStore — issue PEXPIRE failure handling", () => {
+	it("cleans up and throws when pExpire returns 0", async () => {
+		// Arrange: a fake client whose pExpire reports failure to set TTL.
+		const inner = createFakeRedis();
+		let pExpireCalls = 0;
+		let delCalls = 0;
+		const client = {
+			...inner,
+			async pExpire(_k: string, _ms: number) {
+				pExpireCalls++;
+				return 0; // simulate "key did not exist" response
+			},
+			async del(k: string) {
+				delCalls++;
+				return inner.del(k);
+			},
+		};
+
+		const s = createRedisSingleUseTokenStore({ client });
+		await expect(s.issue("webauthn:reg", "k1", new Date(Date.now() + 60_000))).rejects.toThrow(
+			/failed to set TTL/,
+		);
+
+		expect(pExpireCalls).toBe(1);
+		expect(delCalls).toBe(1);
+		// The hash should not survive the failed issue.
+		expect(inner._store.size).toBe(0);
+	});
+});

--- a/packages/core/src/single-use-tokens/__tests__/types.compile.test.mts
+++ b/packages/core/src/single-use-tokens/__tests__/types.compile.test.mts
@@ -5,9 +5,9 @@
 
 import { describe, expect, it } from "vitest";
 import {
-	SingleUseTokenError,
 	type SingleUseConsumeOutcome,
 	type SingleUseMarkSeenOutcome,
+	SingleUseTokenError,
 } from "#/single-use-tokens/types.mjs";
 
 describe("SingleUseConsumeOutcome", () => {

--- a/packages/core/src/single-use-tokens/__tests__/types.compile.test.mts
+++ b/packages/core/src/single-use-tokens/__tests__/types.compile.test.mts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	SingleUseTokenError,
+	type SingleUseConsumeOutcome,
+	type SingleUseMarkSeenOutcome,
+} from "#/single-use-tokens/types.mjs";
+
+describe("SingleUseConsumeOutcome", () => {
+	it("narrows on the `outcome` discriminator", () => {
+		const v: SingleUseConsumeOutcome = { outcome: "consumed" };
+		if (v.outcome === "consumed") {
+			expect(v.outcome).toBe("consumed");
+		} else if (v.outcome === "unknown") {
+			expect.fail("unreachable");
+		} else if (v.outcome === "replayed") {
+			expect.fail("unreachable");
+		}
+	});
+});
+
+describe("SingleUseMarkSeenOutcome", () => {
+	it("narrows on the `outcome` discriminator", () => {
+		const v: SingleUseMarkSeenOutcome = { outcome: "fresh" };
+		if (v.outcome === "fresh") {
+			expect(v.outcome).toBe("fresh");
+		} else if (v.outcome === "replayed") {
+			expect.fail("unreachable");
+		}
+	});
+});
+
+describe("SingleUseTokenError", () => {
+	it("carries `reason` and a default message", () => {
+		const e = new SingleUseTokenError({ reason: "duplicate" });
+		expect(e.name).toBe("SingleUseTokenError");
+		expect(e.reason).toBe("duplicate");
+		expect(e.message).toContain("duplicate");
+		expect(e).toBeInstanceOf(Error);
+	});
+
+	it("accepts a custom message", () => {
+		const e = new SingleUseTokenError({
+			reason: "expired-at-issue",
+			message: "exp claim already past",
+		});
+		expect(e.reason).toBe("expired-at-issue");
+		expect(e.message).toBe("exp claim already past");
+	});
+});

--- a/packages/core/src/single-use-tokens/adapters/memory.mts
+++ b/packages/core/src/single-use-tokens/adapters/memory.mts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { canonicalKey } from "../keyEncoding.mjs";
+import {
+	SingleUseTokenError,
+	type SingleUseConsumeOutcome,
+	type SingleUseMarkSeenOutcome,
+	type SingleUseTokenStoreBase,
+} from "../types.mjs";
+
+interface Entry {
+	expiresAtMs: number;
+	consumed: boolean;
+}
+
+export function createInMemorySingleUseTokenStore(): SingleUseTokenStoreBase {
+	const store = new Map<string, Entry>();
+
+	const gc = (composite: string, nowMs: number): void => {
+		const e = store.get(composite);
+		if (e !== undefined && e.expiresAtMs <= nowMs) store.delete(composite);
+	};
+
+	return {
+		kind: "memory",
+
+		async issue(scope, key, expiresAt) {
+			const nowMs = Date.now();
+			const expMs = expiresAt.getTime();
+			if (expMs <= nowMs) {
+				throw new SingleUseTokenError({ reason: "expired-at-issue" });
+			}
+			const composite = canonicalKey(scope, key);
+			gc(composite, nowMs);
+			if (store.has(composite)) {
+				throw new SingleUseTokenError({ reason: "duplicate" });
+			}
+			store.set(composite, { expiresAtMs: expMs, consumed: false });
+		},
+
+		async consume(_scope, _key): Promise<SingleUseConsumeOutcome> {
+			// Implemented in Task 4.
+			throw new Error("consume not implemented yet");
+		},
+
+		async markSeen(_scope, _key, _expiresAt): Promise<SingleUseMarkSeenOutcome> {
+			// Implemented in Task 5.
+			throw new Error("markSeen not implemented yet");
+		},
+	};
+}

--- a/packages/core/src/single-use-tokens/adapters/memory.mts
+++ b/packages/core/src/single-use-tokens/adapters/memory.mts
@@ -52,9 +52,18 @@ export function createInMemorySingleUseTokenStore(): SingleUseTokenStoreBase {
 			store.set(composite, { expiresAtMs: expMs, consumed: false });
 		},
 
-		async consume(_scope, _key): Promise<SingleUseConsumeOutcome> {
-			// Implemented in Task 4.
-			throw new Error("consume not implemented yet");
+		async consume(scope, key): Promise<SingleUseConsumeOutcome> {
+			const nowMs = Date.now();
+			const composite = canonicalKey(scope, key);
+			gc(composite, nowMs);
+			const e = store.get(composite);
+			if (e === undefined) return { outcome: "unknown" };
+			// Synchronous block: no `await` between `get` and `set`, so the JS
+			// event loop cannot interleave another consume into this critical
+			// section. This is what guarantees concurrent fairness.
+			if (e.consumed) return { outcome: "replayed" };
+			e.consumed = true;
+			return { outcome: "consumed" };
 		},
 
 		async markSeen(_scope, _key, _expiresAt): Promise<SingleUseMarkSeenOutcome> {

--- a/packages/core/src/single-use-tokens/adapters/memory.mts
+++ b/packages/core/src/single-use-tokens/adapters/memory.mts
@@ -16,9 +16,9 @@
 
 import { canonicalKey } from "../keyEncoding.mjs";
 import {
-	SingleUseTokenError,
 	type SingleUseConsumeOutcome,
 	type SingleUseMarkSeenOutcome,
+	SingleUseTokenError,
 	type SingleUseTokenStoreBase,
 } from "../types.mjs";
 

--- a/packages/core/src/single-use-tokens/adapters/memory.mts
+++ b/packages/core/src/single-use-tokens/adapters/memory.mts
@@ -66,9 +66,19 @@ export function createInMemorySingleUseTokenStore(): SingleUseTokenStoreBase {
 			return { outcome: "consumed" };
 		},
 
-		async markSeen(_scope, _key, _expiresAt): Promise<SingleUseMarkSeenOutcome> {
-			// Implemented in Task 5.
-			throw new Error("markSeen not implemented yet");
+		async markSeen(scope, key, expiresAt): Promise<SingleUseMarkSeenOutcome> {
+			const nowMs = Date.now();
+			const expMs = expiresAt.getTime();
+			if (expMs <= nowMs) {
+				throw new SingleUseTokenError({ reason: "expired-at-issue" });
+			}
+			const composite = canonicalKey(scope, key);
+			gc(composite, nowMs);
+			if (store.has(composite)) return { outcome: "replayed" };
+			// Reuse the same Entry shape — `consumed: false` is the natural
+			// state for markSeen records (they are never consumed; they expire).
+			store.set(composite, { expiresAtMs: expMs, consumed: false });
+			return { outcome: "fresh" };
 		},
 	};
 }

--- a/packages/core/src/single-use-tokens/adapters/redis.mts
+++ b/packages/core/src/single-use-tokens/adapters/redis.mts
@@ -36,6 +36,7 @@ export interface RedisLikeClient {
 	hSetNX(key: string, field: string, value: string): Promise<number>;
 	hGet(key: string, field: string): Promise<string | null>;
 	pExpire(key: string, ms: number): Promise<number>;
+	del(key: string): Promise<number>;
 }
 
 export interface RedisSingleUseTokenStoreOptions {
@@ -72,11 +73,15 @@ export function createRedisSingleUseTokenStore(
 			if (created !== 1) {
 				throw new SingleUseTokenError({ reason: "duplicate" });
 			}
-			// Apply TTL on the hash key. There is a small window between HSETNX and
-			// PEXPIRE where the process could die and leave a TTL-less hash; the
-			// next `issue` for the same (scope, key) will still surface `duplicate`,
-			// matching node-oidc-provider's behavior.
-			await client.pExpire(k, ttlMs);
+			// Apply TTL on the hash key. PEXPIRE returns 0 only if the key
+			// vanished between HSETNX and here (process kill / network partition).
+			// Clean up the orphaned hash so the next `issue` doesn't see a stale
+			// duplicate; surface the failure to the caller.
+			const expireResult = await client.pExpire(k, ttlMs);
+			if (expireResult !== 1) {
+				await client.del(k);
+				throw new Error("redis: failed to set TTL on issued single-use token");
+			}
 		},
 
 		async consume(scope, key): Promise<SingleUseConsumeOutcome> {
@@ -85,10 +90,19 @@ export function createRedisSingleUseTokenStore(
 			// one concurrent caller writes (returns 1), the rest return 0.
 			const won = await client.hSetNX(k, FIELD_CONSUMED, Date.now().toString());
 			if (won === 1) {
-				// We won the race. Confirm the entry was actually issued (not a stray
-				// consume against an attacker-fabricated key).
+				// We won the race. Confirm the entry was actually issued.
 				const issued = await client.hGet(k, FIELD_ISSUED);
-				if (issued === null) return { outcome: "unknown" };
+				if (issued === null) {
+					// Stray consume on a never-issued key. `HSETNX` just created a
+					// hash with `consumed` but no TTL. Clean up to:
+					//   1. Prevent future legitimate `issue` from being false-flagged
+					//      as `replayed` by our leftover `consumed` field (poisoning).
+					//   2. Avoid unbounded memory growth from attackers spamming
+					//      `consume` against random keys.
+					// See spec §5.2.2 "Poisoning attack mitigation".
+					await client.del(k);
+					return { outcome: "unknown" };
+				}
 				return { outcome: "consumed" };
 			}
 			// Lost the race. Either someone consumed first, or the key never existed.

--- a/packages/core/src/single-use-tokens/adapters/redis.mts
+++ b/packages/core/src/single-use-tokens/adapters/redis.mts
@@ -27,15 +27,15 @@ import {
  * existing convention (federation-tokens, user-sessions), each store defines
  * its own `RedisLikeClient` shape so the dependency is local and testable
  * with a hand-rolled fake.
+ *
+ * Naming follows redis v5 (`hSetNX`, `hGet`, `pExpire`); ioredis users can
+ * adapt with a thin wrapper.
  */
 export interface RedisLikeClient {
-	get(key: string): Promise<string | null>;
 	set(key: string, value: string, opts?: { PX?: number; NX?: boolean }): Promise<string | null>;
-	pTTL(key: string): Promise<number>;
-	eval(
-		script: string,
-		opts: { keys: string[]; arguments?: string[] },
-	): Promise<string | number | null>;
+	hSetNX(key: string, field: string, value: string): Promise<number>;
+	hGet(key: string, field: string): Promise<string | null>;
+	pExpire(key: string, ms: number): Promise<number>;
 }
 
 export interface RedisSingleUseTokenStoreOptions {
@@ -45,6 +45,9 @@ export interface RedisSingleUseTokenStoreOptions {
 }
 
 const DEFAULT_KEY_PREFIX = "stk:";
+
+const FIELD_ISSUED = "issued";
+const FIELD_CONSUMED = "consumed";
 
 export function createRedisSingleUseTokenStore(
 	opts: RedisSingleUseTokenStoreOptions,
@@ -62,14 +65,36 @@ export function createRedisSingleUseTokenStore(
 			if (ttlMs <= 0) {
 				throw new SingleUseTokenError({ reason: "expired-at-issue" });
 			}
-			const result = await client.set(fullKey(scope, key), "issued", { NX: true, PX: ttlMs });
-			if (result === null) {
+			const k = fullKey(scope, key);
+			// Atomically set the `issued` field only when it is absent.
+			// `HSETNX` returns 1 on first write, 0 if the field (or key) already exists.
+			const created = await client.hSetNX(k, FIELD_ISSUED, "1");
+			if (created !== 1) {
 				throw new SingleUseTokenError({ reason: "duplicate" });
 			}
+			// Apply TTL on the hash key. There is a small window between HSETNX and
+			// PEXPIRE where the process could die and leave a TTL-less hash; the
+			// next `issue` for the same (scope, key) will still surface `duplicate`,
+			// matching node-oidc-provider's behavior.
+			await client.pExpire(k, ttlMs);
 		},
 
-		async consume(_scope, _key): Promise<SingleUseConsumeOutcome> {
-			throw new Error("consume not implemented yet");
+		async consume(scope, key): Promise<SingleUseConsumeOutcome> {
+			const k = fullKey(scope, key);
+			// `HSETNX consumed <ts>` is the atomic "first wins" primitive: exactly
+			// one concurrent caller writes (returns 1), the rest return 0.
+			const won = await client.hSetNX(k, FIELD_CONSUMED, Date.now().toString());
+			if (won === 1) {
+				// We won the race. Confirm the entry was actually issued (not a stray
+				// consume against an attacker-fabricated key).
+				const issued = await client.hGet(k, FIELD_ISSUED);
+				if (issued === null) return { outcome: "unknown" };
+				return { outcome: "consumed" };
+			}
+			// Lost the race. Either someone consumed first, or the key never existed.
+			const consumed = await client.hGet(k, FIELD_CONSUMED);
+			if (consumed !== null) return { outcome: "replayed" };
+			return { outcome: "unknown" };
 		},
 
 		async markSeen(scope, key, expiresAt): Promise<SingleUseMarkSeenOutcome> {

--- a/packages/core/src/single-use-tokens/adapters/redis.mts
+++ b/packages/core/src/single-use-tokens/adapters/redis.mts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { canonicalKey } from "../keyEncoding.mjs";
+import {
+	type SingleUseConsumeOutcome,
+	type SingleUseMarkSeenOutcome,
+	SingleUseTokenError,
+	type SingleUseTokenStoreBase,
+} from "../types.mjs";
+
+/**
+ * Subset of the redis v5 client surface used by SingleUseTokenStore. Per
+ * existing convention (federation-tokens, user-sessions), each store defines
+ * its own `RedisLikeClient` shape so the dependency is local and testable
+ * with a hand-rolled fake.
+ */
+export interface RedisLikeClient {
+	get(key: string): Promise<string | null>;
+	set(key: string, value: string, opts?: { PX?: number; NX?: boolean }): Promise<string | null>;
+	pTTL(key: string): Promise<number>;
+	eval(
+		script: string,
+		opts: { keys: string[]; arguments?: string[] },
+	): Promise<string | number | null>;
+}
+
+export interface RedisSingleUseTokenStoreOptions {
+	client: RedisLikeClient;
+	/** Default: "stk:" (single-use token). */
+	keyPrefix?: string;
+}
+
+const DEFAULT_KEY_PREFIX = "stk:";
+
+export function createRedisSingleUseTokenStore(
+	opts: RedisSingleUseTokenStoreOptions,
+): SingleUseTokenStoreBase {
+	const { client, keyPrefix = DEFAULT_KEY_PREFIX } = opts;
+
+	const fullKey = (scope: string, key: string): string => `${keyPrefix}${canonicalKey(scope, key)}`;
+
+	return {
+		kind: "redis",
+
+		async issue(scope, key, expiresAt) {
+			const nowMs = Date.now();
+			const ttlMs = expiresAt.getTime() - nowMs;
+			if (ttlMs <= 0) {
+				throw new SingleUseTokenError({ reason: "expired-at-issue" });
+			}
+			const result = await client.set(fullKey(scope, key), "issued", { NX: true, PX: ttlMs });
+			if (result === null) {
+				throw new SingleUseTokenError({ reason: "duplicate" });
+			}
+		},
+
+		async consume(_scope, _key): Promise<SingleUseConsumeOutcome> {
+			throw new Error("consume not implemented yet");
+		},
+
+		async markSeen(scope, key, expiresAt): Promise<SingleUseMarkSeenOutcome> {
+			const nowMs = Date.now();
+			const ttlMs = expiresAt.getTime() - nowMs;
+			if (ttlMs <= 0) {
+				throw new SingleUseTokenError({ reason: "expired-at-issue" });
+			}
+			const result = await client.set(fullKey(scope, key), "1", { NX: true, PX: ttlMs });
+			return result === "OK" ? { outcome: "fresh" } : { outcome: "replayed" };
+		},
+	};
+}

--- a/packages/core/src/single-use-tokens/adapters/redis.mts
+++ b/packages/core/src/single-use-tokens/adapters/redis.mts
@@ -86,29 +86,21 @@ export function createRedisSingleUseTokenStore(
 
 		async consume(scope, key): Promise<SingleUseConsumeOutcome> {
 			const k = fullKey(scope, key);
-			// `HSETNX consumed <ts>` is the atomic "first wins" primitive: exactly
-			// one concurrent caller writes (returns 1), the rest return 0.
-			const won = await client.hSetNX(k, FIELD_CONSUMED, Date.now().toString());
-			if (won === 1) {
-				// We won the race. Confirm the entry was actually issued.
-				const issued = await client.hGet(k, FIELD_ISSUED);
-				if (issued === null) {
-					// Stray consume on a never-issued key. `HSETNX` just created a
-					// hash with `consumed` but no TTL. Clean up to:
-					//   1. Prevent future legitimate `issue` from being false-flagged
-					//      as `replayed` by our leftover `consumed` field (poisoning).
-					//   2. Avoid unbounded memory growth from attackers spamming
-					//      `consume` against random keys.
-					// See spec §5.2.2 "Poisoning attack mitigation".
-					await client.del(k);
-					return { outcome: "unknown" };
-				}
-				return { outcome: "consumed" };
+			// Non-mutating existence check first. Only issued entries are eligible
+			// for consumption. Reading `issued` before writing anything keeps stray
+			// consumes ZERO side-effect, so partial failures (crash / netsplit
+			// between commands) cannot leave behind a TTL-less hash that poisons
+			// future legitimate issue/consume for the same (scope, key).
+			// See spec §5.2.2 "Poisoning attack mitigation".
+			const issued = await client.hGet(k, FIELD_ISSUED);
+			if (issued === null) {
+				return { outcome: "unknown" };
 			}
-			// Lost the race. Either someone consumed first, or the key never existed.
-			const consumed = await client.hGet(k, FIELD_CONSUMED);
-			if (consumed !== null) return { outcome: "replayed" };
-			return { outcome: "unknown" };
+			// `HSETNX consumed <ts>` is the atomic "first wins" primitive for keys
+			// that are known to have been issued: exactly one concurrent caller
+			// writes (returns 1), the rest return 0.
+			const won = await client.hSetNX(k, FIELD_CONSUMED, Date.now().toString());
+			return won === 1 ? { outcome: "consumed" } : { outcome: "replayed" };
 		},
 
 		async markSeen(scope, key, expiresAt): Promise<SingleUseMarkSeenOutcome> {

--- a/packages/core/src/single-use-tokens/factory.mts
+++ b/packages/core/src/single-use-tokens/factory.mts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createAdapterFactory } from "../adapters/AdapterFactory.mjs";
+import { createInMemorySingleUseTokenStore } from "./adapters/memory.mjs";
+import type { SingleUseTokenStoreBase, SingleUseTokenStoreFactory } from "./types.mjs";
+
+export function createSingleUseTokenStoreFactory(): SingleUseTokenStoreFactory {
+	return createAdapterFactory<SingleUseTokenStoreBase>("SingleUseTokenStore");
+}
+
+export function registerBuiltinSingleUseTokenStores(factory: SingleUseTokenStoreFactory): void {
+	factory.register("memory", () => createInMemorySingleUseTokenStore());
+	factory.register("redis", async (config) => {
+		const client = (config as { client?: unknown }).client;
+		if (!client) {
+			throw new Error(
+				"singleUseTokenStore.redis: 'client' option is required. Pass a connected redis v5 client via AppOptions wiring.",
+			);
+		}
+		const keyPrefix =
+			typeof (config as { keyPrefix?: unknown }).keyPrefix === "string"
+				? (config as { keyPrefix: string }).keyPrefix
+				: undefined;
+		const { createRedisSingleUseTokenStore } = await import("./adapters/redis.mjs");
+		return createRedisSingleUseTokenStore({
+			client: client as Parameters<typeof createRedisSingleUseTokenStore>[0]["client"],
+			keyPrefix,
+		});
+	});
+}
+
+export type { SingleUseTokenStoreFactory };

--- a/packages/core/src/single-use-tokens/keyEncoding.mts
+++ b/packages/core/src/single-use-tokens/keyEncoding.mts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Combine `scope` and `key` into a single storage key with length-prefix
+ * encoding. The length prefix neutralises any delimiter collision because
+ * the parser would always need the prefix to decide where each segment ends.
+ *
+ * Both adapters (memory, redis) MUST use this same encoding so a key written
+ * by one is readable by the other (relevant in tests that swap adapters).
+ *
+ * `String.prototype.length` (UTF-16 code units) is used because the value
+ * just needs to be self-consistent within one adapter instance — not match
+ * any external Unicode definition.
+ */
+export function canonicalKey(scope: string, key: string): string {
+	return `${scope.length}:${scope}|${key.length}:${key}`;
+}

--- a/packages/core/src/single-use-tokens/types.mts
+++ b/packages/core/src/single-use-tokens/types.mts
@@ -16,11 +16,35 @@
 
 import type { AdapterFactory } from "../adapters/AdapterFactory.mjs";
 
+/**
+ * Outcome of consuming a server-issued single-use token (challenge).
+ *
+ * - `consumed`: token was registered at issue time, not yet consumed, within TTL.
+ *   Caller MAY proceed with the protected operation.
+ * - `unknown`:  no record matches `(scope, key)`. Either never issued, expired
+ *   (TTL elapsed), or already consumed and GC-ed. Caller MUST reject.
+ * - `replayed`: a record exists but was already consumed. Caller MUST reject
+ *   AND treat as a replay attack signal (audit log, increment counter).
+ *
+ * Implementations MUST NOT collapse `unknown` and `replayed` into one variant —
+ * the security distinction (audit-worthy vs not) is preserved by the contract.
+ */
 export type SingleUseConsumeOutcome =
 	| { readonly outcome: "consumed" }
 	| { readonly outcome: "unknown" }
 	| { readonly outcome: "replayed" };
 
+/**
+ * Outcome of recording a client-supplied JWT `jti` for replay protection.
+ *
+ * - `fresh`:    `(scope, key)` was not previously seen within `expiresAt`.
+ *   Caller MAY accept the assertion.
+ * - `replayed`: `(scope, key)` was already recorded. Caller MUST reject the
+ *   assertion as a replay.
+ *
+ * No `unknown` variant — `markSeen` always either records or detects replay;
+ * there is no third outcome.
+ */
 export type SingleUseMarkSeenOutcome =
 	| { readonly outcome: "fresh" }
 	| { readonly outcome: "replayed" };
@@ -32,8 +56,12 @@ export interface SingleUseTokenStoreBase {
 	 * Register a server-issued single-use token (e.g. WebAuthn challenge).
 	 *
 	 * Throws SingleUseTokenError({ reason: "duplicate" }) when (scope, key)
-	 * has any non-expired record (issued OR consumed) — re-issuing on top of
-	 * a consumed record would defeat replay detection.
+	 * has any non-expired record (issued OR consumed). Re-issuing on top of
+	 * a `consumed` record would defeat replay detection — the consumed flag
+	 * exists precisely to keep returning `replayed` until `expiresAt`.
+	 * Server-issued tokens are random with sufficient entropy that a
+	 * within-TTL collision implies a bug or programming error, never a
+	 * legitimate retry; callers MUST NOT wrap `issue` in a retry loop.
 	 *
 	 * Throws SingleUseTokenError({ reason: "expired-at-issue" }) when
 	 * expiresAt <= now at call time, before any state mutation.

--- a/packages/core/src/single-use-tokens/types.mts
+++ b/packages/core/src/single-use-tokens/types.mts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { AdapterFactory } from "../adapters/AdapterFactory.mjs";
+
+export type SingleUseConsumeOutcome =
+	| { readonly outcome: "consumed" }
+	| { readonly outcome: "unknown" }
+	| { readonly outcome: "replayed" };
+
+export type SingleUseMarkSeenOutcome =
+	| { readonly outcome: "fresh" }
+	| { readonly outcome: "replayed" };
+
+export interface SingleUseTokenStoreBase {
+	readonly kind: string;
+
+	/**
+	 * Register a server-issued single-use token (e.g. WebAuthn challenge).
+	 *
+	 * Throws SingleUseTokenError({ reason: "duplicate" }) when (scope, key)
+	 * has any non-expired record (issued OR consumed) — re-issuing on top of
+	 * a consumed record would defeat replay detection.
+	 *
+	 * Throws SingleUseTokenError({ reason: "expired-at-issue" }) when
+	 * expiresAt <= now at call time, before any state mutation.
+	 */
+	issue(scope: string, key: string, expiresAt: Date): Promise<void>;
+
+	/**
+	 * Atomically consume a previously-issued single-use token. Concurrent
+	 * consume calls for the same (scope, key) MUST yield exactly one
+	 * `consumed` and the rest `replayed` — never two `consumed`, never
+	 * `unknown` for an issued-then-consumed token until expiresAt.
+	 */
+	consume(scope: string, key: string): Promise<SingleUseConsumeOutcome>;
+
+	/**
+	 * Atomically check-and-record a client-supplied identifier (e.g. JWT jti)
+	 * for replay protection. Returns `fresh` on first observation within the
+	 * TTL window, `replayed` on subsequent calls.
+	 *
+	 * Throws SingleUseTokenError({ reason: "expired-at-issue" }) when
+	 * expiresAt <= now.
+	 *
+	 * markSeen and consume MUST NOT share a key namespace — caller's
+	 * responsibility to keep `scope` disjoint between the two operations.
+	 */
+	markSeen(scope: string, key: string, expiresAt: Date): Promise<SingleUseMarkSeenOutcome>;
+}
+
+export type SingleUseTokenStoreFactory = AdapterFactory<SingleUseTokenStoreBase>;
+
+/**
+ * Structured error type for `issue` / `markSeen` rejections.
+ *
+ * - `duplicate`: (scope, key) already has a non-expired record (issued OR consumed).
+ * - `expired-at-issue`: expiresAt <= now at call time.
+ *
+ * Adapters MUST throw this exact class so consumers can branch on `reason`.
+ * Future variants are additive only.
+ */
+export class SingleUseTokenError extends Error {
+	readonly reason: "duplicate" | "expired-at-issue";
+
+	constructor(opts: { reason: "duplicate" | "expired-at-issue"; message?: string }) {
+		super(opts.message ?? `SingleUseTokenError: ${opts.reason}`);
+		this.name = "SingleUseTokenError";
+		this.reason = opts.reason;
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `SingleUseTokenStore` extension point to `@o3co/auth-provider-core`: one interface, two op shapes (`issue`/`consume` for server-issued challenges, `markSeen` for client-supplied JWT `jti` replay detection).
- Built-in `memory` (single-process / dev) + `redis` (production multi-instance) adapters. Redis uses Hash + `HSETNX` for atomic state transition (no Lua), aligned with the dominant Node.js auth ecosystem pattern (`node-oidc-provider`, Ory `fosite`).
- Wired as optional `AppOptions.singleUseTokenStore`. Future consumers: jwt-bearer (#4) and WebAuthn (#10-13).

## Design background

- Pivoted from initial Lua/EVAL design to `HSETNX` after surveying 5 OSS auth implementations (0/5 use Lua for `consume`). The "consumed" marker is retained as a hash field until TTL elapses, which preserves the `replayed` vs `unknown` security distinction.
- Multi-agent review (Claude `code-reviewer` + Codex `review`) independently flagged a poisoning vulnerability: `HSETNX` on a non-existent key creates a new hash, allowing an attacker who can guess `(scope, key)` to pre-poison the store. Fix: `consume` cleans up the residue with `DEL` on the stray-consume branch. Regression test verified to FAIL on the unfixed code → PASS on the fixed code.

## Scope

- New file structure under `packages/core/src/single-use-tokens/` (mirrors `refresh/` / `user-sessions/` / `federation-tokens/` pattern).
- Public exports added to `@o3co/auth-provider-core` index.
- `AppOptions` + `ModuleContext` slot wiring with 2 forwarding tests.
- README section + CHANGELOG entry.
- 54 new tests (3 type narrowing, 6 key encoding, 20 memory, 16 redis, 6 factory, 2 wiring, 1 lint cleanup spillover).
- 464 / 464 tests pass across all packages, biome lint clean (0 errors).

## Out of scope (separate plans)

- jwt-bearer grant (`#4` of v0.5.0 scope) — will use `markSeen("jwt-bearer:<issuer>", jti, exp)`.
- WebAuthn `ChallengeStore` (`#10-13`) — will re-export `SingleUseTokenStoreBase` as `ChallengeStore` from `@o3co/auth-provider-webauthn`.
- DPoP (post-1.0) — pre-declared use site only.

## Test plan

- [ ] CI green (build + test + lint + biome + cross-project gate)
- [ ] Copilot review addressed (all threads resolved)
- [ ] Branch up-to-date with `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)