### PR TITLE
v0.5.0 pre-tag: RefreshTokenFamilyRotation rename + foundation cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   module: `defineModule({ contributes: { tokenExchangeValidators:
   { "urn:my:type": (deps) => myValidator } } })`. (per A2-γ §3.3)
 - `registerBuiltinAdapters({ userFactory, codeFactory, pathResolver? })` from
-  `@o3co/auth-provider-foundation` — **DELETED**. Add `httpUserRepositoryModule`
-  / `redisCodeRepositoryModule` from `@o3co/auth-provider-foundation` to the
-  manifest list instead. (per A2-γ §3.7)
+  `@o3co/auth-provider-foundation` — **signature narrowed** to
+  `registerBuiltinAdapters({ userFactory })`. The `codeFactory` and
+  `pathResolver` parameters are removed; foundation only registers the `"http"`
+  user-authentication adapter. The Redis `CodeRepository` was relocated to
+  `@o3co/auth-provider-redis` (Phase 10). Consumers needing Redis code storage
+  call `codeFactory.register("redis", redisCodeRepositoryBuilder)` directly
+  after importing from `@o3co/auth-provider-redis`. (per Phase 10 + interface
+  review pre-tag M3/M4)
 
 #### Registry policy (A6+A7)
 
@@ -93,16 +98,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     Method shape changes drastically; not a transparent rename.
   - **Adapter responsibility narrows**: `rotate(...)`, `isFamilyRevoked(...)`, and
     `revokeFamily(...)` move out of the storage adapter and into wrapper interfaces
-    (`RefreshTokenRotation`, `RefreshTokenFamilyRevocation`).
+    (`RefreshTokenFamilyRotation`, `RefreshTokenFamilyRevocation`).
   - **Outcome union renamed and shifted**: `RefreshTokenRotateOutcome` →
-    `RefreshTokenRotationOutcome`; the `unknown` variant is renamed `unknown_family`;
+    `RefreshTokenFamilyRotationOutcome`; the `unknown` variant is renamed `unknown_family`;
     the `replayed` variant loses its `familyId` field (the wrapper caller already has
     `familyId` in scope). (per A3 §4)
   - **`rotate(previousJti=null, ...)` overload deleted**: initial issue moves to
-    `RefreshTokenRotation.register(jti, familyId, expiresAtMs)`. (per A3 §4)
+    `RefreshTokenFamilyRotation.register(jti, familyId, expiresAtMs)`. (per A3 §4)
   - **`expiresAt` parameter type changed** from `Date` to epoch-ms `number` in
-    `RefreshTokenRotation.rotate(prev, new, familyId, expiresAtMs)` and
-    `RefreshTokenRotation.register(jti, familyId, expiresAtMs)` — defence against
+    `RefreshTokenFamilyRotation.rotate(prev, new, familyId, expiresAtMs)` and
+    `RefreshTokenFamilyRotation.register(jti, familyId, expiresAtMs)` — defence against
     `Date.setTime` mutation. (per A3 §5.1)
 - All in-tree callers (`authorization.mts`, `refreshToken.mts`, `cascadeLogout.mts`,
   `userinfo.mts`, `federationToken.mts`) are rewired to the new wrapper interfaces
@@ -151,17 +156,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `RefreshTokenStoreBase` — **removed** from `@o3co/auth-provider-core` (factory,
   types, and `__tests__/` under `packages/core/src/refresh/`). Consumers migrate to
-  the A3 triple `RefreshTokenRotation` / `RefreshTokenFamilyRevocation` /
+  the A3 triple `RefreshTokenFamilyRotation` / `RefreshTokenFamilyRevocation` /
   `RefreshTokenFamilyStore` introduced in Phase 6.
-- `RefreshTokenRotation.rotate(prev, new, familyId, expiresAtMs: number)` —
+- `RefreshTokenFamilyRotation.rotate(prev, new, familyId, expiresAtMs: number)` —
   `expiresAt` parameter changed from `Date` to epoch-ms `number` (defence against
   `Date.setTime` mutation per A3 §5.1).
-- `RefreshTokenRotation.register(jti, familyId, expiresAtMs)` is the dedicated
+- `RefreshTokenFamilyRotation.register(jti, familyId, expiresAtMs)` is the dedicated
   initial-issue method, replacing the v0.4.x `rotate(null, jti, ...)` trick.
 - `ComponentMap.refreshTokenStore?` slot removed.
 - `GrantContext.refreshTokenStore?` field removed.
 - `oauthAuthorizationModule.optional` slot renamed
-  `"refreshTokenStore"` → `"refreshTokenRotation"`.
+  `"refreshTokenStore"` → `"refreshTokenFamilyRotation"`.
 - `oauthModule.optional` slot renamed
   `"refreshTokenStore"` → `"refreshTokenFamilyRevocation"`.
 - `tokenExchangeModule.optional` slot renamed

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -346,7 +346,7 @@ function createDefaultFactories(): {
 - `create()` は未登録 `type` で `AdapterFactoryError` を throw する。error は `kind` / `type` / `registered` を構造化フィールドとして保持する。
 - `BuilderContext` は factory 単位で共有される（call ごとのコピーではない）。builder 側では read-only として扱うこと。
 
-`createDefaultFactories` は組み込みの `yaml` / `static`（client、user）と `memory`（code）タイプが登録済みの 3 つのファクトリーを返します。`http` / `redis` は `@o3co/auth-provider-foundation` の `registerBuiltinAdapters` で追加できます。独自の backend は `register` で追加してください。
+`createDefaultFactories` は組み込みの `yaml` / `static`（client、user）と `memory`（code）タイプが登録済みの 3 つのファクトリーを返します。`@o3co/auth-provider-foundation` の `registerBuiltinAdapters` で `http` ユーザー認証アダプターを追加できます。独自の backend は `register` で追加してください。Redis バックエンドの code / store アダプターは `@o3co/auth-provider-redis` を参照してください。
 
 ### モジュールシステム
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -346,7 +346,7 @@ Key contract properties:
 - `create()` throws `AdapterFactoryError` when `type` is not registered; the error carries the `kind`, `type`, and `registered` list.
 - `BuilderContext` is shared by reference across builder invocations for a given factory. Treat it as read-only from builders.
 
-`createDefaultFactories` returns three factories pre-registered with the built-in `yaml`/`static` (client, user) and `memory` (code) types. Use `registerBuiltinAdapters` from `@o3co/auth-provider-foundation` to add `http` and `redis` adapters, or register your own types to support other backends.
+`createDefaultFactories` returns three factories pre-registered with the built-in `yaml`/`static` (client, user) and `memory` (code) types. Use `registerBuiltinAdapters` from `@o3co/auth-provider-foundation` to add the `http` user-authentication adapter, or register your own types to support other backends. For Redis-backed code/store adapters, see `@o3co/auth-provider-redis`.
 
 ### Module System
 

--- a/packages/core/src/grants/types.mts
+++ b/packages/core/src/grants/types.mts
@@ -21,7 +21,7 @@ import type { PathResolver } from "../modules/types.mjs";
 import type { GrantPolicyHookBase } from "../policy/types.mjs";
 import type {
 	RefreshTokenFamilyRevocation,
-	RefreshTokenRotation,
+	RefreshTokenFamilyRotation,
 } from "../refresh-token-family/types.mjs";
 import type {
 	SessionFamilyIndex,
@@ -81,7 +81,7 @@ export interface GrantDependencies {
 	config: CoreConfig & Record<string, unknown>;
 	keyStore: KeyStore;
 	pathResolver?: PathResolver;
-	refreshTokenRotation?: RefreshTokenRotation;
+	refreshTokenFamilyRotation?: RefreshTokenFamilyRotation;
 	refreshTokenFamilyRevocation?: RefreshTokenFamilyRevocation;
 	grantPolicy?: GrantPolicyHookBase;
 	userSessionStore?: UserSessionStore;

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -336,7 +336,7 @@ export { memoryReplaySeenSetModule } from "./replay-seen-set/module.mjs";
 export type { ReplaySeenSet, ReplaySeenSetClient } from "./replay-seen-set/types.mjs";
 
 // ===========================================================================
-// A3 — RefreshTokenFamilyStore + RefreshTokenRotation + RefreshTokenFamilyRevocation
+// A3 — RefreshTokenFamilyStore + RefreshTokenFamilyRotation + RefreshTokenFamilyRevocation
 // ===========================================================================
 
 export { createMemoryRefreshTokenFamilyStore } from "./refresh-token-family/adapters/memory.mjs";
@@ -351,7 +351,7 @@ export {
 } from "./refresh-token-family/factory.mjs";
 export {
 	defaultRefreshTokenFamilyRevocationModule,
-	defaultRefreshTokenRotationModule,
+	defaultRefreshTokenFamilyRotationModule,
 	memoryRefreshTokenFamilyStoreModule,
 } from "./refresh-token-family/module.mjs";
 
@@ -360,8 +360,8 @@ export {
 	type DefaultRefreshTokenFamilyRevocationDeps,
 } from "./refresh-token-family/revocation.mjs";
 export {
-	createDefaultRefreshTokenRotation,
-	type DefaultRefreshTokenRotationDeps,
+	createDefaultRefreshTokenFamilyRotation,
+	type DefaultRefreshTokenFamilyRotationDeps,
 } from "./refresh-token-family/rotation.mjs";
 export type {
 	DisposableRefreshTokenFamilyClient,
@@ -369,8 +369,8 @@ export type {
 	RefreshTokenFamilyClient,
 	RefreshTokenFamilyMultiClient,
 	RefreshTokenFamilyRevocation,
+	RefreshTokenFamilyRotation,
+	RefreshTokenFamilyRotationOutcome,
 	RefreshTokenFamilyStore,
 	RefreshTokenFamilyUpdateResult,
-	RefreshTokenRotation,
-	RefreshTokenRotationOutcome,
 } from "./refresh-token-family/types.mjs";

--- a/packages/core/src/modules/manifest/__tests__/component-map.test.mts
+++ b/packages/core/src/modules/manifest/__tests__/component-map.test.mts
@@ -31,7 +31,7 @@ test("ComponentMap does NOT contain v0.4.x legacy slots (X1/X2 amendment)", () =
 	//   when a regression reintroduces the legacy SHAPE.
 	//
 	// - `refreshTokenStore`: A3 retires this slot NAME entirely (replaced by
-	//   `refreshTokenFamilyStore` + `refreshTokenRotation` +
+	//   `refreshTokenFamilyStore` + `refreshTokenFamilyRotation` +
 	//   `refreshTokenFamilyRevocation`). Issue #101 (Task A8) deletes the
 	//   transitional bridge; the presence-based check below is now active.
 

--- a/packages/core/src/modules/manifest/__tests__/legacy-slots-absent.test.mts
+++ b/packages/core/src/modules/manifest/__tests__/legacy-slots-absent.test.mts
@@ -10,7 +10,7 @@ import { expectTypeOf, test } from "vitest";
 //
 // Phases 5 (A1), 6 (A3), 8 (A4) declaration-merge their replacement slots:
 //   - challengeStore, replaySeenSet, challengeCeremony (A1)
-//   - refreshTokenFamilyStore, refreshTokenRotation,
+//   - refreshTokenFamilyStore, refreshTokenFamilyRotation,
 //     refreshTokenFamilyRevocation (A3)
 //   - userSessionStore (A4 — narrowed type, NOT UserSessionStoreBase),
 //     sessionRPRegistry, sessionFamilyIndex, sessionFederationIndex,
@@ -44,7 +44,7 @@ test("legacy v0.4.x slots are NOT in v0.5.0 ComponentMap (package-boundary check
 	expectTypeOf<_A1>().toEqualTypeOf<true>();
 
 	// refreshTokenStore: A3 retires the slot NAME entirely (replaced by
-	// refreshTokenFamilyStore + refreshTokenRotation +
+	// refreshTokenFamilyStore + refreshTokenFamilyRotation +
 	// refreshTokenFamilyRevocation). Issue #101 (Task A8) deletes the
 	// transitional bridge that was added during Phase 9; this assertion
 	// is now active.

--- a/packages/core/src/refresh-token-family/__tests__/module.test.mts
+++ b/packages/core/src/refresh-token-family/__tests__/module.test.mts
@@ -27,9 +27,9 @@ describe("memoryRefreshTokenFamilyStoreModule", () => {
 });
 
 describe("defaultRefreshTokenFamilyRotationModule", () => {
-	it("has the canonical module name 'core-default-refresh-token-rotation'", () => {
+	it("has the canonical module name 'core-default-refresh-token-family-rotation'", () => {
 		expect(defaultRefreshTokenFamilyRotationModule.name).toBe(
-			"core-default-refresh-token-rotation",
+			"core-default-refresh-token-family-rotation",
 		);
 	});
 

--- a/packages/core/src/refresh-token-family/__tests__/module.test.mts
+++ b/packages/core/src/refresh-token-family/__tests__/module.test.mts
@@ -5,7 +5,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	defaultRefreshTokenFamilyRevocationModule,
-	defaultRefreshTokenRotationModule,
+	defaultRefreshTokenFamilyRotationModule,
 	memoryRefreshTokenFamilyStoreModule,
 } from "../module.mjs";
 
@@ -26,18 +26,20 @@ describe("memoryRefreshTokenFamilyStoreModule", () => {
 	});
 });
 
-describe("defaultRefreshTokenRotationModule", () => {
+describe("defaultRefreshTokenFamilyRotationModule", () => {
 	it("has the canonical module name 'core-default-refresh-token-rotation'", () => {
-		expect(defaultRefreshTokenRotationModule.name).toBe("core-default-refresh-token-rotation");
+		expect(defaultRefreshTokenFamilyRotationModule.name).toBe(
+			"core-default-refresh-token-rotation",
+		);
 	});
 
-	it("requires refreshTokenFamilyStore and provides refreshTokenRotation", () => {
-		expect(new Set(defaultRefreshTokenRotationModule.requires ?? [])).toEqual(
+	it("requires refreshTokenFamilyStore and provides refreshTokenFamilyRotation", () => {
+		expect(new Set(defaultRefreshTokenFamilyRotationModule.requires ?? [])).toEqual(
 			new Set(["refreshTokenFamilyStore"]),
 		);
-		expect(typeof defaultRefreshTokenRotationModule.provides?.refreshTokenRotation).toBe(
-			"function",
-		);
+		expect(
+			typeof defaultRefreshTokenFamilyRotationModule.provides?.refreshTokenFamilyRotation,
+		).toBe("function");
 	});
 });
 

--- a/packages/core/src/refresh-token-family/__tests__/rotation.test.mts
+++ b/packages/core/src/refresh-token-family/__tests__/rotation.test.mts
@@ -5,14 +5,14 @@
 import { describe, expect, it } from "vitest";
 import { createMemoryRefreshTokenFamilyStore } from "../adapters/memory.mjs";
 import { RefreshTokenStorageError } from "../errors.mjs";
-import { createDefaultRefreshTokenRotation } from "../rotation.mjs";
+import { createDefaultRefreshTokenFamilyRotation } from "../rotation.mjs";
 
 const FUTURE = (): number => Date.now() + 60_000;
 
-describe("createDefaultRefreshTokenRotation", () => {
+describe("createDefaultRefreshTokenFamilyRotation", () => {
 	it("register then findFamily shows the new family", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenRotation({ refreshTokenFamilyStore: store });
+		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		await rotation.register("jti-1", "fam-1", FUTURE());
 		const fam = await store.findFamily("fam-1");
 		expect(fam).not.toBeNull();
@@ -22,7 +22,7 @@ describe("createDefaultRefreshTokenRotation", () => {
 
 	it("register throws duplicate-family on second call", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenRotation({ refreshTokenFamilyStore: store });
+		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		await rotation.register("jti-1", "fam-1", FUTURE());
 		await expect(rotation.register("jti-2", "fam-1", FUTURE())).rejects.toMatchObject({
 			name: "RefreshTokenStorageError",
@@ -32,7 +32,7 @@ describe("createDefaultRefreshTokenRotation", () => {
 
 	it("register throws expired-at-issue when expiresAt is past", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenRotation({ refreshTokenFamilyStore: store });
+		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		await expect(rotation.register("jti-1", "fam-1", Date.now() - 1)).rejects.toBeInstanceOf(
 			RefreshTokenStorageError,
 		);
@@ -40,7 +40,7 @@ describe("createDefaultRefreshTokenRotation", () => {
 
 	it("rotate returns 'rotated' when previousJti matches and family is healthy", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenRotation({ refreshTokenFamilyStore: store });
+		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		await rotation.register("jti-1", "fam-1", FUTURE());
 		const out = await rotation.rotate("jti-1", "jti-2", "fam-1", FUTURE());
 		expect(out.outcome).toBe("rotated");
@@ -50,7 +50,7 @@ describe("createDefaultRefreshTokenRotation", () => {
 
 	it("rotate returns 'replayed' when previousJti does NOT match the active jti", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenRotation({ refreshTokenFamilyStore: store });
+		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		await rotation.register("jti-1", "fam-1", FUTURE());
 		// Try to rotate using a stale previousJti.
 		const out = await rotation.rotate("jti-stale", "jti-2", "fam-1", FUTURE());
@@ -61,7 +61,7 @@ describe("createDefaultRefreshTokenRotation", () => {
 
 	it("rotate returns 'revoked' when family is revoked (regardless of previousJti match)", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenRotation({ refreshTokenFamilyStore: store });
+		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		await rotation.register("jti-1", "fam-1", FUTURE());
 		await store.updateFamily("fam-1", (cur) => ({ ...cur, revoked: true }));
 		const out = await rotation.rotate("jti-1", "jti-2", "fam-1", FUTURE());
@@ -70,14 +70,14 @@ describe("createDefaultRefreshTokenRotation", () => {
 
 	it("rotate returns 'unknown_family' when family does not exist", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenRotation({ refreshTokenFamilyStore: store });
+		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		const out = await rotation.rotate("jti-x", "jti-y", "ghost-fam", FUTURE());
 		expect(out.outcome).toBe("unknown_family");
 	});
 
 	it("outcome objects are frozen at runtime", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenRotation({ refreshTokenFamilyStore: store });
+		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		await rotation.register("jti-1", "fam-1", FUTURE());
 		const rotated = await rotation.rotate("jti-1", "jti-2", "fam-1", FUTURE());
 		expect(Object.isFrozen(rotated)).toBe(true);

--- a/packages/core/src/refresh-token-family/__tests__/types.test.mts
+++ b/packages/core/src/refresh-token-family/__tests__/types.test.mts
@@ -18,10 +18,10 @@ import type { ComponentMap } from "../../modules/manifest/component-map.mjs";
 import type {
 	RefreshTokenFamily,
 	RefreshTokenFamilyRevocation,
+	RefreshTokenFamilyRotation,
+	RefreshTokenFamilyRotationOutcome,
 	RefreshTokenFamilyStore,
 	RefreshTokenFamilyUpdateResult,
-	RefreshTokenRotation,
-	RefreshTokenRotationOutcome,
 } from "../types.mjs";
 
 test("RefreshTokenFamily fields are readonly with correct types", () => {
@@ -69,8 +69,8 @@ test("RefreshTokenFamilyUpdateResult committed variant carries family", () => {
 	}
 });
 
-test("RefreshTokenRotationOutcome is a 4-variant discriminated union", () => {
-	expectTypeOf<RefreshTokenRotationOutcome>().toEqualTypeOf<
+test("RefreshTokenFamilyRotationOutcome is a 4-variant discriminated union", () => {
+	expectTypeOf<RefreshTokenFamilyRotationOutcome>().toEqualTypeOf<
 		| { readonly outcome: "rotated" }
 		| { readonly outcome: "replayed" }
 		| { readonly outcome: "revoked" }
@@ -78,7 +78,7 @@ test("RefreshTokenRotationOutcome is a 4-variant discriminated union", () => {
 	>();
 });
 
-test("RefreshTokenRotation exposes register and rotate methods", () => {
+test("RefreshTokenFamilyRotation exposes register and rotate methods", () => {
 	type RotationShape = {
 		register(newJti: string, familyId: string, expiresAtMs: number): Promise<void>;
 		rotate(
@@ -86,9 +86,9 @@ test("RefreshTokenRotation exposes register and rotate methods", () => {
 			newJti: string,
 			familyId: string,
 			expiresAtMs: number,
-		): Promise<RefreshTokenRotationOutcome>;
+		): Promise<RefreshTokenFamilyRotationOutcome>;
 	};
-	expectTypeOf<RefreshTokenRotation>().toEqualTypeOf<RotationShape>();
+	expectTypeOf<RefreshTokenFamilyRotation>().toEqualTypeOf<RotationShape>();
 });
 
 test("RefreshTokenFamilyRevocation exposes revokeFamily + isFamilyRevoked", () => {
@@ -103,8 +103,8 @@ test("ComponentMap exposes the 3 A3 slots as readonly optional", () => {
 	expectTypeOf<ComponentMap["refreshTokenFamilyStore"]>().toEqualTypeOf<
 		RefreshTokenFamilyStore | undefined
 	>();
-	expectTypeOf<ComponentMap["refreshTokenRotation"]>().toEqualTypeOf<
-		RefreshTokenRotation | undefined
+	expectTypeOf<ComponentMap["refreshTokenFamilyRotation"]>().toEqualTypeOf<
+		RefreshTokenFamilyRotation | undefined
 	>();
 	expectTypeOf<ComponentMap["refreshTokenFamilyRevocation"]>().toEqualTypeOf<
 		RefreshTokenFamilyRevocation | undefined

--- a/packages/core/src/refresh-token-family/__tests__/wiring.test.mts
+++ b/packages/core/src/refresh-token-family/__tests__/wiring.test.mts
@@ -19,7 +19,7 @@ import {
 	createApp,
 	createMemoryRefreshTokenFamilyStore,
 	defaultRefreshTokenFamilyRevocationModule,
-	defaultRefreshTokenRotationModule,
+	defaultRefreshTokenFamilyRotationModule,
 	defineModule,
 	memoryRefreshTokenFamilyStoreModule,
 } from "../../index.mjs";
@@ -42,7 +42,7 @@ const minBoot = {
 // via their own route handler modules.
 const activatorModule = defineModule({
 	name: "test-activate-refresh-token-wrappers",
-	requires: ["refreshTokenRotation", "refreshTokenFamilyRevocation"] as const,
+	requires: ["refreshTokenFamilyRotation", "refreshTokenFamilyRevocation"] as const,
 	contributes: {
 		routes: [
 			{
@@ -59,15 +59,15 @@ describe("A3 wiring — happy path with all-memory composition", () => {
 		const handle = await createApp({
 			modules: [
 				memoryRefreshTokenFamilyStoreModule,
-				defaultRefreshTokenRotationModule,
+				defaultRefreshTokenFamilyRotationModule,
 				defaultRefreshTokenFamilyRevocationModule,
 				activatorModule,
 			],
 			bootstrapComponents: minBoot,
 		});
 
-		const rotation = (handle.components as { refreshTokenRotation?: unknown })
-			.refreshTokenRotation as unknown as {
+		const rotation = (handle.components as { refreshTokenFamilyRotation?: unknown })
+			.refreshTokenFamilyRotation as unknown as {
 			register(j: string, f: string, e: number): Promise<void>;
 			rotate(p: string, n: string, f: string, e: number): Promise<{ outcome: string }>;
 		};
@@ -91,12 +91,12 @@ describe("A3 wiring — happy path with all-memory composition", () => {
 });
 
 describe("A3 wiring — override path", () => {
-	it("custom refreshTokenRotation module REPLACES the default (no duplicate-provides error)", async () => {
+	it("custom refreshTokenFamilyRotation module REPLACES the default (no duplicate-provides error)", async () => {
 		const customRotationModule = defineModule({
 			name: "test-custom-rotation",
 			requires: ["refreshTokenFamilyStore"] as const,
 			provides: {
-				refreshTokenRotation: () => ({
+				refreshTokenFamilyRotation: () => ({
 					async register() {},
 					async rotate() {
 						return { outcome: "unknown_family" as const };
@@ -115,8 +115,8 @@ describe("A3 wiring — override path", () => {
 			bootstrapComponents: minBoot,
 		});
 
-		const rotation = (handle.components as { refreshTokenRotation?: unknown })
-			.refreshTokenRotation as unknown as {
+		const rotation = (handle.components as { refreshTokenFamilyRotation?: unknown })
+			.refreshTokenFamilyRotation as unknown as {
 			rotate(p: string, n: string, f: string, e: number): Promise<{ outcome: string }>;
 		};
 		const out = await rotation.rotate("a", "b", "c", Date.now() + 60_000);
@@ -125,12 +125,12 @@ describe("A3 wiring — override path", () => {
 		await handle.dispose();
 	});
 
-	it("adding BOTH default and custom refreshTokenRotation modules throws duplicate-provides", async () => {
+	it("adding BOTH default and custom refreshTokenFamilyRotation modules throws duplicate-provides", async () => {
 		const customRotationModule = defineModule({
 			name: "test-conflict-rotation",
 			requires: ["refreshTokenFamilyStore"] as const,
 			provides: {
-				refreshTokenRotation: () => ({
+				refreshTokenFamilyRotation: () => ({
 					async register() {},
 					async rotate() {
 						return { outcome: "unknown_family" as const };
@@ -143,7 +143,7 @@ describe("A3 wiring — override path", () => {
 			createApp({
 				modules: [
 					memoryRefreshTokenFamilyStoreModule,
-					defaultRefreshTokenRotationModule,
+					defaultRefreshTokenFamilyRotationModule,
 					customRotationModule,
 					defaultRefreshTokenFamilyRevocationModule,
 				],

--- a/packages/core/src/refresh-token-family/module.mts
+++ b/packages/core/src/refresh-token-family/module.mts
@@ -42,7 +42,7 @@ export const memoryRefreshTokenFamilyStoreModule = defineModule({
  * Per A3 §8.1.
  */
 export const defaultRefreshTokenFamilyRotationModule = defineModule({
-	name: "core-default-refresh-token-rotation",
+	name: "core-default-refresh-token-family-rotation",
 	requires: ["refreshTokenFamilyStore"] as const,
 	provides: {
 		refreshTokenFamilyRotation: (deps) =>

--- a/packages/core/src/refresh-token-family/module.mts
+++ b/packages/core/src/refresh-token-family/module.mts
@@ -16,7 +16,7 @@
 import { defineModule } from "../modules/manifest/define-module.mjs";
 import { createMemoryRefreshTokenFamilyStore } from "./adapters/memory.mjs";
 import { createDefaultRefreshTokenFamilyRevocation } from "./revocation.mjs";
-import { createDefaultRefreshTokenRotation } from "./rotation.mjs";
+import { createDefaultRefreshTokenFamilyRotation } from "./rotation.mjs";
 
 /**
  * Memory-backed RefreshTokenFamilyStore module. Test + dev only — no
@@ -32,21 +32,21 @@ export const memoryRefreshTokenFamilyStoreModule = defineModule({
 });
 
 /**
- * Default RefreshTokenRotation wrapper module. Composes the storage
+ * Default RefreshTokenFamilyRotation wrapper module. Composes the storage
  * primitive into the 4-outcome rotation ceremony. Replaceable via DI:
  * consumers wanting custom rotation policy (audit-emitting, grace-period,
- * etc.) provide a module with `provides: { refreshTokenRotation: ... }`
+ * etc.) provide a module with `provides: { refreshTokenFamilyRotation: ... }`
  * INSTEAD of this one — boot planner enforces uniqueness via
  * BootError({ reason: "duplicate-provides" }).
  *
  * Per A3 §8.1.
  */
-export const defaultRefreshTokenRotationModule = defineModule({
+export const defaultRefreshTokenFamilyRotationModule = defineModule({
 	name: "core-default-refresh-token-rotation",
 	requires: ["refreshTokenFamilyStore"] as const,
 	provides: {
-		refreshTokenRotation: (deps) =>
-			createDefaultRefreshTokenRotation({
+		refreshTokenFamilyRotation: (deps) =>
+			createDefaultRefreshTokenFamilyRotation({
 				refreshTokenFamilyStore: deps.refreshTokenFamilyStore,
 			}),
 	},

--- a/packages/core/src/refresh-token-family/rotation.mts
+++ b/packages/core/src/refresh-token-family/rotation.mts
@@ -15,24 +15,24 @@
  */
 import type {
 	RefreshTokenFamily,
+	RefreshTokenFamilyRotation,
+	RefreshTokenFamilyRotationOutcome,
 	RefreshTokenFamilyStore,
-	RefreshTokenRotation,
-	RefreshTokenRotationOutcome,
 } from "./types.mjs";
 
 /**
- * Inputs for the default RefreshTokenRotation composition.
+ * Inputs for the default RefreshTokenFamilyRotation composition.
  * Per A3 §6.1.
  */
-export interface DefaultRefreshTokenRotationDeps {
+export interface DefaultRefreshTokenFamilyRotationDeps {
 	readonly refreshTokenFamilyStore: RefreshTokenFamilyStore;
 }
 
 /**
- * Default RefreshTokenRotation composition: builds a fresh
+ * Default RefreshTokenFamilyRotation composition: builds a fresh
  * RefreshTokenFamily aggregate on `register`, and translates
  * RefreshTokenFamilyStore.updateFamily outcomes into the 4-variant
- * RefreshTokenRotationOutcome on `rotate`.
+ * RefreshTokenFamilyRotationOutcome on `rotate`.
  *
  * The closure-captured `abortReason` is reset at the top of every updater
  * invocation so CAS retries observe the freshest classification (the LAST
@@ -45,9 +45,9 @@ export interface DefaultRefreshTokenRotationDeps {
  *
  * Per A3 §6.1.
  */
-export function createDefaultRefreshTokenRotation(
-	deps: DefaultRefreshTokenRotationDeps,
-): RefreshTokenRotation {
+export function createDefaultRefreshTokenFamilyRotation(
+	deps: DefaultRefreshTokenFamilyRotationDeps,
+): RefreshTokenFamilyRotation {
 	return {
 		async register(newJti, familyId, expiresAtMs) {
 			const family: RefreshTokenFamily = Object.freeze({
@@ -85,7 +85,7 @@ export function createDefaultRefreshTokenRotation(
 				case "aborted":
 					return Object.freeze({
 						outcome: abortReason ?? "replayed",
-					} as const) as RefreshTokenRotationOutcome;
+					} as const) as RefreshTokenFamilyRotationOutcome;
 				case "committed":
 					return Object.freeze({ outcome: "rotated" } as const);
 			}

--- a/packages/core/src/refresh-token-family/types.mts
+++ b/packages/core/src/refresh-token-family/types.mts
@@ -59,7 +59,7 @@ export type RefreshTokenFamilyUpdateResult =
  *
  * Theme A: this interface exposes only single-key atomic primitives. The
  * 4-outcome rotation ceremony (`rotated | replayed | revoked |
- * unknown_family`) is composed in the wrapper layer (`RefreshTokenRotation`),
+ * unknown_family`) is composed in the wrapper layer (`RefreshTokenFamilyRotation`),
  * NOT classified by the adapter.
  *
  * Per A3 §5.1.
@@ -125,7 +125,7 @@ export interface RefreshTokenFamilyStore {
 	 *   - Updater MAY use a closure-captured variable to communicate the
 	 *     abort reason to the caller; the closure is reset at the top of
 	 *     each updater invocation. This is the wrapper pattern used by
-	 *     `createDefaultRefreshTokenRotation` to translate "aborted"
+	 *     `createDefaultRefreshTokenFamilyRotation` to translate "aborted"
 	 *     results into "replayed" or "revoked" outcomes.
 	 *   - Updater MUST NOT return a RefreshTokenFamily whose `expiresAtMs` is
 	 *     `<= now()`. Both adapters fail-closed by throwing
@@ -166,7 +166,7 @@ export interface RefreshTokenFamilyStore {
  *
  * Per A3 §5.2.
  */
-export type RefreshTokenRotationOutcome =
+export type RefreshTokenFamilyRotationOutcome =
 	| { readonly outcome: "rotated" }
 	| { readonly outcome: "replayed" }
 	| { readonly outcome: "revoked" }
@@ -175,14 +175,14 @@ export type RefreshTokenRotationOutcome =
 /**
  * Rotation ceremony wrapper. Composes `RefreshTokenFamilyStore.updateFamily`
  * into the 4-outcome union. The default impl
- * (`createDefaultRefreshTokenRotation`) is shipped as
- * `defaultRefreshTokenRotationModule`; consumers needing custom policy
+ * (`createDefaultRefreshTokenFamilyRotation`) is shipped as
+ * `defaultRefreshTokenFamilyRotationModule`; consumers needing custom policy
  * (audit-emitting rotation, grace-period rotation, etc.) replace the
  * module with their own.
  *
  * Per A3 §5.2.
  */
-export interface RefreshTokenRotation {
+export interface RefreshTokenFamilyRotation {
 	/**
 	 * Register a new refresh-token family at initial issue time (e.g., from
 	 * the authorization_code grant handler).
@@ -215,7 +215,7 @@ export interface RefreshTokenRotation {
 		newJti: string,
 		familyId: string,
 		expiresAtMs: number,
-	): Promise<RefreshTokenRotationOutcome>;
+	): Promise<RefreshTokenFamilyRotationOutcome>;
 }
 
 /**
@@ -264,14 +264,14 @@ export interface RefreshTokenFamilyRevocation {
 // resolves them from module `provides` at boot time per A2-beta §5.3.
 //
 // Slot-name reservation policy (A1 §5.5): unnamespaced names
-// (refreshTokenFamilyStore, refreshTokenRotation, refreshTokenFamilyRevocation)
+// (refreshTokenFamilyStore, refreshTokenFamilyRotation, refreshTokenFamilyRevocation)
 // are reserved for o3co packages. Consumers augmenting ComponentMap for
 // their own use MUST namespace their key (e.g. acme.refreshTokenStore).
 // ---------------------------------------------------------------------------
 declare module "@o3co/auth-provider-core" {
 	interface ComponentMap {
 		readonly refreshTokenFamilyStore?: RefreshTokenFamilyStore;
-		readonly refreshTokenRotation?: RefreshTokenRotation;
+		readonly refreshTokenFamilyRotation?: RefreshTokenFamilyRotation;
 		readonly refreshTokenFamilyRevocation?: RefreshTokenFamilyRevocation;
 	}
 }

--- a/packages/core/src/repositories/RepositoryFactory.mts
+++ b/packages/core/src/repositories/RepositoryFactory.mts
@@ -25,8 +25,9 @@ import type { UserRepository } from "./UserRepository.mjs";
 
 /**
  * Construct the three default repository factories with built-in yaml/static/memory
- * adapters pre-registered. Consumers register additional adapters (e.g. http, redis)
- * via `registerBuiltinAdapters` from `@o3co/auth-provider-foundation`.
+ * adapters pre-registered. Consumers register additional adapters via:
+ *   - `@o3co/auth-provider-foundation` `registerBuiltinAdapters` — http user repo
+ *   - `@o3co/auth-provider-redis` builders (e.g. `redisCodeRepositoryBuilder`)
  */
 export const createDefaultFactories = (): {
 	clientFactory: AdapterFactory<ClientRepository>;

--- a/packages/foundation/README.ja.md
+++ b/packages/foundation/README.ja.md
@@ -1,6 +1,8 @@
 # @o3co/auth-provider-foundation
 
-auth.provider 向けの組み込みリポジトリ実装パッケージ。HTTP ベースのユーザー認証と、Redis を使った認可コードのストレージを提供する。
+auth.provider 向けの本番用 HTTP ユーザー認証アダプターパッケージ。`"http"` アダプター型を `UserRepository` ファクトリーに登録し、`authenticate` / `authenticateByToken` を上流 HTTP サービスへ委譲する。
+
+このパッケージのスコープは v0.5.0 モジュールシステムにおける **本番用の非データベース / 外部サービスアダプター** であり、v0.5.0 時点では `HttpUserRepository` のみを提供する。以前同梱されていた Redis `CodeRepository` アダプターは Phase 10 で [`@o3co/auth-provider-redis`](../redis/README.ja.md) に移管された。
 
 ## インストール
 
@@ -8,25 +10,25 @@ auth.provider 向けの組み込みリポジトリ実装パッケージ。HTTP �
 npm install @o3co/auth-provider-foundation
 # peer dependency（必須）:
 npm install @o3co/auth-provider-core
-# peer dependency（任意 — RedisCodeRepository を使う場合のみ必要）:
-npm install redis
 ```
 
 ## パブリック API
 
 ### `registerBuiltinAdapters`
 
-組み込みアダプターのファクトリーを、指定されたファクトリーインスタンスに登録する。
-
-- `"http"` を `userFactory` に登録 → `HttpUserRepository` を生成
-- `"redis"` を `codeFactory` に登録 → `RedisCodeRepository` を生成
+`"http"` アダプター型を、指定された `userFactory` に登録する。
 
 ```typescript
 function registerBuiltinAdapters(factories: {
   userFactory: AdapterFactory<UserRepository>;
-  codeFactory: AdapterFactory<CodeRepository>;
-  pathResolver?: PathResolver; // 任意 — "redis" モジュールのパス解決に使用
 }): void;
+```
+
+Redis を使った認可コードストレージが必要な場合は、`@o3co/auth-provider-redis` の builder を直接登録する:
+
+```typescript
+import { redisCodeRepositoryBuilder } from "@o3co/auth-provider-redis";
+codeFactory.register("redis", redisCodeRepositoryBuilder);
 ```
 
 ### `HttpUserRepository`
@@ -52,45 +54,15 @@ class HttpUserRepository implements UserRepository {
 - HTTP 401 または 403 の場合は `null` を返す。
 - その他の非 OK ステータスの場合はエラーをスローする。
 
-### `RedisCodeRepository`
-
-Redis に認可コードを保存する `CodeRepository` 実装。キーは `oauth:code:<base64url-code>` 形式で保存され、TTL を設定できる。
-
-```typescript
-class RedisCodeRepository implements CodeRepository {
-  constructor(redis: RedisClient, defaultExpiresIn?: number); // defaultExpiresIn のデフォルトは 600 秒
-
-  // ファクトリーメソッド — config から Redis クライアントを生成して接続する
-  static create(
-    config: Record<string, unknown>,
-    pathResolver?: PathResolver,
-  ): Promise<RedisCodeRepository>;
-  // config のキー:
-  //   endpointUri      (string, 必須) — Redis 接続 URI
-  //   password         (string, 任意) — Redis パスワード
-  //   defaultExpiresIn (number, 任意) — TTL（秒）、デフォルト 600
-
-  initialize(): Promise<void>;   // Redis クライアントを接続する
-  createCode(params: {
-    code_challenge?: string;
-    code_challenge_method?: string;
-    expiresIn?: number;          // このコードだけ defaultExpiresIn を上書きする
-  }): Promise<Code>;
-  getByCode(code: string): Promise<Code | null>;
-  consumeByCode(code: string): Promise<Code | null>; // アトミックな GET + DEL
-  removeByCode(code: string): Promise<void>;
-}
-```
-
 ## 使い方
 
 ```typescript
 import { createDefaultFactories } from "@o3co/auth-provider-core";
 import { registerBuiltinAdapters } from "@o3co/auth-provider-foundation";
 
-const { userFactory, codeFactory } = createDefaultFactories();
+const { userFactory } = createDefaultFactories();
 
-registerBuiltinAdapters({ userFactory, codeFactory });
+registerBuiltinAdapters({ userFactory });
 
 // ファクトリー経由で HTTP ユーザーリポジトリを生成
 const userRepo = await userFactory.create({
@@ -99,16 +71,10 @@ const userRepo = await userFactory.create({
   authenticateByTokenUrl: "https://users.example.com/authenticate-by-token",
   timeout: 5000,
 });
-
-// ファクトリー経由で Redis コードリポジトリを生成
-const codeRepo = await codeFactory.create({
-  type: "redis",
-  endpointUri: "redis://localhost:6379",
-  defaultExpiresIn: 300,
-});
 ```
 
 ## 関連
 
-- [`@o3co/auth-provider-core`](../core/README.md) — コアインターフェース（`UserRepository`、`CodeRepository`、`AdapterFactory`、`createAdapterFactory`、`BuilderContext`、`PathResolver`）
+- [`@o3co/auth-provider-core`](../core/README.ja.md) — コアインターフェース（`UserRepository`、`CodeRepository`、`AdapterFactory`、`createAdapterFactory`、`BuilderContext`、`PathResolver`）
+- [`@o3co/auth-provider-redis`](../redis/README.ja.md) — Redis バックエンドのアダプター群（challenges、replay-seen-set、refresh-token-family、user-sessions、federation-tokens、**code-repository**、rate-limiter）
 - [auth.provider](../../README.md) — リポジトリ全体のドキュメント

--- a/packages/foundation/README.md
+++ b/packages/foundation/README.md
@@ -1,6 +1,8 @@
 # @o3co/auth-provider-foundation
 
-Built-in repository implementations for auth.provider. Provides HTTP-based user authentication and Redis-backed authorization code storage.
+Production HTTP user-authentication adapter for auth.provider. Registers the `"http"` adapter type into a `UserRepository` factory, which delegates `authenticate` / `authenticateByToken` to an upstream HTTP service.
+
+This package's scope is **production non-database / external-service adapters** for the v0.5.0 module system. As of v0.5.0 it ships exactly one such adapter (`HttpUserRepository`); the previous Redis `CodeRepository` adapter was relocated to [`@o3co/auth-provider-redis`](../redis/README.md) in Phase 10.
 
 ## Install
 
@@ -8,25 +10,25 @@ Built-in repository implementations for auth.provider. Provides HTTP-based user 
 npm install @o3co/auth-provider-foundation
 # Peer dependency (required):
 npm install @o3co/auth-provider-core
-# Peer dependency (optional — required only when using RedisCodeRepository):
-npm install redis
 ```
 
 ## Public API
 
 ### `registerBuiltinAdapters`
 
-Registers the built-in adapter factories into the provided factory instances.
-
-- Registers `"http"` into `userFactory` → creates `HttpUserRepository`
-- Registers `"redis"` into `codeFactory` → creates `RedisCodeRepository`
+Registers the `"http"` adapter type into the provided `userFactory`.
 
 ```typescript
 function registerBuiltinAdapters(factories: {
   userFactory: AdapterFactory<UserRepository>;
-  codeFactory: AdapterFactory<CodeRepository>;
-  pathResolver?: PathResolver; // optional — used to resolve the "redis" module path
 }): void;
+```
+
+For Redis-backed code storage, register the builder from `@o3co/auth-provider-redis` directly:
+
+```typescript
+import { redisCodeRepositoryBuilder } from "@o3co/auth-provider-redis";
+codeFactory.register("redis", redisCodeRepositoryBuilder);
 ```
 
 ### `HttpUserRepository`
@@ -52,45 +54,15 @@ class HttpUserRepository implements UserRepository {
 - Returns `null` on HTTP 401 or 403.
 - Throws an error on any other non-OK HTTP status.
 
-### `RedisCodeRepository`
-
-A `CodeRepository` implementation that stores authorization codes in Redis. Keys are stored as `oauth:code:<base64url-code>` with a configurable TTL.
-
-```typescript
-class RedisCodeRepository implements CodeRepository {
-  constructor(redis: RedisClient, defaultExpiresIn?: number); // defaultExpiresIn defaults to 600 seconds
-
-  // Factory method — creates and connects a Redis client from config
-  static create(
-    config: Record<string, unknown>,
-    pathResolver?: PathResolver,
-  ): Promise<RedisCodeRepository>;
-  // config keys:
-  //   endpointUri (string, required) — Redis connection URI
-  //   password    (string, optional) — Redis password
-  //   defaultExpiresIn (number, optional) — TTL in seconds, default 600
-
-  initialize(): Promise<void>;   // connects the Redis client
-  createCode(params: {
-    code_challenge?: string;
-    code_challenge_method?: string;
-    expiresIn?: number;          // overrides defaultExpiresIn for this code
-  }): Promise<Code>;
-  getByCode(code: string): Promise<Code | null>;
-  consumeByCode(code: string): Promise<Code | null>; // atomic GET + DEL
-  removeByCode(code: string): Promise<void>;
-}
-```
-
 ## Usage Example
 
 ```typescript
 import { createDefaultFactories } from "@o3co/auth-provider-core";
 import { registerBuiltinAdapters } from "@o3co/auth-provider-foundation";
 
-const { userFactory, codeFactory } = createDefaultFactories();
+const { userFactory } = createDefaultFactories();
 
-registerBuiltinAdapters({ userFactory, codeFactory });
+registerBuiltinAdapters({ userFactory });
 
 // Create an HTTP user repository via the factory
 const userRepo = await userFactory.create({
@@ -99,16 +71,10 @@ const userRepo = await userFactory.create({
   authenticateByTokenUrl: "https://users.example.com/authenticate-by-token",
   timeout: 5000,
 });
-
-// Create a Redis code repository via the factory
-const codeRepo = await codeFactory.create({
-  type: "redis",
-  endpointUri: "redis://localhost:6379",
-  defaultExpiresIn: 300,
-});
 ```
 
 ## See Also
 
 - [`@o3co/auth-provider-core`](../core/README.md) — Core interfaces (`UserRepository`, `CodeRepository`, `AdapterFactory`, `createAdapterFactory`, `BuilderContext`, `PathResolver`)
+- [`@o3co/auth-provider-redis`](../redis/README.md) — Redis-backed adapters (challenges, replay-seen-set, refresh-token-family, user-sessions, federation-tokens, **code-repository**, rate-limiter)
 - [auth.provider](../../README.md) — Top-level repository documentation

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@o3co/auth-provider-foundation",
-	"description": "Production adapters for auth.provider",
+	"description": "Production HTTP user-authentication adapter for auth.provider",
 	"version": "0.0.0",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/foundation/src/index.mts
+++ b/packages/foundation/src/index.mts
@@ -14,33 +14,11 @@
  * limitations under the License.
  */
 
-import type {
-	AdapterFactory,
-	CodeRepository,
-	PathResolver,
-	UserRepository,
-} from "@o3co/auth-provider-core";
+import type { AdapterFactory, UserRepository } from "@o3co/auth-provider-core";
 import { HttpUserRepository } from "./repositories/HttpUserRepository.mjs";
 
-/**
- * Registers the foundation's built-in adapter factories. As of v0.5.0
- * (Phase 10 Q4), the only built-in adapter remaining in foundation is
- * the HTTP UserRepository — the Redis CodeRepository was relocated to
- * `@o3co/auth-provider-redis`.
- *
- * The `codeFactory` parameter is retained for backward compatibility with
- * the v0.4.x signature; foundation no longer registers any code adapter.
- *
- * Consumers that need redis-backed code storage should wire it directly:
- *
- *   import { redisCodeRepositoryBuilder } from "@o3co/auth-provider-redis";
- *   codeFactory.register("redis", redisCodeRepositoryBuilder);
- */
 export const registerBuiltinAdapters = (factories: {
 	userFactory: AdapterFactory<UserRepository>;
-	// Kept for v0.4.x signature compatibility; no registrations performed.
-	codeFactory?: AdapterFactory<CodeRepository>;
-	pathResolver?: PathResolver;
 }): void => {
 	factories.userFactory.register("http", (config) => {
 		if (typeof config.authenticateUrl !== "string") {

--- a/packages/foundation/src/repositories/__tests__/registerBuiltinAdapters.test.mts
+++ b/packages/foundation/src/repositories/__tests__/registerBuiltinAdapters.test.mts
@@ -16,7 +16,6 @@
 
 import {
 	AdapterFactoryError,
-	type CodeRepository,
 	createAdapterFactory,
 	type UserRepository,
 } from "@o3co/auth-provider-core";
@@ -52,9 +51,8 @@ afterAll(() => server.close());
 describe("registerBuiltinAdapters", () => {
 	it("registers 'http' type in userFactory", async () => {
 		const userFactory = createAdapterFactory<UserRepository>("UserRepository");
-		const codeFactory = createAdapterFactory<CodeRepository>("CodeRepository");
 
-		registerBuiltinAdapters({ userFactory, codeFactory });
+		registerBuiltinAdapters({ userFactory });
 
 		try {
 			await userFactory.create({ type: "unknown" });
@@ -68,19 +66,9 @@ describe("registerBuiltinAdapters", () => {
 		}
 	});
 
-	it("does NOT register 'redis' type in codeFactory (relocated to @o3co/auth-provider-redis in Phase 10)", async () => {
-		const userFactory = createAdapterFactory<UserRepository>("UserRepository");
-		const codeFactory = createAdapterFactory<CodeRepository>("CodeRepository");
-
-		registerBuiltinAdapters({ userFactory, codeFactory });
-
-		expect(codeFactory.registeredTypes()).not.toContain("redis");
-	});
-
 	it("http builder creates a working HttpUserRepository", async () => {
 		const userFactory = createAdapterFactory<UserRepository>("UserRepository");
-		const codeFactory = createAdapterFactory<CodeRepository>("CodeRepository");
-		registerBuiltinAdapters({ userFactory, codeFactory });
+		registerBuiltinAdapters({ userFactory });
 
 		const repo = await userFactory.create({
 			type: "http",
@@ -102,8 +90,7 @@ describe("registerBuiltinAdapters", () => {
 
 	it("http builder coerces string timeout to number (env-override path)", async () => {
 		const userFactory = createAdapterFactory<UserRepository>("UserRepository");
-		const codeFactory = createAdapterFactory<CodeRepository>("CodeRepository");
-		registerBuiltinAdapters({ userFactory, codeFactory });
+		registerBuiltinAdapters({ userFactory });
 
 		const repo = await userFactory.create({
 			type: "http",
@@ -120,18 +107,10 @@ describe("registerBuiltinAdapters", () => {
 
 	it("http builder throws when authenticateUrl is missing", async () => {
 		const userFactory = createAdapterFactory<UserRepository>("UserRepository");
-		const codeFactory = createAdapterFactory<CodeRepository>("CodeRepository");
-		registerBuiltinAdapters({ userFactory, codeFactory });
+		registerBuiltinAdapters({ userFactory });
 
 		await expect(userFactory.create({ type: "http", timeout: 5000 })).rejects.toThrow(
 			/authenticateUrl/,
 		);
-	});
-
-	it("codeFactory accepts optional parameter (v0.4.x signature compat)", async () => {
-		const userFactory = createAdapterFactory<UserRepository>("UserRepository");
-
-		// codeFactory is now optional — omitting it should not throw
-		expect(() => registerBuiltinAdapters({ userFactory })).not.toThrow();
 	});
 });

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -20,7 +20,7 @@ import {
 	createSymmetricKeyStore,
 	type GrantContext,
 	type GrantDependencies,
-	type RefreshTokenRotation,
+	type RefreshTokenFamilyRotation,
 	type SessionFamilyIndex,
 	type SessionRPRegistry,
 } from "@o3co/auth-provider-core";
@@ -179,15 +179,15 @@ describe("createAuthorizationGrant", () => {
 			expect(sessionMutation?.clear).toContain("granted_scopes");
 		});
 
-		it("registers initial rt+jwt via refreshTokenRotation.register (CP-2)", async () => {
+		it("registers initial rt+jwt via refreshTokenFamilyRotation.register (CP-2)", async () => {
 			const registerSpy = vi.fn(async () => {});
-			const refreshTokenRotation: RefreshTokenRotation = {
+			const refreshTokenFamilyRotation: RefreshTokenFamilyRotation = {
 				register: registerSpy,
 				rotate: vi.fn(async () => ({ outcome: "rotated" as const })),
 			};
 			const deps = {
 				...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" })),
-				refreshTokenRotation,
+				refreshTokenFamilyRotation,
 			};
 			const handler = createAuthorizationGrant(deps);
 			const ctx: GrantContext = {
@@ -220,8 +220,8 @@ describe("createAuthorizationGrant", () => {
 			expect(expiresAtMs).toBeGreaterThan(Date.now());
 		});
 
-		it("returns 503 temporarily_unavailable when refreshTokenRotation.register throws (CP-16)", async () => {
-			const throwingRotation: RefreshTokenRotation = {
+		it("returns 503 temporarily_unavailable when refreshTokenFamilyRotation.register throws (CP-16)", async () => {
+			const throwingRotation: RefreshTokenFamilyRotation = {
 				register: async () => {
 					throw new Error("store down");
 				},
@@ -229,7 +229,7 @@ describe("createAuthorizationGrant", () => {
 			};
 			const deps = {
 				...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" })),
-				refreshTokenRotation: throwingRotation,
+				refreshTokenFamilyRotation: throwingRotation,
 			};
 			const handler = createAuthorizationGrant(deps);
 
@@ -250,7 +250,7 @@ describe("createAuthorizationGrant", () => {
 			expect(result.error).toBe("temporarily_unavailable");
 		});
 
-		it("skips initial-register when no refreshTokenRotation is configured (CP-2 graceful)", async () => {
+		it("skips initial-register when no refreshTokenFamilyRotation is configured (CP-2 graceful)", async () => {
 			const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" }));
 			const handler = createAuthorizationGrant(deps);
 			const { result } = await handler.handle({

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -23,7 +23,7 @@ import {
 	type GrantDependencies,
 	type GrantPolicyHookBase,
 	GrantRegistry,
-	type RefreshTokenRotation,
+	type RefreshTokenFamilyRotation,
 	type SessionFamilyIndex,
 	type SessionRPRegistry,
 	type UserSessionStore,
@@ -192,15 +192,15 @@ describe("oauthAuthorizationModule — manifest shape", () => {
 
 	// Boot planner only injects keys listed in `requires` ∪ `optional` into
 	// contribution-factory `deps`. Both grant factories read
-	// `deps.refreshTokenRotation` (A3 §5.2 rotation persistence) and
+	// `deps.refreshTokenFamilyRotation` (A3 §5.2 rotation persistence) and
 	// `deps.grantPolicy` (CP-18 fail-closed gate). If they are not declared
 	// here, a composition root that wires either component will see it
 	// silently dropped at the grant boundary — refresh-token rotation stops
 	// recording, and grantPolicy enforcement becomes dead code.
-	it("declares refreshTokenRotation + grantPolicy in optional so deps reach the grants", () => {
+	it("declares refreshTokenFamilyRotation + grantPolicy in optional so deps reach the grants", () => {
 		const config = makeValidAppConfig();
 		const module = oauthAuthorizationModule({ config });
-		expect(module.optional).toContain("refreshTokenRotation");
+		expect(module.optional).toContain("refreshTokenFamilyRotation");
 		expect(module.optional).toContain("grantPolicy");
 	});
 });
@@ -261,10 +261,10 @@ describe("oauthAuthorizationModule — createTestApp integration", () => {
 // the module-level tests via module.init(ctx).
 // ---------------------------------------------------------------------------
 
-describe("createRefreshTokenGrant — refreshTokenRotation forwarding", () => {
-	it("calls refreshTokenRotation.rotate when a valid refresh_token is presented", async () => {
+describe("createRefreshTokenGrant — refreshTokenFamilyRotation forwarding", () => {
+	it("calls refreshTokenFamilyRotation.rotate when a valid refresh_token is presented", async () => {
 		const rotateSpy = vi.fn().mockResolvedValue({ outcome: "rotated" });
-		const refreshTokenRotation: RefreshTokenRotation = {
+		const refreshTokenFamilyRotation: RefreshTokenFamilyRotation = {
 			register: vi.fn(async () => {}),
 			rotate: rotateSpy,
 		};
@@ -278,7 +278,7 @@ describe("createRefreshTokenGrant — refreshTokenRotation forwarding", () => {
 				},
 			} as unknown as GrantDependencies["config"],
 			keyStore,
-			refreshTokenRotation,
+			refreshTokenFamilyRotation,
 		};
 
 		const handler = createRefreshTokenGrant(baseDeps);

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -19,7 +19,7 @@ import {
 	type GrantContext,
 	type GrantDependencies,
 	type GrantPolicyHookBase,
-	type RefreshTokenRotation,
+	type RefreshTokenFamilyRotation,
 	type UserSessionStore,
 } from "@o3co/auth-provider-core";
 import { SignJWT } from "jose";
@@ -293,10 +293,10 @@ describe("createRefreshTokenGrant", () => {
 		});
 	});
 
-	describe("family_id and refreshTokenRotation integration", () => {
+	describe("family_id and refreshTokenFamilyRotation integration", () => {
 		function createStubRotation(
 			outcome: "rotated" | "replayed" | "revoked" | "unknown_family",
-		): RefreshTokenRotation {
+		): RefreshTokenFamilyRotation {
 			return {
 				async register() {},
 				async rotate() {
@@ -338,7 +338,7 @@ describe("createRefreshTokenGrant", () => {
 
 		it("returns invalid_grant/replay_detected when the rotation reports 'replayed'", async () => {
 			const stub = createStubRotation("replayed");
-			const depsWithStore: GrantDependencies = { ...mockDeps, refreshTokenRotation: stub };
+			const depsWithStore: GrantDependencies = { ...mockDeps, refreshTokenFamilyRotation: stub };
 			// Token must include a jti so that previousJti !== null and rotate() is called
 			const token = await new SignJWT({ sub: "u1", scope: "read write" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
@@ -364,8 +364,8 @@ describe("createRefreshTokenGrant", () => {
 			}
 		});
 
-		it("returns 503 temporarily_unavailable when refreshTokenRotation.rotate throws (CP-17)", async () => {
-			const throwingRotation: RefreshTokenRotation = {
+		it("returns 503 temporarily_unavailable when refreshTokenFamilyRotation.rotate throws (CP-17)", async () => {
+			const throwingRotation: RefreshTokenFamilyRotation = {
 				async register() {},
 				async rotate() {
 					throw new Error("redis down");
@@ -373,7 +373,7 @@ describe("createRefreshTokenGrant", () => {
 			};
 			const depsWithStore: GrantDependencies = {
 				...mockDeps,
-				refreshTokenRotation: throwingRotation,
+				refreshTokenFamilyRotation: throwingRotation,
 			};
 			const token = await new SignJWT({ sub: "u1", scope: "read write" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
@@ -396,7 +396,7 @@ describe("createRefreshTokenGrant", () => {
 
 		it("returns invalid_grant/family_revoked when the rotation reports 'revoked'", async () => {
 			const stub = createStubRotation("revoked");
-			const depsWithStore: GrantDependencies = { ...mockDeps, refreshTokenRotation: stub };
+			const depsWithStore: GrantDependencies = { ...mockDeps, refreshTokenFamilyRotation: stub };
 			// Token must include a jti so that previousJti !== null and rotate() is called
 			const token = await new SignJWT({ sub: "u1", scope: "read write" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -305,9 +305,9 @@ export const createAuthorizationGrant = (
 
 			// Register the initial refresh token family so replay detection is
 			// active from the first use. Per A3 §5.2: use the dedicated
-			// RefreshTokenRotation.register(newJti, familyId, expiresAtMs) rather
+			// RefreshTokenFamilyRotation.register(newJti, familyId, expiresAtMs) rather
 			// than the v0.4.x rotate(null, ...) trick — expiresAtMs is epoch-ms.
-			if (deps.refreshTokenRotation) {
+			if (deps.refreshTokenFamilyRotation) {
 				const payload = decodeJwtPayload(refreshToken.token);
 				const jti = payload.jti as string | undefined;
 				const exp = payload.exp as number | undefined;
@@ -319,7 +319,7 @@ export const createAuthorizationGrant = (
 					// a controlled 503 JSON so clients see a retryable error instead
 					// of an unhandled HTML 500 from express.
 					try {
-						await deps.refreshTokenRotation.register(jti, familyId, exp * 1000);
+						await deps.refreshTokenFamilyRotation.register(jti, familyId, exp * 1000);
 					} catch {
 						return {
 							result: {

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -280,7 +280,7 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				},
 			);
 
-			if (deps.refreshTokenRotation && previousJti !== null) {
+			if (deps.refreshTokenFamilyRotation && previousJti !== null) {
 				const newRefreshPayload = decodeJwtPayload(newRefreshToken.token);
 				const newJti = newRefreshPayload.jti as string | undefined;
 				const newExp = newRefreshPayload.exp as number | undefined;
@@ -290,9 +290,9 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 					// jti and register the new one, so replay detection cannot
 					// be guaranteed. Return 503 so the client retries rather
 					// than bubbling an unhandled 500 HTML from express.
-					let rotateResult: Awaited<ReturnType<typeof deps.refreshTokenRotation.rotate>>;
+					let rotateResult: Awaited<ReturnType<typeof deps.refreshTokenFamilyRotation.rotate>>;
 					try {
-						rotateResult = await deps.refreshTokenRotation.rotate(
+						rotateResult = await deps.refreshTokenFamilyRotation.rotate(
 							previousJti,
 							newJti,
 							newFamilyId,

--- a/packages/oauth/src/oauthAuthorization.mts
+++ b/packages/oauth/src/oauthAuthorization.mts
@@ -71,7 +71,7 @@ export const oauthAuthorizationModule = (params: { config: AppConfig }): Module 
 			// read these to back refresh-token rotation persistence and CP-18 grant
 			// policy enforcement. Boot planner only injects keys listed here, so
 			// omitting them silently drops both features at the grant boundary.
-			"refreshTokenRotation", // A3 §5.2 — replaces legacy refreshTokenStore (#101)
+			"refreshTokenFamilyRotation", // A3 §5.2 — replaces legacy refreshTokenStore (#101)
 			"grantPolicy",
 			"userSessionStore",
 			"sessionRPRegistry", // Amendment 4 (§1.1.4)

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -7,7 +7,7 @@ This package ships nine adapters covering every redis-backed component that
 
 - `ChallengeStore` (challenges)
 - `ReplaySeenSet` (replay-seen-set)
-- `RefreshTokenFamilyStore` / `RefreshTokenRotation` /
+- `RefreshTokenFamilyStore` / `RefreshTokenFamilyRotation` /
   `RefreshTokenFamilyRevocation` (refresh-token-family)
 - `UserSessionStore`, `SessionRPRegistry`, `SessionFamilyIndex`,
   `SessionFederationIndex` (user sessions, A4 four-store split)

--- a/packages/redis/__tests__/refresh-token-family-wiring.test.mts
+++ b/packages/redis/__tests__/refresh-token-family-wiring.test.mts
@@ -17,7 +17,7 @@ import {
 	type BootstrapMap,
 	createApp,
 	defaultRefreshTokenFamilyRevocationModule,
-	defaultRefreshTokenRotationModule,
+	defaultRefreshTokenFamilyRotationModule,
 	defineModule,
 } from "@o3co/auth-provider-core";
 import { makeValidCoreConfig } from "@o3co/auth-provider-core/testing";
@@ -51,7 +51,7 @@ describe("A3 wiring — full Redis composition (createApp + redis modules)", () 
 			name: "test-activator",
 			requires: [
 				"refreshTokenFamilyStore",
-				"refreshTokenRotation",
+				"refreshTokenFamilyRotation",
 				"refreshTokenFamilyRevocation",
 			] as const,
 			contributes: {
@@ -83,7 +83,7 @@ describe("A3 wiring — full Redis composition (createApp + redis modules)", () 
 		const handle = await createApp({
 			modules: [
 				redisRefreshTokenFamilyStoreModule,
-				defaultRefreshTokenRotationModule,
+				defaultRefreshTokenFamilyRotationModule,
 				defaultRefreshTokenFamilyRevocationModule,
 				activatorModule,
 			],
@@ -91,8 +91,8 @@ describe("A3 wiring — full Redis composition (createApp + redis modules)", () 
 		});
 
 		try {
-			const rotation = (handle.components as { refreshTokenRotation?: unknown })
-				.refreshTokenRotation as unknown as {
+			const rotation = (handle.components as { refreshTokenFamilyRotation?: unknown })
+				.refreshTokenFamilyRotation as unknown as {
 				register(j: string, f: string, e: number): Promise<void>;
 				rotate(p: string, n: string, f: string, e: number): Promise<{ outcome: string }>;
 			};

--- a/templates/standalone/src/buildModules.mts
+++ b/templates/standalone/src/buildModules.mts
@@ -16,7 +16,7 @@
 import {
 	type AppConfig,
 	defaultRefreshTokenFamilyRevocationModule,
-	defaultRefreshTokenRotationModule,
+	defaultRefreshTokenFamilyRotationModule,
 	type Module,
 	memoryRefreshTokenFamilyStoreModule,
 } from "@o3co/auth-provider-core";
@@ -72,7 +72,7 @@ export function buildModules(config: AppConfig, overrides: BuildModulesOverrides
 		overrides.repositoriesModule ?? repositoriesModule,
 		overrides.storesModule ?? storesModule,
 		memoryRefreshTokenFamilyStoreModule,
-		defaultRefreshTokenRotationModule,
+		defaultRefreshTokenFamilyRotationModule,
 		defaultRefreshTokenFamilyRevocationModule,
 	];
 }

--- a/templates/standalone/src/modules.mts
+++ b/templates/standalone/src/modules.mts
@@ -84,11 +84,11 @@ export const keyStoreModule: Module = defineModule({
  */
 export const repositoriesModule: Module = defineModule({
 	name: "standalone:repositories",
-	requires: ["config", "pathResolver"] as const,
+	requires: ["config"] as const,
 	provides: {
-		clientRepository: async ({ config, pathResolver }) => {
-			const { clientFactory, userFactory, codeFactory } = createDefaultFactories();
-			registerBuiltinAdapters({ userFactory, codeFactory, pathResolver });
+		clientRepository: async ({ config }) => {
+			const { clientFactory, userFactory } = createDefaultFactories();
+			registerBuiltinAdapters({ userFactory });
 			const slice = flattenAdapterConfig(
 				(config as AppConfig).repositories.client as { type: string } & Record<string, unknown>,
 			);
@@ -97,18 +97,18 @@ export const repositoriesModule: Module = defineModule({
 			}
 			return clientFactory.create(slice);
 		},
-		userRepository: async ({ config, pathResolver }) => {
-			const { userFactory, codeFactory } = createDefaultFactories();
-			registerBuiltinAdapters({ userFactory, codeFactory, pathResolver });
+		userRepository: async ({ config }) => {
+			const { userFactory } = createDefaultFactories();
+			registerBuiltinAdapters({ userFactory });
 			return userFactory.create(
 				flattenAdapterConfig(
 					(config as AppConfig).repositories.user as { type: string } & Record<string, unknown>,
 				),
 			);
 		},
-		codeRepository: async ({ config, pathResolver }) => {
+		codeRepository: async ({ config }) => {
 			const { userFactory, codeFactory } = createDefaultFactories();
-			registerBuiltinAdapters({ userFactory, codeFactory, pathResolver });
+			registerBuiltinAdapters({ userFactory });
 			codeFactory.register("redis", redisCodeRepositoryBuilder);
 			return codeFactory.create(
 				flattenAdapterConfig(


### PR DESCRIPTION
## Summary

Pre-tag interface review fixes for v0.5.0. Closes #104.

- **M2** — `RefreshTokenFamily*` triple naming consistency. `RefreshTokenRotation` was the lone exception missing "Family" despite operating on the family aggregate. Renamed across the public surface (interface + outcome union + ComponentMap slot + factory + module manifest).
- **M3+M4** — `@o3co/auth-provider-foundation` scope clarification. `registerBuiltinAdapters` signature trimmed from `{ userFactory, codeFactory, pathResolver? }` to `{ userFactory }` (the codeFactory + pathResolver params became dead in Phase 10 when RedisCodeRepository was relocated to `@o3co/auth-provider-redis`). README en+ja rewritten to remove stale RedisCodeRepository docs that misled consumers; package.json description tightened. CHANGELOG entry corrected (was aspirational — claimed `registerBuiltinAdapters` was DELETED when it was actually retained).
- Plus a follow-up commit catching one more stale JSDoc on `createDefaultFactories` in core, flagged by multi-agent-review.

**M1** (SessionRPRegistry rename) was rejected by Codex second-opinion as defensible naming and deferred to v0.6 minor.

## Why this lands before v0.5.0 tag

After tag push, every change here becomes a major-bump breaking change. v0.5.0 is pre-1.0 and breaking-major already, so trimming dead params is preferred over carrying no-op surface for "v0.4.x compatibility" rationale.

## Verification

- `make test` — 2140 tests pass (foundation 12→10 reflects 2 obsolete test cases removed alongside signature trim)
- `tsc --noEmit` — clean across all 10 packages
- `biome check` — 0 errors, 15 pre-existing warnings (tracked in #71) untouched
- `codex review --commit` — no actionable correctness issues
- `superpowers:code-reviewer` — caught 1 Important (RepositoryFactory.mts:28-29 stale JSDoc) → fixed in 2fa0d872

## Commits

1. `c7093a61` — v0.5.0 pre-tag interface fixes: RefreshTokenFamilyRotation rename + foundation cleanup
2. `2fa0d872` — docs(core): redirect createDefaultFactories JSDoc to @o3co/auth-provider-redis (review fix)

## Test plan

- [x] Full `make test` green
- [x] Typecheck clean
- [x] Lint clean (no new warnings)
- [x] Multi-agent review (Claude + Codex)
- [ ] Copilot review on PR
- [ ] Tag v0.5.0 after merge

## Out of scope (followups)

- S/C tier interface review items (createDefault* prefix, federation provider name, backing-client method names, Module vs ModuleSpec, MutableUserSessionStore) — separate post-publish pass
- M1 (SessionRPRegistry → SessionRPIndex) — Codex rejected; revisit at v0.6
- `templates/standalone/src/modules.mts` redundant `registerBuiltinAdapters` calls in `clientRepository` / `codeRepository` providers (pre-existing pattern)
- `RedisCodeRepository.create` orphaned `pathResolver` parameter (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)