### PR TITLE
v0.5.0 pre-tag Group A: createDefault prefix + federation single-tenant + drop pre-declared MutableUserSessionStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `createDefaultFactories` → `createRepositoryFactories` (specifically
     repository factories, not generic "default factories")
 
+  The companion parameter types lose the `Default` prefix in lockstep
+  (consumers writing typed glue code update type imports too):
+
+  - `DefaultChallengeCeremonyDeps` → `ChallengeCeremonyDeps`
+  - `DefaultRefreshTokenFamilyRotationDeps` → `RefreshTokenFamilyRotationDeps`
+  - `DefaultRefreshTokenFamilyRevocationDeps` → `RefreshTokenFamilyRevocationDeps`
+  - `DefaultFederationRedirectPolicyConfig` → `FederationRedirectPolicyConfig`
+
   Module names retain the `default*Module` form where default-ness is the
   intended distinction.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,8 +119,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `UserSessionStore` (3 methods) + `SessionRPRegistry` + `SessionFamilyIndex` +
   `SessionFederationIndex`. (per A4 §4 "Breaking changes vs v0.4.x", item 1)
 - Methods removed from `UserSessionStore`: `registerRP`, `linkFamily`,
-  `updateClaims`, `removeFederation`. Each migrated to a sibling store (or in
-  `updateClaims` case, deferred to v0.6+ `MutableUserSessionStore`). (per A4 §4, item 2)
+  `updateClaims`, `removeFederation`. Each migrated to a sibling store
+  (`updateClaims` deferred post-publish; no v0.5.0 surface). (per A4 §4, item 2)
 - `UserSession` value type narrowed: `activeRPs`, `familyIds`, `federations` fields
   removed (now owned by sibling stores). (per A4 §4, item 3)
 - `UserSessionStoreFactory` (alias for `AdapterFactory<UserSessionStoreBase>`) →
@@ -174,6 +174,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - New `BootError` reasons: `"mfa-partial-wiring"` and
   `"federation-stores-incomplete"` — boot-time guards restored from v0.4.x
   `app-extensions.test.mts` after Phase 9 deletion.
+
+### Breaking Changes (pre-tag interface review — Group A)
+
+- **`createDefault*` factory prefix dropped** for all 5 factories. Use the
+  unprefixed name; "Default" implied "1 of N" but only one implementation
+  ships per name. Reference libraries (node-oidc-provider, NextAuth, Lucia)
+  do not use this prefix:
+  - `createDefaultChallengeCeremony` → `createChallengeCeremony`
+  - `createDefaultRefreshTokenFamilyRotation` → `createRefreshTokenFamilyRotation`
+  - `createDefaultRefreshTokenFamilyRevocation` → `createRefreshTokenFamilyRevocation`
+  - `createDefaultFederationRedirectPolicy` → `createFederationRedirectPolicy`
+  - `createDefaultFactories` → `createRepositoryFactories` (specifically
+    repository factories, not generic "default factories")
+
+  Module names retain the `default*Module` form where default-ness is the
+  intended distinction.
+
+- **`name` field removed from `GithubProviderConfig` / `GoogleProviderConfig`**.
+  v0.5.0 is single-tenant: `provider.name` is fixed at `"github"` / `"google"`,
+  matching the federation contribution key. The `name` config field was
+  misleading because the const-module forced the contribution key regardless
+  of consumer input. Multi-tenant support (multiple GitHub/Google apps in one
+  provider) is deferred post-publish — when added, the Config shape will gain
+  `name` back additively (backward-compatible).
+
+- **`MutableUserSessionStore` interface removed** from
+  `@o3co/auth-provider-core` public exports. The interface was pre-declared
+  for v0.6+ federation re-link claim propagation but had no v0.5.0
+  implementation, no v0.5.0 caller, and no test exercising the actual
+  contract. Shipping a CAS callback shape without an implementation freezes
+  the hardest part prematurely. The interface will be re-added when v0.6+
+  ships an actual implementation.
+  - Also removed: `mutableUserSessionStore` ComponentMap slot.
 
 ### Breaking Changes (Phase 10 — Redis Adapter Relocation)
 

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -332,7 +332,7 @@ class AdapterFactoryError extends Error {
   readonly registered: readonly string[];
 }
 
-function createDefaultFactories(): {
+function createRepositoryFactories(): {
   clientFactory: AdapterFactory<ClientRepository>;
   userFactory: AdapterFactory<UserRepository>;
   codeFactory: AdapterFactory<CodeRepository>;
@@ -346,7 +346,7 @@ function createDefaultFactories(): {
 - `create()` は未登録 `type` で `AdapterFactoryError` を throw する。error は `kind` / `type` / `registered` を構造化フィールドとして保持する。
 - `BuilderContext` は factory 単位で共有される（call ごとのコピーではない）。builder 側では read-only として扱うこと。
 
-`createDefaultFactories` は組み込みの `yaml` / `static`（client、user）と `memory`（code）タイプが登録済みの 3 つのファクトリーを返します。`@o3co/auth-provider-foundation` の `registerBuiltinAdapters` で `http` ユーザー認証アダプターを追加できます。独自の backend は `register` で追加してください。Redis バックエンドの code / store アダプターは `@o3co/auth-provider-redis` を参照してください。
+`createRepositoryFactories` は組み込みの `yaml` / `static`（client、user）と `memory`（code）タイプが登録済みの 3 つのファクトリーを返します。`@o3co/auth-provider-foundation` の `registerBuiltinAdapters` で `http` ユーザー認証アダプターを追加できます。独自の backend は `register` で追加してください。Redis バックエンドの code / store アダプターは `@o3co/auth-provider-redis` を参照してください。
 
 ### モジュールシステム
 
@@ -405,7 +405,7 @@ import express from "express";
 import {
   AppConfigSchema,
   createApp,
-  createDefaultFactories,
+  createRepositoryFactories,
   createKeyStoreFactory,
   defineModule,
   registerBuiltinKeyStores,
@@ -436,7 +436,7 @@ const keyStoreFactory = createKeyStoreFactory();
 registerBuiltinKeyStores(keyStoreFactory);
 const keyStore = await keyStoreFactory.create(flatten(config.oauth.jwt.signingKey));
 
-const { clientFactory, userFactory, codeFactory } = createDefaultFactories();
+const { clientFactory, userFactory, codeFactory } = createRepositoryFactories();
 
 const clientRepository = await clientFactory.create(flatten(config.repositories.client));
 const userRepository = await userFactory.create(flatten(config.repositories.user));

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -332,7 +332,7 @@ class AdapterFactoryError extends Error {
   readonly registered: readonly string[];
 }
 
-function createDefaultFactories(): {
+function createRepositoryFactories(): {
   clientFactory: AdapterFactory<ClientRepository>;
   userFactory: AdapterFactory<UserRepository>;
   codeFactory: AdapterFactory<CodeRepository>;
@@ -346,7 +346,7 @@ Key contract properties:
 - `create()` throws `AdapterFactoryError` when `type` is not registered; the error carries the `kind`, `type`, and `registered` list.
 - `BuilderContext` is shared by reference across builder invocations for a given factory. Treat it as read-only from builders.
 
-`createDefaultFactories` returns three factories pre-registered with the built-in `yaml`/`static` (client, user) and `memory` (code) types. Use `registerBuiltinAdapters` from `@o3co/auth-provider-foundation` to add the `http` user-authentication adapter, or register your own types to support other backends. For Redis-backed code/store adapters, see `@o3co/auth-provider-redis`.
+`createRepositoryFactories` returns three factories pre-registered with the built-in `yaml`/`static` (client, user) and `memory` (code) types. Use `registerBuiltinAdapters` from `@o3co/auth-provider-foundation` to add the `http` user-authentication adapter, or register your own types to support other backends. For Redis-backed code/store adapters, see `@o3co/auth-provider-redis`.
 
 ### Module System
 
@@ -412,7 +412,7 @@ import express from "express";
 import {
   AppConfigSchema,
   createApp,
-  createDefaultFactories,
+  createRepositoryFactories,
   createKeyStoreFactory,
   defineModule,
   registerBuiltinKeyStores,
@@ -444,7 +444,7 @@ const keyStoreFactory = createKeyStoreFactory();
 registerBuiltinKeyStores(keyStoreFactory);
 const keyStore = await keyStoreFactory.create(flatten(config.oauth.jwt.signingKey));
 
-const { clientFactory, userFactory, codeFactory } = createDefaultFactories();
+const { clientFactory, userFactory, codeFactory } = createRepositoryFactories();
 
 const clientRepository = await clientFactory.create(flatten(config.repositories.client));
 const userRepository = await userFactory.create(flatten(config.repositories.user));

--- a/packages/core/src/__tests__/index.test.mts
+++ b/packages/core/src/__tests__/index.test.mts
@@ -5,8 +5,8 @@ import {
 	createAdapterFactory,
 	createApp,
 	createAsymmetricKeyStore,
-	createDefaultFactories,
 	createKeyStoreFactory,
+	createRepositoryFactories,
 	createSymmetricKeyStore,
 	formatObject,
 	GrantRegistry,
@@ -50,8 +50,8 @@ describe("public API", () => {
 		expect(typeof AdapterFactoryError).toBe("function");
 	});
 
-	it("exports createDefaultFactories function", () => {
-		expect(typeof createDefaultFactories).toBe("function");
+	it("exports createRepositoryFactories function", () => {
+		expect(typeof createRepositoryFactories).toBe("function");
 	});
 
 	it("exports createSymmetricKeyStore function", () => {

--- a/packages/core/src/challenges/__tests__/ceremony.test.mts
+++ b/packages/core/src/challenges/__tests__/ceremony.test.mts
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createMemoryReplaySeenSet } from "../../replay-seen-set/adapters/memory.mjs";
 import type { ReplaySeenSet } from "../../replay-seen-set/types.mjs";
 import { createMemoryChallengeStore } from "../adapters/memory.mjs";
-import { createDefaultChallengeCeremony } from "../ceremony.mjs";
+import { createChallengeCeremony } from "../ceremony.mjs";
 import { ChallengeStorageError } from "../errors.mjs";
 
 const future = (): number => Date.now() + 60_000;
@@ -17,11 +17,11 @@ function makeCeremonyWithMemoryBackends() {
 	return {
 		store,
 		set,
-		ceremony: createDefaultChallengeCeremony({ challengeStore: store, replaySeenSet: set }),
+		ceremony: createChallengeCeremony({ challengeStore: store, replaySeenSet: set }),
 	};
 }
 
-describe("createDefaultChallengeCeremony — 3-outcome path (memory backends)", () => {
+describe("createChallengeCeremony — 3-outcome path (memory backends)", () => {
 	it("never-issued → outcome 'unknown'", async () => {
 		const { ceremony } = makeCeremonyWithMemoryBackends();
 		const result = await ceremony.consume("scope-A", "never-existed");
@@ -77,7 +77,7 @@ describe("createDefaultChallengeCeremony — 3-outcome path (memory backends)", 
 			}),
 			contains: vi.fn(async () => false),
 		};
-		const ceremony = createDefaultChallengeCeremony({ challengeStore: store, replaySeenSet: set });
+		const ceremony = createChallengeCeremony({ challengeStore: store, replaySeenSet: set });
 		await store.issue("scope-A", "race-ttl", future());
 		const result = await ceremony.consume("scope-A", "race-ttl");
 		expect(result).toEqual({ outcome: "consumed" });
@@ -94,7 +94,7 @@ describe("createDefaultChallengeCeremony — 3-outcome path (memory backends)", 
 			}),
 			contains: vi.fn(async () => false),
 		};
-		const ceremony = createDefaultChallengeCeremony({ challengeStore: store, replaySeenSet: set });
+		const ceremony = createChallengeCeremony({ challengeStore: store, replaySeenSet: set });
 		await store.issue("scope-A", "system-err", future());
 		await expect(ceremony.consume("scope-A", "system-err")).rejects.toBe(innerError);
 	});

--- a/packages/core/src/challenges/ceremony.mts
+++ b/packages/core/src/challenges/ceremony.mts
@@ -43,9 +43,7 @@ export interface DefaultChallengeCeremonyDeps {
  *
  * Per A1 §6 + §6.1.
  */
-export function createDefaultChallengeCeremony(
-	deps: DefaultChallengeCeremonyDeps,
-): ChallengeCeremony {
+export function createChallengeCeremony(deps: DefaultChallengeCeremonyDeps): ChallengeCeremony {
 	return {
 		async consume(scope, value): Promise<ChallengeCeremonyOutcome> {
 			// Step 1: find — lookup the challenge.

--- a/packages/core/src/challenges/ceremony.mts
+++ b/packages/core/src/challenges/ceremony.mts
@@ -18,16 +18,16 @@ import { ChallengeStorageError } from "./errors.mjs";
 import type { ChallengeCeremony, ChallengeCeremonyOutcome, ChallengeStore } from "./types.mjs";
 
 /**
- * Inputs for the default 3-outcome challenge ceremony composition.
+ * Inputs for the 3-outcome challenge ceremony composition.
  * Per A1 §6 (lines 341-398).
  */
-export interface DefaultChallengeCeremonyDeps {
+export interface ChallengeCeremonyDeps {
 	readonly challengeStore: ChallengeStore;
 	readonly replaySeenSet: ReplaySeenSet;
 }
 
 /**
- * Default ChallengeCeremony composition: combines ChallengeStore (issue/find/
+ * ChallengeCeremony composition: combines ChallengeStore (issue/find/
  * consume) and ReplaySeenSet (markSeen/contains) into the 3-outcome wrapper
  * (consumed | replayed | unknown).
  *
@@ -43,7 +43,7 @@ export interface DefaultChallengeCeremonyDeps {
  *
  * Per A1 §6 + §6.1.
  */
-export function createChallengeCeremony(deps: DefaultChallengeCeremonyDeps): ChallengeCeremony {
+export function createChallengeCeremony(deps: ChallengeCeremonyDeps): ChallengeCeremony {
 	return {
 		async consume(scope, value): Promise<ChallengeCeremonyOutcome> {
 			// Step 1: find — lookup the challenge.

--- a/packages/core/src/challenges/module.mts
+++ b/packages/core/src/challenges/module.mts
@@ -15,7 +15,7 @@
  */
 import { defineModule } from "../modules/manifest/index.mjs";
 import { createMemoryChallengeStore } from "./adapters/memory.mjs";
-import { createDefaultChallengeCeremony } from "./ceremony.mjs";
+import { createChallengeCeremony } from "./ceremony.mjs";
 
 /**
  * Built-in module that provides the in-process memory ChallengeStore.
@@ -42,7 +42,7 @@ export const defaultChallengeCeremonyModule = defineModule({
 	requires: ["challengeStore", "replaySeenSet"] as const,
 	provides: {
 		challengeCeremony: (deps) =>
-			createDefaultChallengeCeremony({
+			createChallengeCeremony({
 				challengeStore: deps.challengeStore,
 				replaySeenSet: deps.replaySeenSet,
 			}),

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -300,8 +300,8 @@ export { createMemoryChallengeStore } from "./challenges/adapters/memory.mjs";
 export { canonicalKey as canonicalChallengeKey } from "./challenges/canonical-key.mjs";
 // Default composition
 export {
+	type ChallengeCeremonyDeps,
 	createChallengeCeremony,
-	type DefaultChallengeCeremonyDeps,
 } from "./challenges/ceremony.mjs";
 export type { ChallengeStorageErrorReason } from "./challenges/errors.mjs";
 // Errors
@@ -356,11 +356,11 @@ export {
 
 export {
 	createRefreshTokenFamilyRevocation,
-	type DefaultRefreshTokenFamilyRevocationDeps,
+	type RefreshTokenFamilyRevocationDeps,
 } from "./refresh-token-family/revocation.mjs";
 export {
 	createRefreshTokenFamilyRotation,
-	type DefaultRefreshTokenFamilyRotationDeps,
+	type RefreshTokenFamilyRotationDeps,
 } from "./refresh-token-family/rotation.mjs";
 export type {
 	DisposableRefreshTokenFamilyClient,

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -251,7 +251,7 @@ export {
 } from "./repositories/InMemoryUserRepository.mjs";
 export { loadYamlMap } from "./repositories/loadYamlMap.mjs";
 // Default repository factories
-export { createDefaultFactories } from "./repositories/RepositoryFactory.mjs";
+export { createRepositoryFactories } from "./repositories/RepositoryFactory.mjs";
 export type { Client, Code, CodeData, User } from "./repositories/types.mjs";
 export type { UserRepository } from "./repositories/UserRepository.mjs";
 export {
@@ -266,12 +266,11 @@ export { createInMemorySessionRPRegistry } from "./user-sessions/memory/sessionR
 export { createInMemoryUserSessionStore } from "./user-sessions/memory/userSessionStore.mjs";
 export { memorySessionStoresModule } from "./user-sessions/modules/memory.mjs";
 // ---------------------------------------------------------------------------
-// A4 user-sessions (post v0.5.0 redesign): 4-way decomposition + Future-Use
-// MutableUserSessionStore. Per spec §5.1-§5.7, §7.1, §8.1.
+// A4 user-sessions (post v0.5.0 redesign): 4-way decomposition.
+// Per spec §5.1-§5.7, §7.1, §8.1.
 // ---------------------------------------------------------------------------
 export type {
 	CreateUserSessionInput,
-	MutableUserSessionStore,
 	RegisteredRP,
 	SessionFamilyIndex,
 	SessionFamilyIndexFactory,
@@ -301,7 +300,7 @@ export { createMemoryChallengeStore } from "./challenges/adapters/memory.mjs";
 export { canonicalKey as canonicalChallengeKey } from "./challenges/canonical-key.mjs";
 // Default composition
 export {
-	createDefaultChallengeCeremony,
+	createChallengeCeremony,
 	type DefaultChallengeCeremonyDeps,
 } from "./challenges/ceremony.mjs";
 export type { ChallengeStorageErrorReason } from "./challenges/errors.mjs";
@@ -356,11 +355,11 @@ export {
 } from "./refresh-token-family/module.mjs";
 
 export {
-	createDefaultRefreshTokenFamilyRevocation,
+	createRefreshTokenFamilyRevocation,
 	type DefaultRefreshTokenFamilyRevocationDeps,
 } from "./refresh-token-family/revocation.mjs";
 export {
-	createDefaultRefreshTokenFamilyRotation,
+	createRefreshTokenFamilyRotation,
 	type DefaultRefreshTokenFamilyRotationDeps,
 } from "./refresh-token-family/rotation.mjs";
 export type {

--- a/packages/core/src/modules/manifest/__tests__/legacy-slots-absent.test.mts
+++ b/packages/core/src/modules/manifest/__tests__/legacy-slots-absent.test.mts
@@ -14,7 +14,7 @@ import { expectTypeOf, test } from "vitest";
 //     refreshTokenFamilyRevocation (A3)
 //   - userSessionStore (A4 — narrowed type, NOT UserSessionStoreBase),
 //     sessionRPRegistry, sessionFamilyIndex, sessionFederationIndex,
-//     mutableUserSessionStore (Future Use), redisClient (A1)
+//     redisClient (A1)
 //
 // This test mirrors the namespace-level test in component-map.test.mts
 // but imports from the package boundary `@o3co/auth-provider-core`.

--- a/packages/core/src/refresh-token-family/__tests__/revocation.test.mts
+++ b/packages/core/src/refresh-token-family/__tests__/revocation.test.mts
@@ -4,7 +4,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { createMemoryRefreshTokenFamilyStore } from "../adapters/memory.mjs";
-import { createDefaultRefreshTokenFamilyRevocation } from "../revocation.mjs";
+import { createRefreshTokenFamilyRevocation } from "../revocation.mjs";
 import type {
 	RefreshTokenFamily,
 	RefreshTokenFamilyStore,
@@ -15,7 +15,7 @@ const FUTURE = (): number => Date.now() + 60_000;
 
 const seed = async () => {
 	const store = createMemoryRefreshTokenFamilyStore();
-	const revocation = createDefaultRefreshTokenFamilyRevocation({
+	const revocation = createRefreshTokenFamilyRevocation({
 		refreshTokenFamilyStore: store,
 	});
 	await store.registerFamily({
@@ -27,7 +27,7 @@ const seed = async () => {
 	return { store, revocation };
 };
 
-describe("createDefaultRefreshTokenFamilyRevocation", () => {
+describe("createRefreshTokenFamilyRevocation", () => {
 	it("revokeFamily flips revoked to true", async () => {
 		const { store, revocation } = await seed();
 		await revocation.revokeFamily("fam-1");
@@ -89,7 +89,7 @@ describe("createDefaultRefreshTokenFamilyRevocation", () => {
 				return { outcome: "committed", family: Object.freeze({ ...next }) };
 			},
 		};
-		const revocation = createDefaultRefreshTokenFamilyRevocation({
+		const revocation = createRefreshTokenFamilyRevocation({
 			refreshTokenFamilyStore: stubStore,
 		});
 		await revocation.revokeFamily("fam-1");

--- a/packages/core/src/refresh-token-family/__tests__/rotation.test.mts
+++ b/packages/core/src/refresh-token-family/__tests__/rotation.test.mts
@@ -5,14 +5,14 @@
 import { describe, expect, it } from "vitest";
 import { createMemoryRefreshTokenFamilyStore } from "../adapters/memory.mjs";
 import { RefreshTokenStorageError } from "../errors.mjs";
-import { createDefaultRefreshTokenFamilyRotation } from "../rotation.mjs";
+import { createRefreshTokenFamilyRotation } from "../rotation.mjs";
 
 const FUTURE = (): number => Date.now() + 60_000;
 
-describe("createDefaultRefreshTokenFamilyRotation", () => {
+describe("createRefreshTokenFamilyRotation", () => {
 	it("register then findFamily shows the new family", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
+		const rotation = createRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		await rotation.register("jti-1", "fam-1", FUTURE());
 		const fam = await store.findFamily("fam-1");
 		expect(fam).not.toBeNull();
@@ -22,7 +22,7 @@ describe("createDefaultRefreshTokenFamilyRotation", () => {
 
 	it("register throws duplicate-family on second call", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
+		const rotation = createRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		await rotation.register("jti-1", "fam-1", FUTURE());
 		await expect(rotation.register("jti-2", "fam-1", FUTURE())).rejects.toMatchObject({
 			name: "RefreshTokenStorageError",
@@ -32,7 +32,7 @@ describe("createDefaultRefreshTokenFamilyRotation", () => {
 
 	it("register throws expired-at-issue when expiresAt is past", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
+		const rotation = createRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		await expect(rotation.register("jti-1", "fam-1", Date.now() - 1)).rejects.toBeInstanceOf(
 			RefreshTokenStorageError,
 		);
@@ -40,7 +40,7 @@ describe("createDefaultRefreshTokenFamilyRotation", () => {
 
 	it("rotate returns 'rotated' when previousJti matches and family is healthy", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
+		const rotation = createRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		await rotation.register("jti-1", "fam-1", FUTURE());
 		const out = await rotation.rotate("jti-1", "jti-2", "fam-1", FUTURE());
 		expect(out.outcome).toBe("rotated");
@@ -50,7 +50,7 @@ describe("createDefaultRefreshTokenFamilyRotation", () => {
 
 	it("rotate returns 'replayed' when previousJti does NOT match the active jti", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
+		const rotation = createRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		await rotation.register("jti-1", "fam-1", FUTURE());
 		// Try to rotate using a stale previousJti.
 		const out = await rotation.rotate("jti-stale", "jti-2", "fam-1", FUTURE());
@@ -61,7 +61,7 @@ describe("createDefaultRefreshTokenFamilyRotation", () => {
 
 	it("rotate returns 'revoked' when family is revoked (regardless of previousJti match)", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
+		const rotation = createRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		await rotation.register("jti-1", "fam-1", FUTURE());
 		await store.updateFamily("fam-1", (cur) => ({ ...cur, revoked: true }));
 		const out = await rotation.rotate("jti-1", "jti-2", "fam-1", FUTURE());
@@ -70,14 +70,14 @@ describe("createDefaultRefreshTokenFamilyRotation", () => {
 
 	it("rotate returns 'unknown_family' when family does not exist", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
+		const rotation = createRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		const out = await rotation.rotate("jti-x", "jti-y", "ghost-fam", FUTURE());
 		expect(out.outcome).toBe("unknown_family");
 	});
 
 	it("outcome objects are frozen at runtime", async () => {
 		const store = createMemoryRefreshTokenFamilyStore();
-		const rotation = createDefaultRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
+		const rotation = createRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 		await rotation.register("jti-1", "fam-1", FUTURE());
 		const rotated = await rotation.rotate("jti-1", "jti-2", "fam-1", FUTURE());
 		expect(Object.isFrozen(rotated)).toBe(true);

--- a/packages/core/src/refresh-token-family/module.mts
+++ b/packages/core/src/refresh-token-family/module.mts
@@ -15,8 +15,8 @@
  */
 import { defineModule } from "../modules/manifest/define-module.mjs";
 import { createMemoryRefreshTokenFamilyStore } from "./adapters/memory.mjs";
-import { createDefaultRefreshTokenFamilyRevocation } from "./revocation.mjs";
-import { createDefaultRefreshTokenFamilyRotation } from "./rotation.mjs";
+import { createRefreshTokenFamilyRevocation } from "./revocation.mjs";
+import { createRefreshTokenFamilyRotation } from "./rotation.mjs";
 
 /**
  * Memory-backed RefreshTokenFamilyStore module. Test + dev only — no
@@ -46,7 +46,7 @@ export const defaultRefreshTokenFamilyRotationModule = defineModule({
 	requires: ["refreshTokenFamilyStore"] as const,
 	provides: {
 		refreshTokenFamilyRotation: (deps) =>
-			createDefaultRefreshTokenFamilyRotation({
+			createRefreshTokenFamilyRotation({
 				refreshTokenFamilyStore: deps.refreshTokenFamilyStore,
 			}),
 	},
@@ -63,7 +63,7 @@ export const defaultRefreshTokenFamilyRevocationModule = defineModule({
 	requires: ["refreshTokenFamilyStore"] as const,
 	provides: {
 		refreshTokenFamilyRevocation: (deps) =>
-			createDefaultRefreshTokenFamilyRevocation({
+			createRefreshTokenFamilyRevocation({
 				refreshTokenFamilyStore: deps.refreshTokenFamilyStore,
 			}),
 	},

--- a/packages/core/src/refresh-token-family/revocation.mts
+++ b/packages/core/src/refresh-token-family/revocation.mts
@@ -37,7 +37,7 @@ export interface DefaultRefreshTokenFamilyRevocationDeps {
  *
  * Per A3 §6.2.
  */
-export function createDefaultRefreshTokenFamilyRevocation(
+export function createRefreshTokenFamilyRevocation(
 	deps: DefaultRefreshTokenFamilyRevocationDeps,
 ): RefreshTokenFamilyRevocation {
 	return {

--- a/packages/core/src/refresh-token-family/revocation.mts
+++ b/packages/core/src/refresh-token-family/revocation.mts
@@ -16,15 +16,15 @@
 import type { RefreshTokenFamilyRevocation, RefreshTokenFamilyStore } from "./types.mjs";
 
 /**
- * Inputs for the default RefreshTokenFamilyRevocation composition.
+ * Inputs for the RefreshTokenFamilyRevocation composition.
  * Per A3 §6.2.
  */
-export interface DefaultRefreshTokenFamilyRevocationDeps {
+export interface RefreshTokenFamilyRevocationDeps {
 	readonly refreshTokenFamilyStore: RefreshTokenFamilyStore;
 }
 
 /**
- * Default RefreshTokenFamilyRevocation composition.
+ * RefreshTokenFamilyRevocation composition.
  *
  * `revokeFamily` is idempotent: returning null from the updater on
  * already-revoked state classifies as "aborted" at the storage layer,
@@ -38,7 +38,7 @@ export interface DefaultRefreshTokenFamilyRevocationDeps {
  * Per A3 §6.2.
  */
 export function createRefreshTokenFamilyRevocation(
-	deps: DefaultRefreshTokenFamilyRevocationDeps,
+	deps: RefreshTokenFamilyRevocationDeps,
 ): RefreshTokenFamilyRevocation {
 	return {
 		async revokeFamily(familyId) {

--- a/packages/core/src/refresh-token-family/rotation.mts
+++ b/packages/core/src/refresh-token-family/rotation.mts
@@ -45,7 +45,7 @@ export interface DefaultRefreshTokenFamilyRotationDeps {
  *
  * Per A3 §6.1.
  */
-export function createDefaultRefreshTokenFamilyRotation(
+export function createRefreshTokenFamilyRotation(
 	deps: DefaultRefreshTokenFamilyRotationDeps,
 ): RefreshTokenFamilyRotation {
 	return {

--- a/packages/core/src/refresh-token-family/rotation.mts
+++ b/packages/core/src/refresh-token-family/rotation.mts
@@ -21,15 +21,15 @@ import type {
 } from "./types.mjs";
 
 /**
- * Inputs for the default RefreshTokenFamilyRotation composition.
+ * Inputs for the RefreshTokenFamilyRotation composition.
  * Per A3 §6.1.
  */
-export interface DefaultRefreshTokenFamilyRotationDeps {
+export interface RefreshTokenFamilyRotationDeps {
 	readonly refreshTokenFamilyStore: RefreshTokenFamilyStore;
 }
 
 /**
- * Default RefreshTokenFamilyRotation composition: builds a fresh
+ * RefreshTokenFamilyRotation composition: builds a fresh
  * RefreshTokenFamily aggregate on `register`, and translates
  * RefreshTokenFamilyStore.updateFamily outcomes into the 4-variant
  * RefreshTokenFamilyRotationOutcome on `rotate`.
@@ -46,7 +46,7 @@ export interface DefaultRefreshTokenFamilyRotationDeps {
  * Per A3 §6.1.
  */
 export function createRefreshTokenFamilyRotation(
-	deps: DefaultRefreshTokenFamilyRotationDeps,
+	deps: RefreshTokenFamilyRotationDeps,
 ): RefreshTokenFamilyRotation {
 	return {
 		async register(newJti, familyId, expiresAtMs) {

--- a/packages/core/src/refresh-token-family/types.mts
+++ b/packages/core/src/refresh-token-family/types.mts
@@ -125,7 +125,7 @@ export interface RefreshTokenFamilyStore {
 	 *   - Updater MAY use a closure-captured variable to communicate the
 	 *     abort reason to the caller; the closure is reset at the top of
 	 *     each updater invocation. This is the wrapper pattern used by
-	 *     `createDefaultRefreshTokenFamilyRotation` to translate "aborted"
+	 *     `createRefreshTokenFamilyRotation` to translate "aborted"
 	 *     results into "replayed" or "revoked" outcomes.
 	 *   - Updater MUST NOT return a RefreshTokenFamily whose `expiresAtMs` is
 	 *     `<= now()`. Both adapters fail-closed by throwing
@@ -175,7 +175,7 @@ export type RefreshTokenFamilyRotationOutcome =
 /**
  * Rotation ceremony wrapper. Composes `RefreshTokenFamilyStore.updateFamily`
  * into the 4-outcome union. The default impl
- * (`createDefaultRefreshTokenFamilyRotation`) is shipped as
+ * (`createRefreshTokenFamilyRotation`) is shipped as
  * `defaultRefreshTokenFamilyRotationModule`; consumers needing custom policy
  * (audit-emitting rotation, grace-period rotation, etc.) replace the
  * module with their own.
@@ -225,7 +225,7 @@ export interface RefreshTokenFamilyRotation {
  * authentication flow), different callers, different expected outcomes.
  *
  * Idempotent revoke + read-only check. The default impl
- * (`createDefaultRefreshTokenFamilyRevocation`) ships as
+ * (`createRefreshTokenFamilyRevocation`) ships as
  * `defaultRefreshTokenFamilyRevocationModule`.
  *
  * Per A3 §5.3.

--- a/packages/core/src/repositories/RepositoryFactory.mts
+++ b/packages/core/src/repositories/RepositoryFactory.mts
@@ -29,7 +29,7 @@ import type { UserRepository } from "./UserRepository.mjs";
  *   - `@o3co/auth-provider-foundation` `registerBuiltinAdapters` — http user repo
  *   - `@o3co/auth-provider-redis` builders (e.g. `redisCodeRepositoryBuilder`)
  */
-export const createDefaultFactories = (): {
+export const createRepositoryFactories = (): {
 	clientFactory: AdapterFactory<ClientRepository>;
 	userFactory: AdapterFactory<UserRepository>;
 	codeFactory: AdapterFactory<CodeRepository>;

--- a/packages/core/src/repositories/__tests__/createRepositoryFactories.test.mts
+++ b/packages/core/src/repositories/__tests__/createRepositoryFactories.test.mts
@@ -24,7 +24,7 @@ describe("createRepositoryFactories", () => {
 	let tmpDir: string;
 
 	beforeEach(() => {
-		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "create-default-factories-"));
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "create-repository-factories-"));
 	});
 
 	afterEach(() => {

--- a/packages/core/src/repositories/__tests__/createRepositoryFactories.test.mts
+++ b/packages/core/src/repositories/__tests__/createRepositoryFactories.test.mts
@@ -18,9 +18,9 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AdapterFactoryError } from "#/adapters/AdapterFactory.mjs";
-import { createDefaultFactories } from "#/repositories/RepositoryFactory.mjs";
+import { createRepositoryFactories } from "#/repositories/RepositoryFactory.mjs";
 
-describe("createDefaultFactories", () => {
+describe("createRepositoryFactories", () => {
 	let tmpDir: string;
 
 	beforeEach(() => {
@@ -50,7 +50,7 @@ describe("createDefaultFactories", () => {
 `,
 			);
 
-			const { clientFactory } = createDefaultFactories();
+			const { clientFactory } = createRepositoryFactories();
 			const repo = await clientFactory.create({ type: "yaml", path: yamlPath });
 			const client = await repo.findById("my-client");
 
@@ -61,7 +61,7 @@ describe("createDefaultFactories", () => {
 		});
 
 		it("throws AdapterFactoryError for unregistered type", async () => {
-			const { clientFactory } = createDefaultFactories();
+			const { clientFactory } = createRepositoryFactories();
 
 			await expect(clientFactory.create({ type: "redis" })).rejects.toBeInstanceOf(
 				AdapterFactoryError,
@@ -87,7 +87,7 @@ describe("createDefaultFactories", () => {
 `,
 			);
 
-			const { userFactory } = createDefaultFactories();
+			const { userFactory } = createRepositoryFactories();
 			const repo = await userFactory.create({ type: "yaml", path: yamlPath });
 			const user = await repo.authenticate("alice", "plainpass");
 
@@ -96,7 +96,7 @@ describe("createDefaultFactories", () => {
 		});
 
 		it("throws AdapterFactoryError for unregistered type", async () => {
-			const { userFactory } = createDefaultFactories();
+			const { userFactory } = createRepositoryFactories();
 
 			await expect(userFactory.create({ type: "http" })).rejects.toBeInstanceOf(
 				AdapterFactoryError,
@@ -115,7 +115,7 @@ describe("createDefaultFactories", () => {
 
 	describe("codeFactory", () => {
 		it("creates a code repository from memory config and supports createCode/getByCode", async () => {
-			const { codeFactory } = createDefaultFactories();
+			const { codeFactory } = createRepositoryFactories();
 			const repo = await codeFactory.create({ type: "memory" });
 			const code = await repo.createCode({});
 
@@ -126,35 +126,35 @@ describe("createDefaultFactories", () => {
 		});
 
 		it("rejects non-numeric defaultExpiresIn", async () => {
-			const { codeFactory } = createDefaultFactories();
+			const { codeFactory } = createRepositoryFactories();
 			await expect(
 				codeFactory.create({ type: "memory", defaultExpiresIn: "not-a-number" }),
 			).rejects.toThrow('"defaultExpiresIn" must be a finite positive number');
 		});
 
 		it("rejects Infinity defaultExpiresIn", async () => {
-			const { codeFactory } = createDefaultFactories();
+			const { codeFactory } = createRepositoryFactories();
 			await expect(
 				codeFactory.create({ type: "memory", defaultExpiresIn: Infinity }),
 			).rejects.toThrow('"defaultExpiresIn" must be a finite positive number');
 		});
 
 		it("rejects negative defaultExpiresIn", async () => {
-			const { codeFactory } = createDefaultFactories();
+			const { codeFactory } = createRepositoryFactories();
 			await expect(codeFactory.create({ type: "memory", defaultExpiresIn: -1 })).rejects.toThrow(
 				'"defaultExpiresIn" must be a finite positive number',
 			);
 		});
 
 		it("rejects zero defaultExpiresIn", async () => {
-			const { codeFactory } = createDefaultFactories();
+			const { codeFactory } = createRepositoryFactories();
 			await expect(codeFactory.create({ type: "memory", defaultExpiresIn: 0 })).rejects.toThrow(
 				'"defaultExpiresIn" must be a finite positive number',
 			);
 		});
 
 		it("throws AdapterFactoryError for unregistered type", async () => {
-			const { codeFactory } = createDefaultFactories();
+			const { codeFactory } = createRepositoryFactories();
 
 			await expect(codeFactory.create({ type: "redis" })).rejects.toBeInstanceOf(
 				AdapterFactoryError,
@@ -172,9 +172,9 @@ describe("createDefaultFactories", () => {
 	});
 });
 
-describe("createDefaultFactories — AdapterFactory shape", () => {
+describe("createRepositoryFactories — AdapterFactory shape", () => {
 	it("returns factories that expose register/create/registeredTypes", () => {
-		const { clientFactory, userFactory, codeFactory } = createDefaultFactories();
+		const { clientFactory, userFactory, codeFactory } = createRepositoryFactories();
 
 		for (const factory of [clientFactory, userFactory, codeFactory]) {
 			expect(typeof factory.register).toBe("function");
@@ -184,7 +184,7 @@ describe("createDefaultFactories — AdapterFactory shape", () => {
 	});
 
 	it("pre-registers yaml + static for client/user, memory for code", () => {
-		const { clientFactory, userFactory, codeFactory } = createDefaultFactories();
+		const { clientFactory, userFactory, codeFactory } = createRepositoryFactories();
 
 		expect(clientFactory.registeredTypes().sort()).toEqual(["static", "yaml"]);
 		expect(userFactory.registeredTypes().sort()).toEqual(["static", "yaml"]);

--- a/packages/core/src/user-sessions/__tests__/types.test.mts
+++ b/packages/core/src/user-sessions/__tests__/types.test.mts
@@ -19,7 +19,6 @@ import { expectTypeOf, test } from "vitest";
 import type { AdapterFactory } from "../../adapters/AdapterFactory.mjs";
 import type {
 	CreateUserSessionInput,
-	MutableUserSessionStore,
 	RegisteredRP,
 	SessionFamilyIndex,
 	SessionFamilyIndexFactory,
@@ -106,21 +105,7 @@ test("SessionFederationIndex has 4 methods including per-element remove", () => 
 	>();
 });
 
-test("MutableUserSessionStore extends UserSessionStore with synchronous claims-only updater", () => {
-	type Updater = MutableUserSessionStore["update"];
-	expectTypeOf<Updater>().toEqualTypeOf<
-		(
-			sid: string,
-			updater: (current: Readonly<UserSession>) => Readonly<UserSessionClaims> | null,
-		) => Promise<UserSession | null>
-	>();
-});
-
-test("MutableUserSessionStore is assignable to UserSessionStore (extends relationship)", () => {
-	expectTypeOf<MutableUserSessionStore>().toMatchTypeOf<UserSessionStore>();
-});
-
-test("ComponentMap declaration-merge: 4 store slots + 1 mutable slot, all optional", () => {
+test("ComponentMap declaration-merge: 4 store slots, all optional", () => {
 	expectTypeOf<ComponentMap["userSessionStore"]>().toEqualTypeOf<UserSessionStore | undefined>();
 	expectTypeOf<ComponentMap["sessionRPRegistry"]>().toEqualTypeOf<SessionRPRegistry | undefined>();
 	expectTypeOf<ComponentMap["sessionFamilyIndex"]>().toEqualTypeOf<
@@ -128,9 +113,6 @@ test("ComponentMap declaration-merge: 4 store slots + 1 mutable slot, all option
 	>();
 	expectTypeOf<ComponentMap["sessionFederationIndex"]>().toEqualTypeOf<
 		SessionFederationIndex | undefined
-	>();
-	expectTypeOf<ComponentMap["mutableUserSessionStore"]>().toEqualTypeOf<
-		MutableUserSessionStore | undefined
 	>();
 });
 

--- a/packages/core/src/user-sessions/types.mts
+++ b/packages/core/src/user-sessions/types.mts
@@ -49,7 +49,7 @@ export interface RegisteredRP {
 
 /**
  * Authenticated user session aggregate. Post-create immutable at v0.5.0
- * (claims update deferred to v0.6+ MutableUserSessionStore). Per A4 §5.1.
+ * (claims update deferred post-publish). Per A4 §5.1.
  */
 export interface UserSession {
 	readonly sid: string;
@@ -79,7 +79,7 @@ export interface CreateUserSessionInput {
 
 /**
  * Sid-keyed store for the authenticated user session. Post-create immutable
- * at v0.5.0; for claims update see `MutableUserSessionStore`. Per A4 §5.1.
+ * at v0.5.0 (claims update deferred post-publish). Per A4 §5.1.
  *
  * Cascade semantics: `delete(sid)` is the global session-invalidation
  * primitive. Sibling reverse-index stores hold orphan entries naturally
@@ -159,31 +159,6 @@ export interface SessionFederationIndex {
 	removeBySid(sid: string): Promise<void>;
 }
 
-/**
- * **PRE-DECLARED ONLY at v0.5.0** — no v0.5.0 implementation, no v0.5.0
- * caller. Type is shipped as a structural constraint for future (v0.6+)
- * implementers. Per A4 §5.5.
- *
- * Updater contract:
- *  - synchronous (returns a value, not a Promise)
- *  - receives `Readonly<UserSession>`; MUST NOT mutate in place
- *  - returns a new `UserSessionClaims` to commit, or `null` to abort
- *  - identity/lifetime fields (sid/sub/authTime/createdAt/expiresAt) are
- *    structurally unchanged by the implementation; updater returns CLAIMS only
- *  - MAY be invoked multiple times due to CAS retry; MUST be replay-safe
- *
- * Driver: TODO-F federation-token-lifecycle (v0.6+ federation re-link claim
- * propagation). When that lands the implementation MUST add memory + redis
- * adapters and the consuming feature MUST declare
- * `requires: ["mutableUserSessionStore"] as const`.
- */
-export interface MutableUserSessionStore extends UserSessionStore {
-	update(
-		sid: string,
-		updater: (current: Readonly<UserSession>) => Readonly<UserSessionClaims> | null,
-	): Promise<UserSession | null>;
-}
-
 // ---------------------------------------------------------------------------
 // AdapterFactory aliases (Theme C: composition-root, throw-on-duplicate)
 // ---------------------------------------------------------------------------
@@ -194,7 +169,7 @@ export type SessionFamilyIndexFactory = AdapterFactory<SessionFamilyIndex>;
 export type SessionFederationIndexFactory = AdapterFactory<SessionFederationIndex>;
 
 // ---------------------------------------------------------------------------
-// ComponentMap declaration-merge (5 slots, all optional)
+// ComponentMap declaration-merge (4 slots, all optional)
 // ---------------------------------------------------------------------------
 
 declare module "@o3co/auth-provider-core" {
@@ -203,12 +178,6 @@ declare module "@o3co/auth-provider-core" {
 		readonly sessionRPRegistry?: SessionRPRegistry;
 		readonly sessionFamilyIndex?: SessionFamilyIndex;
 		readonly sessionFederationIndex?: SessionFederationIndex;
-		/**
-		 * Optional capability slot for adapters that implement
-		 * `MutableUserSessionStore`. Reserved for v0.6+ federation re-link
-		 * claim propagation; no v0.5.0 implementation.
-		 */
-		readonly mutableUserSessionStore?: MutableUserSessionStore;
 	}
 }
 

--- a/packages/federation-github/README.md
+++ b/packages/federation-github/README.md
@@ -24,7 +24,6 @@ const githubConfigBridgeModule = defineModule({
       const slice = extractFederationSection(deps.config.federations, "github");
       if (!slice) throw new Error("federations.github must be enabled");
       return {
-        name: "github",
         clientId: slice.clientId as string,
         clientSecret: slice.clientSecret as string,
         callbackURL: slice.callbackURL as string,
@@ -44,15 +43,14 @@ const handle = await createApp({
 });
 ```
 
-For advanced or multi-tenant setups, call `createGithubProvider(config)`
-directly and wrap with a custom `defineModule(...)` factory per
-A2-α §7.1.
+v0.5.0 is single-tenant: `provider.name` is fixed at `"github"`. Multi-tenant
+setups (multiple GitHub apps in one provider) are deferred post-publish.
 
 ## Public API
 
 - `githubFederationModule` — const Module contributing `federations.github` +
   `federationRedirectPolicies.github`
 - `createGithubProvider(config: GithubProviderConfig): GithubProvider` —
-  pure constructor (advanced / multi-tenant use)
+  pure constructor
 - `GithubProviderConfig`, `GithubProvider` — types
 - `githubFederationConfig` — declared ComponentMap slot for the config bridge

--- a/packages/federation-github/src/__tests__/github-module-boot.test.mts
+++ b/packages/federation-github/src/__tests__/github-module-boot.test.mts
@@ -45,7 +45,6 @@ const minBoot = {
 } as never;
 
 const stubGithubConfig: GithubProviderConfig = {
-	name: "github",
 	clientId: "test-client-id",
 	clientSecret: "test-client-secret",
 	callbackURL: "https://example.com/auth/github/callback",

--- a/packages/federation-github/src/__tests__/github-module.test.mts
+++ b/packages/federation-github/src/__tests__/github-module.test.mts
@@ -35,14 +35,13 @@ describe("githubFederationModule const Module", () => {
 		);
 	});
 
-	it("forces provider.name to 'github' regardless of config.name (Codex P2 fix)", () => {
-		// const-module path is single-tenant — provider.name MUST equal the
-		// contribution key. See google-module.test.mts for the full rationale.
+	it("produces provider.name == 'github' (single-tenant invariant)", () => {
+		// v0.5.0 single-tenant: provider.name is fixed at "github". See
+		// google-module.test.mts for the full rationale.
 		const factory = githubFederationModule.contributes?.federations?.github;
 		if (typeof factory !== "function") throw new Error("factory missing");
 		const provider = factory({
 			githubFederationConfig: {
-				name: "MyTenantGithub", // intentionally divergent
 				clientId: "abc",
 				clientSecret: "xyz",
 				callbackURL: "https://example.com/cb",

--- a/packages/federation-github/src/__tests__/github.test.mts
+++ b/packages/federation-github/src/__tests__/github.test.mts
@@ -46,7 +46,6 @@ import { createGithubProvider } from "../github.mjs";
 
 describe("createGithubProvider on openid-client", () => {
 	const baseConfig = {
-		name: "github",
 		clientId: "client-id",
 		clientSecret: "client-secret",
 		callbackURL: "https://app.example.com/session/oauth/federation/github/callback",

--- a/packages/federation-github/src/github.mts
+++ b/packages/federation-github/src/github.mts
@@ -17,7 +17,7 @@
 import { defineModule } from "@o3co/auth-provider-core";
 import {
 	codeChallenge,
-	createDefaultFederationRedirectPolicy,
+	createFederationRedirectPolicy,
 	type EndSessionRequest,
 	type EndSessionResult,
 	type FederationProfile,
@@ -42,8 +42,6 @@ const SCOPES = ["read:user", "user:email"] as const;
 const GITHUB_EMAILS_URL = "https://api.github.com/user/emails";
 
 export interface GithubProviderConfig {
-	/** Strategy identifier — use a unique name per tenant for multi-tenant setups. */
-	name: string;
 	clientId: string;
 	clientSecret: string;
 	callbackURL: string;
@@ -62,9 +60,7 @@ export type GithubProvider = FederationProvider & SupportsLogout & SupportsClaim
 
 export function createGithubProvider(config: GithubProviderConfig): GithubProvider {
 	if (!config.clientId || !config.clientSecret || !config.callbackURL) {
-		throw new Error(
-			`GitHub federation "${config.name}" requires clientId, clientSecret, and callbackURL`,
-		);
+		throw new Error(`GitHub federation "github" requires clientId, clientSecret, and callbackURL`);
 	}
 
 	// GitHub does not expose an OIDC discovery document, so we construct ServerMetadata manually.
@@ -79,7 +75,7 @@ export function createGithubProvider(config: GithubProviderConfig): GithubProvid
 	const oidcConfig = new oidc.Configuration(serverMetadata, config.clientId, config.clientSecret);
 
 	return {
-		name: config.name,
+		name: "github",
 		scope: SCOPES,
 
 		buildAuthorizationUrl(params: {
@@ -129,7 +125,7 @@ export function createGithubProvider(config: GithubProviderConfig): GithubProvid
 							? ghId
 							: "";
 			if (!sub) {
-				throw new Error(`GitHub federation "${config.name}" received userinfo without id/sub`);
+				throw new Error(`GitHub federation "github" received userinfo without id/sub`);
 			}
 
 			// Fetch primary+verified email from /user/emails.
@@ -196,7 +192,7 @@ export function createGithubProvider(config: GithubProviderConfig): GithubProvid
 					url = new URL(config.endSessionEndpoint);
 				} catch {
 					throw new Error(
-						`GitHub federation "${config.name}" has an invalid endSessionEndpoint: ${config.endSessionEndpoint}`,
+						`GitHub federation "github" has an invalid endSessionEndpoint: ${config.endSessionEndpoint}`,
 					);
 				}
 				if (req.idTokenHint) url.searchParams.set("id_token_hint", req.idTokenHint);
@@ -211,7 +207,7 @@ export function createGithubProvider(config: GithubProviderConfig): GithubProvid
 				url = new URL(base);
 			} catch {
 				throw new Error(
-					`GitHub federation "${config.name}" received an invalid postLogoutRedirectUri: ${base}`,
+					`GitHub federation "github" received an invalid postLogoutRedirectUri: ${base}`,
 				);
 			}
 			if (req.state) url.searchParams.set("state", req.state);
@@ -246,17 +242,13 @@ export const githubFederationModule = defineModule({
 	requires: ["githubFederationConfig"] as const,
 	contributes: {
 		federations: {
-			// const-module path is single-tenant: see google.mts for the full
-			// rationale. provider.name forced to the contribution key "github"
-			// regardless of config.name. Multi-tenant consumers use a factory
-			// wrap per A5 §10.1 + A2-α §7.1.
-			github: (deps) => ({
-				...createGithubProvider(deps.githubFederationConfig),
-				name: "github",
-			}),
+			// v0.5.0 is single-tenant: provider.name is fixed at "github".
+			// Multi-tenant support deferred to post-publish; consumers needing
+			// multiple GitHub apps will get an additive Config shape.
+			github: (deps) => createGithubProvider(deps.githubFederationConfig),
 		},
 		federationRedirectPolicies: {
-			github: (deps) => createDefaultFederationRedirectPolicy(deps.githubFederationConfig),
+			github: (deps) => createFederationRedirectPolicy(deps.githubFederationConfig),
 		},
 	},
 });

--- a/packages/federation-google/README.md
+++ b/packages/federation-google/README.md
@@ -24,7 +24,6 @@ const googleConfigBridgeModule = defineModule({
       const slice = extractFederationSection(deps.config.federations, "google");
       if (!slice) throw new Error("federations.google must be enabled");
       return {
-        name: "google",
         clientId: slice.clientId as string,
         clientSecret: slice.clientSecret as string,
         callbackURL: slice.callbackURL as string,
@@ -44,15 +43,14 @@ const handle = await createApp({
 });
 ```
 
-For advanced or multi-tenant setups, call `createGoogleProvider(config)`
-directly and wrap with a custom `defineModule(...)` factory per
-A2-α §7.1.
+v0.5.0 is single-tenant: `provider.name` is fixed at `"google"`. Multi-tenant
+setups (multiple Google apps in one provider) are deferred post-publish.
 
 ## Public API
 
 - `googleFederationModule` — const Module contributing `federations.google` +
   `federationRedirectPolicies.google`
 - `createGoogleProvider(config: GoogleProviderConfig): GoogleProvider` —
-  pure constructor (advanced / multi-tenant use)
+  pure constructor
 - `GoogleProviderConfig`, `GoogleProvider` — types
 - `googleFederationConfig` — declared ComponentMap slot for the config bridge

--- a/packages/federation-google/src/__tests__/google-module-boot.test.mts
+++ b/packages/federation-google/src/__tests__/google-module-boot.test.mts
@@ -45,7 +45,6 @@ const minBoot = {
 } as never;
 
 const stubGoogleConfig: GoogleProviderConfig = {
-	name: "google",
 	clientId: "test-client-id",
 	clientSecret: "test-client-secret",
 	callbackURL: "https://example.com/auth/google/callback",

--- a/packages/federation-google/src/__tests__/google-module.test.mts
+++ b/packages/federation-google/src/__tests__/google-module.test.mts
@@ -35,16 +35,15 @@ describe("googleFederationModule const Module", () => {
 		);
 	});
 
-	it("forces provider.name to 'google' regardless of config.name (Codex P2 fix)", () => {
-		// const-module path is single-tenant — provider.name MUST equal the
-		// contribution key, even if config.name diverges. The route layer keys
-		// session state / callback URL / redirect-policy lookup by provider.name;
-		// a divergent config.name would silently break runtime resolution.
+	it("produces provider.name == 'google' (single-tenant invariant)", () => {
+		// v0.5.0 single-tenant: provider.name is fixed at "google", matching
+		// the contribution key. The route layer keys session state / callback
+		// URL / redirect-policy lookup by provider.name; no consumer-supplied
+		// name can divert it. Multi-tenant support is deferred post-publish.
 		const factory = googleFederationModule.contributes?.federations?.google;
 		if (typeof factory !== "function") throw new Error("factory missing");
 		const provider = factory({
 			googleFederationConfig: {
-				name: "MyTenantGoogle", // intentionally divergent
 				clientId: "abc",
 				clientSecret: "xyz",
 				callbackURL: "https://example.com/cb",

--- a/packages/federation-google/src/__tests__/google.test.mts
+++ b/packages/federation-google/src/__tests__/google.test.mts
@@ -46,7 +46,6 @@ import { createGoogleProvider } from "../google.mjs";
 
 describe("createGoogleProvider on openid-client", () => {
 	const baseConfig = {
-		name: "google",
 		clientId: "client-id",
 		clientSecret: "client-secret",
 		callbackURL: "https://app.example.com/session/oauth/federation/google/callback",

--- a/packages/federation-google/src/google.mts
+++ b/packages/federation-google/src/google.mts
@@ -17,7 +17,7 @@
 import { defineModule } from "@o3co/auth-provider-core";
 import {
 	codeChallenge,
-	createDefaultFederationRedirectPolicy,
+	createFederationRedirectPolicy,
 	type EndSessionRequest,
 	type EndSessionResult,
 	type FederationProfile,
@@ -43,8 +43,6 @@ const GOOGLE_ISSUER = "https://accounts.google.com";
 const SCOPES = ["openid", "profile", "email"] as const;
 
 export interface GoogleProviderConfig {
-	/** Strategy identifier — use a unique name per tenant for multi-tenant setups. */
-	name: string;
 	clientId: string;
 	clientSecret: string;
 	callbackURL: string;
@@ -66,9 +64,7 @@ export type GoogleProvider = FederationProvider &
 
 export function createGoogleProvider(config: GoogleProviderConfig): GoogleProvider {
 	if (!config.clientId || !config.clientSecret || !config.callbackURL) {
-		throw new Error(
-			`Google federation "${config.name}" requires clientId, clientSecret, and callbackURL`,
-		);
+		throw new Error(`Google federation "google" requires clientId, clientSecret, and callbackURL`);
 	}
 
 	// ServerMetadata constructed locally — no discovery call. Google's endpoints are stable.
@@ -83,7 +79,7 @@ export function createGoogleProvider(config: GoogleProviderConfig): GoogleProvid
 	const oidcConfig = new oidc.Configuration(serverMetadata, config.clientId, config.clientSecret);
 
 	return {
-		name: config.name,
+		name: "google",
 		scope: SCOPES,
 
 		buildAuthorizationUrl(params: {
@@ -170,7 +166,7 @@ export function createGoogleProvider(config: GoogleProviderConfig): GoogleProvid
 					url = new URL(config.endSessionEndpoint);
 				} catch {
 					throw new Error(
-						`Google federation "${config.name}" has an invalid endSessionEndpoint: ${config.endSessionEndpoint}`,
+						`Google federation "google" has an invalid endSessionEndpoint: ${config.endSessionEndpoint}`,
 					);
 				}
 				if (req.idTokenHint) url.searchParams.set("id_token_hint", req.idTokenHint);
@@ -185,7 +181,7 @@ export function createGoogleProvider(config: GoogleProviderConfig): GoogleProvid
 				url = new URL(base);
 			} catch {
 				throw new Error(
-					`Google federation "${config.name}" received an invalid postLogoutRedirectUri: ${base}`,
+					`Google federation "google" received an invalid postLogoutRedirectUri: ${base}`,
 				);
 			}
 			if (req.state) url.searchParams.set("state", req.state);
@@ -213,9 +209,8 @@ export function createGoogleProvider(config: GoogleProviderConfig): GoogleProvid
  * — consumer redirect URL policy).
  *
  * Config supplied via the `googleFederationConfig` ComponentMap slot
- * (per A5 §10.1 const-Module pattern). Single-tenant baseline: one Google
- * federation under name "google". Multi-tenant consumers wrap with a factory
- * per A2-α §7.1.
+ * (per A5 §10.1 const-Module pattern). v0.5.0 is single-tenant: the federation
+ * is registered under name "google". Multi-tenant support deferred post-publish.
  *
  * Per A5 §10.1.
  */
@@ -224,19 +219,13 @@ export const googleFederationModule = defineModule({
 	requires: ["googleFederationConfig"] as const,
 	contributes: {
 		federations: {
-			// const-module path is single-tenant: `provider.name` is forced to the
-			// contribution key "google" regardless of `config.name`. The route
-			// layer keys session state, callback URL lookup, and redirect-policy
-			// resolution by `provider.name`; a divergent `config.name` would
-			// cause silent runtime mismatch (provider.name="MyGoogle" registered
-			// at federations.google → resolver lookup with key "MyGoogle" fails).
-			// Multi-tenant consumers wrap with `(config) => Module` per
-			// A5 §10.1 + A2-α §7.1 — that path supplies the contribution key
-			// and `config.name` together.
-			google: (deps) => ({ ...createGoogleProvider(deps.googleFederationConfig), name: "google" }),
+			// v0.5.0 is single-tenant: provider.name is fixed at "google".
+			// Multi-tenant support deferred to post-publish; consumers needing
+			// multiple Google apps will get an additive Config shape.
+			google: (deps) => createGoogleProvider(deps.googleFederationConfig),
 		},
 		federationRedirectPolicies: {
-			google: (deps) => createDefaultFederationRedirectPolicy(deps.googleFederationConfig),
+			google: (deps) => createFederationRedirectPolicy(deps.googleFederationConfig),
 		},
 	},
 });

--- a/packages/foundation/README.ja.md
+++ b/packages/foundation/README.ja.md
@@ -57,10 +57,10 @@ class HttpUserRepository implements UserRepository {
 ## 使い方
 
 ```typescript
-import { createDefaultFactories } from "@o3co/auth-provider-core";
+import { createRepositoryFactories } from "@o3co/auth-provider-core";
 import { registerBuiltinAdapters } from "@o3co/auth-provider-foundation";
 
-const { userFactory } = createDefaultFactories();
+const { userFactory } = createRepositoryFactories();
 
 registerBuiltinAdapters({ userFactory });
 

--- a/packages/foundation/README.md
+++ b/packages/foundation/README.md
@@ -57,10 +57,10 @@ class HttpUserRepository implements UserRepository {
 ## Usage Example
 
 ```typescript
-import { createDefaultFactories } from "@o3co/auth-provider-core";
+import { createRepositoryFactories } from "@o3co/auth-provider-core";
 import { registerBuiltinAdapters } from "@o3co/auth-provider-foundation";
 
-const { userFactory } = createDefaultFactories();
+const { userFactory } = createRepositoryFactories();
 
 registerBuiltinAdapters({ userFactory });
 

--- a/packages/redis/src/userSessionStore.mts
+++ b/packages/redis/src/userSessionStore.mts
@@ -62,8 +62,7 @@ const fromEnvelope = (e: Envelope): UserSession => ({
  * applied via SET PX. The v0.4.x lost-update window is **structurally
  * absent**: this adapter exposes only `create` (atomic SET NX),
  * `get`, `delete`. No GET → mutate → SET path exists at the v0.5.0
- * `UserSessionStore` interface level; claims update lives in the
- * Future-Use `MutableUserSessionStore` (no v0.5.0 implementation).
+ * `UserSessionStore` interface level; claims update is deferred post-publish.
  *
  * Atomicity:
  *  - `create` uses SET NX PX — atomic insert-only, same primitive as A1

--- a/packages/session/README.ja.md
+++ b/packages/session/README.ja.md
@@ -89,7 +89,7 @@ interface FederationProvider {
 - `buildAuthorizationUrl` — RFC 6749 §4.1 + RFC 7636 の認可 URL を構築する。`codeVerifier` はルート層が生成して渡す。`code_challenge` の計算には `codeChallenge(codeVerifier)` を使うこと。
 - `exchangeCode` — 認可コードを `FederationProfile` に交換する。`issuer` と `sub` は必須。
 
-> **Note (A5 split, v0.5.0):** リダイレクト URL のハンドリング（`validateRedirect` / `resolveCallbackRedirect`）は `FederationProvider` から外され、専用の `FederationRedirectPolicy` capability に分離された。per-federation module は `federationRedirectPolicies.<name>` で policy を contribute する。built-in は `createDefaultFederationRedirectPolicy(...)` を使う。カスタム provider は `FederationProvider` 上にこれらのメソッドを実装しない。
+> **Note (A5 split, v0.5.0):** リダイレクト URL のハンドリング（`validateRedirect` / `resolveCallbackRedirect`）は `FederationProvider` から外され、専用の `FederationRedirectPolicy` capability に分離された。per-federation module は `federationRedirectPolicies.<name>` で policy を contribute する。built-in は `createFederationRedirectPolicy(...)` を使う。カスタム provider は `FederationProvider` 上にこれらのメソッドを実装しない。
 
 ---
 
@@ -356,7 +356,7 @@ federations {
 import { defineModule } from "@o3co/auth-provider-core";
 import {
   codeChallenge,
-  createDefaultFederationRedirectPolicy,
+  createFederationRedirectPolicy,
   type FederationProvider,
 } from "@o3co/auth-provider-session";
 
@@ -374,7 +374,7 @@ export const microsoftFederationModule = defineModule({
       microsoft: (deps) => buildMicrosoftProvider(deps.microsoftFederationConfig),
     },
     federationRedirectPolicies: {
-      microsoft: (deps) => createDefaultFederationRedirectPolicy(deps.microsoftFederationConfig),
+      microsoft: (deps) => createFederationRedirectPolicy(deps.microsoftFederationConfig),
     },
   },
 });

--- a/packages/session/README.md
+++ b/packages/session/README.md
@@ -109,7 +109,7 @@ Implement this interface to add a custom OAuth 2.0 / OIDC federation provider. O
 > `resolveCallbackRedirect` — was moved off `FederationProvider` and onto a
 > dedicated `FederationRedirectPolicy` capability. Per-federation modules
 > contribute the policy via `federationRedirectPolicies.<name>`; built-ins
-> use `createDefaultFederationRedirectPolicy(...)`. Custom providers do not
+> use `createFederationRedirectPolicy(...)`. Custom providers do not
 > implement these methods on `FederationProvider`.
 
 ---
@@ -390,7 +390,7 @@ for the reference implementation. The minimal sketch:
 import { defineModule } from "@o3co/auth-provider-core";
 import {
   codeChallenge,
-  createDefaultFederationRedirectPolicy,
+  createFederationRedirectPolicy,
   type FederationProvider,
 } from "@o3co/auth-provider-session";
 
@@ -408,7 +408,7 @@ export const microsoftFederationModule = defineModule({
       microsoft: (deps) => buildMicrosoftProvider(deps.microsoftFederationConfig),
     },
     federationRedirectPolicies: {
-      microsoft: (deps) => createDefaultFederationRedirectPolicy(deps.microsoftFederationConfig),
+      microsoft: (deps) => createFederationRedirectPolicy(deps.microsoftFederationConfig),
     },
   },
 });

--- a/packages/session/src/federations/__tests__/redirect-policy.test.mts
+++ b/packages/session/src/federations/__tests__/redirect-policy.test.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
-import { createDefaultFederationRedirectPolicy } from "../redirect-policy.mjs";
+import { createFederationRedirectPolicy } from "../redirect-policy.mjs";
 
 const baseConfig = {
 	sessionDomain: "example.com",
@@ -22,21 +22,21 @@ const baseConfig = {
 	clientUrl: "https://app.example.com",
 };
 
-describe("createDefaultFederationRedirectPolicy — validateRedirect", () => {
+describe("createFederationRedirectPolicy — validateRedirect", () => {
 	it("accepts a valid URL on the session domain", () => {
-		const policy = createDefaultFederationRedirectPolicy(baseConfig);
+		const policy = createFederationRedirectPolicy(baseConfig);
 		const result = policy.validateRedirect("https://example.com/dashboard");
 		expect(result.ok).toBe(true);
 	});
 
 	it("accepts a subdomain of the session domain", () => {
-		const policy = createDefaultFederationRedirectPolicy(baseConfig);
+		const policy = createFederationRedirectPolicy(baseConfig);
 		const result = policy.validateRedirect("https://sub.example.com/page");
 		expect(result.ok).toBe(true);
 	});
 
 	it("rejects a URL on a different domain", () => {
-		const policy = createDefaultFederationRedirectPolicy(baseConfig);
+		const policy = createFederationRedirectPolicy(baseConfig);
 		const result = policy.validateRedirect("https://evil.com/steal");
 		expect(result.ok).toBe(false);
 		if (!result.ok) {
@@ -46,7 +46,7 @@ describe("createDefaultFederationRedirectPolicy — validateRedirect", () => {
 	});
 
 	it("rejects a URL that exceeds 2048 characters", () => {
-		const policy = createDefaultFederationRedirectPolicy(baseConfig);
+		const policy = createFederationRedirectPolicy(baseConfig);
 		// "https://example.com/" = 21 chars; pad to total > 2048
 		const longUrl = `https://example.com/${"x".repeat(2100)}`;
 		const result = policy.validateRedirect(longUrl);
@@ -58,7 +58,7 @@ describe("createDefaultFederationRedirectPolicy — validateRedirect", () => {
 	});
 
 	it("rejects a non-http/https scheme", () => {
-		const policy = createDefaultFederationRedirectPolicy(baseConfig);
+		const policy = createFederationRedirectPolicy(baseConfig);
 		const result = policy.validateRedirect("ftp://example.com/file");
 		expect(result.ok).toBe(false);
 		if (!result.ok) {
@@ -68,7 +68,7 @@ describe("createDefaultFederationRedirectPolicy — validateRedirect", () => {
 	});
 
 	it("accepts any domain when sessionDomain is not configured", () => {
-		const policy = createDefaultFederationRedirectPolicy({
+		const policy = createFederationRedirectPolicy({
 			authCallbackUrl: "https://app.example.com/auth/callback",
 			clientUrl: "https://app.example.com",
 		});
@@ -77,9 +77,9 @@ describe("createDefaultFederationRedirectPolicy — validateRedirect", () => {
 	});
 });
 
-describe("createDefaultFederationRedirectPolicy — resolveCallbackRedirect", () => {
+describe("createFederationRedirectPolicy — resolveCallbackRedirect", () => {
 	it("returns authCallbackUrl?redirect_to=<encoded> when session has redirectTo", () => {
-		const policy = createDefaultFederationRedirectPolicy(baseConfig);
+		const policy = createFederationRedirectPolicy(baseConfig);
 		const redirectTo = "https://example.com/dashboard";
 		const result = policy.resolveCallbackRedirect({ redirectTo });
 		expect(result.ok).toBe(true);
@@ -91,7 +91,7 @@ describe("createDefaultFederationRedirectPolicy — resolveCallbackRedirect", ()
 	});
 
 	it("returns clientUrl fallback when session has no redirectTo", () => {
-		const policy = createDefaultFederationRedirectPolicy(baseConfig);
+		const policy = createFederationRedirectPolicy(baseConfig);
 		const result = policy.resolveCallbackRedirect({});
 		expect(result.ok).toBe(true);
 		if (result.ok) {
@@ -100,7 +100,7 @@ describe("createDefaultFederationRedirectPolicy — resolveCallbackRedirect", ()
 	});
 
 	it("returns misconfiguration error when redirectTo present but authCallbackUrl absent", () => {
-		const policy = createDefaultFederationRedirectPolicy({
+		const policy = createFederationRedirectPolicy({
 			clientUrl: "https://app.example.com",
 		});
 		const result = policy.resolveCallbackRedirect({ redirectTo: "https://example.com/x" });
@@ -112,7 +112,7 @@ describe("createDefaultFederationRedirectPolicy — resolveCallbackRedirect", ()
 	});
 
 	it("returns misconfiguration error when no redirectTo and clientUrl absent", () => {
-		const policy = createDefaultFederationRedirectPolicy({
+		const policy = createFederationRedirectPolicy({
 			authCallbackUrl: "https://app.example.com/auth/callback",
 		});
 		const result = policy.resolveCallbackRedirect({});
@@ -124,9 +124,9 @@ describe("createDefaultFederationRedirectPolicy — resolveCallbackRedirect", ()
 	});
 });
 
-describe("createDefaultFederationRedirectPolicy — return value is frozen", () => {
+describe("createFederationRedirectPolicy — return value is frozen", () => {
 	it("returned policy is Object.frozen", () => {
-		const policy = createDefaultFederationRedirectPolicy(baseConfig);
+		const policy = createFederationRedirectPolicy(baseConfig);
 		expect(Object.isFrozen(policy)).toBe(true);
 	});
 });

--- a/packages/session/src/federations/redirect-policy.mts
+++ b/packages/session/src/federations/redirect-policy.mts
@@ -64,7 +64,7 @@ export type FederationRedirectPolicyFactory<Deps = ProviderDeps<never, never>> =
 ) => FederationRedirectPolicy;
 
 /**
- * Config slice consumed by the default redirect policy.
+ * Config slice consumed by the redirect policy.
  *
  * This is the v0.4.x helper-facing shape (see `helpers.mts`):
  *   - `sessionDomain`: cookie domain; redirect targets must match or be
@@ -73,12 +73,12 @@ export type FederationRedirectPolicyFactory<Deps = ProviderDeps<never, never>> =
  *     consumer-supplied `redirect_to` query parameter.
  *   - `clientUrl`: fallback redirect when session has no `redirectTo`.
  *
- * A `Pick<RedirectConfig, ...>` projection limits the default policy to the
+ * A `Pick<RedirectConfig, ...>` projection limits the policy to the
  * fields it actually consumes. A5 does NOT invent new field names.
  *
  * Per A5 §9.
  */
-export type DefaultFederationRedirectPolicyConfig = Pick<
+export type FederationRedirectPolicyConfig = Pick<
 	RedirectConfig,
 	"sessionDomain" | "authCallbackUrl" | "clientUrl"
 >;
@@ -95,7 +95,7 @@ export type DefaultFederationRedirectPolicyConfig = Pick<
  * Per A5 §9.
  */
 export function createFederationRedirectPolicy(
-	config: DefaultFederationRedirectPolicyConfig,
+	config: FederationRedirectPolicyConfig,
 ): FederationRedirectPolicy {
 	// Defensive snapshot: detach from caller's reference so post-construction
 	// mutation of the supplied config (e.g. `config.sessionDomain = "evil.com"`

--- a/packages/session/src/federations/redirect-policy.mts
+++ b/packages/session/src/federations/redirect-policy.mts
@@ -94,7 +94,7 @@ export type DefaultFederationRedirectPolicyConfig = Pick<
  *
  * Per A5 §9.
  */
-export function createDefaultFederationRedirectPolicy(
+export function createFederationRedirectPolicy(
 	config: DefaultFederationRedirectPolicyConfig,
 ): FederationRedirectPolicy {
 	// Defensive snapshot: detach from caller's reference so post-construction

--- a/packages/session/src/index.mts
+++ b/packages/session/src/index.mts
@@ -24,7 +24,7 @@ export type {
 	FederationRedirectPolicy,
 	FederationRedirectPolicyFactory,
 } from "./federations/redirect-policy.mjs";
-export { createDefaultFederationRedirectPolicy } from "./federations/redirect-policy.mjs";
+export { createFederationRedirectPolicy } from "./federations/redirect-policy.mjs";
 export type {
 	EndSessionRequest,
 	EndSessionResult,

--- a/packages/session/src/index.mts
+++ b/packages/session/src/index.mts
@@ -20,8 +20,8 @@ export { resolveCallbackRedirect, validateRedirect } from "./federations/helpers
 export { codeChallenge } from "./federations/pkce.mjs";
 // A5 redirect-policy split (per A5 §5.2/§5.3/§9)
 export type {
-	DefaultFederationRedirectPolicyConfig,
 	FederationRedirectPolicy,
+	FederationRedirectPolicyConfig,
 	FederationRedirectPolicyFactory,
 } from "./federations/redirect-policy.mjs";
 export { createFederationRedirectPolicy } from "./federations/redirect-policy.mjs";

--- a/templates/standalone/src/modules.mts
+++ b/templates/standalone/src/modules.mts
@@ -16,13 +16,13 @@
 import path from "node:path";
 import {
 	type AppConfig,
-	createDefaultFactories,
 	createFederationTokenStoreFactory,
 	createInMemorySessionFamilyIndex,
 	createInMemorySessionFederationIndex,
 	createInMemorySessionRPRegistry,
 	createInMemoryUserSessionStore,
 	createKeyStoreFactory,
+	createRepositoryFactories,
 	defineModule,
 	type Module,
 	registerBuiltinFederationTokenStores,
@@ -87,7 +87,7 @@ export const repositoriesModule: Module = defineModule({
 	requires: ["config"] as const,
 	provides: {
 		clientRepository: async ({ config }) => {
-			const { clientFactory, userFactory } = createDefaultFactories();
+			const { clientFactory, userFactory } = createRepositoryFactories();
 			registerBuiltinAdapters({ userFactory });
 			const slice = flattenAdapterConfig(
 				(config as AppConfig).repositories.client as { type: string } & Record<string, unknown>,
@@ -98,7 +98,7 @@ export const repositoriesModule: Module = defineModule({
 			return clientFactory.create(slice);
 		},
 		userRepository: async ({ config }) => {
-			const { userFactory } = createDefaultFactories();
+			const { userFactory } = createRepositoryFactories();
 			registerBuiltinAdapters({ userFactory });
 			return userFactory.create(
 				flattenAdapterConfig(
@@ -107,7 +107,7 @@ export const repositoriesModule: Module = defineModule({
 			);
 		},
 		codeRepository: async ({ config }) => {
-			const { userFactory, codeFactory } = createDefaultFactories();
+			const { userFactory, codeFactory } = createRepositoryFactories();
 			registerBuiltinAdapters({ userFactory });
 			codeFactory.register("redis", redisCodeRepositoryBuilder);
 			return codeFactory.create(
@@ -178,7 +178,7 @@ export const googleFederationConfigModule: Module = defineModule({
 					"federations.google requires clientId, clientSecret, callbackURL when enabled",
 				);
 			}
-			return { name: "google", clientId, clientSecret, callbackURL };
+			return { clientId, clientSecret, callbackURL };
 		},
 	},
 });


### PR DESCRIPTION
## Summary

Pre-tag Interface Review pass 第 2 弾 (Group A). Closes #106.

Builds on PR #105 (RefreshTokenFamilyRotation rename + foundation cleanup, merged ec08289b). v0.5.0 is unpublished pre-1.0; the lens is "is the new shape genuinely better" not "is migration cost worth it".

- **S1** — Drop "Default" prefix from 5 factories + 4 companion Deps/Config types. The prefix implied "1 of N" but only one impl ships; reference libs (node-oidc-provider, NextAuth, Lucia) do not use this pattern. `createDefaultFactories` specifically renamed to `createRepositoryFactories` since it returns repository factories. Module names retain the `default*Module` form where default-ness is the intended distinction.
- **S2** — Remove `name` field from `GithubProviderConfig` / `GoogleProviderConfig`. The const-module forced `provider.name` regardless of consumer input, making the field misleading. v0.5.0 is single-tenant: provider name fixed at `"github"` / `"google"`. Multi-tenant deferred post-publish; can be re-added additively.
- **S5** — Remove `MutableUserSessionStore` interface + `mutableUserSessionStore` ComponentMap slot. Pre-declared for v0.6+ federation re-link claim propagation but had no v0.5.0 impl, no caller, no contract test. Re-add when v0.6 ships an implementation.
- **N1** — Codex earlier flagged `BootErrorReason` count comment stale; verified already accurate post PR #103. **No-op**.

## Why this lands before v0.5.0 tag

Pre-1.0 + breaking-major: trimming dead surface and aligning naming is cheap now, expensive after tag push.

**Rejected from this scope:**
- M1 (`SessionRPRegistry` rename) — Codex + Claude convergent verdict: Don't (OAuth domain term carries semantic weight; shape genuinely differs from `*Index` siblings)
- S4 (`Module` vs `ModuleSpec` dual exposure) — Codex verdict: Don't (`ModuleSpec<R,O>` is authoring shape, `Module` is erased boot-planner value; both serve distinct purposes)
- C1/C2/C3 — Don't (deferred or anti-pattern)
- S3 (`*Client` interface move from core to redis) — Group B 別 PR で扱う

## Verification

- `make test` — 2136 tests pass (S5 で type-shape test 4 件削除分の差分)
- `tsc --noEmit` — clean across all 10 packages
- `biome check` — 0 errors, 15 pre-existing warnings (#71) untouched
- `codex review --commit` — no actionable correctness issues
- `superpowers:code-reviewer` — caught 1 Important (`Default*Deps` parameter type asymmetry) → fixed in 683bcd27

## Commits

1. `dc1bcefc` — drop createDefault prefix + federation single-tenant + drop pre-declared MutableUserSessionStore
2. `683bcd27` — rename Default-prefixed Deps/Config types + minor S1 followups (review fix)

## Test plan

- [x] Full `make test` green
- [x] Typecheck clean
- [x] Lint clean (no new warnings)
- [x] Multi-agent review (Claude + Codex)
- [ ] Copilot review on PR
- [ ] Group B PR after this merges (`*Client` interface move from core to redis)
- [ ] Tag v0.5.0 after Group B merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)