### PR TITLE
fix(create-app): unbrittle versions.json test + add oauth-token-exchange entry

### DIFF
--- a/create-app/scripts/copy-templates.mjs
+++ b/create-app/scripts/copy-templates.mjs
@@ -33,6 +33,9 @@ const versions = {
 		"../../packages/federation-github/package.json",
 	),
 	"@o3co/auth-provider-oauth": readVersion("../../packages/oauth/package.json"),
+	"@o3co/auth-provider-oauth-token-exchange": readVersion(
+		"../../packages/oauth-token-exchange/package.json",
+	),
 	"@o3co/auth-provider-session": readVersion("../../packages/session/package.json"),
 	"@o3co/auth-provider-foundation": readVersion("../../packages/foundation/package.json"),
 	"@o3co/auth-provider-redis": readVersion("../../packages/redis/package.json"),

--- a/create-app/src/__tests__/index.test.mts
+++ b/create-app/src/__tests__/index.test.mts
@@ -73,11 +73,31 @@ describe("scaffold", () => {
 		expect(pkg.name).toBe("@piratis-blossoms/auth.provider");
 	});
 
-	it("ships versions for optional federation provider packages", () => {
-		const versions = JSON.parse(readFileSync(join("templates", "versions.json"), "utf-8"));
+	it("ships versions for every workspace auth-provider package, in sync with each package.json", () => {
+		const versions: Record<string, string> = JSON.parse(
+			readFileSync(join("templates", "versions.json"), "utf-8"),
+		);
 
-		expect(versions["@o3co/auth-provider-federation-google"]).toBe("0.0.0");
-		expect(versions["@o3co/auth-provider-federation-github"]).toBe("0.0.0");
+		const expectedPackages: Record<string, string> = {
+			"@o3co/auth-provider-core": "../packages/core/package.json",
+			"@o3co/auth-provider-federation-github": "../packages/federation-github/package.json",
+			"@o3co/auth-provider-federation-google": "../packages/federation-google/package.json",
+			"@o3co/auth-provider-foundation": "../packages/foundation/package.json",
+			"@o3co/auth-provider-oauth": "../packages/oauth/package.json",
+			"@o3co/auth-provider-oauth-token-exchange": "../packages/oauth-token-exchange/package.json",
+			"@o3co/auth-provider-redis": "../packages/redis/package.json",
+			"@o3co/auth-provider-session": "../packages/session/package.json",
+		};
+
+		for (const [name, pkgPath] of Object.entries(expectedPackages)) {
+			const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+			expect(versions[name], `versions.json missing entry for ${name}`).toBeDefined();
+			expect(versions[name], `versions.json[${name}] out of sync with ${pkgPath}`).toBe(
+				pkg.version,
+			);
+		}
+
+		expect(Object.keys(versions).sort()).toEqual(Object.keys(expectedPackages).sort());
 	});
 });
 


### PR DESCRIPTION
## Summary

- Fix release.yml CI failure that blocked v0.5.0 tag: \`create-app\` test asserted hardcoded \`"0.0.0"\` against \`versions.json\`, which is invalid after \`pnpm version <tag>\` rewrites all workspace package.json files at release time.
- Test now reads each package's actual \`version\` from \`packages/<name>/package.json\` and asserts \`versions.json\` matches. Key set is also asserted against the expected workspace inventory.
- Add \`@o3co/auth-provider-oauth-token-exchange\` to \`copy-templates.mjs\`'s generated \`versions.json\` (was missing despite being a workspace package).

## Why now

v0.5.0 tag was pushed earlier today (\`b9be1786\`). Release workflow [run 25323323429](https://github.com/o3co/auth.provider/actions/runs/25323323429) failed at \`pnpm run test\` before reaching the publish step. Fixing this is required for the workflow to succeed on retry, OR for any future v0.5.x patch release.

## Verification

- \`make test\`: full suite green (~2136 tests across 10 packages)
- \`pnpm -r exec pnpm version 0.5.0 --no-git-tag-version\` + \`prebuild\` + \`create-app\` test: green — simulates release.yml's version rewrite step that previously broke the test
- \`pnpm run lint\`: 0 errors (15 pre-existing warnings untouched)
- \`pnpm exec tsc --noEmit\` (create-app): clean

## Test plan

- [x] make test green
- [x] simulated 0.5.0 version-rewrite green
- [x] lint clean
- [ ] /multi-agent-review pass
- [ ] Copilot review
- [ ] Merge → manual npm publish for v0.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)