### PR TITLE
feat(core): D-3 ADR + D-4 Logger interface redesign (v0.5.1 F1 PR1)

### DIFF
--- a/packages/core/src/adapters/AdapterFactory.mts
+++ b/packages/core/src/adapters/AdapterFactory.mts
@@ -67,6 +67,17 @@ export interface AdapterFactory<T> {
 	 * - If `type` is NOT registered: throws {@link AdapterFactoryError} with
 	 *   `reason: "unknown-replace"`. Replacing a non-existent entry is an
 	 *   error — the caller's mental model is wrong about what is registered.
+	 *
+	 * Security note: `replace()` has zero production callers at v0.5.0 and is
+	 * intended exclusively for test-fixture override of built-in adapters
+	 * (e.g., substituting a memory adapter for a Redis adapter in tests). The
+	 * runtime security boundary is the resolved adapter instance returned by
+	 * {@link AdapterFactory.create}, not this factory's builders map.
+	 * Freezing this factory would protect an object already off the runtime
+	 * path post-boot. See ADR:
+	 * `.claude/audit/decisions/D-3-resolution.md` (D-3, 2026-05-05) for the
+	 * full wrong-layer framing analysis and the explicit decision to close
+	 * SF-11 by documentation, not by adding `freeze()`.
 	 */
 	replace(type: string, builder: AdapterBuilder<T>): void;
 

--- a/packages/core/src/federation-tokens/factory.mts
+++ b/packages/core/src/federation-tokens/factory.mts
@@ -4,6 +4,8 @@
  */
 
 import { createAdapterFactory } from "../adapters/AdapterFactory.mjs";
+import { consoleLogger } from "../logging/consoleLogger.mjs";
+import type { Logger } from "../logging/Logger.mjs";
 import { createInMemoryFederationTokenStore } from "./adapters/memory.mjs";
 import type { FederationTokenStoreBase, FederationTokenStoreFactory } from "./types.mjs";
 
@@ -21,11 +23,17 @@ export function createFederationTokenStoreFactory(): FederationTokenStoreFactory
  *
  * Or use the declarative `redisFederationTokenStoreModule` in their `modules`
  * array.
+ *
+ * @param factory - the FederationTokenStore factory to populate.
+ * @param logger - structured logger for the dev/test warning emitted at
+ *                 builder invocation. Defaults to `consoleLogger`.
  */
-export function registerBuiltinFederationTokenStores(factory: FederationTokenStoreFactory): void {
+export function registerBuiltinFederationTokenStores(
+	factory: FederationTokenStoreFactory,
+	logger: Logger = consoleLogger,
+): void {
 	factory.register("memory", () => {
-		// eslint-disable-next-line no-console
-		console.warn(
+		logger.warn(
 			"federationTokenStore: in-memory adapter is for dev/test only — do not use in production (tokens are lost on restart, no cross-instance replication).",
 		);
 		return createInMemoryFederationTokenStore();

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -148,6 +148,7 @@ export {
 	createAsymmetricKeyStore,
 	createSymmetricKeyStore,
 } from "./keys/KeyStore.mjs";
+export { consoleLogger, createConsoleLogger } from "./logging/consoleLogger.mjs";
 // Logging
 export type { Logger } from "./logging/Logger.mjs";
 export { createMfaProviderFactory } from "./mfa/factory.mjs";

--- a/packages/core/src/logging/Logger.mts
+++ b/packages/core/src/logging/Logger.mts
@@ -14,15 +14,64 @@
  */
 
 /**
- * Minimal structural logger interface used by @o3co/auth-provider internals.
+ * Structured logger interface for @o3co/auth-provider internals.
  *
- * Structurally compatible with `console`, pino, winston, bunyan, etc. Consumers
- * can pass any object matching the subset of methods used at each call site.
+ * Pino-compatible for the call shapes in use here. A pino instance satisfies
+ * this interface without an adapter; consumers may inject any object exposing
+ * these six methods + child(). Not full pino parity — pino additionally
+ * supports `Error` as the first argument and printf-style interpolation via
+ * the trailing `...args` (covered by the `unknown[]` rest below for assignment
+ * compatibility, but not interpreted by the default `consoleLogger`).
  *
- * Additional methods (`info`, `error`, `debug`) will be added when an internal
- * call site needs them — kept minimal until then to avoid implementers having
- * to stub unused methods.
+ * The first argument may be either a structured object or a plain string.
+ * When an object is passed, structured fields are propagated by the
+ * implementation; the optional second `msg` becomes the human-readable
+ * summary. Object-first is preferred at security-relevant call sites: it makes
+ * field-path-based redaction (PII, credentials) tractable, since the keys are
+ * directly inspectable rather than embedded inside a format string. The
+ * trailing `...args: unknown[]` rest preserves source compatibility with
+ * legacy string-first call sites that pass an extra error/value as the second
+ * argument; the default `consoleLogger` forwards them verbatim to `console.*`.
+ *
+ * BREAKING CHANGE (v0.5.1, D-4): the prior interface had only
+ * `warn(message: string, ...args: unknown[]): void`. Implementations conforming
+ * to that older shape must now add `trace`, `debug`, `info`, `error`, `fatal`,
+ * and `child`. The console-backed default (`consoleLogger`) satisfies this
+ * interface; consumers without a structured logger should rely on it via the
+ * optional `ComponentMap.logger` slot.
  */
 export interface Logger {
-	warn(message: string, ...args: unknown[]): void;
+	// Two overload shapes mirror pino: object-first carries structured
+	// bindings + optional message, string-first carries a printf-style
+	// message + any extra arguments (forwarded verbatim by `consoleLogger`).
+	trace(obj: Record<string, unknown>, msg?: string, ...args: unknown[]): void;
+	trace(msg: string, ...args: unknown[]): void;
+	debug(obj: Record<string, unknown>, msg?: string, ...args: unknown[]): void;
+	debug(msg: string, ...args: unknown[]): void;
+	info(obj: Record<string, unknown>, msg?: string, ...args: unknown[]): void;
+	info(msg: string, ...args: unknown[]): void;
+	warn(obj: Record<string, unknown>, msg?: string, ...args: unknown[]): void;
+	warn(msg: string, ...args: unknown[]): void;
+	error(obj: Record<string, unknown>, msg?: string, ...args: unknown[]): void;
+	error(msg: string, ...args: unknown[]): void;
+	fatal(obj: Record<string, unknown>, msg?: string, ...args: unknown[]): void;
+	fatal(msg: string, ...args: unknown[]): void;
+	/**
+	 * Return a child logger that prepends `bindings` to every subsequent log
+	 * call. Per-call object fields win over child bindings on key collision
+	 * (last-write-wins, mirroring pino).
+	 */
+	child(bindings: Record<string, unknown>): Logger;
+}
+
+/**
+ * Optional `logger` slot on the manifest `ComponentMap`. When absent, modules
+ * fall back to the `consoleLogger` default exported from
+ * `@o3co/auth-provider-core`. Declared via TypeScript declaration merge per
+ * the existing pattern (see e.g. `ratelimit/types.mts:54-66`).
+ */
+declare module "@o3co/auth-provider-core" {
+	interface ComponentMap {
+		readonly logger?: Logger;
+	}
 }

--- a/packages/core/src/logging/__tests__/Logger.test.mts
+++ b/packages/core/src/logging/__tests__/Logger.test.mts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ */
+
+import { consoleLogger, type Logger } from "@o3co/auth-provider-core";
+import { describe, expect, it } from "vitest";
+
+describe("Logger interface contract", () => {
+	it("consoleLogger satisfies the Logger interface with all 6 levels + child", () => {
+		expect(typeof consoleLogger.trace).toBe("function");
+		expect(typeof consoleLogger.debug).toBe("function");
+		expect(typeof consoleLogger.info).toBe("function");
+		expect(typeof consoleLogger.warn).toBe("function");
+		expect(typeof consoleLogger.error).toBe("function");
+		expect(typeof consoleLogger.fatal).toBe("function");
+		expect(typeof consoleLogger.child).toBe("function");
+	});
+
+	it("Logger interface accepts a structurally complete implementation (compile-time check)", () => {
+		// If `Logger` is missing any of the 6 methods + child, this object literal
+		// assignment fails at compile time via excess-property checks.
+		// Bound to `Logger` rather than `as any` to keep the contract enforced.
+		const candidate: Logger = {
+			trace: () => {},
+			debug: () => {},
+			info: () => {},
+			warn: () => {},
+			error: () => {},
+			fatal: () => {},
+			child(_bindings) {
+				return candidate;
+			},
+		};
+		expect(candidate.warn).toBeTypeOf("function");
+	});
+
+	it("Logger.child returns a Logger (structural recursion)", () => {
+		const child = consoleLogger.child({ requestId: "r1" });
+		expect(typeof child.trace).toBe("function");
+		expect(typeof child.debug).toBe("function");
+		expect(typeof child.info).toBe("function");
+		expect(typeof child.warn).toBe("function");
+		expect(typeof child.error).toBe("function");
+		expect(typeof child.fatal).toBe("function");
+		expect(typeof child.child).toBe("function");
+	});
+});

--- a/packages/core/src/logging/__tests__/Logger.test.mts
+++ b/packages/core/src/logging/__tests__/Logger.test.mts
@@ -3,8 +3,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License").
  */
 
-import { consoleLogger, type Logger } from "@o3co/auth-provider-core";
 import { describe, expect, it } from "vitest";
+import { consoleLogger } from "../consoleLogger.mjs";
+import type { Logger } from "../Logger.mjs";
 
 describe("Logger interface contract", () => {
 	it("consoleLogger satisfies the Logger interface with all 6 levels + child", () => {

--- a/packages/core/src/logging/__tests__/consoleLogger.test.mts
+++ b/packages/core/src/logging/__tests__/consoleLogger.test.mts
@@ -3,8 +3,8 @@
  * Licensed under the Apache License, Version 2.0 (the "License").
  */
 
-import { consoleLogger, createConsoleLogger } from "@o3co/auth-provider-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { consoleLogger, createConsoleLogger } from "../consoleLogger.mjs";
 
 describe("consoleLogger level routing", () => {
 	afterEach(() => vi.restoreAllMocks());
@@ -61,6 +61,12 @@ describe("consoleLogger level routing", () => {
 		consoleLogger.warn({ a: 1 });
 		expect(spy).toHaveBeenCalledWith({ a: 1 });
 		expect(spy).not.toHaveBeenCalledWith({ a: 1 }, undefined);
+	});
+
+	it("string-first call with msg + extra args forwards all positional args (pino interpolation)", () => {
+		const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		consoleLogger.warn("base %s", "interp1", "interp2");
+		expect(spy).toHaveBeenCalledWith({}, "base %s", "interp1", "interp2");
 	});
 });
 

--- a/packages/core/src/logging/__tests__/consoleLogger.test.mts
+++ b/packages/core/src/logging/__tests__/consoleLogger.test.mts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ */
+
+import { consoleLogger, createConsoleLogger } from "@o3co/auth-provider-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("consoleLogger level routing", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("routes trace to console.debug", () => {
+		const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
+		consoleLogger.trace({ x: 1 }, "trace message");
+		expect(spy).toHaveBeenCalledWith({ x: 1 }, "trace message");
+	});
+
+	it("routes debug to console.debug", () => {
+		const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
+		consoleLogger.debug({ x: 1 }, "debug message");
+		expect(spy).toHaveBeenCalledWith({ x: 1 }, "debug message");
+	});
+
+	it("routes info to console.info", () => {
+		const spy = vi.spyOn(console, "info").mockImplementation(() => {});
+		consoleLogger.info({ x: 1 }, "info message");
+		expect(spy).toHaveBeenCalledWith({ x: 1 }, "info message");
+	});
+
+	it("routes warn to console.warn", () => {
+		const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		consoleLogger.warn({ err: new Error("x") }, "warn message");
+		expect(spy).toHaveBeenCalledWith({ err: expect.any(Error) }, "warn message");
+	});
+
+	it("routes error to console.error", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		consoleLogger.error({ err: new Error("x") }, "error message");
+		expect(spy).toHaveBeenCalledWith({ err: expect.any(Error) }, "error message");
+	});
+
+	it("routes fatal to console.error", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		consoleLogger.fatal({ code: "PANIC" }, "fatal message");
+		expect(spy).toHaveBeenCalledWith({ code: "PANIC" }, "fatal message");
+	});
+
+	it("accepts plain string as first arg (no obj)", () => {
+		const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		consoleLogger.warn("plain string message");
+		// When string is passed, emit { ...bindings } as obj + the string as msg.
+		expect(spy).toHaveBeenCalledWith({}, "plain string message");
+	});
+});
+
+describe("consoleLogger.child binding propagation", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("child bindings appear in every subsequent log call", () => {
+		const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const child = consoleLogger.child({ sid: "abc", requestId: "r1" });
+		child.warn({ err: new Error("x") }, "test");
+		expect(spy).toHaveBeenCalledWith(
+			expect.objectContaining({ sid: "abc", requestId: "r1", err: expect.any(Error) }),
+			"test",
+		);
+	});
+
+	it("per-call obj wins over child bindings on collision", () => {
+		const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const child = consoleLogger.child({ sid: "parent-sid" });
+		child.warn({ sid: "override-sid" }, "test");
+		expect(spy).toHaveBeenCalledWith(expect.objectContaining({ sid: "override-sid" }), "test");
+	});
+
+	it("nested child() merges bindings cumulatively", () => {
+		const spy = vi.spyOn(console, "info").mockImplementation(() => {});
+		const child1 = consoleLogger.child({ a: 1 });
+		const child2 = child1.child({ b: 2 });
+		child2.info({}, "test");
+		expect(spy).toHaveBeenCalledWith(expect.objectContaining({ a: 1, b: 2 }), "test");
+	});
+
+	it("child(string) uses bindings only (no additional obj merge)", () => {
+		const spy = vi.spyOn(console, "info").mockImplementation(() => {});
+		const child = consoleLogger.child({ sid: "abc" });
+		child.info("plain string with bindings");
+		expect(spy).toHaveBeenCalledWith({ sid: "abc" }, "plain string with bindings");
+	});
+});
+
+describe("createConsoleLogger factory", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("returns an independent logger instance with given bindings", () => {
+		const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const a = createConsoleLogger({ a: 1 });
+		const b = createConsoleLogger({ b: 2 });
+		a.warn({}, "test-a");
+		b.warn({}, "test-b");
+		expect(spy).toHaveBeenNthCalledWith(1, { a: 1 }, "test-a");
+		expect(spy).toHaveBeenNthCalledWith(2, { b: 2 }, "test-b");
+	});
+
+	it("createConsoleLogger() with no args is equivalent to the singleton root", () => {
+		const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const root = createConsoleLogger();
+		root.warn({ x: 1 }, "test");
+		expect(spy).toHaveBeenCalledWith({ x: 1 }, "test");
+	});
+});

--- a/packages/core/src/logging/__tests__/consoleLogger.test.mts
+++ b/packages/core/src/logging/__tests__/consoleLogger.test.mts
@@ -51,6 +51,17 @@ describe("consoleLogger level routing", () => {
 		// When string is passed, emit { ...bindings } as obj + the string as msg.
 		expect(spy).toHaveBeenCalledWith({}, "plain string message");
 	});
+
+	// Copilot review on PR #113: previously the object-first branch always
+	// forwarded `msg` to `console[method]`, so `logger.warn({ a: 1 })` printed
+	// an extra `undefined` argument. The branch now mirrors the string-first
+	// conditional and omits `msg` when it is `undefined`.
+	it("object-first call with no msg does NOT forward undefined", () => {
+		const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		consoleLogger.warn({ a: 1 });
+		expect(spy).toHaveBeenCalledWith({ a: 1 });
+		expect(spy).not.toHaveBeenCalledWith({ a: 1 }, undefined);
+	});
 });
 
 describe("consoleLogger.child binding propagation", () => {

--- a/packages/core/src/logging/consoleLogger.mts
+++ b/packages/core/src/logging/consoleLogger.mts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Logger } from "./Logger.mjs";
+
+/**
+ * Console-backed `Logger` implementation. Default fallback when no structured
+ * logger is injected via the manifest `ComponentMap.logger` slot.
+ *
+ * Level routing (6 logger levels → 4 available `console.*` methods):
+ *   trace → console.debug
+ *   debug → console.debug
+ *   info  → console.info
+ *   warn  → console.warn
+ *   error → console.error
+ *   fatal → console.error
+ *
+ * The merged object (child bindings + per-call obj) is passed verbatim to the
+ * underlying `console.*` method. No `JSON.stringify` happens here — Node's
+ * console formats objects with `util.inspect` for terminal output, while
+ * structured log aggregators (Datadog, GCP, etc.) generally consume the
+ * unmodified object form. Tests should spy on `console.*` and assert on the
+ * call arguments rather than on string output.
+ *
+ * Per-call obj wins over child bindings on key collision (pino-compatible
+ * last-write-wins).
+ */
+function emit(
+	method: "debug" | "info" | "warn" | "error",
+	bindings: Record<string, unknown>,
+	obj: Record<string, unknown> | string,
+	msg: string | undefined,
+	args: unknown[],
+): void {
+	if (typeof obj === "string") {
+		// biome-ignore lint/suspicious/noConsole: this IS the default Logger fallback
+		console[method]({ ...bindings }, obj, ...(msg !== undefined ? [msg] : []), ...args);
+	} else {
+		// biome-ignore lint/suspicious/noConsole: this IS the default Logger fallback
+		console[method]({ ...bindings, ...obj }, msg, ...args);
+	}
+}
+
+/**
+ * Create a `Logger` instance backed by `console.*`, optionally pre-bound with
+ * the given `bindings`. Pass no argument to obtain a logger with no bindings
+ * (equivalent to the exported `consoleLogger` singleton).
+ */
+export function createConsoleLogger(bindings: Record<string, unknown> = {}): Logger {
+	const frozen = { ...bindings };
+	const logger: Logger = {
+		trace(obj: Record<string, unknown> | string, msg?: string, ...args: unknown[]) {
+			emit("debug", frozen, obj, msg, args);
+		},
+		debug(obj: Record<string, unknown> | string, msg?: string, ...args: unknown[]) {
+			emit("debug", frozen, obj, msg, args);
+		},
+		info(obj: Record<string, unknown> | string, msg?: string, ...args: unknown[]) {
+			emit("info", frozen, obj, msg, args);
+		},
+		warn(obj: Record<string, unknown> | string, msg?: string, ...args: unknown[]) {
+			emit("warn", frozen, obj, msg, args);
+		},
+		error(obj: Record<string, unknown> | string, msg?: string, ...args: unknown[]) {
+			emit("error", frozen, obj, msg, args);
+		},
+		fatal(obj: Record<string, unknown> | string, msg?: string, ...args: unknown[]) {
+			emit("error", frozen, obj, msg, args);
+		},
+		child(extra) {
+			return createConsoleLogger({ ...frozen, ...extra });
+		},
+	};
+	return logger;
+}
+
+/**
+ * Pre-created root `Logger` (zero bindings) backed by `console.*`. Used as the
+ * DI fallback when `ComponentMap.logger` is not provided.
+ */
+export const consoleLogger: Logger = createConsoleLogger();

--- a/packages/core/src/logging/consoleLogger.mts
+++ b/packages/core/src/logging/consoleLogger.mts
@@ -49,7 +49,11 @@ function emit(
 		console[method]({ ...bindings }, obj, ...(msg !== undefined ? [msg] : []), ...args);
 	} else {
 		// biome-ignore lint/suspicious/noConsole: this IS the default Logger fallback
-		console[method]({ ...bindings, ...obj }, msg, ...args);
+		console[method](
+			{ ...bindings, ...obj },
+			...(msg !== undefined ? [msg] : []),
+			...args,
+		);
 	}
 }
 

--- a/packages/core/src/logging/consoleLogger.mts
+++ b/packages/core/src/logging/consoleLogger.mts
@@ -49,11 +49,7 @@ function emit(
 		console[method]({ ...bindings }, obj, ...(msg !== undefined ? [msg] : []), ...args);
 	} else {
 		// biome-ignore lint/suspicious/noConsole: this IS the default Logger fallback
-		console[method](
-			{ ...bindings, ...obj },
-			...(msg !== undefined ? [msg] : []),
-			...args,
-		);
+		console[method]({ ...bindings, ...obj }, ...(msg !== undefined ? [msg] : []), ...args);
 	}
 }
 

--- a/packages/oauth/src/__tests__/_helpers/mockLogger.mts
+++ b/packages/oauth/src/__tests__/_helpers/mockLogger.mts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ */
+
+import type { Logger } from "@o3co/auth-provider-core";
+import { type Mock, vi } from "vitest";
+
+/**
+ * Test-only `Logger` mock. Each level + `child` is a `vi.fn()`; `child` returns
+ * the same instance so spy assertions in nested handlers still resolve to the
+ * same set of mock fns. Intended only for unit tests that need to satisfy the
+ * `Logger` interface without standing up a real structured logger.
+ */
+export interface MockLogger extends Logger {
+	trace: Mock;
+	debug: Mock;
+	info: Mock;
+	warn: Mock;
+	error: Mock;
+	fatal: Mock;
+	child: Mock;
+}
+
+export function createMockLogger(): MockLogger {
+	const m: MockLogger = {
+		trace: vi.fn(),
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		fatal: vi.fn(),
+		child: vi.fn(() => m),
+	};
+	return m;
+}

--- a/packages/oauth/src/__tests__/federationToken.test.mts
+++ b/packages/oauth/src/__tests__/federationToken.test.mts
@@ -32,6 +32,7 @@ import { SignJWT } from "jose";
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
 import { createRouter } from "#/routes/federationToken.mjs";
+import { createMockLogger } from "./_helpers/mockLogger.mjs";
 
 const SECRET = "test-secret-at-least-32-chars!!";
 const keyStore = createSymmetricKeyStore(SECRET);
@@ -991,8 +992,8 @@ describe("POST /oauth/federation/:name/token", () => {
 
 	describe("logger routing", () => {
 		it("routes failures to opts.logger, not console", async () => {
-			const warnSpy = vi.fn<(message: string, ...args: unknown[]) => void>();
-			const logger: Logger = { warn: warnSpy };
+			const logger = createMockLogger();
+			const warnSpy = logger.warn;
 			const sessionStore = makeSessionStore({
 				get: vi.fn().mockRejectedValue(new Error("redis down")),
 			});

--- a/packages/oauth/src/__tests__/logout.test.mts
+++ b/packages/oauth/src/__tests__/logout.test.mts
@@ -34,6 +34,7 @@ import { SignJWT } from "jose";
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
 import { createRouter } from "#/routes/logout.mjs";
+import { createMockLogger } from "./_helpers/mockLogger.mjs";
 
 const SECRET = "test-secret-at-least-32-chars!!";
 const keyStore = createSymmetricKeyStore(SECRET);
@@ -664,8 +665,8 @@ describe("POST /oauth/logout", () => {
 				name: "google",
 				endSession: vi.fn().mockRejectedValue(new Error("IdP down")),
 			};
-			const warnSpy = vi.fn<(message: string, ...args: unknown[]) => void>();
-			const logger: Logger = { warn: warnSpy };
+			const logger = createMockLogger();
+			const warnSpy = logger.warn;
 			const app = buildApp({
 				sessionStore,
 				sessionFederationIndex,
@@ -974,8 +975,8 @@ describe("POST /oauth/federation/:name/logout", () => {
 
 	describe("logger routing", () => {
 		it("routes /federation/:name/logout failures to opts.logger (not console)", async () => {
-			const warnSpy = vi.fn<(message: string, ...args: unknown[]) => void>();
-			const logger: Logger = { warn: warnSpy };
+			const logger = createMockLogger();
+			const warnSpy = logger.warn;
 			const fedTokenStore = makeFedTokenStore({
 				delete: vi.fn().mockRejectedValue(new Error("boom")),
 			});

--- a/packages/oauth/src/logout/__tests__/broadcastBackchannel.test.mts
+++ b/packages/oauth/src/logout/__tests__/broadcastBackchannel.test.mts
@@ -16,6 +16,7 @@
 import { createSymmetricKeyStore } from "@o3co/auth-provider-core";
 import { decodeJwt } from "jose";
 import { describe, expect, it, vi } from "vitest";
+import { createMockLogger } from "../../__tests__/_helpers/mockLogger.mjs";
 import { broadcastBackchannelLogout } from "../broadcastBackchannel.mjs";
 
 const keyStore = createSymmetricKeyStore("test-secret-32-chars-xxxxxxxxxx");
@@ -136,7 +137,7 @@ describe("broadcastBackchannelLogout", () => {
 		const fetchImpl = vi.fn((url: string, init?: RequestInit) => {
 			return url === "https://slow.example/bc" ? slow(url, init) : fast(url, init);
 		}) as unknown as typeof fetch;
-		const logger = { warn: vi.fn() };
+		const logger = createMockLogger();
 		const start = Date.now();
 		await broadcastBackchannelLogout({
 			rps: [
@@ -162,7 +163,7 @@ describe("broadcastBackchannelLogout", () => {
 			status: 500,
 			statusText: "Internal Server Error",
 		}));
-		const logger = { warn: vi.fn() };
+		const logger = createMockLogger();
 		await expect(
 			broadcastBackchannelLogout({
 				rps: [{ clientId: "rp1", backchannelLogoutUri: "https://rp.example/bc" }],
@@ -179,7 +180,7 @@ describe("broadcastBackchannelLogout", () => {
 
 	it("uses opts.logger over console.warn when provided", async () => {
 		const fetchMock = vi.fn(async () => ({ ok: false, status: 500, statusText: "" }));
-		const logger = { warn: vi.fn() };
+		const logger = createMockLogger();
 		const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		try {
 			await broadcastBackchannelLogout({
@@ -202,7 +203,7 @@ describe("broadcastBackchannelLogout", () => {
 		const fetchMock = vi.fn(async () => {
 			throw new Error("network partition");
 		});
-		const logger = { warn: vi.fn() };
+		const logger = createMockLogger();
 		await expect(
 			broadcastBackchannelLogout({
 				rps: [

--- a/packages/oauth/src/logout/__tests__/cascadeLogout.test.mts
+++ b/packages/oauth/src/logout/__tests__/cascadeLogout.test.mts
@@ -7,6 +7,7 @@ import type {
 	UserSessionStore,
 } from "@o3co/auth-provider-core";
 import { describe, expect, it, vi } from "vitest";
+import { createMockLogger } from "../../__tests__/_helpers/mockLogger.mjs";
 import { cascadeLogout } from "../cascadeLogout.mjs";
 
 // ---------------------------------------------------------------------------
@@ -331,7 +332,7 @@ describe("cascadeLogout (A4 §6.2)", () => {
 					listFamilyIds: vi.fn(async () => ["f"]),
 				}),
 				sessionFederationIndex: makeSessionFederationIndex(),
-				logger: { warn: loggerWarn },
+				logger: Object.assign(createMockLogger(), { warn: loggerWarn }),
 			});
 			expect(loggerWarn).toHaveBeenCalledTimes(1);
 			expect(loggerWarn.mock.calls[0]?.[0]).toMatch(/cascadeLogout/);

--- a/packages/oauth/src/logout/__tests__/renderFrontchannel.test.mts
+++ b/packages/oauth/src/logout/__tests__/renderFrontchannel.test.mts
@@ -1,4 +1,5 @@
 import { assert, describe, expect, it, vi } from "vitest";
+import { createMockLogger } from "../../__tests__/_helpers/mockLogger.mjs";
 import { renderFrontchannelLogoutHtml } from "../renderFrontchannel.mjs";
 
 describe("renderFrontchannelLogoutHtml", () => {
@@ -170,7 +171,7 @@ describe("renderFrontchannelLogoutHtml", () => {
 	});
 
 	it("skips RPs with invalid frontchannelLogoutUri instead of throwing", () => {
-		const logger = { warn: vi.fn() };
+		const logger = createMockLogger();
 		const html = renderFrontchannelLogoutHtml({
 			rps: [
 				{ clientId: "good", frontchannelLogoutUri: "https://good.example/fc" },

--- a/packages/oauth/src/middleware/clientAuth.mts
+++ b/packages/oauth/src/middleware/clientAuth.mts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import type { ClientRepository, PublicClient } from "@o3co/auth-provider-core";
+import {
+	type ClientRepository,
+	consoleLogger,
+	type Logger,
+	type PublicClient,
+} from "@o3co/auth-provider-core";
 import type { RequestHandler } from "express";
 
 // Module augmentation: expose `req.oauthClient` for consumers who compose this
@@ -65,9 +70,14 @@ function formUrlDecode(s: string): string {
  * operational detail to callers.
  *
  * @param clientRepository - used to look up the client by credential pair.
+ * @param logger - structured logger for repository-failure traces. Defaults to
+ *                 `consoleLogger` so existing callers compile unchanged.
  * @returns an express RequestHandler.
  */
-export function createClientAuthMiddleware(clientRepository: ClientRepository): RequestHandler {
+export function createClientAuthMiddleware(
+	clientRepository: ClientRepository,
+	logger: Logger = consoleLogger,
+): RequestHandler {
 	return async (req, res, next) => {
 		let clientId: string | undefined;
 		let clientSecret: string | undefined;
@@ -128,7 +138,7 @@ export function createClientAuthMiddleware(clientRepository: ClientRepository): 
 		} catch (err) {
 			// Fail-closed: repository unavailability must not grant access.
 			// Log server-side for operators; do NOT leak store details to callers.
-			console.warn({ err }, "client credential lookup failed");
+			logger.warn({ err }, "client credential lookup failed");
 			res.set("WWW-Authenticate", WWW_AUTH);
 			res.status(401).json({ error: "invalid_client" });
 			return;

--- a/packages/oauth/src/module.mts
+++ b/packages/oauth/src/module.mts
@@ -16,6 +16,7 @@
 
 import {
 	type AppConfig,
+	consoleLogger,
 	defineModule,
 	type FederationProviderHandle,
 	type GrantRegistry,
@@ -117,6 +118,7 @@ export const oauthModule = (params: { config: AppConfig }): Module => {
 		| "sessionFederationIndex"
 		| "federationTokenStore"
 		| "federationProviders"
+		| "logger"
 	>({
 		name: "oauth",
 		configSchema: oauthConfigSchema,
@@ -138,6 +140,7 @@ export const oauthModule = (params: { config: AppConfig }): Module => {
 			"sessionFederationIndex", // Amendment 4 (§1.1.4)
 			"federationTokenStore", // Phase 9 Task 4 augmentation — federation-token routes
 			"federationProviders", // synthetic — boot planner injects ReadonlyMap from federation contributions
+			"logger", // D-4 — structured logger; falls back to consoleLogger when absent
 		],
 		contributes: {
 			routes: [
@@ -163,6 +166,7 @@ export const oauthModule = (params: { config: AppConfig }): Module => {
 						sessionFamilyIndex: deps.sessionFamilyIndex,
 						sessionFederationIndex: deps.sessionFederationIndex,
 						federationTokenStore: deps.federationTokenStore,
+						logger: deps.logger ?? consoleLogger,
 						// Theme E structural fix: typed deps replace the v0.4.x lazy
 						// () => ctx.federationProviders closure. The closure here only
 						// re-wraps the typed read so the legacy `getFederationProviders`
@@ -198,6 +202,7 @@ export const oauthModule = (params: { config: AppConfig }): Module => {
 									| "sessionFederationIndex"
 									| "federationTokenStore"
 									| "federationProviders"
+									| "logger"
 								>,
 							) => {
 								const logoutSupported =

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -19,6 +19,7 @@ import {
 	type AuditSinkBase,
 	type ClientRepository,
 	type CodeRepository,
+	consoleLogger,
 	emitAuditEvent,
 	type FederationProviderHandle,
 	type FederationTokenStoreBase,
@@ -26,6 +27,7 @@ import {
 	type GrantPolicyHookBase,
 	type GrantRegistry,
 	type KeyStore,
+	type Logger,
 	type PublicClient,
 	type RateLimiterBase,
 	type RefreshTokenFamilyRevocation,
@@ -78,6 +80,7 @@ export const createOAuthRouter = async (
 		sessionFederationIndex,
 		federationTokenStore,
 		getFederationProviders = () => undefined,
+		logger = consoleLogger,
 	}: {
 		registry: GrantRegistry;
 		config: AppConfig;
@@ -99,12 +102,13 @@ export const createOAuthRouter = async (
 		 * from `module.mts`. Defaults to `() => undefined` when not provided.
 		 */
 		getFederationProviders?: () => ReadonlyMap<string, FederationProviderHandle> | undefined;
+		logger?: Logger;
 	},
 ): Promise<{ router: Router; registry: GrantRegistry }> => {
 	const router = express.Router();
 
 	// Construct once at router-creation time so the closure is not re-allocated per request.
-	const clientAuthMw = createClientAuthMiddleware(clientRepository);
+	const clientAuthMw = createClientAuthMiddleware(clientRepository, logger);
 
 	async function checkRateLimit(req: Request, res: Response, tag: string): Promise<boolean> {
 		if (!rateLimiter) return true;
@@ -658,6 +662,7 @@ export const createOAuthRouter = async (
 				clientRepository,
 				getFederationProviders,
 				auditSink,
+				logger,
 			}),
 		);
 	}
@@ -677,6 +682,7 @@ export const createOAuthRouter = async (
 				clientRepository,
 				getFederationProviders,
 				auditSink,
+				logger,
 			}),
 		);
 	}

--- a/packages/redis/src/code-repository.mts
+++ b/packages/redis/src/code-repository.mts
@@ -15,7 +15,14 @@
  */
 
 import crypto from "node:crypto";
-import type { AdapterBuilder, Code, CodeRepository, PathResolver } from "@o3co/auth-provider-core";
+import {
+	type AdapterBuilder,
+	type Code,
+	type CodeRepository,
+	consoleLogger,
+	type Logger,
+	type PathResolver,
+} from "@o3co/auth-provider-core";
 
 const KEY_PREFIX = "oauth:code:";
 
@@ -32,15 +39,18 @@ interface RedisClient {
 export class RedisCodeRepository implements CodeRepository {
 	private redis: RedisClient;
 	private defaultExpiresIn: number;
+	private logger: Logger;
 
-	constructor(redis: RedisClient, defaultExpiresIn = 600) {
+	constructor(redis: RedisClient, defaultExpiresIn = 600, logger: Logger = consoleLogger) {
 		this.redis = redis;
 		this.defaultExpiresIn = defaultExpiresIn;
+		this.logger = logger;
 	}
 
 	static async create(
 		config: Record<string, unknown>,
 		pathResolver?: PathResolver,
+		logger: Logger = consoleLogger,
 	): Promise<RedisCodeRepository> {
 		if (typeof config.endpointUri !== "string") {
 			throw new Error('RedisCodeRepository requires "endpointUri" in config');
@@ -63,7 +73,7 @@ export class RedisCodeRepository implements CodeRepository {
 		});
 		const defaultExpiresIn =
 			typeof config.defaultExpiresIn === "number" ? config.defaultExpiresIn : undefined;
-		const repo = new RedisCodeRepository(redis as unknown as RedisClient, defaultExpiresIn);
+		const repo = new RedisCodeRepository(redis as unknown as RedisClient, defaultExpiresIn, logger);
 		await repo.initialize();
 		return repo;
 	}
@@ -112,7 +122,7 @@ export class RedisCodeRepository implements CodeRepository {
 			return { ...JSON.parse(value), code } as Code;
 		} catch (err) {
 			const codeHash = crypto.createHash("sha256").update(code).digest("hex").slice(0, 16);
-			console.error(`RedisCodeRepository: corrupted data for code (hash=${codeHash})`, err);
+			this.logger.error({ err, codeHash }, "RedisCodeRepository: corrupted data for code");
 			return null;
 		}
 	}

--- a/packages/session/src/module.mts
+++ b/packages/session/src/module.mts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { type AppConfig, defineModule, fullSectionsSchema } from "@o3co/auth-provider-core";
+import {
+	type AppConfig,
+	consoleLogger,
+	defineModule,
+	fullSectionsSchema,
+} from "@o3co/auth-provider-core";
 import express from "express";
 import { extractFederationSection } from "./federations/extract-federation-section.mjs";
 import type { FederationProvider } from "./federations/types.mjs";
@@ -104,7 +109,8 @@ export const sessionModule = defineModule<
 	| "federationTokenStore"
 	| "sessionFederationIndex"
 	| "federationProviders"
-	| "federationRedirectPolicyResolver"
+	| "federationRedirectPolicyResolver",
+	"logger"
 >({
 	name: "session",
 	configSchema: sessionConfigSchema,
@@ -117,6 +123,7 @@ export const sessionModule = defineModule<
 		"federationProviders",
 		"federationRedirectPolicyResolver",
 	],
+	optional: ["logger"],
 	contributes: {
 		routes: [
 			(deps) => {
@@ -129,6 +136,7 @@ export const sessionModule = defineModule<
 						config,
 						userSessionStore: deps.userSessionStore,
 						sessionTtlMs: config.session.maxAge,
+						logger: deps.logger ?? consoleLogger,
 					}),
 				};
 			},
@@ -156,6 +164,7 @@ export const sessionModule = defineModule<
 						sessionFederationIndex: deps.sessionFederationIndex,
 						federationTokenStore: deps.federationTokenStore,
 						sessionTtlMs: config.session.maxAge,
+						logger: deps.logger ?? consoleLogger,
 					}),
 				};
 			},

--- a/packages/session/src/routes/Federation.mts
+++ b/packages/session/src/routes/Federation.mts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 import { randomBytes, randomUUID } from "node:crypto";
-import type {
-	AppConfig,
-	FederationTokenStoreBase,
-	SessionFederationIndex,
-	UserRepository,
-	UserSessionStore,
+import {
+	type AppConfig,
+	consoleLogger,
+	type FederationTokenStoreBase,
+	type Logger,
+	type SessionFederationIndex,
+	type UserRepository,
+	type UserSessionStore,
 } from "@o3co/auth-provider-core";
 import type { Request, RequestHandler, Response, Router } from "express";
 import { extractUserClaims } from "#/internal/extractUserClaims.mjs";
@@ -62,6 +64,7 @@ export const createRouter = (
 		sessionFederationIndex,
 		federationTokenStore,
 		sessionTtlMs = DEFAULT_SESSION_TTL_MS,
+		logger = consoleLogger,
 	}: {
 		config: AppConfig;
 		federationProviders: ReadonlyMap<string, FederationProvider>;
@@ -72,6 +75,7 @@ export const createRouter = (
 		sessionFederationIndex: SessionFederationIndex;
 		federationTokenStore: FederationTokenStoreBase;
 		sessionTtlMs?: number;
+		logger?: Logger;
 	},
 ): Router => {
 	if (!userSessionStore) throw new Error("federation routes require userSessionStore");
@@ -159,6 +163,11 @@ export const createRouter = (
 				return res.status(404).json({ message: "NotFound" });
 			}
 
+			// Per-handler logger child carrying the provider binding. After
+			// `randomUUID()` produces `sid` below, we rebind to include `sid`
+			// so subsequent calls do not need to repeat either field.
+			let log = logger.child({ provider: provider.name });
+
 			const fed = req.session.federation;
 
 			// Check session.federation present and name matches
@@ -189,10 +198,7 @@ export const createRouter = (
 				req.session.save((err) => resolve(err ?? null));
 			});
 			if (reusePrevSaveErr) {
-				console.warn(
-					{ err: reusePrevSaveErr, provider: provider.name },
-					"reuse-prevention session save failed",
-				);
+				log.warn({ err: reusePrevSaveErr }, "reuse-prevention session save failed");
 				return res.status(500).json({
 					error: "server_error",
 					error_description: "Session store unavailable",
@@ -227,7 +233,7 @@ export const createRouter = (
 					redirectUri: callbackUrl,
 				});
 			} catch (err) {
-				console.warn({ err, provider: provider.name }, "federation token exchange failed");
+				log.warn({ err }, "federation token exchange failed");
 				return res.status(502).json({
 					error: "exchange_failed",
 					error_description: "Token exchange with upstream IdP failed",
@@ -245,7 +251,7 @@ export const createRouter = (
 			try {
 				user = await userRepository.authenticateByToken(`${provider.name}:${profile.sub}`);
 			} catch (err) {
-				console.warn({ err, provider: provider.name }, "user repository lookup failed");
+				log.warn({ err }, "user repository lookup failed");
 				return res.status(503).json({
 					error: "temporarily_unavailable",
 					error_description: "User directory temporarily unavailable",
@@ -265,6 +271,8 @@ export const createRouter = (
 			};
 
 			const sid = randomUUID();
+			// Rebind: from this point onward, every log call carries `provider` AND `sid`.
+			log = log.child({ sid });
 			const authTime = new Date();
 			const expiresAt = new Date(Date.now() + sessionTtlMs);
 
@@ -277,7 +285,7 @@ export const createRouter = (
 					claims,
 				});
 			} catch (err) {
-				console.warn({ err, provider: provider.name }, "userSession create failed");
+				log.warn({ err }, "userSession create failed");
 				return res.status(503).json({
 					error: "temporarily_unavailable",
 					error_description: "Session store unavailable",
@@ -300,10 +308,7 @@ export const createRouter = (
 				} catch {
 					// best-effort — ignore (the original error is the one returned)
 				}
-				console.warn(
-					{ err, provider: provider.name },
-					"sessionFederationIndex.addFederation failed",
-				);
+				log.warn({ err }, "sessionFederationIndex.addFederation failed");
 				return res.status(503).json({
 					error: "temporarily_unavailable",
 					error_description: "Session store unavailable",
@@ -340,8 +345,8 @@ export const createRouter = (
 				} catch {
 					// best-effort — ignore
 				}
-				console.error(
-					{ err: regenerateErr, sid, provider: provider.name },
+				log.error(
+					{ err: regenerateErr },
 					"session regeneration failed after userSessionStore.create",
 				);
 				return res.status(500).json({
@@ -422,7 +427,7 @@ export const createRouter = (
 				await new Promise<void>((resolve) => {
 					req.session.destroy(() => resolve());
 				});
-				console.error({ err, sid, provider: provider.name }, "session post-create failed");
+				log.error({ err }, "session post-create failed");
 				return res.status(500).json({
 					error: "session_create_failed",
 					error_description: "Internal error: session could not be persisted",

--- a/packages/session/src/routes/Session.mts
+++ b/packages/session/src/routes/Session.mts
@@ -15,7 +15,14 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { AppConfig, User, UserRepository, UserSessionStore } from "@o3co/auth-provider-core";
+import {
+	type AppConfig,
+	consoleLogger,
+	type Logger,
+	type User,
+	type UserRepository,
+	type UserSessionStore,
+} from "@o3co/auth-provider-core";
 import type { NextFunction, Request, RequestHandler, Response, Router } from "express";
 import rateLimit from "express-rate-limit";
 import { extractUserClaims } from "#/internal/extractUserClaims.mjs";
@@ -43,12 +50,14 @@ export const createRouter = (
 		config,
 		userSessionStore,
 		sessionTtlMs = DEFAULT_SESSION_TTL_MS,
+		logger = consoleLogger,
 	}: {
 		userRepository: UserRepository;
 		config: AppConfig;
 		userSessionStore?: UserSessionStore;
 		/** Session TTL in milliseconds. Default: 24h. */
 		sessionTtlMs?: number;
+		logger?: Logger;
 	},
 ): Router => {
 	const router = express.Router();
@@ -139,7 +148,7 @@ export const createRouter = (
 				try {
 					user = await userRepository.authenticate(username, password);
 				} catch (err) {
-					console.warn({ err }, "local login authenticate failed");
+					logger.warn({ err }, "local login authenticate failed");
 					return res.status(503).json({
 						error: "temporarily_unavailable",
 						error_description: "User directory temporarily unavailable",


### PR DESCRIPTION
## Summary

First PR of v0.5.1 Phase F (F1 foundation batch). Combines two zero-/low-coupling deliverables:

- **D-3** — append SF-11 wrong-layer ADR reference to `AdapterFactory.replace()` JSDoc (no behavior change). Locks the A6+A7 §2.3 carve-out so future audits encounter the dismissal rationale.
- **D-4** — widen the `Logger` interface to a pino-aligned shape (**BREAKING for v0.5.1**) and migrate all 11 in-tree `console.*` runtime sites onto a DI-injected logger.

Spec inputs: [`D-3-resolution.md`](.claude/audit/decisions/D-3-resolution.md) · [`d4-logger-interface.md`](.claude/superpowers/specs/2026-05-05-d4-logger-interface.md)
Phase F dep graph: [`2026-05-06-phase-f-dependency-graph.md`](.claude/audit/2026-05-06-phase-f-dependency-graph.md) §3 F1.

## D-4 design

- **6 mandatory levels** (trace/debug/info/warn/error/fatal) + `child(bindings)`.
- **Dual overload** — object-first (`Record<string, unknown>, msg?, ...args`) for structured logging at security-relevant sites; string-first (`msg, ...args`) preserves source compatibility with the existing `logger.warn(string, error)` call sites in `routes/logout.mts` and `routes/federationToken.mts` (those remain out of D-4 scope).
- **`consoleLogger` default impl** — pre-created singleton + `createConsoleLogger(bindings)` factory. Last-write-wins child binding merge mirrors pino. No JSON.stringify — raw objects pass through to `console.*` for log-aggregator consumption.
- **`ComponentMap.logger?: Logger`** declared via the canonical `declare module "@o3co/auth-provider-core"` pattern (parallel to `ratelimit/types.mts`).
- **Module wiring** — `sessionModule` and `oauthModule` add `"logger"` to their `defineModule<R, O>` optional union AND `optional: [...]` array. `createOAuthRouter` forwards the logger to **all** child routes (`clientAuthMiddleware`, `logoutRoute.createRouter`, `federationTokenRoute.createRouter`) — fix from Codex review.

## Migrated console.* sites (11 / 11)

| File | Sites | Notes |
|---|---|---|
| `packages/session/src/routes/Federation.mts` | 7 | `let log = logger.child({provider})` then `log = log.child({sid})` after `randomUUID()` per pino child pattern |
| `packages/session/src/routes/Session.mts` | 1 | local-login authenticate failure |
| `packages/oauth/src/middleware/clientAuth.mts` | 1 | repository-failure log; `logger?: Logger` param defaults to `consoleLogger` |
| `packages/redis/src/code-repository.mts` | 1 | `RedisCodeRepository` now stores `logger`; `static create()` accepts a 3rd arg |
| `packages/core/src/federation-tokens/factory.mts` | 1 | `registerBuiltinFederationTokenStores(factory, logger?)` |

`packages/redis/src/federation-tokens.mts:235` (allow-plaintext warning) **explicitly NOT migrated** — assigned to Area 4 / CC-3 scope per spec.

## D-3 change

Single JSDoc paragraph appended to `AdapterFactory.replace()` referencing `.claude/audit/decisions/D-3-resolution.md`. The class-level §2.3 framing at lines 47-53 is preserved unchanged.

## Tests

16 new tests in `packages/core/src/logging/__tests__/` — Logger contract (compile-time satisfies + runtime method existence), level routing (6 → 4 console methods), child binding propagation (3 cases), `createConsoleLogger` factory (2 cases), plain-string-first-arg compat. Shared `MockLogger` helper (`packages/oauth/src/__tests__/_helpers/mockLogger.mts`) for migrated oauth tests.

**Total test count after this PR: 1953 (all GREEN).**

## Multi-agent review

- 🔵 Claude (design + logic): **Approved with minor follow-ups** — 3 minors deferred (test plan #4 module-DI default + #5 Federation.mts:192 regression; MockLogger.child fragility).
- 🟠 Codex (security + perf): **1 P2 found and fixed** — `createOAuthRouter` was forwarding `logger` only to `clientAuthMiddleware`; missed `logoutRoute` + `federationTokenRoute` mounts. Fixed before commit.

## Closes

- **D-3** — SF-11 (Phase B / CC-5 cluster)
- **D-4** — OR-6 (full); MIN-1 (11/12 — OR-12 site at `redis/src/federation-tokens.mts:235` deferred to Area 4)

## Breaking changes (CHANGELOG note for v0.5.1)

- `Logger` interface gains `trace` / `debug` / `info` / `error` / `fatal` / `child` (previously only `warn`). Consumer impls of the old shape will fail to compile until they implement all 6 + child(), or inject a pino instance directly.
- `Logger.warn` first-arg widens from `string` to `Record<string, unknown> | string` via overload — strictly additive, existing string-first calls compile unchanged.
- Module wiring optional `"logger"` slot added to `sessionModule` + `oauthModule` — additive, default falls back to `consoleLogger` (no consumer migration required).

## Known follow-ups (post-merge)

- Spec Test #4 — boot `sessionModule` without `logger` override and assert `consoleLogger` is wired
- Spec Test #5 — exercise `Federation.mts:192` (reuse-prevention save fail) with injected `logger.warn` spy assertion
- `MockLogger.child()` returns base instance — foot-gun for any future test that asserts on `logger.child(...).warn(...)`. Refactor when Test #5 lands.

## Test plan

- [x] `make test` (1953 passing)
- [x] `pnpm -r build` (all packages compile)
- [x] `pnpm exec biome check --write` (clean)
- [x] Multi-agent review (Claude + Codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)