### PR TITLE
refactor: schema/default separation + @o3co/auth-provider-core/testing subpath (PR α)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- `@o3co/auth-provider-core/testing` subpath. Exposes the
+  `makeValidCoreConfig` / `makeValidFullSections` / `makeValidAppConfig`
+  fixture factories so sibling packages and downstream test suites can
+  build a schema-valid config baseline without re-implementing it. The
+  subpath is consumer-test-only — production runtime code MUST NOT
+  import from it.
 - `@o3co/auth-provider-federation-google` package with `createGoogleProvider()` and `registerGoogleFederation(factory)`.
 - `@o3co/auth-provider-federation-github` package with `createGithubProvider()` and `registerGithubFederation(factory)`.
 - `sessionModule({ federationProviderFactory })` option for composition roots that explicitly register federation provider packages.
@@ -28,6 +34,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Breaking Changes
 
+- **Config schema is strict; defaults live exclusively in HOCON.**
+  `application.schema.mts` no longer carries `.default(X)` for fields
+  that hocon already supplies. Operators see the same effective
+  defaults at boot — `application.conf` continues to provide them —
+  but the schema layer no longer fills in missing values. Two
+  concrete operator-facing consequences:
+  - **`federations.<name>.enabled` is strict.** Pre-PR the schema-side
+    `enabled` carried `.default(false)`, but its composition with
+    surrounding `z.preprocess` / `z.optional` was fragile: a bare
+    federation entry sometimes parsed as `enabled = false` and
+    sometimes caused boot to reject the entry (the trap that
+    motivated this refactor). The schema-side default is now
+    removed. Each federation entry must declare
+    `enabled = true` / `enabled = false` explicitly, or be omitted
+    from the config entirely. Bare `federations { google {} }`
+    shapes will now fail validation at boot deterministically. If
+    you want a federation provider to be active, write
+    `enabled = true` in its entry; if you want it inactive, either
+    write `enabled = false` or remove the entry.
+  - **Library consumers** who construct `AppConfig` from a non-HOCON
+    source (TOML, env-only, in-memory object, etc.) must now supply
+    every required leaf themselves before calling `validate()` /
+    `composeConfigSchema().parse()`. Previously, schema-side
+    `.default()` masked missing leaves; that path is gone. See
+    `packages/core/docs/adr/2026-04-30-config-schema-strict-defaults-from-hocon.md`
+    (consequences I2 / I4) for the rationale and the
+    `@o3co/auth-provider-core/testing` subpath for a reference
+    fixture baseline. Note that the `testing` factory is intentionally
+    a minimal schema-valid baseline rather than a hocon mirror —
+    consumers that want the production hocon defaults should load
+    `application.conf` directly.
 - **`grant_type` wire values (RFC compliance + URN-ification):**
   - `grant_type=authorization` → `grant_type=authorization_code` (RFC 6749 §4.1.3)
   - `grant_type=session` unchanged

--- a/packages/core/docs/adr/2026-04-30-config-schema-strict-defaults-from-hocon.md
+++ b/packages/core/docs/adr/2026-04-30-config-schema-strict-defaults-from-hocon.md
@@ -57,8 +57,17 @@ Concretely:
   (e.g. `oauth.jwt.issuer`, `signingKey.local.{secret,privateKey,...}`,
   `endpoints.*.url`).
 - Tests that previously relied on schema-side defaults to populate bare
-  `{}` inputs now supply the same values that hocon would have produced,
-  via the shared fixture `src/__tests__/fixtures/valid-config.mts`.
+  `{}` inputs now supply explicit values via the shared factory in
+  `src/testing/fixtures/valid-config.mts`. The factory returns a
+  minimal schema-valid baseline rather than a hocon mirror —
+  `session.storage.type` is `memory` and `federations` is `{}` for
+  test ergonomics, which intentionally diverges from
+  `application.conf` (where `storage.type = "redis"` and a built-in
+  `federations.google` block is shipped). The factory is exposed to
+  consumer test code through the `./testing` subpath in
+  `package.json#exports` (per A2-γ spec §6.1 + §7), so sibling
+  packages and downstream applications can reuse the same baseline
+  without copying it.
 
 ## Rationale
 
@@ -97,12 +106,40 @@ Concretely:
 
 - Tests that need a parsable config must now supply every required leaf.
   Bare `{ http: {}, oauth: { jwt: {}, ... } }` inputs no longer parse.
-  The shared fixture in `src/__tests__/fixtures/valid-config.mts`
-  centralises this to prevent inline duplication.
+  The shared fixture in `src/testing/fixtures/valid-config.mts`,
+  re-exported from `@o3co/auth-provider-core/testing`, centralises this
+  to prevent inline duplication across packages.
 - A future contributor who adds `default(X)` back to the schema would
   re-introduce the drift hazard. This ADR plus the docstring at the top
   of `application.schema.mts` are the only guards against that
   regression.
+- **I2 — library-consumer perspective.** Consumers that embed
+  `@o3co/auth-provider-core` outside the standalone deployment shape
+  (e.g. composing modules manually, loading config from TOML / env
+  vars / an in-memory object instead of `application.conf`) are
+  responsible for supplying the defaults that hocon would otherwise
+  inject before passing the object to `validate()` /
+  `composeConfigSchema().parse()`. The hocon-default coupling is
+  intentional for the standalone deployment path, but library
+  consumers see it as an additional integration constraint rather
+  than a hidden default. The exported `makeValidCoreConfig` /
+  `makeValidAppConfig` factories from
+  `@o3co/auth-provider-core/testing` provide a reference baseline
+  consumers can adapt; production consumers should encode their own
+  defaulting layer rather than depend on test fixtures at runtime.
+- **I4 — `federations.<name>.enabled` is now strict.** Pre-PR the
+  schema-side `coerceBooleanFromEnv` carried `.default(false)`, but the
+  composition with surrounding `z.preprocess` / `z.optional` / object
+  shape was fragile: absent `enabled` sometimes parsed as `false` and
+  sometimes caused boot to reject the entry outright (the trap that
+  motivated this refactor — see Context). With the schema-side default
+  removed, both branches collapse into a single contract: operators
+  must write `enabled = true` / `enabled = false` explicitly inside
+  each federation entry, or omit the entry entirely. Configurations
+  that relied on a bare `federations { google {} }` shape now fail
+  validation at boot deterministically. The hardening is intentional
+  (no ambiguity about which providers are active) but is breaking and
+  operator-visible; see `CHANGELOG.md` for the migration note.
 
 ### Neutral
 
@@ -117,8 +154,8 @@ Fields that are optional and have no hocon-side default — only an
 schema. Examples:
 
 - `oauth.jwt.issuer`
-- `signingKey.local.{secret,privateKey,privateKeyPath,publicKey,publicKeyPath}`
-- `redis.password`
+- `oauth.jwt.signingKey.local.{secret,privateKey,privateKeyPath,publicKey,publicKeyPath}`
+- `session.storage.redis.password`
 - `endpoints.{login,client,authCallback}.url`
 
 These are not "schema defaults"; they are valid-when-absent fields whose

--- a/packages/core/docs/adr/2026-04-30-config-schema-strict-defaults-from-hocon.md
+++ b/packages/core/docs/adr/2026-04-30-config-schema-strict-defaults-from-hocon.md
@@ -1,0 +1,146 @@
+# ADR 2026-04-30 — Config schema is a pure type contract; defaults live in hocon
+
+## Status
+
+Accepted (2026-04-30).
+
+## Context
+
+`packages/core/src/config/application.schema.mts` defines `CoreConfigSchema`
+and `AppConfigSchema` (Zod). At the boundary, configuration also flows
+through `packages/core/config/application.conf` (HOCON parsed by
+`@o3co/ts.hocon`), which supplies values and applies `${?ENV_VAR}`
+substitutions for operator overrides.
+
+Until this change, both layers carried the same defaults:
+
+```typescript
+// schema
+http: z.object({
+  port: z.coerce.number().default(3000),
+  trustProxy: z.boolean().default(false),
+})
+```
+
+```hocon
+# hocon
+http {
+  port = 3000
+  port = ${?HTTP_PORT}
+  trustProxy = false
+  trustProxy = ${?HTTP_TRUST_PROXY}
+}
+```
+
+This split caused real harm during `feat/v0.5.0-module-system-redesign`
+(PR #97). A change to `federations.<name>.enabled` had to coerce env-var
+strings (`"false"` → `false`) via `z.preprocess`, but Zod's `.default()`
+inside a `preprocess` does not propagate the "optional" flag to the
+enclosing object schema. That made the field effectively required at parse
+time despite its visible `.default(false)`. CI failures on `federations:
+{}` inputs surfaced the trap. Two fixes existed: hoist `.default(false)`
+outside the preprocess (Option A — short-circuit), or remove the
+schema-side default entirely and rely on hocon (Option C — root cause).
+
+## Decision
+
+Schemas in `application.schema.mts` describe the **shape** required at the
+boundary. They do not carry runtime default values. All defaults live
+exclusively in `packages/core/config/application.conf`. `${?ENV_VAR}`
+substitutions in that file are the only override surface.
+
+Concretely:
+
+- Removed `.default(X)` from 21 locations in the schema where hocon already
+  supplies the same value.
+- Kept `optional()` for fields that are env-only and have no hocon default
+  (e.g. `oauth.jwt.issuer`, `signingKey.local.{secret,privateKey,...}`,
+  `endpoints.*.url`).
+- Tests that previously relied on schema-side defaults to populate bare
+  `{}` inputs now supply the same values that hocon would have produced,
+  via the shared fixture `src/__tests__/fixtures/valid-config.mts`.
+
+## Rationale
+
+1. **Single Responsibility at the layer level.** The schema's job is type
+   contract enforcement. The hocon layer's job is supplying values and
+   reading env-var overrides. Mixing the two creates two sources of
+   truth for the same fact, and they can drift silently.
+
+2. **Eliminates a real trap.** The PR #97 incident demonstrated that
+   schema-level defaults interact non-trivially with `z.preprocess`,
+   `z.optional`, and surrounding `z.object` semantics. Removing
+   schema-side defaults removes that interaction surface.
+
+3. **Operator mental model is hocon-first.** Operators read
+   `application.conf` to understand what the system does at runtime; a
+   default that lives only in code (Zod) is invisible to them.
+
+4. **Test fixtures become honest.** A test that asserts "this value is
+   `3000`" now must explicitly supply `3000`, which forces the test to
+   declare what it actually depends on rather than inheriting a hidden
+   default.
+
+## Consequences
+
+### Positive
+
+- Drift between schema defaults and hocon defaults is eliminated by
+  construction.
+- Failure modes from `.default()` interacting with `preprocess` /
+  `optional` cannot recur at the schema layer.
+- Adding a new config field requires a deliberate decision about which
+  source supplies its default — not a copy-paste of the same value into
+  two places.
+
+### Negative
+
+- Tests that need a parsable config must now supply every required leaf.
+  Bare `{ http: {}, oauth: { jwt: {}, ... } }` inputs no longer parse.
+  The shared fixture in `src/__tests__/fixtures/valid-config.mts`
+  centralises this to prevent inline duplication.
+- A future contributor who adds `default(X)` back to the schema would
+  re-introduce the drift hazard. This ADR plus the docstring at the top
+  of `application.schema.mts` are the only guards against that
+  regression.
+
+### Neutral
+
+- The hocon file `packages/core/config/application.conf` is now the
+  single source of truth for defaults. Editing it is the only way to
+  change the runtime default for a configurable field.
+
+## Pattern preserved (env-only optional fields)
+
+Fields that are optional and have no hocon-side default — only an
+`${?ENV_VAR}` substitution — remain `z.string().optional()` in the
+schema. Examples:
+
+- `oauth.jwt.issuer`
+- `signingKey.local.{secret,privateKey,privateKeyPath,publicKey,publicKeyPath}`
+- `redis.password`
+- `endpoints.{login,client,authCallback}.url`
+
+These are not "schema defaults"; they are valid-when-absent fields whose
+absence is expected and meaningful (e.g. asymmetric key configurations
+omit `secret`).
+
+## How to apply this rule going forward
+
+When adding a new config field:
+
+1. Decide whether the field has a sensible default for "no operator
+   intervention". If yes, supply that default in
+   `application.conf` only — never in the schema.
+2. If the field is env-only and absence is meaningful, mark it
+   `z.<type>().optional()` in the schema and add `${?ENV_VAR}` (without a
+   preceding default line) in `application.conf`.
+3. Never add `.default(X)` to the schema. If a reviewer suggests it,
+   point to this ADR.
+
+## Related
+
+- PR #97 (feat/v0.5.0-module-system-redesign) — surfaced the trap that
+  motivated this ADR.
+- This refactor's PR — implements the change across the schema and
+  associated test fixtures.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,10 @@
 		"./modules/manifest": {
 			"import": "./dist/modules/manifest/index.mjs",
 			"types": "./dist/modules/manifest/index.d.mts"
+		},
+		"./testing": {
+			"import": "./dist/testing/index.mjs",
+			"types": "./dist/testing/index.d.mts"
 		}
 	},
 	"files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,8 +16,8 @@
 			"types": "./dist/modules/manifest/index.d.mts"
 		},
 		"./testing": {
-			"import": "./dist/testing/index.mjs",
-			"types": "./dist/testing/index.d.mts"
+			"types": "./dist/testing/index.d.mts",
+			"import": "./dist/testing/index.mjs"
 		}
 	},
 	"files": [

--- a/packages/core/src/__tests__/config-composition.test.mts
+++ b/packages/core/src/__tests__/config-composition.test.mts
@@ -92,7 +92,12 @@ describe("CoreConfigSchema", () => {
 			...minimalCoreConfig,
 			oauth: {
 				...minimalCoreConfig.oauth,
-				jwt: { signingKey: { provider: "local", local: { algorithm: "HS256" } } },
+				jwt: {
+					signingKey: {
+						provider: "local",
+						local: { algorithm: "HS256", kid: "v0", previousKeys: [] },
+					},
+				},
 			},
 		});
 		expect(result.success).toBe(true);

--- a/packages/core/src/__tests__/config.test.mts
+++ b/packages/core/src/__tests__/config.test.mts
@@ -32,7 +32,8 @@ describe("provider config", () => {
 		expect(local).toBeDefined();
 		expect(local.secret).toBe("test-secret");
 
-		// algorithm and kid defaults applied
+		// algorithm and kid come from hocon (`application.conf`); the schema
+		// is strict and supplies no defaults of its own (ADR 2026-04-30).
 		expect(local.algorithm).toBe("HS256");
 		expect(local.kid).toBe("v0");
 	});
@@ -67,7 +68,7 @@ describe("provider config", () => {
 		// federation entries is tested in federations-schema.test.mts.
 	});
 
-	it("repositories.client.type defaults to yaml", () => {
+	it("repositories.client.type is yaml when application.conf is loaded with no override", () => {
 		const raw = parseFile(new URL("../../config/application.conf", import.meta.url).pathname, {
 			env: {
 				OAUTH_JWT_SECRET: "test-secret",
@@ -80,7 +81,7 @@ describe("provider config", () => {
 		expect(config.repositories.client.type).toBe("yaml");
 	});
 
-	it("repositories.user.type defaults to yaml", () => {
+	it("repositories.user.type is yaml when application.conf is loaded with no override", () => {
 		const raw = parseFile(new URL("../../config/application.conf", import.meta.url).pathname, {
 			env: {
 				OAUTH_JWT_SECRET: "test-secret",
@@ -91,7 +92,7 @@ describe("provider config", () => {
 		expect(config.repositories.user.type).toBe("yaml");
 	});
 
-	it("repositories.code.type defaults to memory", () => {
+	it("repositories.code.type is memory when application.conf is loaded with no override", () => {
 		const raw = parseFile(new URL("../../config/application.conf", import.meta.url).pathname, {
 			env: {
 				OAUTH_JWT_SECRET: "test-secret",

--- a/packages/core/src/__tests__/config.test.mts
+++ b/packages/core/src/__tests__/config.test.mts
@@ -104,27 +104,27 @@ describe("provider config", () => {
 });
 
 describe("jwt config schema", () => {
-	// Schema-level acceptance tests — verify the nested signingKey shape is accepted
-	// and that schema-level defaults are applied inside signingKey.local.
+	// Schema-level acceptance tests — verify the nested signingKey shape is
+	// accepted. Per ADR 2026-04-30 the schema is a pure type contract:
+	// algorithm/kid/previousKeys are required at the schema boundary, and
+	// hocon (`packages/core/config/application.conf`) supplies the runtime
+	// defaults that production callers rely on.
 
-	it("algorithm defaults to HS256", () => {
-		// When local sub-section is absent, signingKey.local is undefined (schema: optional).
-		// The default lives in signingKeyLocalSchema; test via parse with explicit local: {}.
-		const result = jwtSchema.parse({ signingKey: { local: {} } });
-		const local = result.signingKey.local as Record<string, unknown>;
-		expect(local.algorithm).toBe("HS256");
-	});
-
-	it("kid defaults to v0", () => {
-		const result = jwtSchema.parse({ signingKey: { local: {} } });
-		const local = result.signingKey.local as Record<string, unknown>;
-		expect(local.kid).toBe("v0");
-	});
-
-	it("previousKeys defaults to empty array", () => {
-		const result = jwtSchema.parse({ signingKey: { local: {} } });
-		const local = result.signingKey.local as Record<string, unknown>;
-		expect(local.previousKeys).toEqual([]);
+	it("rejects bare local sub-section (algorithm/kid/previousKeys are required at the schema boundary)", () => {
+		const result = jwtSchema.safeParse({
+			signingKey: { provider: "local", local: { secret: "x" } },
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const paths = result.error.issues.map((i) => i.path.join("."));
+			expect(paths).toEqual(
+				expect.arrayContaining([
+					"signingKey.local.algorithm",
+					"signingKey.local.kid",
+					"signingKey.local.previousKeys",
+				]),
+			);
+		}
 	});
 
 	it("accepts RS256 with key fields", () => {
@@ -133,6 +133,8 @@ describe("jwt config schema", () => {
 				provider: "local",
 				local: {
 					algorithm: "RS256",
+					kid: "v0",
+					previousKeys: [],
 					privateKey: "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----",
 					publicKey: "-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----",
 				},
@@ -146,12 +148,30 @@ describe("jwt config schema", () => {
 
 	it("accepts ES256 and EdDSA algorithms", () => {
 		const es256 = jwtSchema.parse({
-			signingKey: { local: { algorithm: "ES256", privateKey: "pk", publicKey: "pub" } },
+			signingKey: {
+				provider: "local",
+				local: {
+					algorithm: "ES256",
+					kid: "v0",
+					previousKeys: [],
+					privateKey: "pk",
+					publicKey: "pub",
+				},
+			},
 		});
 		expect((es256.signingKey.local as Record<string, unknown>).algorithm).toBe("ES256");
 
 		const eddsa = jwtSchema.parse({
-			signingKey: { local: { algorithm: "EdDSA", privateKey: "pk", publicKey: "pub" } },
+			signingKey: {
+				provider: "local",
+				local: {
+					algorithm: "EdDSA",
+					kid: "v0",
+					previousKeys: [],
+					privateKey: "pk",
+					publicKey: "pub",
+				},
+			},
 		});
 		expect((eddsa.signingKey.local as Record<string, unknown>).algorithm).toBe("EdDSA");
 	});
@@ -159,8 +179,10 @@ describe("jwt config schema", () => {
 	it("accepts previousKeys array with valid entries", () => {
 		const result = jwtSchema.parse({
 			signingKey: {
+				provider: "local",
 				local: {
 					algorithm: "ES256",
+					kid: "v1",
 					privateKey: "pk",
 					publicKey: "pub",
 					previousKeys: [
@@ -186,7 +208,16 @@ describe("jwt config schema", () => {
 
 	it("secret is optional for asymmetric algorithms", () => {
 		const result = jwtSchema.parse({
-			signingKey: { local: { algorithm: "ES256", privateKey: "pk", publicKey: "pub" } },
+			signingKey: {
+				provider: "local",
+				local: {
+					algorithm: "ES256",
+					kid: "v0",
+					previousKeys: [],
+					privateKey: "pk",
+					publicKey: "pub",
+				},
+			},
 		});
 		const local = result.signingKey.local as Record<string, unknown>;
 		expect(local.secret).toBeUndefined();
@@ -198,7 +229,12 @@ describe("jwt config schema", () => {
 
 	it("rejects HS256 without secret (builder-level)", async () => {
 		// Schema parse succeeds — no secret required at schema level.
-		const parsed = jwtSchema.parse({ signingKey: { local: { algorithm: "HS256" } } });
+		const parsed = jwtSchema.parse({
+			signingKey: {
+				provider: "local",
+				local: { algorithm: "HS256", kid: "v0", previousKeys: [] },
+			},
+		});
 		const local = parsed.signingKey.local as Record<string, unknown>;
 		await expect(makeFactory().create({ type: "local", ...local })).rejects.toThrow(
 			/secret is required for HS256 algorithm/i,
@@ -207,7 +243,10 @@ describe("jwt config schema", () => {
 
 	it("rejects asymmetric algorithm without privateKey (builder-level)", async () => {
 		const parsed = jwtSchema.parse({
-			signingKey: { local: { algorithm: "ES256", publicKey: "pub" } },
+			signingKey: {
+				provider: "local",
+				local: { algorithm: "ES256", kid: "v0", previousKeys: [], publicKey: "pub" },
+			},
 		});
 		const local = parsed.signingKey.local as Record<string, unknown>;
 		await expect(makeFactory().create({ type: "local", ...local })).rejects.toThrow(
@@ -217,7 +256,10 @@ describe("jwt config schema", () => {
 
 	it("rejects asymmetric algorithm without publicKey (builder-level)", async () => {
 		const parsed = jwtSchema.parse({
-			signingKey: { local: { algorithm: "RS256", privateKey: "pk" } },
+			signingKey: {
+				provider: "local",
+				local: { algorithm: "RS256", kid: "v0", previousKeys: [], privateKey: "pk" },
+			},
 		});
 		const local = parsed.signingKey.local as Record<string, unknown>;
 		await expect(makeFactory().create({ type: "local", ...local })).rejects.toThrow(
@@ -231,8 +273,10 @@ describe("jwt config schema", () => {
 		// throws before it attempts to import them, so actual crypto validity is irrelevant here.
 		const parsed = jwtSchema.parse({
 			signingKey: {
+				provider: "local",
 				local: {
 					algorithm: "ES256",
+					kid: "v0",
 					privateKey: "pk",
 					publicKey: "pub",
 					previousKeys: [{ kid: "old", expiresAt: "2099-01-01T00:00:00Z" }],

--- a/packages/core/src/__tests__/fixtures/valid-config.mts
+++ b/packages/core/src/__tests__/fixtures/valid-config.mts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Valid-config fixtures for tests that need to satisfy CoreConfigSchema or
+ * AppConfigSchema parse.
+ *
+ * Background: per ADR 2026-04-30, schema is a pure type contract — defaults
+ * live exclusively in `packages/core/config/application.conf`. Tests that
+ * previously relied on schema-side `.default(X)` to populate bare `{}`
+ * inputs must now supply the same values that hocon would have produced.
+ *
+ * These factories return fresh, mutable objects so each test can apply local
+ * overrides without bleeding into siblings. The values mirror
+ * `application.conf` defaults; if hocon defaults change, update here.
+ */
+
+export function makeValidCoreConfig() {
+	return {
+		http: { port: 3000, trustProxy: false },
+		oauth: {
+			jwt: {
+				signingKey: {
+					provider: "local",
+					local: {
+						algorithm: "HS256",
+						kid: "v0",
+						secret: "test-secret",
+						previousKeys: [],
+					},
+				},
+			},
+			accessToken: { expiresIn: 3600 },
+			refreshToken: { expiresIn: 86400 },
+			grants: {},
+		},
+	};
+}
+
+export function makeValidFullSections() {
+	return {
+		session: {
+			secret: "test-session-secret",
+			maxAge: 3600000,
+			secure: true,
+			sameSite: "lax" as const,
+			domain: null,
+			storage: { type: "memory" },
+		},
+		rateLimit: {
+			login: { windowMs: 900000, limit: 20 },
+		},
+		federations: {},
+		repositories: {
+			client: { type: "yaml" },
+			user: { type: "yaml" },
+			code: { type: "memory" },
+		},
+		endpoints: {
+			login: {},
+		},
+		cors: { allowedOrigins: [] },
+	};
+}
+
+export function makeValidAppConfig() {
+	return {
+		...makeValidCoreConfig(),
+		...makeValidFullSections(),
+	};
+}

--- a/packages/core/src/boot/__tests__/apply-contributions.test.mts
+++ b/packages/core/src/boot/__tests__/apply-contributions.test.mts
@@ -15,8 +15,8 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { applyContributions } from "../apply-contributions.mjs";
 import { materializeComponents } from "../materialize-components.mjs";
 import { planBoot } from "../plan-boot.mjs";

--- a/packages/core/src/boot/__tests__/apply-contributions.test.mts
+++ b/packages/core/src/boot/__tests__/apply-contributions.test.mts
@@ -45,8 +45,9 @@ declare module "@o3co/auth-provider-core" {
 // ---------------------------------------------------------------------------
 
 // Per ADR 2026-04-30: schema is a pure type contract; defaults live in
-// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
-// fixture must mirror what hocon would have produced.
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so the
+// fixture supplies a minimal schema-valid baseline (intentionally
+// diverges from application.conf — see makeValidCoreConfig docstring).
 const minBoot = {
 	config: makeValidCoreConfig() as never,
 	pathResolver: (s: string) => s,

--- a/packages/core/src/boot/__tests__/apply-contributions.test.mts
+++ b/packages/core/src/boot/__tests__/apply-contributions.test.mts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
 import { applyContributions } from "../apply-contributions.mjs";
 import { materializeComponents } from "../materialize-components.mjs";

--- a/packages/core/src/boot/__tests__/apply-contributions.test.mts
+++ b/packages/core/src/boot/__tests__/apply-contributions.test.mts
@@ -15,6 +15,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
+import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
 import { applyContributions } from "../apply-contributions.mjs";
 import { materializeComponents } from "../materialize-components.mjs";
@@ -43,11 +44,11 @@ declare module "@o3co/auth-provider-core" {
 // Minimal bootstrap
 // ---------------------------------------------------------------------------
 
-// Minimum config that satisfies CoreConfigSchema (Codex P2-A hardening:
-// validateAndComposeConfig now always runs CoreConfigSchema). All required
-// nested objects present as empty so Zod defaults populate every leaf.
+// Per ADR 2026-04-30: schema is a pure type contract; defaults live in
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
+// fixture must mirror what hocon would have produced.
 const minBoot = {
-	config: { http: {}, oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} } } as never,
+	config: makeValidCoreConfig() as never,
 	pathResolver: (s: string) => s,
 } satisfies Record<string, unknown> as BootstrapMap;
 

--- a/packages/core/src/boot/__tests__/create-app.test.mts
+++ b/packages/core/src/boot/__tests__/create-app.test.mts
@@ -28,7 +28,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
 import { createApp } from "../create-app.mjs";
 import type {

--- a/packages/core/src/boot/__tests__/create-app.test.mts
+++ b/packages/core/src/boot/__tests__/create-app.test.mts
@@ -28,8 +28,8 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { createApp } from "../create-app.mjs";
 import type {
 	AppHandle,

--- a/packages/core/src/boot/__tests__/create-app.test.mts
+++ b/packages/core/src/boot/__tests__/create-app.test.mts
@@ -28,6 +28,7 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
 import { createApp } from "../create-app.mjs";
 import type {
@@ -53,11 +54,11 @@ declare module "@o3co/auth-provider-core" {
 // Minimal bootstrap stub
 // ---------------------------------------------------------------------------
 
-// Minimum config that satisfies CoreConfigSchema (Codex P2-A hardening:
-// validateAndComposeConfig now always runs CoreConfigSchema). All required
-// nested objects present as empty so Zod defaults populate every leaf.
+// Per ADR 2026-04-30: schema is a pure type contract; defaults live in
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
+// fixture must mirror what hocon would have produced.
 const minBoot = {
-	config: { http: {}, oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} } } as never,
+	config: makeValidCoreConfig() as never,
 	pathResolver: (s: string) => s,
 } satisfies Record<string, unknown> as BootstrapMap;
 

--- a/packages/core/src/boot/__tests__/create-app.test.mts
+++ b/packages/core/src/boot/__tests__/create-app.test.mts
@@ -55,8 +55,9 @@ declare module "@o3co/auth-provider-core" {
 // ---------------------------------------------------------------------------
 
 // Per ADR 2026-04-30: schema is a pure type contract; defaults live in
-// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
-// fixture must mirror what hocon would have produced.
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so the
+// fixture supplies a minimal schema-valid baseline (intentionally
+// diverges from application.conf — see makeValidCoreConfig docstring).
 const minBoot = {
 	config: makeValidCoreConfig() as never,
 	pathResolver: (s: string) => s,
@@ -157,9 +158,11 @@ describe("createApp — 1. happy path: minimal manifest boots", () => {
 		expect(Object.isFrozen(handle)).toBe(true);
 		// components map is accessible and contains the bootstrap keys
 		expect(handle.components).toBeDefined();
-		// config is now the parsed (CoreConfigSchema-validated) result with
-		// Zod defaults applied — not the raw bootstrap reference. See
-		// validateAndComposeConfig substitution per Codex P2-A hardening.
+		// config is now the parsed (CoreConfigSchema-validated) result —
+		// not the raw bootstrap reference. See validateAndComposeConfig
+		// substitution per Codex P2-A hardening. The `port: 3000` value
+		// comes from the makeValidCoreConfig fixture; per ADR 2026-04-30
+		// the schema layer no longer carries a default for it.
 		expect((handle.components.config as { http: { port: number } }).http.port).toBe(3000);
 		expect(handle.components.pathResolver).toBe(minBoot.pathResolver);
 		// The slot provided by the module is materialised (eager activation)
@@ -181,9 +184,11 @@ describe("createApp — 1. happy path: minimal manifest boots", () => {
 		expect(Object.isFrozen(handle)).toBe(true);
 		expect(Object.isFrozen(handle.components)).toBe(true);
 		// Bootstrap components are present in the frozen component map.
-		// config is now the parsed (CoreConfigSchema-validated) result with
-		// Zod defaults applied — not the raw bootstrap reference. See
-		// validateAndComposeConfig substitution per Codex P2-A hardening.
+		// config is now the parsed (CoreConfigSchema-validated) result —
+		// not the raw bootstrap reference. See validateAndComposeConfig
+		// substitution per Codex P2-A hardening. The `port: 3000` value
+		// comes from the makeValidCoreConfig fixture; per ADR 2026-04-30
+		// the schema layer no longer carries a default for it.
 		expect((handle.components.config as { http: { port: number } }).http.port).toBe(3000);
 		expect(handle.components.pathResolver).toBe(minBoot.pathResolver);
 	});

--- a/packages/core/src/boot/__tests__/federation-pairing.test.mts
+++ b/packages/core/src/boot/__tests__/federation-pairing.test.mts
@@ -26,11 +26,12 @@
  * Per A5 §8.1, §8.2.
  */
 import { describe, expect, it } from "vitest";
+import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
 import { createBootApp, defineModule } from "../../index.mjs";
 import { BootError } from "../types.mjs";
 
 const minBoot = {
-	config: { http: {}, oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} } },
+	config: makeValidCoreConfig(),
 	pathResolver: (p: string) => p,
 } as never;
 

--- a/packages/core/src/boot/__tests__/federation-pairing.test.mts
+++ b/packages/core/src/boot/__tests__/federation-pairing.test.mts
@@ -26,8 +26,8 @@
  * Per A5 §8.1, §8.2.
  */
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { createBootApp, defineModule } from "../../index.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { BootError } from "../types.mjs";
 
 const minBoot = {

--- a/packages/core/src/boot/__tests__/federation-pairing.test.mts
+++ b/packages/core/src/boot/__tests__/federation-pairing.test.mts
@@ -26,7 +26,7 @@
  * Per A5 §8.1, §8.2.
  */
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { createBootApp, defineModule } from "../../index.mjs";
 import { BootError } from "../types.mjs";
 

--- a/packages/core/src/boot/__tests__/federation-policy-override.test.mts
+++ b/packages/core/src/boot/__tests__/federation-policy-override.test.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { createBootApp, defineModule } from "../../index.mjs";
 
 const minBoot = {

--- a/packages/core/src/boot/__tests__/federation-policy-override.test.mts
+++ b/packages/core/src/boot/__tests__/federation-policy-override.test.mts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
+import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
 import { createBootApp, defineModule } from "../../index.mjs";
 
 const minBoot = {
-	config: { http: {}, oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} } },
+	config: makeValidCoreConfig(),
 	pathResolver: (p: string) => p,
 } as never;
 

--- a/packages/core/src/boot/__tests__/federation-policy-override.test.mts
+++ b/packages/core/src/boot/__tests__/federation-policy-override.test.mts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { createBootApp, defineModule } from "../../index.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 
 const minBoot = {
 	config: makeValidCoreConfig(),

--- a/packages/core/src/boot/__tests__/integration.test.mts
+++ b/packages/core/src/boot/__tests__/integration.test.mts
@@ -29,9 +29,9 @@
 
 import { Router } from "express";
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { createBootApp } from "../../index.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import type { BootstrapMap } from "../types.mjs";
 import { BootError } from "../types.mjs";
 

--- a/packages/core/src/boot/__tests__/integration.test.mts
+++ b/packages/core/src/boot/__tests__/integration.test.mts
@@ -29,7 +29,7 @@
 
 import { Router } from "express";
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { createBootApp } from "../../index.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
 import type { BootstrapMap } from "../types.mjs";

--- a/packages/core/src/boot/__tests__/integration.test.mts
+++ b/packages/core/src/boot/__tests__/integration.test.mts
@@ -29,6 +29,7 @@
 
 import { Router } from "express";
 import { describe, expect, it } from "vitest";
+import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
 import { createBootApp } from "../../index.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
 import type { BootstrapMap } from "../types.mjs";
@@ -68,11 +69,11 @@ declare module "@o3co/auth-provider-core" {
 // Shared bootstrap stub
 // ---------------------------------------------------------------------------
 
-// Minimum config that satisfies CoreConfigSchema (Codex P2-A hardening:
-// validateAndComposeConfig now always runs CoreConfigSchema). All required
-// nested objects present as empty so Zod defaults populate every leaf.
+// Per ADR 2026-04-30: schema is a pure type contract, defaults live in
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
+// fixture must mirror what hocon would have produced.
 const minBoot = {
-	config: { http: {}, oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} } } as never,
+	config: makeValidCoreConfig() as never,
 	pathResolver: (s: string) => s,
 } satisfies Record<string, unknown> as BootstrapMap;
 

--- a/packages/core/src/boot/__tests__/integration.test.mts
+++ b/packages/core/src/boot/__tests__/integration.test.mts
@@ -70,8 +70,9 @@ declare module "@o3co/auth-provider-core" {
 // ---------------------------------------------------------------------------
 
 // Per ADR 2026-04-30: schema is a pure type contract, defaults live in
-// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
-// fixture must mirror what hocon would have produced.
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so the
+// fixture supplies a minimal schema-valid baseline (intentionally
+// diverges from application.conf — see makeValidCoreConfig docstring).
 const minBoot = {
 	config: makeValidCoreConfig() as never,
 	pathResolver: (s: string) => s,
@@ -174,9 +175,11 @@ describe("integration — Scenario 1: happy boot of a multi-module manifest", ()
 		expect(handle.components.auditSink).toBe(stubAuditSink);
 
 		// Bootstrap components are accessible.
-		// config is now the parsed (CoreConfigSchema-validated) result with
-		// Zod defaults applied — not the raw bootstrap reference. See
-		// validateAndComposeConfig substitution per Codex P2-A hardening.
+		// config is now the parsed (CoreConfigSchema-validated) result —
+		// not the raw bootstrap reference. See validateAndComposeConfig
+		// substitution per Codex P2-A hardening. The `port: 3000` value
+		// comes from the makeValidCoreConfig fixture; per ADR 2026-04-30
+		// the schema layer no longer carries a default for it.
 		expect((handle.components.config as { http: { port: number } }).http.port).toBe(3000);
 		expect(handle.components.pathResolver).toBe(minBoot.pathResolver);
 

--- a/packages/core/src/boot/__tests__/materialize-components.test.mts
+++ b/packages/core/src/boot/__tests__/materialize-components.test.mts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import { describe, expect, it, vi } from "vitest";
-import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { materializeComponents } from "../materialize-components.mjs";
 import { planBoot } from "../plan-boot.mjs";
 import type { BootstrapMap } from "../types.mjs";

--- a/packages/core/src/boot/__tests__/materialize-components.test.mts
+++ b/packages/core/src/boot/__tests__/materialize-components.test.mts
@@ -40,8 +40,9 @@ declare module "@o3co/auth-provider-core" {
 // ---------------------------------------------------------------------------
 
 // Per ADR 2026-04-30: schema is a pure type contract; defaults live in
-// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
-// fixture must mirror what hocon would have produced.
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so the
+// fixture supplies a minimal schema-valid baseline (intentionally
+// diverges from application.conf — see makeValidCoreConfig docstring).
 const minBoot = {
 	config: makeValidCoreConfig() as never,
 	pathResolver: (s: string) => s,

--- a/packages/core/src/boot/__tests__/materialize-components.test.mts
+++ b/packages/core/src/boot/__tests__/materialize-components.test.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it, vi } from "vitest";
+import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
 import { materializeComponents } from "../materialize-components.mjs";
 import { planBoot } from "../plan-boot.mjs";
@@ -38,11 +39,11 @@ declare module "@o3co/auth-provider-core" {
 // Helpers
 // ---------------------------------------------------------------------------
 
-// Minimum config that satisfies CoreConfigSchema (Codex P2-A hardening:
-// validateAndComposeConfig now always runs CoreConfigSchema). All required
-// nested objects present as empty so Zod defaults populate every leaf.
+// Per ADR 2026-04-30: schema is a pure type contract; defaults live in
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
+// fixture must mirror what hocon would have produced.
 const minBoot = {
-	config: { http: {}, oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} } } as never,
+	config: makeValidCoreConfig() as never,
 	pathResolver: (s: string) => s,
 } satisfies Record<string, unknown> as BootstrapMap;
 

--- a/packages/core/src/boot/__tests__/materialize-components.test.mts
+++ b/packages/core/src/boot/__tests__/materialize-components.test.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it, vi } from "vitest";
-import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
 import { materializeComponents } from "../materialize-components.mjs";
 import { planBoot } from "../plan-boot.mjs";

--- a/packages/core/src/boot/__tests__/plan-boot.test.mts
+++ b/packages/core/src/boot/__tests__/plan-boot.test.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
 import { planBoot } from "../plan-boot.mjs";
 import type { BootstrapMap as BM, BootstrapMap } from "../types.mjs";

--- a/packages/core/src/boot/__tests__/plan-boot.test.mts
+++ b/packages/core/src/boot/__tests__/plan-boot.test.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
+import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
 import { planBoot } from "../plan-boot.mjs";
 import type { BootstrapMap as BM, BootstrapMap } from "../types.mjs";
@@ -65,11 +66,11 @@ function makeStubListCollector() {
 	};
 }
 
-// Minimum config that satisfies CoreConfigSchema (Codex P2-A hardening:
-// validateAndComposeConfig now always runs CoreConfigSchema). All required
-// nested objects present as empty so Zod defaults populate every leaf.
+// Per ADR 2026-04-30: schema is a pure type contract; defaults live in
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
+// fixture must mirror what hocon would have produced.
 const minBootstrap = {
-	config: { http: {}, oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} } } as never,
+	config: makeValidCoreConfig() as never,
 	pathResolver: (s: string) => s,
 } satisfies Record<string, unknown> as BM;
 

--- a/packages/core/src/boot/__tests__/plan-boot.test.mts
+++ b/packages/core/src/boot/__tests__/plan-boot.test.mts
@@ -67,8 +67,9 @@ function makeStubListCollector() {
 }
 
 // Per ADR 2026-04-30: schema is a pure type contract; defaults live in
-// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
-// fixture must mirror what hocon would have produced.
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so the
+// fixture supplies a minimal schema-valid baseline (intentionally
+// diverges from application.conf — see makeValidCoreConfig docstring).
 const minBootstrap = {
 	config: makeValidCoreConfig() as never,
 	pathResolver: (s: string) => s,

--- a/packages/core/src/boot/__tests__/plan-boot.test.mts
+++ b/packages/core/src/boot/__tests__/plan-boot.test.mts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { planBoot } from "../plan-boot.mjs";
 import type { BootstrapMap as BM, BootstrapMap } from "../types.mjs";
 import { BootError } from "../types.mjs";

--- a/packages/core/src/boot/__tests__/validate-manifests.test.mts
+++ b/packages/core/src/boot/__tests__/validate-manifests.test.mts
@@ -15,8 +15,8 @@
  */
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { BootError } from "../types.mjs";
 import { validateManifests } from "../validate-manifests.mjs";
 

--- a/packages/core/src/boot/__tests__/validate-manifests.test.mts
+++ b/packages/core/src/boot/__tests__/validate-manifests.test.mts
@@ -15,7 +15,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
 import { BootError } from "../types.mjs";
 import { validateManifests } from "../validate-manifests.mjs";
@@ -783,15 +783,17 @@ describe("validateManifests — step 12: lifecycle-without-provides", () => {
 
 describe("validateManifests — step 13: config-validation-failed", () => {
 	it("composes configSchemas and throws config-validation-failed on parse error", () => {
+		// Module-specific top-level key (`cfgModRetries`) chosen so it cannot
+		// visually collide with `http.port` from CoreConfigSchema's `minCoreConfig`.
 		const m = defineModule({
 			name: "cfg-mod",
-			configSchema: z.object({ port: z.number() }),
+			configSchema: z.object({ cfgModRetries: z.number() }),
 		});
 		try {
 			validateManifests({
 				modules: [m],
 				bootstrapComponents: {
-					config: { ...minCoreConfig, port: "not-a-number" } as never,
+					config: { ...minCoreConfig, cfgModRetries: "not-a-number" } as never,
 					pathResolver: minBootstrap.pathResolver,
 				},
 			});

--- a/packages/core/src/boot/__tests__/validate-manifests.test.mts
+++ b/packages/core/src/boot/__tests__/validate-manifests.test.mts
@@ -15,6 +15,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
+import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
 import { BootError } from "../types.mjs";
 import { validateManifests } from "../validate-manifests.mjs";
@@ -33,15 +34,10 @@ declare module "@o3co/auth-provider-core" {
 // the full AppConfig shape (which would require all nested required fields).
 import type { BootstrapMap } from "../types.mjs";
 
-// Minimum config that satisfies CoreConfigSchema — all required nested
-// objects present as empty so Zod defaults populate every leaf.
-// Per Codex P2-A hardening: validateAndComposeConfig now ALWAYS runs
-// CoreConfigSchema, even when no module declares a configSchema, so this
-// stub must satisfy CoreConfigSchema's required structure.
-const minCoreConfig = {
-	http: {},
-	oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} },
-};
+// Per ADR 2026-04-30: schema is a pure type contract; defaults live in
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
+// fixture must mirror what hocon would have produced.
+const minCoreConfig = makeValidCoreConfig();
 
 const minBootstrap = {
 	config: minCoreConfig as never,
@@ -843,19 +839,18 @@ describe("validateManifests — step 13: config-validation-failed", () => {
 		expect.fail("should have thrown");
 	});
 
-	it("CoreConfigSchema defaults are applied even when zero modules declare configSchema", () => {
+	it("propagates parsed config through bootstrapComponents even with zero configSchema modules", () => {
 		// Companion to the regression above: with zero configSchema modules and
-		// a minimal valid config, the parsed config carries CoreConfigSchema's
-		// Zod defaults (e.g. http.port=3000) into bootstrapComponents.
+		// a minimal valid config, the parsed config (which now carries no
+		// schema-injected values per ADR 2026-04-30 — defaults live in hocon)
+		// must still flow into bootstrapComponents intact.
 		const noSchema = defineModule({ name: "no-schema" });
 		const result = validateManifests({
 			modules: [noSchema],
 			bootstrapComponents: minBootstrap,
 		});
-		// The parsed config substituted into bootstrapComponents should carry
-		// CoreConfigSchema defaults applied.
 		const parsed = result.bootstrapComponents.config as { http: { port: number } };
-		expect(parsed.http.port).toBe(3000);
+		expect(parsed.http.port).toBe(minCoreConfig.http.port);
 	});
 
 	it("preserves top-level extra config keys not in any schema (Codex P2 strip-unknown regression)", () => {
@@ -880,8 +875,8 @@ describe("validateManifests — step 13: config-validation-failed", () => {
 			},
 		});
 		const cfg = result.bootstrapComponents.config as Record<string, unknown>;
-		// CoreConfigSchema defaults still applied
-		expect((cfg.http as { port: number }).port).toBe(3000);
+		// Parsed config flows through with the values supplied at the boundary
+		expect((cfg.http as { port: number }).port).toBe(minCoreConfig.http.port);
 		// Top-level extras preserved
 		expect(cfg.session).toEqual({ strategy: "jwt-signed-cookie", cookieName: "_sess" });
 		expect(cfg.customConsumerKey).toEqual({ whatever: 42 });
@@ -992,15 +987,7 @@ describe("validateManifests — step 13: parsed config carried forward in bootst
 		const result = validateManifests({
 			modules: [m],
 			bootstrapComponents: {
-				config: {
-					http: { port: 3000, trustProxy: false },
-					oauth: {
-						jwt: {},
-						accessToken: { expiresIn: 3600 },
-						refreshToken: { expiresIn: 86400 },
-						grants: {},
-					},
-				} as never,
+				config: minCoreConfig as never,
 				pathResolver: (s: string) => s,
 			},
 		});

--- a/packages/core/src/boot/__tests__/validate-manifests.test.mts
+++ b/packages/core/src/boot/__tests__/validate-manifests.test.mts
@@ -35,8 +35,9 @@ declare module "@o3co/auth-provider-core" {
 import type { BootstrapMap } from "../types.mjs";
 
 // Per ADR 2026-04-30: schema is a pure type contract; defaults live in
-// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
-// fixture must mirror what hocon would have produced.
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so the
+// fixture supplies a minimal schema-valid baseline (intentionally
+// diverges from application.conf — see makeValidCoreConfig docstring).
 const minCoreConfig = makeValidCoreConfig();
 
 const minBootstrap = {

--- a/packages/core/src/challenges/__tests__/wiring.test.mts
+++ b/packages/core/src/challenges/__tests__/wiring.test.mts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import type { BootstrapMap } from "../../boot/types.mjs";
 import {
 	createBootApp,
@@ -25,6 +24,7 @@ import {
 	memoryChallengeStoreModule,
 	memoryReplaySeenSetModule,
 } from "../../index.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 
 // Per ADR 2026-04-30: schema is a pure type contract; defaults live in
 // hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so the

--- a/packages/core/src/challenges/__tests__/wiring.test.mts
+++ b/packages/core/src/challenges/__tests__/wiring.test.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
+import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
 import type { BootstrapMap } from "../../boot/types.mjs";
 import {
 	createBootApp,
@@ -25,11 +26,11 @@ import {
 	memoryReplaySeenSetModule,
 } from "../../index.mjs";
 
-// Minimum config that satisfies CoreConfigSchema (Codex P2-A hardening:
-// validateAndComposeConfig now always runs CoreConfigSchema). All required
-// nested objects present as empty so Zod defaults populate every leaf.
+// Per ADR 2026-04-30: schema is a pure type contract; defaults live in
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
+// fixture must mirror what hocon would have produced.
 const minBoot = {
-	config: { http: {}, oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} } } as never,
+	config: makeValidCoreConfig() as never,
 	pathResolver: (s: string) => s,
 } satisfies Record<string, unknown> as BootstrapMap;
 

--- a/packages/core/src/challenges/__tests__/wiring.test.mts
+++ b/packages/core/src/challenges/__tests__/wiring.test.mts
@@ -27,8 +27,9 @@ import {
 } from "../../index.mjs";
 
 // Per ADR 2026-04-30: schema is a pure type contract; defaults live in
-// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
-// fixture must mirror what hocon would have produced.
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so the
+// fixture supplies a minimal schema-valid baseline (intentionally
+// diverges from application.conf — see makeValidCoreConfig docstring).
 const minBoot = {
 	config: makeValidCoreConfig() as never,
 	pathResolver: (s: string) => s,

--- a/packages/core/src/challenges/__tests__/wiring.test.mts
+++ b/packages/core/src/challenges/__tests__/wiring.test.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import type { BootstrapMap } from "../../boot/types.mjs";
 import {
 	createBootApp,

--- a/packages/core/src/config/__tests__/federations-schema.test.mts
+++ b/packages/core/src/config/__tests__/federations-schema.test.mts
@@ -15,7 +15,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { AppConfigSchema, fullSectionsSchema } from "#/config/application.schema.mjs";
-import { makeValidAppConfig } from "../../__tests__/fixtures/valid-config.mjs";
+import { makeValidAppConfig } from "../../testing/fixtures/valid-config.mjs";
 
 /**
  * Access the federations schema directly for sub-schema-level tests.

--- a/packages/core/src/config/__tests__/federations-schema.test.mts
+++ b/packages/core/src/config/__tests__/federations-schema.test.mts
@@ -15,6 +15,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { AppConfigSchema, fullSectionsSchema } from "#/config/application.schema.mjs";
+import { makeValidAppConfig } from "../../__tests__/fixtures/valid-config.mjs";
 
 /**
  * Access the federations schema directly for sub-schema-level tests.
@@ -23,34 +24,13 @@ import { AppConfigSchema, fullSectionsSchema } from "#/config/application.schema
 const federationsSchema = fullSectionsSchema.shape.federations;
 
 /**
- * Minimal config for a full AppConfigSchema.parse() call.
- * Derived by observing which fields are required (have no defaults).
+ * Per ADR 2026-04-30: schema is a pure type contract; defaults live in
+ * hocon. AppConfigSchema.parse rejects bare `{}` inputs, so the fixture
+ * mirrors what hocon would have produced. Per-test overrides target only
+ * the field-under-test (e.g. add `federations` for federation-specific
+ * assertions).
  */
-const minimalConfig = {
-	http: {},
-	oauth: {
-		jwt: { signingKey: { local: { secret: "s3cret" } } },
-		accessToken: {},
-		refreshToken: {},
-		grants: {},
-	},
-	session: {
-		secret: "session-secret",
-		storage: { type: "memory" },
-	},
-	rateLimit: {
-		login: { windowMs: 60000, limit: 10 },
-	},
-	repositories: {
-		client: {},
-		user: {},
-		code: {},
-	},
-	endpoints: {
-		login: {},
-	},
-	cors: {},
-};
+const minimalConfig = makeValidAppConfig();
 
 describe("federations schema — open to z.record with passthrough", () => {
 	it("accepts shorthand: federations.google { enabled: true, clientId, clientSecret, callbackURL }", () => {
@@ -72,6 +52,7 @@ describe("federations schema — open to z.record with passthrough", () => {
 	it("accepts explicit multi-tenant: federations['google-work'] { type: 'google', google: { clientId, ... } }", () => {
 		const parsed = federationsSchema.parse({
 			"google-work": {
+				enabled: false,
 				type: "google",
 				google: {
 					clientId: "work-client-id",
@@ -89,6 +70,7 @@ describe("federations schema — open to z.record with passthrough", () => {
 	it("accepts arbitrary custom type: federations['corporate-sso'] { type: 'saml', saml: { entityId: '...' } }", () => {
 		const parsed = federationsSchema.parse({
 			"corporate-sso": {
+				enabled: false,
 				type: "saml",
 				saml: {
 					entityId: "https://idp.example.com/saml",
@@ -102,18 +84,24 @@ describe("federations schema — open to z.record with passthrough", () => {
 		expect(saml.entityId).toBe("https://idp.example.com/saml");
 	});
 
-	it("defaults enabled to false when section is present but enabled is omitted", () => {
-		const parsed = federationsSchema.parse({
+	it("rejects entries that omit enabled (schema is strict — defaults live in hocon)", () => {
+		const result = federationsSchema.safeParse({
 			google: {
 				clientId: "test-client-id",
 				clientSecret: "test-client-secret",
 				callbackURL: "https://example.com/callback",
 			},
 		});
-		expect(parsed.google.enabled).toBe(false);
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const paths = result.error.issues.map((i) => i.path.join("."));
+			expect(paths).toContain("google.enabled");
+		}
 	});
 
-	it("defaults federations to empty object when entire section is omitted (AppConfigSchema.parse)", () => {
+	it("preserves an empty federations record passed by the caller (no schema-side default)", () => {
+		// hocon supplies the default federations record at runtime; the schema
+		// itself does not inject `{}` when the section is omitted.
 		const parsed = AppConfigSchema.parse(minimalConfig);
 		expect(parsed.federations).toEqual({});
 	});

--- a/packages/core/src/config/__tests__/federations-schema.test.mts
+++ b/packages/core/src/config/__tests__/federations-schema.test.mts
@@ -26,9 +26,10 @@ const federationsSchema = fullSectionsSchema.shape.federations;
 /**
  * Per ADR 2026-04-30: schema is a pure type contract; defaults live in
  * hocon. AppConfigSchema.parse rejects bare `{}` inputs, so the fixture
- * mirrors what hocon would have produced. Per-test overrides target only
- * the field-under-test (e.g. add `federations` for federation-specific
- * assertions).
+ * supplies a minimal schema-valid baseline (intentionally diverges from
+ * application.conf — see makeValidAppConfig docstring). Per-test
+ * overrides target only the field-under-test (e.g. add `federations`
+ * for federation-specific assertions).
  */
 const minimalConfig = makeValidAppConfig();
 

--- a/packages/core/src/config/__tests__/schema-open-type.test.mts
+++ b/packages/core/src/config/__tests__/schema-open-type.test.mts
@@ -16,26 +16,44 @@
 import { describe, expect, it } from "vitest";
 import { AppConfigSchema, fullSectionsSchema } from "#/config/application.schema.mjs";
 
+/**
+ * Per ADR 2026-04-30: schema is a pure type contract; defaults live in
+ * hocon. session.{maxAge,secure,sameSite,domain} are required at the
+ * schema boundary, so each test supplies them explicitly.
+ */
+function validSession(overrides: Record<string, unknown> = {}) {
+	return {
+		secret: "s",
+		maxAge: 3600000,
+		secure: true,
+		sameSite: "lax" as const,
+		domain: null,
+		...overrides,
+	};
+}
+
 describe("schema open type", () => {
 	it("accepts non-builtin session storage type (validated at factory level, not schema)", () => {
-		const parsed = fullSectionsSchema.shape.session.parse({
-			secret: "s",
-			storage: {
-				type: "memcached",
-				redis: { url: "redis://localhost:6379" },
-			},
-		});
+		const parsed = fullSectionsSchema.shape.session.parse(
+			validSession({
+				storage: {
+					type: "memcached",
+					redis: { url: "redis://localhost:6379" },
+				},
+			}),
+		);
 		expect(parsed.storage.type).toBe("memcached");
 	});
 
 	it("preserves custom session storage sub-section (passthrough carries memcached.servers)", () => {
-		const parsed = fullSectionsSchema.shape.session.parse({
-			secret: "s",
-			storage: {
-				type: "memcached",
-				memcached: { servers: ["mc1.example.com:11211", "mc2.example.com:11211"] },
-			},
-		});
+		const parsed = fullSectionsSchema.shape.session.parse(
+			validSession({
+				storage: {
+					type: "memcached",
+					memcached: { servers: ["mc1.example.com:11211", "mc2.example.com:11211"] },
+				},
+			}),
+		);
 		expect(parsed.storage.type).toBe("memcached");
 		expect(
 			(parsed.storage as unknown as { memcached?: { servers?: string[] } }).memcached?.servers,
@@ -43,22 +61,24 @@ describe("schema open type", () => {
 	});
 
 	it("allows omitting the redis sub-section when type != 'redis'", () => {
-		const parsed = fullSectionsSchema.shape.session.parse({
-			secret: "s",
-			storage: { type: "memory" },
-		});
+		const parsed = fullSectionsSchema.shape.session.parse(
+			validSession({
+				storage: { type: "memory" },
+			}),
+		);
 		expect(parsed.storage.type).toBe("memory");
 	});
 
 	it("still accepts the builtin session storage types", () => {
 		for (const type of ["redis", "memory"]) {
-			const parsed = fullSectionsSchema.shape.session.parse({
-				secret: "s",
-				storage: {
-					type,
-					redis: { url: "redis://localhost:6379" },
-				},
-			});
+			const parsed = fullSectionsSchema.shape.session.parse(
+				validSession({
+					storage: {
+						type,
+						redis: { url: "redis://localhost:6379" },
+					},
+				}),
+			);
 			expect(parsed.storage.type).toBe(type);
 		}
 	});

--- a/packages/core/src/config/__tests__/signing-key-schema.test.mts
+++ b/packages/core/src/config/__tests__/signing-key-schema.test.mts
@@ -22,24 +22,41 @@ import { AppConfigSchema, CoreConfigSchema } from "#/config/application.schema.m
  */
 const jwtSchema = CoreConfigSchema.shape.oauth.shape.jwt;
 
+/**
+ * Per ADR 2026-04-30: signingKey.local fields are required at the schema
+ * level — defaults live in hocon. Tests assemble valid-shape inputs by
+ * supplying every required field; per-test overrides target only the
+ * field-under-test.
+ */
+function validLocal(overrides: Record<string, unknown> = {}) {
+	return {
+		algorithm: "HS256",
+		kid: "v0",
+		secret: "s3cret",
+		previousKeys: [],
+		...overrides,
+	};
+}
+
 describe("oauth.jwt.signingKey schema", () => {
 	it("accepts nested signingKey.provider = 'local' with local sub-section", () => {
 		const parsed = jwtSchema.parse({
 			issuer: "https://auth.example.com",
-			signingKey: {
-				provider: "local",
-				local: { algorithm: "HS256", kid: "v0", secret: "s3cret", previousKeys: [] },
-			},
+			signingKey: { provider: "local", local: validLocal() },
 		});
 		expect(parsed.signingKey.provider).toBe("local");
 		expect((parsed.signingKey.local as { secret: string }).secret).toBe("s3cret");
 	});
 
-	it("defaults signingKey.provider to 'local'", () => {
-		const parsed = jwtSchema.parse({
-			signingKey: { local: { secret: "x" } },
+	it("rejects signingKey when provider is omitted (schema is strict — defaults live in hocon)", () => {
+		const result = jwtSchema.safeParse({
+			signingKey: { local: validLocal() },
 		});
-		expect(parsed.signingKey.provider).toBe("local");
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const paths = result.error.issues.map((i) => i.path.join("."));
+			expect(paths).toContain("signingKey.provider");
+		}
 	});
 
 	it("preserves unknown provider sub-sections via passthrough", () => {
@@ -54,17 +71,22 @@ describe("oauth.jwt.signingKey schema", () => {
 	it("accepts issuer at oauth.jwt.issuer (not under signingKey)", () => {
 		const parsed = jwtSchema.parse({
 			issuer: "https://auth.example.com",
-			signingKey: { local: { secret: "x" } },
+			signingKey: { provider: "local", local: validLocal() },
 		});
 		expect(parsed.issuer).toBe("https://auth.example.com");
 	});
 
 	it("does NOT superRefine-reject missing secret for HS256 (schema does shape only; builder enforces field presence)", () => {
-		// Previously the schema would reject { algorithm: "HS256" } without secret.
-		// After this migration the schema only enforces shape; the builder throws at create() time.
+		// Previously the schema would reject HS256 without a secret. After
+		// migration the schema only enforces shape (field presence per the
+		// type contract); the builder throws at create() time when the
+		// algorithm-specific key material is absent.
 		expect(() =>
 			jwtSchema.parse({
-				signingKey: { provider: "local", local: { algorithm: "HS256" } },
+				signingKey: {
+					provider: "local",
+					local: { algorithm: "HS256", kid: "v0", previousKeys: [] },
+				},
 			}),
 		).not.toThrow();
 	});
@@ -107,10 +129,7 @@ describe("jwtSchema - legacy flat field detection", () => {
 	it("accepts valid nested signingKey shape without triggering legacy detection", () => {
 		const result = jwtSchema.safeParse({
 			issuer: "https://auth.example.com",
-			signingKey: {
-				provider: "local",
-				local: { algorithm: "HS256", kid: "v0", secret: "s3cret" },
-			},
+			signingKey: { provider: "local", local: validLocal() },
 		});
 		expect(result.success).toBe(true);
 	});

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -23,8 +23,11 @@
  *
  * Consequence: schema parse rejects bare `{}` inputs. Tests that need a
  * valid config must either (a) load it through `parseFile` against the
- * built-in hocon, or (b) supply a fixture that mirrors what hocon would
- * have produced. See ADR 2026-04-30.
+ * built-in hocon, or (b) supply a minimal schema-valid baseline (e.g.
+ * the `makeValidCoreConfig` factory exposed via the
+ * `@o3co/auth-provider-core/testing` subpath, which intentionally
+ * diverges from `application.conf` for test ergonomics). See
+ * ADR 2026-04-30.
  */
 import { z } from "zod";
 

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -13,6 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Schema design principle: pure type contract.
+ *
+ * Schemas in this file describe the SHAPE that is required to be present at
+ * the boundary, not the value that is "reasonable to default to." Defaults
+ * live in a single place — `packages/core/config/application.conf` — and
+ * `${?ENV_VAR}` substitutions in that file are the only override surface.
+ *
+ * Consequence: schema parse rejects bare `{}` inputs. Tests that need a
+ * valid config must either (a) load it through `parseFile` against the
+ * built-in hocon, or (b) supply a fixture that mirrors what hocon would
+ * have produced. See ADR 2026-04-30.
+ */
 import { z } from "zod";
 
 const rateLimitSchema = z.object({
@@ -22,29 +35,27 @@ const rateLimitSchema = z.object({
 
 const signingKeyLocalSchema = z
 	.object({
-		algorithm: z.enum(["HS256", "RS256", "ES256", "EdDSA"]).default("HS256"),
-		kid: z.string().default("v0"),
+		algorithm: z.enum(["HS256", "RS256", "ES256", "EdDSA"]),
+		kid: z.string(),
 		secret: z.string().optional(),
 		privateKey: z.string().optional(),
 		privateKeyPath: z.string().optional(),
 		publicKey: z.string().optional(),
 		publicKeyPath: z.string().optional(),
-		previousKeys: z
-			.array(
-				z.object({
-					kid: z.string(),
-					publicKey: z.string().optional(),
-					publicKeyPath: z.string().optional(),
-					expiresAt: z.string(),
-				}),
-			)
-			.default([]),
+		previousKeys: z.array(
+			z.object({
+				kid: z.string(),
+				publicKey: z.string().optional(),
+				publicKeyPath: z.string().optional(),
+				expiresAt: z.string(),
+			}),
+		),
 	})
 	.passthrough();
 
 const signingKeySchema = z
 	.object({
-		provider: z.string().default("local"),
+		provider: z.string(),
 		local: signingKeyLocalSchema.optional(),
 	})
 	.passthrough();
@@ -62,7 +73,7 @@ const LEGACY_JWT_FIELDS = [
 
 const jwtSchemaBase = z.object({
 	issuer: z.string().optional(),
-	signingKey: signingKeySchema.default({ provider: "local" }),
+	signingKey: signingKeySchema,
 });
 
 /**
@@ -97,16 +108,16 @@ const jwtSchema = z.preprocess((raw, ctx) => {
  */
 export const CoreConfigSchema = z.object({
 	http: z.object({
-		port: z.coerce.number().default(3000),
-		trustProxy: z.boolean().default(false),
+		port: z.coerce.number(),
+		trustProxy: z.boolean(),
 	}),
 	oauth: z.object({
 		jwt: jwtSchema,
 		accessToken: z.object({
-			expiresIn: z.coerce.number().default(3600),
+			expiresIn: z.coerce.number(),
 		}),
 		refreshToken: z.object({
-			expiresIn: z.coerce.number().default(86400),
+			expiresIn: z.coerce.number(),
 		}),
 		grants: z.object({}).passthrough(),
 	}),
@@ -140,17 +151,15 @@ export function composeConfigSchema(moduleSchemas: z.ZodObject<z.ZodRawShape>[])
  *   boolean             → pass-through unchanged
  *   other values        → forwarded to z.boolean() which rejects with a type error
  */
-const coerceBooleanFromEnv = z
-	.preprocess((val) => {
-		if (typeof val === "boolean") return val;
-		if (typeof val === "string") {
-			const normalized = val.trim().toLowerCase();
-			if (normalized === "true" || normalized === "1") return true;
-			if (normalized === "false" || normalized === "0" || normalized === "") return false;
-		}
-		return val; // zod rejects with a type error for other values
-	}, z.boolean())
-	.default(false);
+const coerceBooleanFromEnv = z.preprocess((val) => {
+	if (typeof val === "boolean") return val;
+	if (typeof val === "string") {
+		const normalized = val.trim().toLowerCase();
+		if (normalized === "true" || normalized === "1") return true;
+		if (normalized === "false" || normalized === "0" || normalized === "") return false;
+	}
+	return val; // zod rejects with a type error for other values
+}, z.boolean());
 
 const federationEntrySchema = z
 	.object({
@@ -162,16 +171,16 @@ const federationEntrySchema = z
 export const fullSectionsSchema = z.object({
 	session: z.object({
 		secret: z.string(),
-		maxAge: z.coerce.number().default(3600000),
-		secure: z.boolean().default(true),
-		sameSite: z.enum(["lax", "none", "strict"]).default("lax"),
-		domain: z.string().nullable().default(null),
+		maxAge: z.coerce.number(),
+		secure: z.boolean(),
+		sameSite: z.enum(["lax", "none", "strict"]),
+		domain: z.string().nullable(),
 		storage: z
 			.object({
-				type: z.string().default("redis"),
+				type: z.string(),
 				redis: z
 					.object({
-						url: z.string().default("redis://localhost:6379"),
+						url: z.string(),
 						password: z.string().optional(),
 					})
 					.optional(),
@@ -181,21 +190,21 @@ export const fullSectionsSchema = z.object({
 	rateLimit: z.object({
 		login: rateLimitSchema,
 	}),
-	federations: z.record(z.string(), federationEntrySchema).default({}),
+	federations: z.record(z.string(), federationEntrySchema),
 	repositories: z.object({
 		client: z
 			.object({
-				type: z.string().default("yaml"),
+				type: z.string(),
 			})
 			.passthrough(),
 		user: z
 			.object({
-				type: z.string().default("yaml"),
+				type: z.string(),
 			})
 			.passthrough(),
 		code: z
 			.object({
-				type: z.string().default("memory"),
+				type: z.string(),
 			})
 			.passthrough(),
 	}),
@@ -205,7 +214,7 @@ export const fullSectionsSchema = z.object({
 		authCallback: z.object({ url: z.string().optional() }).optional(),
 	}),
 	cors: z.object({
-		allowedOrigins: z.array(z.string()).default([]),
+		allowedOrigins: z.array(z.string()),
 	}),
 });
 

--- a/packages/core/src/refresh-token-family/__tests__/wiring.test.mts
+++ b/packages/core/src/refresh-token-family/__tests__/wiring.test.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
+import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
 import type { BootstrapMap } from "../../boot/types.mjs";
 import {
 	createBootApp,
@@ -24,11 +25,11 @@ import {
 	memoryRefreshTokenFamilyStoreModule,
 } from "../../index.mjs";
 
-// Minimum config that satisfies CoreConfigSchema (Codex P2-A hardening:
-// validateAndComposeConfig now always runs CoreConfigSchema). All required
-// nested objects present as empty so Zod defaults populate every leaf.
+// Per ADR 2026-04-30: schema is a pure type contract; defaults live in
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
+// fixture must mirror what hocon would have produced.
 const minBoot = {
-	config: { http: {}, oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} } } as never,
+	config: makeValidCoreConfig() as never,
 	pathResolver: (s: string) => s,
 } satisfies Record<string, unknown> as BootstrapMap;
 

--- a/packages/core/src/refresh-token-family/__tests__/wiring.test.mts
+++ b/packages/core/src/refresh-token-family/__tests__/wiring.test.mts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import type { BootstrapMap } from "../../boot/types.mjs";
 import {
 	createBootApp,
@@ -24,6 +23,7 @@ import {
 	defineModule,
 	memoryRefreshTokenFamilyStoreModule,
 } from "../../index.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 
 // Per ADR 2026-04-30: schema is a pure type contract; defaults live in
 // hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so the

--- a/packages/core/src/refresh-token-family/__tests__/wiring.test.mts
+++ b/packages/core/src/refresh-token-family/__tests__/wiring.test.mts
@@ -26,8 +26,9 @@ import {
 } from "../../index.mjs";
 
 // Per ADR 2026-04-30: schema is a pure type contract; defaults live in
-// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so this
-// fixture must mirror what hocon would have produced.
+// hocon. validateAndComposeConfig calls CoreConfigSchema.parse, so the
+// fixture supplies a minimal schema-valid baseline (intentionally
+// diverges from application.conf — see makeValidCoreConfig docstring).
 const minBoot = {
 	config: makeValidCoreConfig() as never,
 	pathResolver: (s: string) => s,

--- a/packages/core/src/refresh-token-family/__tests__/wiring.test.mts
+++ b/packages/core/src/refresh-token-family/__tests__/wiring.test.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import type { BootstrapMap } from "../../boot/types.mjs";
 import {
 	createBootApp,

--- a/packages/core/src/testing/fixtures/valid-config.mts
+++ b/packages/core/src/testing/fixtures/valid-config.mts
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+import type { z } from "zod";
+import type {
+	AppConfig,
+	CoreConfig,
+	fullSectionsSchema,
+} from "../../config/application.schema.mjs";
+
 /**
  * Minimal schema-valid config factories for tests that need to satisfy
  * `CoreConfigSchema` or `AppConfigSchema` parse without exercising the
@@ -21,10 +28,23 @@
  *
  * These factories return the smallest object shape that passes schema
  * validation; they intentionally diverge from `packages/core/config/
- * application.conf` for test ergonomics (e.g. raw secrets instead of
- * env-substituted placeholders, no signing-key alternatives). They are
- * NOT a hocon mirror — if you need fixture values that match production
- * defaults, parse `application.conf` directly via the test harness.
+ * application.conf` for test ergonomics. The deliberate divergences are:
+ *
+ * - `session.storage.type` is `"memory"` (hocon defaults to `"redis"`).
+ * - `federations` is `{}` (hocon ships a built-in `federations.google`
+ *   block with `enabled = false`).
+ * - `oauth.jwt.signingKey.local.secret` carries an inline test secret
+ *   (hocon uses `${?OAUTH_JWT_SECRET}` substitution).
+ * - `repositories.{client,user,code}` declare only the discriminator
+ *   `type` field; nested adapter-specific fields (`yaml.path`,
+ *   `memory.defaultExpiresIn`, …) are omitted because the schema marks
+ *   them optional or the adapter-specific factory is not exercised.
+ * - `endpoints.client` and `endpoints.authCallback` are omitted because
+ *   the schema marks them `.optional()`. Callers exercising those
+ *   endpoints' behaviour should add the missing fields per-test.
+ *
+ * If you need fixture values that match production defaults, parse
+ * `application.conf` directly via the test harness.
  *
  * Background: per ADR 2026-04-30 (schema-strict defaults from hocon),
  * defaults live exclusively in `application.conf`. Tests that previously
@@ -32,9 +52,17 @@
  * now supply explicit values; these factories provide the canonical
  * minimal shape so each call site does not re-invent it.
  *
+ * The factories use `satisfies` against `CoreConfig` / `AppConfig` so
+ * the returned object is type-checked against the schema *and* preserves
+ * the narrow inferred shape (literal enum values such as `algorithm:
+ * "HS256"` are not widened to `string`), so consumer tests can assign
+ * the result to typed variables without casts.
+ *
  * Each factory returns a fresh, mutable object so callers can apply
  * local overrides without bleeding into siblings.
  */
+
+type FullSectionsConfig = z.infer<typeof fullSectionsSchema>;
 
 export function makeValidCoreConfig() {
 	return {
@@ -55,7 +83,7 @@ export function makeValidCoreConfig() {
 			refreshToken: { expiresIn: 86400 },
 			grants: {},
 		},
-	};
+	} satisfies CoreConfig;
 }
 
 export function makeValidFullSections() {
@@ -64,7 +92,7 @@ export function makeValidFullSections() {
 			secret: "test-session-secret",
 			maxAge: 3600000,
 			secure: true,
-			sameSite: "lax" as const,
+			sameSite: "lax",
 			domain: null,
 			storage: { type: "memory" },
 		},
@@ -81,12 +109,12 @@ export function makeValidFullSections() {
 			login: {},
 		},
 		cors: { allowedOrigins: [] },
-	};
+	} satisfies FullSectionsConfig;
 }
 
 export function makeValidAppConfig() {
 	return {
 		...makeValidCoreConfig(),
 		...makeValidFullSections(),
-	};
+	} satisfies AppConfig;
 }

--- a/packages/core/src/testing/fixtures/valid-config.mts
+++ b/packages/core/src/testing/fixtures/valid-config.mts
@@ -15,17 +15,25 @@
  */
 
 /**
- * Valid-config fixtures for tests that need to satisfy CoreConfigSchema or
- * AppConfigSchema parse.
+ * Minimal schema-valid config factories for tests that need to satisfy
+ * `CoreConfigSchema` or `AppConfigSchema` parse without exercising the
+ * HOCON load pipeline.
  *
- * Background: per ADR 2026-04-30, schema is a pure type contract — defaults
- * live exclusively in `packages/core/config/application.conf`. Tests that
- * previously relied on schema-side `.default(X)` to populate bare `{}`
- * inputs must now supply the same values that hocon would have produced.
+ * These factories return the smallest object shape that passes schema
+ * validation; they intentionally diverge from `packages/core/config/
+ * application.conf` for test ergonomics (e.g. raw secrets instead of
+ * env-substituted placeholders, no signing-key alternatives). They are
+ * NOT a hocon mirror — if you need fixture values that match production
+ * defaults, parse `application.conf` directly via the test harness.
  *
- * These factories return fresh, mutable objects so each test can apply local
- * overrides without bleeding into siblings. The values mirror
- * `application.conf` defaults; if hocon defaults change, update here.
+ * Background: per ADR 2026-04-30 (schema-strict defaults from hocon),
+ * defaults live exclusively in `application.conf`. Tests that previously
+ * relied on schema-side `.default(X)` to populate bare `{}` inputs must
+ * now supply explicit values; these factories provide the canonical
+ * minimal shape so each call site does not re-invent it.
+ *
+ * Each factory returns a fresh, mutable object so callers can apply
+ * local overrides without bleeding into siblings.
  */
 
 export function makeValidCoreConfig() {

--- a/packages/core/src/testing/index.mts
+++ b/packages/core/src/testing/index.mts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Public test-helper surface for `@o3co/auth-provider-core`.
+ *
+ * Exposed via the `./testing` subpath in `package.json#exports`. Consumer
+ * test code (sibling packages, downstream applications, OSS adopters) may
+ * import from here; production runtime code MUST NOT — the symbols here
+ * are intended for fixtures and integration tests only.
+ *
+ * A2-γ spec §6.1 + §7 prescribes this subpath; PR α (orthogonal
+ * schema/default cleanup) lands the initial export surface (config-fixture
+ * factories). The `createTestApp` / `TestInspect` helpers prescribed by
+ * §7.2 will be added in a later PR (Phase 9 caller migration).
+ *
+ * Stability: identifiers exported here follow the same semver discipline
+ * as the main `.` export — additions are minor, signature changes are
+ * major.
+ */
+
+export {
+	makeValidAppConfig,
+	makeValidCoreConfig,
+	makeValidFullSections,
+} from "./fixtures/valid-config.mjs";

--- a/packages/core/src/user-sessions/__tests__/module.memory.test.mts
+++ b/packages/core/src/user-sessions/__tests__/module.memory.test.mts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { createBootApp, defineModule } from "../../index.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { memorySessionStoresModule } from "../modules/memory.mjs";
 
 const minBoot = {

--- a/packages/core/src/user-sessions/__tests__/module.memory.test.mts
+++ b/packages/core/src/user-sessions/__tests__/module.memory.test.mts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
+import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
 import { createBootApp, defineModule } from "../../index.mjs";
 import { memorySessionStoresModule } from "../modules/memory.mjs";
 
 const minBoot = {
-	config: { http: {}, oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} } },
+	config: makeValidCoreConfig(),
 	pathResolver: (p: string) => p,
 } as never;
 

--- a/packages/core/src/user-sessions/__tests__/module.memory.test.mts
+++ b/packages/core/src/user-sessions/__tests__/module.memory.test.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
-import { makeValidCoreConfig } from "../../__tests__/fixtures/valid-config.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { createBootApp, defineModule } from "../../index.mjs";
 import { memorySessionStoresModule } from "../modules/memory.mjs";
 

--- a/packages/federation-github/src/__tests__/github-module-boot.test.mts
+++ b/packages/federation-github/src/__tests__/github-module-boot.test.mts
@@ -34,12 +34,13 @@
  * Per A5 §10.1 + Cl-M2.
  */
 import { createBootApp, defineModule } from "@o3co/auth-provider-core";
+import { makeValidCoreConfig } from "@o3co/auth-provider-core/testing";
 import type { FederationProvider, FederationRedirectPolicy } from "@o3co/auth-provider-session";
 import { describe, expect, it } from "vitest";
 import { type GithubProviderConfig, githubFederationModule } from "../github.mjs";
 
 const minBoot = {
-	config: { http: {}, oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} } },
+	config: makeValidCoreConfig(),
 	pathResolver: (p: string) => p,
 } as never;
 

--- a/packages/federation-google/src/__tests__/google-module-boot.test.mts
+++ b/packages/federation-google/src/__tests__/google-module-boot.test.mts
@@ -34,12 +34,13 @@
  * Per A5 §10.1 + Cl-M2.
  */
 import { createBootApp, defineModule } from "@o3co/auth-provider-core";
+import { makeValidCoreConfig } from "@o3co/auth-provider-core/testing";
 import type { FederationProvider, FederationRedirectPolicy } from "@o3co/auth-provider-session";
 import { describe, expect, it } from "vitest";
 import { type GoogleProviderConfig, googleFederationModule } from "../google.mjs";
 
 const minBoot = {
-	config: { http: {}, oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} } },
+	config: makeValidCoreConfig(),
 	pathResolver: (p: string) => p,
 } as never;
 

--- a/packages/redis/__tests__/redisSessionStoresModule.test.mts
+++ b/packages/redis/__tests__/redisSessionStoresModule.test.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { BootError, createBootApp, defineModule } from "@o3co/auth-provider-core";
+import { createBootApp, defineModule } from "@o3co/auth-provider-core";
 import { makeValidCoreConfig } from "@o3co/auth-provider-core/testing";
 import Redis from "ioredis";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";

--- a/packages/redis/__tests__/redisSessionStoresModule.test.mts
+++ b/packages/redis/__tests__/redisSessionStoresModule.test.mts
@@ -15,6 +15,7 @@
  */
 
 import { BootError, createBootApp, defineModule } from "@o3co/auth-provider-core";
+import { makeValidCoreConfig } from "@o3co/auth-provider-core/testing";
 import Redis from "ioredis";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -36,8 +37,7 @@ afterAll(async () => {
 
 const minBoot = (extra: Record<string, unknown>) =>
 	({
-		http: {},
-		oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} },
+		...makeValidCoreConfig(),
 		...extra,
 	}) as never;
 

--- a/packages/redis/__tests__/refresh-token-family-wiring.test.mts
+++ b/packages/redis/__tests__/refresh-token-family-wiring.test.mts
@@ -20,6 +20,7 @@ import {
 	defaultRefreshTokenRotationModule,
 	defineModule,
 } from "@o3co/auth-provider-core";
+import { makeValidCoreConfig } from "@o3co/auth-provider-core/testing";
 import Redis from "ioredis";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -115,8 +116,7 @@ describe("A3 wiring — full Redis composition (createBootApp + redis modules)",
 		});
 
 		const config = {
-			http: {},
-			oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} },
+			...makeValidCoreConfig(),
 			redisRefreshTokenFamilyStore: {
 				keyPrefix: `rtfam:wiring-${Date.now()}:`,
 				casRetryLimit: 3,

--- a/packages/redis/__tests__/wiring.test.mts
+++ b/packages/redis/__tests__/wiring.test.mts
@@ -19,6 +19,7 @@ import {
 	defaultChallengeCeremonyModule,
 	defineModule,
 } from "@o3co/auth-provider-core";
+import { makeValidCoreConfig } from "@o3co/auth-provider-core/testing";
 import Redis from "ioredis";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -70,13 +71,12 @@ describe("A1 wiring — full Redis composition (createBootApp + redis modules)",
 			},
 		});
 
-		// CoreConfigSchema (always composed in by composeConfigSchema) requires
-		// `http` and `oauth` top-level sections. Provide minimal stubs so the
-		// schema parses; the redis modules' own namespaced keys carry the
-		// per-test isolation prefixes.
+		// `makeValidCoreConfig` supplies the schema-required core sections
+		// (CoreConfigSchema is always composed in via composeConfigSchema).
+		// The redis modules' own namespaced keys carry per-test isolation
+		// prefixes appended after the core baseline.
 		const config = {
-			http: {},
-			oauth: { jwt: {}, accessToken: {}, refreshToken: {}, grants: {} },
+			...makeValidCoreConfig(),
 			redisChallengeStore: { keyPrefix: `chal:wiring-${Date.now()}:` },
 			redisReplaySeenSet: { keyPrefix: `replay:wiring-${Date.now()}:` },
 		};


### PR DESCRIPTION
## Summary

- Remove 21 schema-side `.default(X)` calls from `packages/core/src/config/application.schema.mts`; defaults now live exclusively in HOCON (`packages/core/config/application.conf`) per **Option C**.
- Add `@o3co/auth-provider-core/testing` subpath exporting `makeValidCoreConfig` / `makeValidFullSections` / `makeValidAppConfig` factories (A2-γ spec §6.1 + §7).
- Migrate 5 cross-package fixture sites (redis ×3, federation-google, federation-github) to consume the testing subpath instead of inline minimal-config construction.
- ADR `2026-04-30-config-schema-strict-defaults-from-hocon.md` documents the layer-level Single Responsibility decision (schema = pure type contract, hocon = single source of truth for defaults).
- ADR augmentations I2 (library-consumer perspective) / I4 (`federations.<name>.enabled` strict) / P2 (fixture honesty) / M3 (full-path Pattern preserved list).
- CHANGELOG breaking-change note covering schema-strict + `federations.<name>.enabled` migration.

## Why

- Schema-strict prevents silent defaulting in non-HOCON consumer paths and removes the `z.preprocess` + `.default()` + `z.optional` interaction trap that was hit during PR #97 (CI rejected `federations: {}` while local tests accepted it).
- The testing subpath unblocks Phase 9 (A2-γ caller migration) — see A2-γ spec §11.6 prerequisite — by giving downstream packages a shared schema-valid baseline without copying the minimal shape into every test file.
- Orthogonal to v0.5.0 module-system redesign (PR #97); no Phase 9 scope creep.

## Test plan

- [x] `make test` green (1889 tests across all packages: core 1062 / oauth 273 / session 151 / redis 124 / oauth-token-exchange 79 / foundation 25 / federation-github 22 / federation-google 13 / templates/standalone 8 / create-app 132)
- [x] `pnpm -r run typecheck` green (6 packages with typecheck script, no errors)
- [x] `pnpm -r run build` clean
- [x] `node -e "import { makeValidAppConfig } from '@o3co/auth-provider-core/testing'"` resolves the subpath from packages/redis (verified)
- [x] Codex independent review = Approved (two Medium issues found in initial review, both corrected; recheck found no new issues)
- [ ] /multi-agent-review (Claude code-reviewer + Codex CLI) on this branch
- [ ] Copilot review

## Notes for reviewers

- The testing subpath is **consumer-test-only** — production runtime code MUST NOT import from it. The factories return fresh mutable objects each call so callers can apply local overrides without bleeding into siblings.
- The fixture is intentionally a minimal schema-valid baseline rather than an `application.conf` mirror — `session.storage.type` is `memory` and `federations` is `{}` for test ergonomics. The ADR's I2 / P2 paragraphs and the fixture docstring make this explicit.
- The `federations.<name>.enabled` change is breaking and operator-visible. Operators with bare `federations { google {} }` shapes must now declare `enabled = true` / `enabled = false` explicitly or omit the entry entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)