### PR TITLE
feat(redis): D-10 Redis 7.2 LTS + pExpireGT NX+GT pair (v0.5.1 F1 PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Breaking Changes (Phase F — D-10 Redis 7.2 LTS minimum, v0.5.1)
+
+- **Redis 7.2 LTS minimum required** (`@o3co/auth-provider-redis`): the Redis-backed
+  session adapters (`createRedisSidSortedSet`, `createRedisSidHash`) now use
+  `PEXPIREAT … NX` + `PEXPIREAT … GT` (Redis 7.0+ flags) on the per-sid TTL
+  pipeline to prevent TTL truncation under concurrent writes (CR-3). The pair
+  is required because Redis treats a non-volatile (no-TTL) key as having
+  infinite TTL for the GT flag, so a bare `PEXPIREAT … GT` silently no-ops on
+  the first write — the NX clause sets the TTL on first write, the GT clause
+  raises it on subsequent writes only when the new ts is strictly greater.
+  Redis 6.x servers do not support either flag and will return `ERR syntax
+  error` at the first session write.
+  **Migration**: upgrade your Redis server to 7.2 LTS or later before deploying
+  v0.5.1. AWS ElastiCache for Redis 7.2, Upstash Redis, and Redis Cloud all
+  support the GT/NX flags. See `SessionRPRegistryMultiClient.pExpireGT` JSDoc
+  in `packages/redis/src/clients.mts` for the full semantics.
+
+- **`engines.node >=18.19.0`** (all eight published packages): every
+  `@o3co/auth-provider-*` package now declares `"engines": { "node": ">=18.19.0" }`.
+  npm/pnpm prints a warning by default; **pnpm enables `engines-strict=true` by
+  default in some configurations**, which causes a hard install failure on
+  Node <18.19. Consumers on Node 18.0.0–18.18.x should upgrade to Node 18.19.0
+  LTS or later before installing v0.5.1; Node 20 LTS and 22 LTS are unaffected.
+
+- **`pExpireGT` added to `SessionRPRegistryClient`/`MultiClient` and
+  `SessionSidSortedSetClient`/`MultiClient`** (`@o3co/auth-provider-redis`): the
+  four backing-client interfaces gain a non-optional `pExpireGT(key, msTimestamp)`
+  method (multi-client variant returns the chainable client for pipelining). The
+  bundled `makeIoredisClients()` adapter implements the new method as a
+  `pexpireat(k, ms, "NX")` + `pexpireat(k, ms, "GT")` pair (the bare GT form
+  silently no-ops on a key with no existing TTL — see method JSDoc). Custom
+  backing-client implementations (non-ioredis) must add `pExpireGT` to compile.
+
 ### Breaking Changes (Phase 1-9 — Module System Redesign)
 
 #### Module manifest pipeline (A2-α/β/γ)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,9 @@
 	"description": "Core types, config, and utilities for auth.provider",
 	"version": "0.0.0",
 	"license": "Apache-2.0",
+	"engines": {
+		"node": ">=18.19.0"
+	},
 	"type": "module",
 	"main": "./dist/index.mjs",
 	"types": "./dist/index.d.mts",

--- a/packages/core/src/__tests__/engines.test.mts
+++ b/packages/core/src/__tests__/engines.test.mts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// Resolve the monorepo root from this test file's location:
+//   packages/core/src/__tests__/engines.test.mts → ../../../..
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..", "..", "..", "..");
+
+/**
+ * The eight published packages that ship to npm. The Redis 7.2 LTS commitment
+ * (D-10) requires every published `package.json` to declare
+ * `engines.node >=18.19.0` so consumers on Node <18.19 see at least a warning,
+ * and a hard install failure with `engines-strict=true`.
+ */
+const PUBLISHED_PACKAGES = [
+	"packages/core",
+	"packages/oauth",
+	"packages/redis",
+	"packages/session",
+	"packages/foundation",
+	"packages/federation-github",
+	"packages/federation-google",
+	"packages/oauth-token-exchange",
+];
+
+describe("D-10: engines.node on every published package", () => {
+	for (const pkg of PUBLISHED_PACKAGES) {
+		it(`${pkg} declares engines.node >=18.19.0`, () => {
+			const pkgPath = resolve(REPO_ROOT, pkg, "package.json");
+			const content = readFileSync(pkgPath, "utf8");
+			const parsed = JSON.parse(content) as { engines?: { node?: string } };
+			expect(parsed.engines?.node).toBe(">=18.19.0");
+		});
+	}
+});

--- a/packages/federation-github/package.json
+++ b/packages/federation-github/package.json
@@ -3,6 +3,9 @@
 	"description": "GitHub federation provider for auth.provider",
 	"version": "0.0.0",
 	"license": "Apache-2.0",
+	"engines": {
+		"node": ">=18.19.0"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/federation-google/package.json
+++ b/packages/federation-google/package.json
@@ -3,6 +3,9 @@
 	"description": "Google federation provider for auth.provider",
 	"version": "0.0.0",
 	"license": "Apache-2.0",
+	"engines": {
+		"node": ">=18.19.0"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -3,6 +3,9 @@
 	"description": "Production HTTP user-authentication adapter for auth.provider",
 	"version": "0.0.0",
 	"license": "Apache-2.0",
+	"engines": {
+		"node": ">=18.19.0"
+	},
 	"type": "module",
 	"main": "./dist/index.mjs",
 	"types": "./dist/index.d.mts",

--- a/packages/oauth-token-exchange/package.json
+++ b/packages/oauth-token-exchange/package.json
@@ -3,6 +3,9 @@
 	"description": "RFC 8693 Token Exchange grant for auth.provider",
 	"version": "0.0.0",
 	"license": "Apache-2.0",
+	"engines": {
+		"node": ">=18.19.0"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -3,6 +3,9 @@
 	"description": "OAuth routes module for auth.provider",
 	"version": "0.0.0",
 	"license": "Apache-2.0",
+	"engines": {
+		"node": ">=18.19.0"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -5,9 +5,12 @@ Redis-backed adapters and `defineModule` manifests for `@o3co/auth-provider-core
 ## Requirements
 
 - **Node.js** `>=18.19.0`
-- **Redis server** `>=7.2 LTS` — the session adapters use `PEXPIREAT … GT` for
-  safe concurrent TTL writes (D-10). Redis 6.x is not supported. Tested
-  against:
+- **Redis server** `>=7.2 LTS` — the session adapters issue a
+  `PEXPIREAT … NX` + `PEXPIREAT … GT` pair for safe concurrent TTL writes
+  (D-10). NX sets the TTL on first write because a bare `… GT` silently
+  no-ops on a key with no existing TTL; GT then prevents truncation under
+  stale-`expiresAt` concurrent writes. Both flags require Redis 7.0+; we
+  pin to 7.2 LTS. Redis 6.x is not supported. Tested against:
   - AWS ElastiCache for Redis 7.2
   - Upstash Redis (7.2 compatible)
   - Redis Cloud 7.2

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -2,6 +2,17 @@
 
 Redis-backed adapters and `defineModule` manifests for `@o3co/auth-provider-core`.
 
+## Requirements
+
+- **Node.js** `>=18.19.0`
+- **Redis server** `>=7.2 LTS` — the session adapters use `PEXPIREAT … GT` for
+  safe concurrent TTL writes (D-10). Redis 6.x is not supported. Tested
+  against:
+  - AWS ElastiCache for Redis 7.2
+  - Upstash Redis (7.2 compatible)
+  - Redis Cloud 7.2
+  - Self-managed `redis:7.2-alpine`
+
 This package ships nine adapters covering every redis-backed component that
 `@o3co/auth-provider-core` exposes as a typed slot:
 

--- a/packages/redis/__tests__/challenges.test.mts
+++ b/packages/redis/__tests__/challenges.test.mts
@@ -15,7 +15,7 @@ let client: Redis;
 let keyCounter = 0;
 
 beforeAll(async () => {
-	container = await new GenericContainer("redis:7-alpine").withExposedPorts(6379).start();
+	container = await new GenericContainer("redis:7.2-alpine").withExposedPorts(6379).start();
 	client = new Redis({
 		host: container.getHost(),
 		port: container.getMappedPort(6379),

--- a/packages/redis/__tests__/internalSidHash.test.mts
+++ b/packages/redis/__tests__/internalSidHash.test.mts
@@ -25,7 +25,7 @@ let raw: Redis;
 let client: SessionRPRegistryClient;
 
 beforeAll(async () => {
-	container = await new GenericContainer("redis:7-alpine").withExposedPorts(6379).start();
+	container = await new GenericContainer("redis:7.2-alpine").withExposedPorts(6379).start();
 	raw = new Redis({ host: container.getHost(), port: container.getMappedPort(6379) });
 	// In production the wrapper adapter normalises ioredis to SessionRPRegistryClient.
 	// For these tests we use a hand-rolled minimal wrapper.
@@ -78,6 +78,38 @@ describe("createRedisSidHash", () => {
 		expect(await h.listValues("sid-1")).toEqual([]);
 	});
 
+	// D-10 / CR-3: a stale-`expiresAt` race with a shorter TTL must NOT truncate
+	// the key's existing TTL. The `pExpireGT` (NX + GT pair) prevents the
+	// write from clobbering a longer existing TTL with a shorter incoming one.
+	it("does NOT truncate the key TTL on a stale-shorter-expiresAt write (CR-3)", async () => {
+		const h = createRedisSidHash({ client, keyPrefix: prefix("ttl-trunc") });
+		const longExpiry = new Date(Date.now() + 5000); // 5s — first writer
+		const stale = new Date(longExpiry.getTime() - 4500); // 0.5s — stale view
+		await h.setField("sid-1", "id-a", JSON.stringify({ x: 1 }), longExpiry);
+		expect(await h.listValues("sid-1")).toHaveLength(1);
+		// Stale write — must NOT truncate the existing 5s TTL.
+		await h.setField("sid-1", "id-b", JSON.stringify({ y: 2 }), stale);
+		expect(await h.listValues("sid-1")).toHaveLength(2);
+		// Wait past the stale TTL window. With bare-PEXPIREAT (no GT) the key
+		// would have been truncated to 0.5s and expired by now; with the GT
+		// guard the key still has ~4s of TTL remaining.
+		await new Promise((r) => setTimeout(r, 700));
+		expect(await h.listValues("sid-1")).toHaveLength(2);
+	});
+
+	// D-10 bootstrap test: the very first write must set the TTL even though
+	// the key has no prior TTL. A bare `PEXPIREAT … GT` would silently no-op
+	// here (Redis treats no-TTL as infinite TTL for the GT flag), leaving the
+	// key persistent. The NX clause in `pExpireGT` covers this bootstrap gap.
+	it("first write to a fresh sid sets a TTL (no infinite-TTL bootstrap leak)", async () => {
+		const h = createRedisSidHash({ client, keyPrefix: prefix("ttl-boot") });
+		await h.setField("sid-fresh", "id-a", JSON.stringify({ x: 1 }), FUTURE());
+		const pttl = await raw.pttl(`${prefix("ttl-boot")}sid-fresh`);
+		// PTTL returns -1 for a key with no TTL (the bug case) and -2 if the
+		// key is missing. A positive value means the TTL is set as expected.
+		expect(pttl).toBeGreaterThan(0);
+	});
+
 	it("removeBySid clears the key", async () => {
 		const h = createRedisSidHash({ client, keyPrefix: prefix("rem") });
 		await h.setField("sid-1", "id-a", JSON.stringify({ x: 1 }), FUTURE());
@@ -124,6 +156,11 @@ function makeWrapper(io: Redis): SessionRPRegistryClient {
 				p.pexpireat(k, ms);
 				return m;
 			},
+			pExpireGT: (k, ms) => {
+				p.pexpireat(k, ms, "NX");
+				p.pexpireat(k, ms, "GT");
+				return m;
+			},
 			exec: async () => p.exec(),
 		};
 		return m;
@@ -135,5 +172,10 @@ function makeWrapper(io: Redis): SessionRPRegistryClient {
 		hVals: (k) => io.hvals(k),
 		multi: () => buildMulti(),
 		pExpireAt: (k, ms) => io.pexpireat(k, ms),
+		pExpireGT: async (k, ms) => {
+			const nx = await io.pexpireat(k, ms, "NX");
+			if (nx === 1) return nx;
+			return io.pexpireat(k, ms, "GT");
+		},
 	};
 }

--- a/packages/redis/__tests__/internalSidSortedSet.test.mts
+++ b/packages/redis/__tests__/internalSidSortedSet.test.mts
@@ -25,7 +25,7 @@ let raw: Redis;
 let client: SessionSidSortedSetClient;
 
 beforeAll(async () => {
-	container = await new GenericContainer("redis:7-alpine").withExposedPorts(6379).start();
+	container = await new GenericContainer("redis:7.2-alpine").withExposedPorts(6379).start();
 	raw = new Redis({ host: container.getHost(), port: container.getMappedPort(6379) });
 	client = makeWrapper(raw);
 }, 60_000);
@@ -85,6 +85,37 @@ describe("createRedisSidSortedSet", () => {
 		expect(await z.list("sid-1")).toEqual([]);
 	});
 
+	// D-10 / CR-3: a stale-`expiresAt` race with a shorter TTL must NOT
+	// truncate the key's existing TTL. The `pExpireGT` (NX + GT pair) prevents
+	// the write from clobbering a longer existing TTL with a shorter one.
+	it("does NOT truncate the key TTL on a stale-shorter-expiresAt write (CR-3)", async () => {
+		const z = createRedisSidSortedSet({ client, keyPrefix: prefix("ttl-trunc") });
+		const longExpiry = new Date(Date.now() + 5000); // 5s — first writer
+		const stale = new Date(longExpiry.getTime() - 4500); // 0.5s — stale view
+		await z.add("sid-1", "google", longExpiry);
+		expect(await z.list("sid-1")).toEqual(["google"]);
+		// Stale write — must NOT truncate the existing 5s TTL.
+		await z.add("sid-1", "github", stale);
+		expect(await z.list("sid-1")).toEqual(["google", "github"]);
+		// Wait past the stale TTL window. With bare-PEXPIREAT (no GT) the key
+		// would have been truncated to 0.5s and expired by now.
+		await new Promise((r) => setTimeout(r, 700));
+		expect(await z.list("sid-1")).toEqual(["google", "github"]);
+	});
+
+	// D-10 bootstrap test: the very first write must set the TTL even though
+	// the key has no prior TTL. A bare `PEXPIREAT … GT` would silently no-op
+	// here (Redis treats no-TTL as infinite TTL for the GT flag), leaving the
+	// key persistent. The NX clause in `pExpireGT` covers this bootstrap gap.
+	it("first write to a fresh sid sets a TTL (no infinite-TTL bootstrap leak)", async () => {
+		const z = createRedisSidSortedSet({ client, keyPrefix: prefix("ttl-boot") });
+		await z.add("sid-fresh", "google", FUTURE());
+		const pttl = await raw.pttl(`${prefix("ttl-boot")}sid-fresh`);
+		// PTTL returns -1 for a key with no TTL (the bug case) and -2 if the
+		// key is missing. A positive value means the TTL is set as expected.
+		expect(pttl).toBeGreaterThan(0);
+	});
+
 	it("remove(sid, member) removes only the named member", async () => {
 		const z = createRedisSidSortedSet({ client, keyPrefix: prefix("rem-one") });
 		await z.add("sid-1", "google", FUTURE());
@@ -128,6 +159,11 @@ function makeWrapper(io: Redis): SessionSidSortedSetClient {
 				p.pexpireat(k, ms);
 				return m;
 			},
+			pExpireGT: (k, ms) => {
+				p.pexpireat(k, ms, "NX");
+				p.pexpireat(k, ms, "GT");
+				return m;
+			},
 			zAdd: (k, e, opts) => {
 				if (opts?.NX) p.zadd(k, "NX", e.score, e.value);
 				else p.zadd(k, e.score, e.value);
@@ -142,6 +178,11 @@ function makeWrapper(io: Redis): SessionSidSortedSetClient {
 		del: (k) => io.del(k),
 		multi: () => buildMulti(),
 		pExpireAt: (k, ms) => io.pexpireat(k, ms),
+		pExpireGT: async (k, ms) => {
+			const nx = await io.pexpireat(k, ms, "NX");
+			if (nx === 1) return nx;
+			return io.pexpireat(k, ms, "GT");
+		},
 		zAdd: (k, e, opts) =>
 			opts?.NX
 				? (io.zadd(k, "NX", e.score, e.value) as Promise<unknown> as Promise<number>)

--- a/packages/redis/__tests__/redis.sessionFamilyIndex.test.mts
+++ b/packages/redis/__tests__/redis.sessionFamilyIndex.test.mts
@@ -25,7 +25,7 @@ let container: StartedTestContainer;
 let raw: Redis;
 
 beforeAll(async () => {
-	container = await new GenericContainer("redis:7-alpine").withExposedPorts(6379).start();
+	container = await new GenericContainer("redis:7.2-alpine").withExposedPorts(6379).start();
 	raw = new Redis({ host: container.getHost(), port: container.getMappedPort(6379) });
 }, 60_000);
 

--- a/packages/redis/__tests__/redis.sessionFederationIndex.test.mts
+++ b/packages/redis/__tests__/redis.sessionFederationIndex.test.mts
@@ -25,7 +25,7 @@ let container: StartedTestContainer;
 let raw: Redis;
 
 beforeAll(async () => {
-	container = await new GenericContainer("redis:7-alpine").withExposedPorts(6379).start();
+	container = await new GenericContainer("redis:7.2-alpine").withExposedPorts(6379).start();
 	raw = new Redis({ host: container.getHost(), port: container.getMappedPort(6379) });
 }, 60_000);
 

--- a/packages/redis/__tests__/redis.sessionRPRegistry.test.mts
+++ b/packages/redis/__tests__/redis.sessionRPRegistry.test.mts
@@ -25,7 +25,7 @@ let container: StartedTestContainer;
 let raw: Redis;
 
 beforeAll(async () => {
-	container = await new GenericContainer("redis:7-alpine").withExposedPorts(6379).start();
+	container = await new GenericContainer("redis:7.2-alpine").withExposedPorts(6379).start();
 	raw = new Redis({ host: container.getHost(), port: container.getMappedPort(6379) });
 }, 60_000);
 

--- a/packages/redis/__tests__/redis.userSessionStore.test.mts
+++ b/packages/redis/__tests__/redis.userSessionStore.test.mts
@@ -25,7 +25,7 @@ let container: StartedTestContainer;
 let raw: Redis;
 
 beforeAll(async () => {
-	container = await new GenericContainer("redis:7-alpine").withExposedPorts(6379).start();
+	container = await new GenericContainer("redis:7.2-alpine").withExposedPorts(6379).start();
 	raw = new Redis({ host: container.getHost(), port: container.getMappedPort(6379) });
 }, 60_000);
 

--- a/packages/redis/__tests__/redisSessionStoresModule.test.mts
+++ b/packages/redis/__tests__/redisSessionStoresModule.test.mts
@@ -26,7 +26,7 @@ let container: StartedTestContainer;
 let raw: Redis;
 
 beforeAll(async () => {
-	container = await new GenericContainer("redis:7-alpine").withExposedPorts(6379).start();
+	container = await new GenericContainer("redis:7.2-alpine").withExposedPorts(6379).start();
 	raw = new Redis({ host: container.getHost(), port: container.getMappedPort(6379) });
 }, 60_000);
 

--- a/packages/redis/__tests__/refresh-token-family-wiring.test.mts
+++ b/packages/redis/__tests__/refresh-token-family-wiring.test.mts
@@ -31,7 +31,7 @@ let container: StartedTestContainer;
 let client: Redis;
 
 beforeAll(async () => {
-	container = await new GenericContainer("redis:7-alpine").withExposedPorts(6379).start();
+	container = await new GenericContainer("redis:7.2-alpine").withExposedPorts(6379).start();
 	client = new Redis({
 		host: container.getHost(),
 		port: container.getMappedPort(6379),

--- a/packages/redis/__tests__/refresh-token-family.test.mts
+++ b/packages/redis/__tests__/refresh-token-family.test.mts
@@ -61,7 +61,7 @@ const adapt = (raw: Redis): RefreshTokenFamilyClient => {
 };
 
 beforeAll(async () => {
-	container = await new GenericContainer("redis:7-alpine").withExposedPorts(6379).start();
+	container = await new GenericContainer("redis:7.2-alpine").withExposedPorts(6379).start();
 	client = new Redis({
 		host: container.getHost(),
 		port: container.getMappedPort(6379),

--- a/packages/redis/__tests__/replay-seen-set.test.mts
+++ b/packages/redis/__tests__/replay-seen-set.test.mts
@@ -15,7 +15,7 @@ let client: Redis;
 let keyCounter = 0;
 
 beforeAll(async () => {
-	container = await new GenericContainer("redis:7-alpine").withExposedPorts(6379).start();
+	container = await new GenericContainer("redis:7.2-alpine").withExposedPorts(6379).start();
 	client = new Redis({
 		host: container.getHost(),
 		port: container.getMappedPort(6379),

--- a/packages/redis/__tests__/types.test.mts
+++ b/packages/redis/__tests__/types.test.mts
@@ -163,14 +163,16 @@ describe("Per-purpose multi-client interfaces", () => {
 		>();
 	});
 
-	it("SessionRPRegistryMultiClient has chainable hSet + pExpireAt + exec", () => {
+	it("SessionRPRegistryMultiClient has chainable hSet + pExpireAt + pExpireGT + exec", () => {
 		expectTypeOf<SessionRPRegistryMultiClient["hSet"]>().toBeFunction();
 		expectTypeOf<SessionRPRegistryMultiClient["pExpireAt"]>().toBeFunction();
+		expectTypeOf<SessionRPRegistryMultiClient["pExpireGT"]>().toBeFunction();
 		expectTypeOf<SessionRPRegistryMultiClient["exec"]>().toBeFunction();
 	});
 
-	it("SessionSidSortedSetMultiClient has chainable pExpireAt + zAdd + exec", () => {
+	it("SessionSidSortedSetMultiClient has chainable pExpireAt + pExpireGT + zAdd + exec", () => {
 		expectTypeOf<SessionSidSortedSetMultiClient["pExpireAt"]>().toBeFunction();
+		expectTypeOf<SessionSidSortedSetMultiClient["pExpireGT"]>().toBeFunction();
 		expectTypeOf<SessionSidSortedSetMultiClient["zAdd"]>().toBeFunction();
 		expectTypeOf<SessionSidSortedSetMultiClient["exec"]>().toBeFunction();
 	});

--- a/packages/redis/__tests__/wiring.test.mts
+++ b/packages/redis/__tests__/wiring.test.mts
@@ -30,7 +30,7 @@ let container: StartedTestContainer;
 let client: Redis;
 
 beforeAll(async () => {
-	container = await new GenericContainer("redis:7-alpine").withExposedPorts(6379).start();
+	container = await new GenericContainer("redis:7.2-alpine").withExposedPorts(6379).start();
 	client = new Redis({
 		host: container.getHost(),
 		port: container.getMappedPort(6379),

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -3,6 +3,9 @@
 	"description": "Redis-backed adapters (ChallengeStore, ReplaySeenSet) for @o3co/auth-provider-core",
 	"version": "0.0.0",
 	"license": "Apache-2.0",
+	"engines": {
+		"node": ">=18.19.0"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/redis/src/clients.mts
+++ b/packages/redis/src/clients.mts
@@ -120,6 +120,25 @@ export interface UserSessionStoreClient {
 export interface SessionRPRegistryMultiClient {
 	hSet(key: string, field: string, value: string): SessionRPRegistryMultiClient;
 	pExpireAt(key: string, msTimestamp: number): SessionRPRegistryMultiClient;
+	/**
+	 * Safely set the key's expiry under concurrent writes (D-10 / CR-3).
+	 *
+	 * Effective semantics:
+	 *   - If the key has no TTL, set it to `msTimestamp` (first-write case).
+	 *   - If the key has a TTL ≥ `msTimestamp`, leave it unchanged
+	 *     (truncation prevented under stale-`expiresAt` races).
+	 *   - If the key has a TTL < `msTimestamp`, raise it to `msTimestamp`
+	 *     (legitimate extension allowed).
+	 *
+	 * Implemented as a `PEXPIREAT … NX` + `PEXPIREAT … GT` pair (Redis 7.0+
+	 * flags). A bare `PEXPIREAT … GT` is insufficient: Redis treats a
+	 * non-volatile key as having infinite TTL for `GT`, so the GT clause
+	 * silently no-ops on first write. The NX clause covers that bootstrap
+	 * gap; the GT clause provides the truncation guard once a TTL exists.
+	 *
+	 * Requires Redis 7.0+. v0.5.1 pins the floor to Redis 7.2 LTS.
+	 */
+	pExpireGT(key: string, msTimestamp: number): SessionRPRegistryMultiClient;
 	exec(): Promise<unknown[] | null>;
 }
 
@@ -133,6 +152,8 @@ export interface SessionRPRegistryClient {
 	hVals(key: string): Promise<string[]>;
 	multi(): SessionRPRegistryMultiClient;
 	pExpireAt(key: string, msTimestamp: number): Promise<number>;
+	/** Non-pipeline variant of `pExpireGT`. See multi-client for semantics. */
+	pExpireGT(key: string, msTimestamp: number): Promise<number>;
 }
 
 // --- SessionSidSortedSetClient ---------------------------------------------
@@ -142,6 +163,25 @@ export interface SessionRPRegistryClient {
  */
 export interface SessionSidSortedSetMultiClient {
 	pExpireAt(key: string, msTimestamp: number): SessionSidSortedSetMultiClient;
+	/**
+	 * Safely set the key's expiry under concurrent writes (D-10 / CR-3).
+	 *
+	 * Effective semantics:
+	 *   - If the key has no TTL, set it to `msTimestamp` (first-write case).
+	 *   - If the key has a TTL ≥ `msTimestamp`, leave it unchanged
+	 *     (truncation prevented under stale-`expiresAt` races).
+	 *   - If the key has a TTL < `msTimestamp`, raise it to `msTimestamp`
+	 *     (legitimate extension allowed).
+	 *
+	 * Implemented as a `PEXPIREAT … NX` + `PEXPIREAT … GT` pair (Redis 7.0+
+	 * flags). A bare `PEXPIREAT … GT` is insufficient: Redis treats a
+	 * non-volatile key as having infinite TTL for `GT`, so the GT clause
+	 * silently no-ops on first write. The NX clause covers that bootstrap
+	 * gap; the GT clause provides the truncation guard once a TTL exists.
+	 *
+	 * Requires Redis 7.0+. v0.5.1 pins the floor to Redis 7.2 LTS.
+	 */
+	pExpireGT(key: string, msTimestamp: number): SessionSidSortedSetMultiClient;
 	zAdd(
 		key: string,
 		entry: { score: number; value: string },
@@ -159,6 +199,8 @@ export interface SessionSidSortedSetClient {
 	del(key: string): Promise<number>;
 	multi(): SessionSidSortedSetMultiClient;
 	pExpireAt(key: string, msTimestamp: number): Promise<number>;
+	/** Non-pipeline variant of `pExpireGT`. See multi-client for semantics. */
+	pExpireGT(key: string, msTimestamp: number): Promise<number>;
 	zAdd(key: string, entry: { score: number; value: string }, opts?: { NX: true }): Promise<number>;
 	zRange(key: string, start: number, stop: number): Promise<string[]>;
 	zRem(key: string, member: string): Promise<number>;

--- a/packages/redis/src/internal/redisSidHash.mts
+++ b/packages/redis/src/internal/redisSidHash.mts
@@ -29,18 +29,19 @@ export interface RedisSidHash {
 
 /**
  * Private redis helper used by `SessionRPRegistry`. Single-key HSET +
- * PEXPIREAT pipeline keyed by `${keyPrefix}${sid}`. Per A4 §7.2.1.
+ * PEXPIREAT … GT pipeline keyed by `${keyPrefix}${sid}`. Per A4 §7.2.1.
  *
  * **HASH-keyed-by-element-id rationale**: SADD-of-JSON cannot dedup by
  * `clientId` when other RP fields change (different bytewise JSON for the
  * same logical clientId would create duplicate entries). HSET dedups on
  * field name = `clientId`, semantically correct for RP upsert.
  *
- * **TTL contract**: callers MUST pass `session.expiresAt`. PEXPIREAT is
- * NOT monotonic; passing a different timestamp across writes for the same
- * sid would shorten the TTL. This restriction is enforced structurally:
+ * **TTL contract**: callers MUST pass `session.expiresAt`. The `pExpireGT`
+ * (PEXPIREAT … GT) modifier guards against stale-`expiresAt` writes
+ * shortening the key's TTL on concurrent same-sid writes; D-10 / CR-3.
+ * Requires Redis 7.0+; v0.5.1 pins the floor to Redis 7.2 LTS.
  * `UserSession.expiresAt` is post-create immutable per A4 §5.1, so the
- * only legal `expiresAt` is the session-create-time value.
+ * legal value is fixed at session-create time.
  *
  * **Writes after expiry are no-op**: prevents zombie keys with no TTL.
  */
@@ -52,7 +53,7 @@ export function createRedisSidHash(opts: RedisSidHashOptions): RedisSidHash {
 			if (expiresAtMs <= Date.now()) return;
 			const pipeline = opts.client.multi();
 			pipeline.hSet(k(sid), id, jsonValue);
-			pipeline.pExpireAt(k(sid), expiresAtMs);
+			pipeline.pExpireGT(k(sid), expiresAtMs);
 			await pipeline.exec();
 		},
 		async listValues(sid) {

--- a/packages/redis/src/internal/redisSidHash.mts
+++ b/packages/redis/src/internal/redisSidHash.mts
@@ -29,7 +29,8 @@ export interface RedisSidHash {
 
 /**
  * Private redis helper used by `SessionRPRegistry`. Single-key HSET +
- * PEXPIREAT … GT pipeline keyed by `${keyPrefix}${sid}`. Per A4 §7.2.1.
+ * (`PEXPIREAT … NX` + `PEXPIREAT … GT`) pipeline keyed by
+ * `${keyPrefix}${sid}`. Per A4 §7.2.1.
  *
  * **HASH-keyed-by-element-id rationale**: SADD-of-JSON cannot dedup by
  * `clientId` when other RP fields change (different bytewise JSON for the
@@ -37,8 +38,10 @@ export interface RedisSidHash {
  * field name = `clientId`, semantically correct for RP upsert.
  *
  * **TTL contract**: callers MUST pass `session.expiresAt`. The `pExpireGT`
- * (PEXPIREAT … GT) modifier guards against stale-`expiresAt` writes
- * shortening the key's TTL on concurrent same-sid writes; D-10 / CR-3.
+ * method emits a `PEXPIREAT … NX` + `PEXPIREAT … GT` pair: NX sets the TTL
+ * on first write (a bare GT silently no-ops on a key with no existing TTL —
+ * Redis treats no-TTL as infinite TTL for the GT flag), GT prevents TTL
+ * truncation on stale-`expiresAt` concurrent writes (D-10 / CR-3).
  * Requires Redis 7.0+; v0.5.1 pins the floor to Redis 7.2 LTS.
  * `UserSession.expiresAt` is post-create immutable per A4 §5.1, so the
  * legal value is fixed at session-create time.

--- a/packages/redis/src/internal/redisSidSortedSet.mts
+++ b/packages/redis/src/internal/redisSidSortedSet.mts
@@ -57,7 +57,7 @@ let _insertionCounter = 0;
 
 /**
  * Private redis helper used by `SessionFamilyIndex` + `SessionFederationIndex`.
- * Single-key ZADD NX + PEXPIREAT pipeline keyed by `${keyPrefix}${sid}`.
+ * Single-key ZADD NX + PEXPIREAT … GT pipeline keyed by `${keyPrefix}${sid}`.
  *
  * Per A4 §7.2.2.
  *
@@ -68,7 +68,10 @@ let _insertionCounter = 0;
  *
  * **TTL contract** (identical to `createRedisSidHash`): callers MUST pass
  * `session.expiresAt`; same-sid writes use the SAME `expiresAt`; writes
- * after expiry no-op.
+ * after expiry no-op. The `pExpireGT` (PEXPIREAT … GT) modifier ensures a
+ * stale-`expiresAt` write does NOT shorten the key's existing TTL — required
+ * for safety under concurrent same-sid writes (D-10 / CR-3). Requires
+ * Redis 7.0+; v0.5.1 pins the floor to Redis 7.2 LTS.
  *
  * **Score**: monotonic module-level counter (see `_insertionCounter` above).
  * The counter replaces `Date.now()` as the score source to guarantee strict
@@ -86,7 +89,7 @@ export function createRedisSidSortedSet(opts: RedisSidSortedSetOptions): RedisSi
 			const score = ++_insertionCounter;
 			const pipeline = opts.client.multi();
 			pipeline.zAdd(k(sid), { score, value: member }, { NX: true });
-			pipeline.pExpireAt(k(sid), expiresAtMs);
+			pipeline.pExpireGT(k(sid), expiresAtMs);
 			await pipeline.exec();
 		},
 		async list(sid) {

--- a/packages/redis/src/internal/redisSidSortedSet.mts
+++ b/packages/redis/src/internal/redisSidSortedSet.mts
@@ -57,21 +57,23 @@ let _insertionCounter = 0;
 
 /**
  * Private redis helper used by `SessionFamilyIndex` + `SessionFederationIndex`.
- * Single-key ZADD NX + PEXPIREAT … GT pipeline keyed by `${keyPrefix}${sid}`.
+ * Single-key ZADD NX + (`PEXPIREAT … NX` + `PEXPIREAT … GT`) pipeline keyed
+ * by `${keyPrefix}${sid}`.
  *
  * Per A4 §7.2.2.
  *
- * **NX semantics**: ZADD ... NX does NOT update the existing member's score.
- * Original insertion-time score is preserved, so re-add of an existing
+ * **NX semantics on ZADD**: ZADD ... NX does NOT update the existing member's
+ * score. Original insertion-time score is preserved, so re-add of an existing
  * member does NOT promote its position. Load-bearing for
  * `SessionFederationIndex` ordering contract (A4 §5.4).
  *
  * **TTL contract** (identical to `createRedisSidHash`): callers MUST pass
  * `session.expiresAt`; same-sid writes use the SAME `expiresAt`; writes
- * after expiry no-op. The `pExpireGT` (PEXPIREAT … GT) modifier ensures a
- * stale-`expiresAt` write does NOT shorten the key's existing TTL — required
- * for safety under concurrent same-sid writes (D-10 / CR-3). Requires
- * Redis 7.0+; v0.5.1 pins the floor to Redis 7.2 LTS.
+ * after expiry no-op. The `pExpireGT` method emits a `PEXPIREAT … NX` +
+ * `PEXPIREAT … GT` pair: NX sets the TTL on first write (a bare GT silently
+ * no-ops on a key with no existing TTL), GT prevents TTL truncation when
+ * a stale-`expiresAt` writer races against a longer existing TTL
+ * (D-10 / CR-3). Requires Redis 7.0+; v0.5.1 pins the floor to Redis 7.2 LTS.
  *
  * **Score**: monotonic module-level counter (see `_insertionCounter` above).
  * The counter replaces `Date.now()` as the score source to guarantee strict

--- a/packages/redis/src/ioredis.mts
+++ b/packages/redis/src/ioredis.mts
@@ -116,6 +116,14 @@ export function makeIoredisClients(io: Redis): {
 		del: (k) => io.del(k),
 	};
 
+	// `pExpireGT` is implemented as `PEXPIREAT NX` followed by `PEXPIREAT GT`
+	// (D-10). Redis 7.0+ treats a non-volatile key as having infinite TTL for
+	// the GT/LT/NX flags, so a bare `PEXPIREAT … GT` against a freshly-created
+	// key (no existing TTL) would silently no-op and leave the key persistent.
+	// The NX clause sets the TTL on first write; the GT clause raises it on
+	// subsequent same-sid writes only when the new ts is strictly greater
+	// (preventing the CR-3 truncation race when a stale `expiresAt` value
+	// arrives concurrently). Same effect in 2 commands within one pipeline.
 	const buildRPRegistryMulti = (p: ReturnType<Redis["multi"]>): SessionRPRegistryMultiClient => {
 		const m: SessionRPRegistryMultiClient = {
 			hSet: (k, f, v) => {
@@ -124,6 +132,11 @@ export function makeIoredisClients(io: Redis): {
 			},
 			pExpireAt: (k, ms) => {
 				p.pexpireat(k, ms);
+				return m;
+			},
+			pExpireGT: (k, ms) => {
+				p.pexpireat(k, ms, "NX");
+				p.pexpireat(k, ms, "GT");
 				return m;
 			},
 			exec: async () => p.exec(),
@@ -137,12 +150,26 @@ export function makeIoredisClients(io: Redis): {
 		hVals: (k) => io.hvals(k),
 		multi: () => buildRPRegistryMulti(io.multi()),
 		pExpireAt: (k, ms) => io.pexpireat(k, ms),
+		// Returns 1 when either NX (first-write) or GT (raise) sets the TTL,
+		// 0 otherwise. Without the early return on NX success the caller would
+		// observe a "failure" (0 from the GT clause that no-ops once NX has
+		// already set TTL == ms), which misreports first-write success.
+		pExpireGT: async (k, ms) => {
+			const nx = await io.pexpireat(k, ms, "NX");
+			if (nx === 1) return nx;
+			return io.pexpireat(k, ms, "GT");
+		},
 	};
 
 	const buildSortedSetMulti = (p: ReturnType<Redis["multi"]>): SessionSidSortedSetMultiClient => {
 		const m: SessionSidSortedSetMultiClient = {
 			pExpireAt: (k, ms) => {
 				p.pexpireat(k, ms);
+				return m;
+			},
+			pExpireGT: (k, ms) => {
+				p.pexpireat(k, ms, "NX");
+				p.pexpireat(k, ms, "GT");
 				return m;
 			},
 			zAdd: (k, e, opts) => {
@@ -159,6 +186,12 @@ export function makeIoredisClients(io: Redis): {
 		del: (k) => io.del(k),
 		multi: () => buildSortedSetMulti(io.multi()),
 		pExpireAt: (k, ms) => io.pexpireat(k, ms),
+		// See sessionRPRegistryClient.pExpireGT above for return-value rationale.
+		pExpireGT: async (k, ms) => {
+			const nx = await io.pexpireat(k, ms, "NX");
+			if (nx === 1) return nx;
+			return io.pexpireat(k, ms, "GT");
+		},
 		zAdd: (k, e, opts) =>
 			opts?.NX
 				? (io.zadd(k, "NX", e.score, e.value) as Promise<unknown> as Promise<number>)

--- a/packages/redis/src/sessionRPRegistry.mts
+++ b/packages/redis/src/sessionRPRegistry.mts
@@ -85,9 +85,11 @@ function deserialize(json: string): RegisteredRP {
  *   logical clientId, creating duplicate set members. HSET uses the field
  *   name as the dedup key, which is exactly `clientId`.
  *
- * TTL: PEXPIREAT is applied atomically in the same pipeline as HSET via
+ * TTL: PEXPIREAT … GT is applied atomically in the same pipeline as HSET via
  * `createRedisSidHash.setField`. The timestamp is `session.expiresAt`,
- * which is post-create immutable per A4 §5.1.
+ * which is post-create immutable per A4 §5.1. The GT modifier (Redis 7.0+)
+ * prevents TTL truncation under concurrent same-sid writes — required floor
+ * is Redis 7.2 LTS per D-10.
  */
 export function createRedisSessionRPRegistry(
 	opts: RedisSessionRPRegistryOptions,

--- a/packages/redis/src/sessionRPRegistry.mts
+++ b/packages/redis/src/sessionRPRegistry.mts
@@ -85,11 +85,14 @@ function deserialize(json: string): RegisteredRP {
  *   logical clientId, creating duplicate set members. HSET uses the field
  *   name as the dedup key, which is exactly `clientId`.
  *
- * TTL: PEXPIREAT … GT is applied atomically in the same pipeline as HSET via
- * `createRedisSidHash.setField`. The timestamp is `session.expiresAt`,
- * which is post-create immutable per A4 §5.1. The GT modifier (Redis 7.0+)
- * prevents TTL truncation under concurrent same-sid writes — required floor
- * is Redis 7.2 LTS per D-10.
+ * TTL: a `PEXPIREAT … NX` + `PEXPIREAT … GT` pair is applied atomically in
+ * the same pipeline as HSET via `createRedisSidHash.setField` (the bare GT
+ * form silently no-ops on a key with no existing TTL — Redis treats no-TTL
+ * as infinite TTL for the GT flag). The NX clause sets the TTL on first
+ * write; the GT clause prevents TTL truncation under stale-`expiresAt`
+ * concurrent writes. The timestamp is `session.expiresAt`, which is
+ * post-create immutable per A4 §5.1. Required Redis floor is 7.2 LTS
+ * per D-10.
  */
 export function createRedisSessionRPRegistry(
 	opts: RedisSessionRPRegistryOptions,

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -3,6 +3,9 @@
 	"description": "Session and federation routes module for auth.provider",
 	"version": "0.0.0",
 	"license": "Apache-2.0",
+	"engines": {
+		"node": ">=18.19.0"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/templates/standalone/docker-compose.test.yml
+++ b/templates/standalone/docker-compose.test.yml
@@ -8,7 +8,7 @@ services:
         condition: service_healthy
 
   redis:
-    image: redis:7-alpine
+    image: redis:7.2-alpine
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s

--- a/templates/standalone/docker-compose.yml
+++ b/templates/standalone/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         required: false
 
   redis:
-    image: redis:7-alpine
+    image: redis:7.2-alpine
     ports:
       - "127.0.0.1:6379:6379"
     healthcheck:

--- a/templates/standalone/package.json
+++ b/templates/standalone/package.json
@@ -3,6 +3,9 @@
 	"version": "0.0.0",
 	"private": true,
 	"license": "Apache-2.0",
+	"engines": {
+		"node": ">=18.19.0"
+	},
 	"packageManager": "pnpm@10.29.3",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

F1 PR2 of v0.5.1 Phase F. Pins the Redis server runtime to 7.2 LTS, adds `engines.node >=18.19.0` to all eight published packages, and introduces `pExpireGT` on the four session backing-client interfaces to prevent TTL truncation under concurrent same-sid writes (CR-3).

Spec: [`d10-redis-7-2-lts.md`](.claude/superpowers/specs/2026-05-05-d10-redis-7-2-lts.md) · Decisions contract D-10 section.

## Implementation departure (NX + GT pair, not bare GT)

The spec proposed a single `PEXPIREAT key ts GT` command, but Redis 7.0+ treats a non-volatile (no-TTL) key as having **infinite** TTL for the GT flag — so a bare `… GT` silently no-ops on the first write, leaving the key persistent. This was caught by 5 failing tests on the first GREEN attempt.

Fix: emit `PEXPIREAT k ms NX` + `PEXPIREAT k ms GT` as a pair within one pipeline (one round-trip):

| Case | NX (set if no TTL) | GT (raise if greater) | Final TTL |
|---|---|---|---|
| First write (no TTL) | sets ms | no-op (cur == ms) | ms ✓ |
| Same-ms re-write | no-op | no-op | unchanged ✓ |
| Stale-shorter race | no-op | no-op (new < cur) | unchanged ✓ (CR-3 guard) |
| Legitimate extend | no-op | sets ms (new > cur) | ms ✓ |

Full semantics in `SessionRPRegistryMultiClient.pExpireGT` JSDoc.

## Files touched

| Area | Files | Change |
|---|---|---|
| Interfaces | `packages/redis/src/clients.mts` | `pExpireGT` declared on 4 interfaces (2 multi + 2 single) with full JSDoc |
| ioredis adapter | `packages/redis/src/ioredis.mts` | NX+GT pair impl (4 sites: 2 multi + 2 single); single-call early-returns NX success per Codex P3 fix |
| Production sites | `redisSidSortedSet.mts:89`, `redisSidHash.mts:55` | `pExpireAt` → `pExpireGT` |
| Stale docs | `sessionRPRegistry.mts:88`, two helper file headers | `PEXPIREAT` → `PEXPIREAT … NX/GT` reference |
| Engines pin | 8 published `package.json` + `templates/standalone/package.json` | `"engines": { "node": ">=18.19.0" }` |
| Container pin | 12 `__tests__/*.mts` testcontainer files + 2 docker-compose | `redis:7-alpine` → `redis:7.2-alpine` |
| Docs | `CHANGELOG.md`, `packages/redis/README.md` | Breaking-change entry + Requirements section |

## Tests

- **Existing 200 + 4 new** redis tests passing (204 total). Core tests gain 8 new sub-tests in `engines.test.mts` (one per published package).
- New tests:
  - **CR-3 truncation regression** (sortedSet + hash): writes long TTL then stale-shorter TTL; asserts both members survive past the short window. With bare PEXPIREAT this would fail.
  - **Bootstrap-NX** (sortedSet + hash): first write to a fresh sid, asserts `PTTL > 0`. With bare GT this would fail (no-TTL leak).
  - **Type-level** (`types.test.mts`): `expectTypeOf<… ["pExpireGT"]>().toBeFunction()` for both Multi clients.
  - **engines smoke** (new file): asserts every published package.json has `engines.node === ">=18.19.0"`.

`make test`: **1948 passing**.

## Multi-agent review

- 🔵 Claude (design + logic): **Major** — flagged missing CR-3 regression test, missing bootstrap-NX test, CHANGELOG bullet 3 misdescribing impl, partial testcontainer pinning (10/12), understated engines-strict pnpm caveat. **All addressed in this PR**.
- 🟠 Codex (security + perf): **P3** — non-pipeline `pExpireGT` was returning the GT clause's `0` after NX successfully bootstrapped the TTL, misreporting first-write success. **Fixed** with early-return on NX success.

## Closes

- D-10 → CR-3 (TTL truncation race), CR-Codex-missed, SC-3 (engines.node)

## Breaking changes (CHANGELOG entries)

- **Redis 7.2 LTS minimum** required (server runtime; npm `redis` SDK peer dep unchanged at `^5.10.0`)
- **`engines.node >=18.19.0`** on all 8 published packages — pnpm `engines-strict=true` (default in some configs) will hard-fail install on Node <18.19
- **`pExpireGT` non-optional** on the 4 backing-client interfaces — custom (non-ioredis) implementations must add the method

## Cross-spec implications

- D-2 (standalone ioredis composition root) consumes the updated `makeIoredisClients()` — no extra GT work needed.
- D-9 (federation lock CAS via Lua) lands under the same Redis 7.2 floor; cluster-mode Lua caveat tracked separately.

## Test plan

- [x] `pnpm -r build` (all packages compile)
- [x] `make test` (1948 tests passing)
- [x] `git grep -n "\.pExpireAt(" packages/redis/src/internal/` → 0 hits
- [x] Multi-agent review (Claude Major + Codex P3) — all critical/important/P3 items addressed in the same commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)