### PR TITLE
fix(ci): drop release.yml's core-only npm_check; trust pnpm per-package skip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,27 +46,13 @@ jobs:
           draft: true
           generate_release_notes: true
 
-      - name: Check if already published
-        id: npm_check
-        shell: bash
-        run: |
-          PACKAGE_VERSION="${GITHUB_REF#refs/tags/v}"
-          set +e
-          OUTPUT="$(npm view "@o3co/auth-provider-core@${PACKAGE_VERSION}" version 2>&1)"
-          STATUS=$?
-          set -e
-          if [ "$STATUS" -eq 0 ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          elif printf '%s\n' "$OUTPUT" | grep -qE 'E404|404 Not Found'; then
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "npm view failed unexpectedly:" >&2
-            printf '%s\n' "$OUTPUT" >&2
-            exit "$STATUS"
-          fi
-
+      # pnpm publish skips per-package when the version is already on the registry,
+      # so the workflow is idempotent on retag and we don't need an upfront
+      # whole-job short-circuit. The previous core-only check caused partial
+      # publishes (e.g. trusted-publisher misconfig on one package) to be
+      # impossible to recover from via tag retag — once core was on the registry,
+      # rerun would skip the entire publish step and never retry the missing packages.
       - name: Publish packages
-        if: steps.npm_check.outputs.skip != 'true'
         run: pnpm -r publish --access public --no-git-checks --provenance
 
       - name: Publish GitHub Release


### PR DESCRIPTION
## Summary

- Remove the \`Check if already published\` step in [.github/workflows/release.yml](.github/workflows/release.yml). It was a core-only short-circuit that broke partial-publish recovery.
- pnpm v10 already skips already-published versions per-package, so the upfront check was redundant for the happy path and harmful for retry/recovery.

## Why now (v0.5.0 recovery context)

v0.5.0 publish ran into trusted-publisher config drift on one package (\`@o3co/auth-provider-redis\`). 5/9 packages published successfully (\`core\`, \`oauth\`, \`oauth-token-exchange\`, \`foundation\`, \`create-auth-provider\`); pnpm aborted at redis (404), leaving 4 unpublished (\`redis\`, \`session\`, \`federation-google\`, \`federation-github\`).

Once the missing trusted-publisher config is fixed, the obvious recovery is "retag and rerun." But the existing \`npm_check\` queries only \`auth-provider-core\` — and core@0.5.0 is now on the registry, so the check sets \`skip=true\`, the \`Publish packages\` step is conditionally skipped, and the 4 missing packages are never retried.

## Behavior after this change

| Scenario | Before | After |
|---|---|---|
| Fresh tag (nothing published) | publish all 9 | publish all 9 |
| Retag, N already published / 9-N missing | skip entire step (BROKEN) | pnpm skips N, publishes 9-N |
| Retag, all 9 already published | skip entire step | pnpm skips all 9, exits 0 |

All three are correct after the change.

## Verification

- pnpm v10's per-package skip behavior is documented at https://pnpm.io/cli/publish — \`pnpm publish\` skips when the latest published version is the same or newer.
- Workflow YAML lints clean (\`actionlint\` would catch syntax issues; default \`yamllint\` rules satisfied).
- No source code changes; only CI workflow.

## Test plan

- [x] YAML syntactically valid
- [x] Diff scope is workflow-only (1 file, +6/-20)
- [ ] Multi-agent-review
- [ ] Merge → retag v0.5.0 → release.yml runs → publishes the 4 missing packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)