### PR TITLE
feat(create-app): D-7 v2 publish-readiness + CC-4 close (v0.5.1 F1 PR3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,45 @@ jobs:
           done
           ls -la /tmp/tarballs
 
+      - name: Pack create-app
+        run: |
+          set -euo pipefail
+          # @o3co/create-auth-provider is published alongside @o3co/auth-provider-*
+          # via `pnpm -r publish` in release.yml. Pack it into the same tarball
+          # destination so the assertion step below covers it too.
+          # The tarball filename (`o3co-create-auth-provider-*.tgz`) is distinct
+          # from the packages tarballs (`o3co-auth-provider-*-*.tgz`).
+          pushd create-app >/dev/null
+          pnpm pack --pack-destination /tmp/tarballs
+          popd >/dev/null
+          echo "create-app tarball:"
+          ls -la /tmp/tarballs/o3co-create-auth-provider-*.tgz
+
+      - name: Assert no __tests__ in published tarballs
+        run: |
+          set -euo pipefail
+          # Per CC-4 (SC-1 + SC-2 + SC-M2): compiled test artifacts must not ship
+          # in any published tarball. The scope is `dist/__tests__/` — legitimate
+          # scaffold content at `package/templates/standalone/src/__tests__/`
+          # (create-app tarball only) is consumer-facing template source and
+          # MUST stay shipped.
+          FAILED=0
+          for tgz in /tmp/tarballs/*.tgz; do
+            HITS=$(tar -tzf "$tgz" | grep -E '/dist/.*__tests__' || true)
+            if [ -n "$HITS" ]; then
+              echo "::error::$tgz contains __tests__ artifacts in dist/:"
+              echo "$HITS"
+              FAILED=1
+            fi
+          done
+          if [ "$FAILED" -eq 1 ]; then
+            exit 1
+          fi
+          echo "OK: no __tests__ artifacts in any published tarball's dist/"
+
+      - name: Check versions.json sync
+        run: node create-app/scripts/check-versions-json.mjs
+
       - name: Build templates/standalone against packed tarballs
         run: |
           set -euo pipefail

--- a/create-app/package.json
+++ b/create-app/package.json
@@ -27,7 +27,11 @@
 	"scripts": {
 		"build": "tsc",
 		"prebuild": "node scripts/copy-templates.mjs",
+		"prepack": "rimraf dist && node scripts/copy-templates.mjs && tsc",
 		"test": "vitest run"
+	},
+	"engines": {
+		"node": ">=18.19.0"
 	},
 	"devDependencies": {
 		"@types/node": "^25.1.0",

--- a/create-app/scripts/check-versions-json.mjs
+++ b/create-app/scripts/check-versions-json.mjs
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// create-app/scripts/ -> create-app/ -> repo root
+const root = resolve(__dirname, "../..");
+const pkgsDir = resolve(root, "packages");
+
+// Enumerate published packages from packages/*/package.json directly.
+// pnpm-workspace.yaml always contains "packages/*" — directory listing is sufficient.
+const publishedPackages = new Set();
+for (const entry of readdirSync(pkgsDir, { withFileTypes: true })) {
+	if (!entry.isDirectory()) continue;
+	const pkgJsonPath = resolve(pkgsDir, entry.name, "package.json");
+	try {
+		const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+		if (pkg.private) continue;
+		publishedPackages.add(pkg.name);
+	} catch {
+		// directory without package.json (e.g. orphaned dirs) — skip
+	}
+}
+
+// Extract tracked package names from copy-templates.mjs source.
+// Pattern: keys of the `versions` object literal — "@o3co/auth-provider-*" strings.
+const copyTemplatesSrc = readFileSync(resolve(__dirname, "copy-templates.mjs"), "utf-8");
+const trackedPackages = new Set(
+	[...copyTemplatesSrc.matchAll(/"(@o3co\/auth-provider-[^"]+)":/g)].map((m) => m[1]),
+);
+
+const missing = [...publishedPackages].filter((name) => !trackedPackages.has(name));
+const extra = [...trackedPackages].filter((name) => !publishedPackages.has(name));
+
+let failed = false;
+
+if (missing.length > 0) {
+	console.error("check-versions-json: packages in workspace but missing from copy-templates.mjs:");
+	for (const name of missing) console.error(`  - ${name}`);
+	console.error(
+		"Fix: add the package to the `versions` object in create-app/scripts/copy-templates.mjs",
+	);
+	failed = true;
+}
+
+if (extra.length > 0) {
+	console.error("check-versions-json: packages in copy-templates.mjs but not in workspace:");
+	for (const name of extra) console.error(`  - ${name}`);
+	console.error("Fix: remove the stale entry from create-app/scripts/copy-templates.mjs");
+	failed = true;
+}
+
+if (failed) process.exit(1);
+console.log(`check-versions-json: OK — ${trackedPackages.size} packages in sync`);

--- a/create-app/tsconfig.json
+++ b/create-app/tsconfig.json
@@ -6,5 +6,5 @@
 		"paths": {}
 	},
 	"include": ["src/**/*"],
-	"exclude": ["node_modules", "dist", "templates"]
+	"exclude": ["node_modules", "dist", "templates", "src/**/__tests__/**"]
 }

--- a/packages/foundation/tsconfig.json
+++ b/packages/foundation/tsconfig.json
@@ -8,5 +8,5 @@
 		}
 	},
 	"include": ["src/**/*"],
-	"exclude": ["node_modules", "dist"]
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
 }

--- a/packages/oauth/tsconfig.json
+++ b/packages/oauth/tsconfig.json
@@ -8,5 +8,5 @@
 		}
 	},
 	"include": ["src/**/*"],
-	"exclude": ["node_modules", "dist"]
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
 }


### PR DESCRIPTION
## Summary

Third PR of v0.5.1 Phase F (F1 foundation batch). Makes `@o3co/create-auth-provider` first-class publish-ready and **simultaneously closes CC-4 cluster** (compiled `__tests__` leaking into `packages/oauth`, `packages/foundation`, and `create-app` tarballs). Wave 5 CC-4 spec is **eliminated** — closed by this PR.

Spec input: [`2026-05-05-d7-create-app-publish-readiness.md`](.claude/superpowers/specs/2026-05-05-d7-create-app-publish-readiness.md) (Codex Approved 2026-05-05).
Phase F dep graph: `.claude/audit/2026-05-06-phase-f-dependency-graph.md` §3 F1.

## Changes (6 files)

| File | Change | Notes |
|---|---|---|
| `packages/oauth/tsconfig.json` | Add `"src/**/__tests__/**"` to `exclude` | +1 line; closes SC-1 / CC-4 |
| `packages/foundation/tsconfig.json` | Add `"src/**/__tests__/**"` to `exclude` | +1 line; closes SC-2 / CC-4 |
| `create-app/tsconfig.json` | Add `"src/**/__tests__/**"` to `exclude` | +1 line; closes SC-M2 / CC-4 |
| `create-app/package.json` | Add `prepack` (clean build) + `engines.node` | rimraf is workspace devDep |
| `create-app/scripts/check-versions-json.mjs` | NEW workspace/versions sync gate | ~50 lines, zero ext deps |
| `.github/workflows/ci.yml` | 3 new steps in `publish-readiness` job | +35 lines |

## Spec departure (worth flagging)

The spec's CI gate B used broad `grep '__tests__'`. This PR narrows it to `grep -E '/dist/.*__tests__'` because `package/templates/standalone/src/__tests__/{configPath,smoke}.test.mts` is **legitimate scaffold content** in the create-app tarball — those are template tests that consumers run on their generated app, not compiled artifacts to exclude. The broad spec pattern would falsely fail the gate.

Verified locally: with the narrow pattern, all 3 affected tarballs (oauth, foundation, create-app) PASS the assertion AND the create-app tarball still ships the scaffold tests for consumers.

## Multi-agent review

- 🔵 **Claude (design + logic): PASS.** 6 minor advisory findings, all non-blocking. Spec departure verified as correct. tsconfig pattern matches 6+ sibling packages.
- 🟠 **Codex (security + perf): APPROVED.** Verified prepack execution, tarball contents, orphan `packages/did/` graceful handling. Final verdict: "no actionable regression in the modified code."

Severity roll-up: **Critical=0 / Important=0 / Minor=6** — all advisory, none blocking. No additional review round needed.

## Closes

- **D-7 (full)** — create-app publish-readiness
- **CC-4 cluster** — SC-1 (oauth), SC-2 (foundation), SC-M1 (publish intent confirmed), SC-M2 (create-app), SC-M3 (clean prepack + versions.json sync gate)

Wave 5 CC-4 spec is **eliminated** by this PR.

## Tests

`make test`: **1900 GREEN** across 10 packages, no regressions. Lint: biome clean.

Verified RED → GREEN for all 8 RED tests defined in spec (tarball assertions + package.json fields + versions.json key count + dist artifact absence).

## Test plan

- [x] All 3 tsconfig `exclude` arrays contain `"src/**/__tests__/**"`
- [x] `create-app/package.json` has `prepack` and `engines.node: ">=18.19.0"`
- [x] `check-versions-json.mjs` exits 0 with "8 packages in sync"
- [x] Clean rebuild + `pnpm pack` of oauth/foundation/create-app: zero `dist/__tests__/` in any tarball
- [x] create-app tarball still ships `templates/standalone/src/__tests__/` (scaffold preservation)
- [x] CI `publish-readiness` workflow includes 3 new steps in correct order
- [x] `make test` 1900 GREEN
- [x] biome check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)