### PR TITLE
feat(redis): D-9 federation lock CAS + OR-12 plaintext production guard (v0.5.1 F2 PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,50 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   silently no-ops on a key with no existing TTL — see method JSDoc). Custom
   backing-client implementations (non-ioredis) must add `pExpireGT` to compile.
 
+### Breaking Changes (Phase F — D-9 federation-tokens lock CAS, v0.5.1)
+
+- **`FederationTokenStoreClient.compareAndDelete` added** (`@o3co/auth-provider-redis`):
+  the `FederationTokenStoreClient` interface gains a required
+  `compareAndDelete(key, expectedValue): Promise<boolean>` method for atomic
+  advisory-lock release (closes CR-1 / OR-13 / SF-4). The pre-D-9 release
+  path was non-atomic GET+DEL, which had a race window during which a
+  TTL-expired holder could evict a freshly-acquired lock owned by a different
+  process. Lock semantics are now atomic via a server-side Lua compare-and-
+  delete script.
+  Custom implementations of `FederationTokenStoreClient` MUST add this method
+  with atomic semantics. Implementation guide: run a Lua `EVAL` script
+  `if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end`
+  with `keys=[key]`, `arguments=[expectedValue]`, returning `result === 1`.
+  Redis Cluster-mode deployments with Lua scripting disabled require an
+  alternative atomic strategy.
+  The bundled `makeIoredisClients()` adapter implements this automatically
+  via Lua `EVAL` with `EVALSHA` caching and `NOSCRIPT` fallback.
+
+- **`RedisLockClient` interface narrowed** (`@o3co/auth-provider-redis`,
+  internal): the lock's minimal client interface drops `get` and `del` in
+  favor of the new `compareAndDelete`. The interface is not exported from
+  the package index and only used internally by the federation-tokens lock
+  bridge — no external impact.
+
 ### Bug Fixes (Phase F — v0.5.1)
+
+- **federation-tokens lock release race**: federation-token refresh paths
+  could spuriously evict a freshly-acquired lock held by a different process
+  when the previous holder's TTL expired mid-call. The release path is now
+  an atomic Lua compare-and-delete (D-9, closes CR-1 / OR-13 / SF-4). Custom
+  `FederationTokenStoreClient` implementations must implement
+  `compareAndDelete` with atomic semantics (see breaking-change entry above).
+
+- **federation-tokens production guard for `allow-plaintext`**: the redis
+  federation-token store builder (`redisFederationTokenStoreBuilder`) now
+  refuses to construct a store with `encryption.mode = "allow-plaintext"`
+  when `NODE_ENV` is `"production"` or `"staging"`, throwing a startup error
+  unless the operator explicitly sets `FEDERATION_TOKENS_ALLOW_INSECURE=1`
+  to opt in (with a CRITICAL `console.error` warning). Pre-fix the builder
+  emitted a soft `console.warn` and continued, allowing federation tokens
+  (long-lived IdP refresh tokens) to ship unencrypted to production by
+  misconfiguration. Dev/test environments retain warn-only behavior. (OR-12,
+  closes CC-3 residual.)
 
 - **federation-refresh:** Fix Google (and other built-in) federation token refresh
   broken in v0.5.0. The route-side duck-type capability check in

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -15,6 +15,15 @@ Redis-backed adapters and `defineModule` manifests for `@o3co/auth-provider-core
   - Upstash Redis (7.2 compatible)
   - Redis Cloud 7.2
   - Self-managed `redis:7.2-alpine`
+- **Redis Lua scripting** (`EVAL` / `EVALSHA`) — the federation-token
+  advisory lock release path is implemented via an atomic Lua compare-and-
+  delete script (D-9, closes CR-1 / OR-13 / SF-4). Lua is enabled by default
+  on Redis standalone and Sentinel mode. **Redis Cluster mode with Lua
+  scripting disabled is not supported by the bundled `makeIoredisClients()`
+  adapter** — operators on AWS ElastiCache for Redis Cluster mode must
+  either enable Lua scripting in their cluster configuration, or wire a
+  custom `FederationTokenStoreClient` whose `compareAndDelete` uses an
+  alternative atomic primitive (e.g., a Cluster-safe transaction).
 
 This package ships nine adapters covering every redis-backed component that
 `@o3co/auth-provider-core` exposes as a typed slot:

--- a/packages/redis/__tests__/federation-tokens-lock.test.mts
+++ b/packages/redis/__tests__/federation-tokens-lock.test.mts
@@ -63,10 +63,7 @@ describe("D-9 — lock release is atomic compare-and-delete (no spurious DEL)", 
 		}
 
 		// Post-fix: compareAndDelete called once, returned false; del NOT called.
-		expect(compareAndDeleteSpy).toHaveBeenCalledWith(
-			"ftlock:sid-1:google",
-			expect.any(String),
-		);
+		expect(compareAndDeleteSpy).toHaveBeenCalledWith("ftlock:sid-1:google", expect.any(String));
 		expect(delSpy).not.toHaveBeenCalled();
 	});
 

--- a/packages/redis/__tests__/federation-tokens-lock.test.mts
+++ b/packages/redis/__tests__/federation-tokens-lock.test.mts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+// D-9 regression: lock release MUST be atomic compare-and-delete. Pre-rename,
+// lock.mts release path was GET + DEL, which has a race window during which a
+// TTL-expired holder's DEL evicts a freshly-acquired lock owned by a different
+// process. Post-rename, the release calls `client.compareAndDelete(key, token)`
+// — a single Lua-backed atomic operation that returns `false` when the stored
+// value does not match the caller's token, and `del` is never issued.
+//
+// These tests exercise the release closure produced by `acquireLock` against a
+// fake client whose stored value differs from the caller's acquire token.
+// Pre-fix: `del` is called regardless. Post-fix: `del` is not called when
+// `compareAndDelete` reports no ownership.
+
+import { describe, expect, it, vi } from "vitest";
+import { createRedisLock } from "../src/internal/lock.mjs";
+
+describe("D-9 — lock release is atomic compare-and-delete (no spurious DEL)", () => {
+	it("release() does NOT call del when compareAndDelete reports value mismatch", async () => {
+		const data = new Map<string, string>();
+		const delSpy = vi.fn(async (key: string) => {
+			if (data.delete(key)) return 1;
+			return 0;
+		});
+		// compareAndDelete: stored value differs from caller's token → returns
+		// false. The lock release path MUST honor this (no fallback to plain del).
+		const compareAndDeleteSpy = vi.fn(async (key: string, expected: string) => {
+			const stored = data.get(key);
+			if (stored !== undefined && stored === expected) {
+				data.delete(key);
+				return true;
+			}
+			return false;
+		});
+		const fakeClient = {
+			get: async (k: string) => data.get(k) ?? null,
+			set: async (k: string, v: string, opts?: { PX?: number; NX?: boolean }) => {
+				if (opts?.NX && data.has(k)) return null;
+				data.set(k, v);
+				return v;
+			},
+			del: delSpy,
+			compareAndDelete: compareAndDeleteSpy,
+		};
+
+		const lock = createRedisLock({
+			// biome-ignore lint/suspicious/noExplicitAny: fake client structurally satisfies the post-D-9 RedisLockClient shape; the cast keeps the test compatible across the interface widening.
+			client: fakeClient as any,
+			keyPrefix: "ftlock:",
+		});
+		const result = await lock.acquireLock({ sid: "sid-1", federationName: "google" });
+		expect(result.acquired).toBe(true);
+
+		// Simulate: between acquire and release, another caller overwrote the
+		// stored value (TTL expired, B acquired). Replace the stored entry.
+		data.set("ftlock:sid-1:google", "interloper-token");
+
+		if (result.acquired) {
+			await result.release();
+		}
+
+		// Post-fix: compareAndDelete called once, returned false; del NOT called.
+		expect(compareAndDeleteSpy).toHaveBeenCalledWith(
+			"ftlock:sid-1:google",
+			expect.any(String),
+		);
+		expect(delSpy).not.toHaveBeenCalled();
+	});
+
+	it("release() calls compareAndDelete (not GET+DEL) when caller still owns the lock", async () => {
+		const data = new Map<string, string>();
+		const getSpy = vi.fn(async (k: string) => data.get(k) ?? null);
+		const delSpy = vi.fn(async (k: string) => (data.delete(k) ? 1 : 0));
+		const compareAndDeleteSpy = vi.fn(async (key: string, expected: string) => {
+			if (data.get(key) === expected) {
+				data.delete(key);
+				return true;
+			}
+			return false;
+		});
+		const fakeClient = {
+			get: getSpy,
+			set: async (k: string, v: string, opts?: { PX?: number; NX?: boolean }) => {
+				if (opts?.NX && data.has(k)) return null;
+				data.set(k, v);
+				return v;
+			},
+			del: delSpy,
+			compareAndDelete: compareAndDeleteSpy,
+		};
+
+		const lock = createRedisLock({
+			// biome-ignore lint/suspicious/noExplicitAny: see prior test.
+			client: fakeClient as any,
+			keyPrefix: "ftlock:",
+		});
+		const result = await lock.acquireLock({ sid: "sid-2", federationName: "google" });
+		expect(result.acquired).toBe(true);
+
+		if (result.acquired) {
+			await result.release();
+		}
+
+		// Post-fix: compareAndDelete is the sole release primitive. The
+		// pre-fix GET+DEL release would have called both.
+		expect(compareAndDeleteSpy).toHaveBeenCalledTimes(1);
+		expect(getSpy).not.toHaveBeenCalled();
+		expect(delSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/redis/__tests__/federation-tokens-module.test.mts
+++ b/packages/redis/__tests__/federation-tokens-module.test.mts
@@ -45,7 +45,13 @@ describe("redisFederationTokenStoreBuilder", () => {
 	});
 
 	it("rejects encryption.required without 32-byte key", () => {
-		const fakeClient = { get: () => null, set: () => null, del: () => 0, scanIterator: () => [] };
+		const fakeClient = {
+			get: () => null,
+			set: () => null,
+			del: () => 0,
+			scanIterator: () => [],
+			compareAndDelete: async () => false,
+		};
 		expect(() =>
 			redisFederationTokenStoreBuilder({
 				client: fakeClient,
@@ -55,7 +61,13 @@ describe("redisFederationTokenStoreBuilder", () => {
 	});
 
 	it("accepts encryption.allow-plaintext", () => {
-		const fakeClient = { get: () => null, set: () => null, del: () => 0, scanIterator: () => [] };
+		const fakeClient = {
+			get: () => null,
+			set: () => null,
+			del: () => 0,
+			scanIterator: () => [],
+			compareAndDelete: async () => false,
+		};
 		// No throw expected
 		const store = redisFederationTokenStoreBuilder({
 			client: fakeClient,

--- a/packages/redis/__tests__/federation-tokens.test.mts
+++ b/packages/redis/__tests__/federation-tokens.test.mts
@@ -9,9 +9,12 @@ import {
 	type SupportsLock,
 	supportsLock,
 } from "@o3co/auth-provider-core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FederationTokenStoreClient } from "../src/clients.mjs";
-import { createRedisFederationTokenStore } from "../src/federation-tokens.mjs";
+import {
+	createRedisFederationTokenStore,
+	redisFederationTokenStoreBuilder,
+} from "../src/federation-tokens.mjs";
 
 function createFakeRedis() {
 	const data = new Map<string, string>();
@@ -46,6 +49,14 @@ function createFakeRedis() {
 			return (async function* () {
 				for (const k of matched) yield k;
 			})();
+		}),
+		compareAndDelete: vi.fn(async (k: string, expected: string): Promise<boolean> => {
+			const stored = data.get(k);
+			if (stored !== undefined && stored === expected) {
+				data.delete(k);
+				return true;
+			}
+			return false;
 		}),
 	} satisfies FederationTokenStoreClient & { data: Map<string, string>; ttls: Map<string, number> };
 }
@@ -310,5 +321,99 @@ describe("redis FederationTokenStore TTL is independent of access_token expiry",
 		await store.attach("sid-gh", "github", { ...tokens, expiresAt: null });
 		const round = await store.get("sid-gh", "github");
 		expect(round?.expiresAt).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// OR-12 — federation-tokens production guard for `allow-plaintext` mode
+// ---------------------------------------------------------------------------
+
+describe("OR-12 — redisFederationTokenStoreBuilder env-based encryption guard", () => {
+	let origEnv: string | undefined;
+	let origInsecure: string | undefined;
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		origEnv = process.env.NODE_ENV;
+		origInsecure = process.env.FEDERATION_TOKENS_ALLOW_INSECURE;
+		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		if (origEnv === undefined) delete process.env.NODE_ENV;
+		else process.env.NODE_ENV = origEnv;
+		if (origInsecure === undefined) delete process.env.FEDERATION_TOKENS_ALLOW_INSECURE;
+		else process.env.FEDERATION_TOKENS_ALLOW_INSECURE = origInsecure;
+		warnSpy.mockRestore();
+		errorSpy.mockRestore();
+	});
+
+	const mockClient = createFakeRedis() as unknown as FederationTokenStoreClient;
+
+	it("throws when NODE_ENV=production and mode=allow-plaintext (no override)", () => {
+		process.env.NODE_ENV = "production";
+		delete process.env.FEDERATION_TOKENS_ALLOW_INSECURE;
+		expect(() =>
+			redisFederationTokenStoreBuilder(
+				{ client: mockClient, encryption: { mode: "allow-plaintext" } },
+				{},
+			),
+		).toThrow(/mode "allow-plaintext" is not allowed in NODE_ENV="production"/);
+	});
+
+	it("throws when NODE_ENV=staging and mode=allow-plaintext (no override)", () => {
+		process.env.NODE_ENV = "staging";
+		delete process.env.FEDERATION_TOKENS_ALLOW_INSECURE;
+		expect(() =>
+			redisFederationTokenStoreBuilder(
+				{ client: mockClient, encryption: { mode: "allow-plaintext" } },
+				{},
+			),
+		).toThrow(/mode "allow-plaintext" is not allowed in NODE_ENV="staging"/);
+	});
+
+	it("succeeds in production with FEDERATION_TOKENS_ALLOW_INSECURE=1 escape hatch (emits CRITICAL)", () => {
+		process.env.NODE_ENV = "production";
+		process.env.FEDERATION_TOKENS_ALLOW_INSECURE = "1";
+		expect(() =>
+			redisFederationTokenStoreBuilder(
+				{ client: mockClient, encryption: { mode: "allow-plaintext" } },
+				{},
+			),
+		).not.toThrow();
+		expect(errorSpy).toHaveBeenCalledWith(
+			expect.stringContaining("FEDERATION_TOKENS_ALLOW_INSECURE=1"),
+		);
+	});
+
+	it("succeeds in development with allow-plaintext (warn-only)", () => {
+		process.env.NODE_ENV = "development";
+		delete process.env.FEDERATION_TOKENS_ALLOW_INSECURE;
+		expect(() =>
+			redisFederationTokenStoreBuilder(
+				{ client: mockClient, encryption: { mode: "allow-plaintext" } },
+				{},
+			),
+		).not.toThrow();
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("allow-plaintext"));
+	});
+
+	it("succeeds silently with mode=required in production (no warn, no throw)", () => {
+		process.env.NODE_ENV = "production";
+		delete process.env.FEDERATION_TOKENS_ALLOW_INSECURE;
+		const key32 = Buffer.alloc(32, 1).toString("base64");
+		expect(() =>
+			redisFederationTokenStoreBuilder(
+				{
+					client: mockClient,
+					encryption: { mode: "required", key: key32 },
+				},
+				{},
+			),
+		).not.toThrow();
+		expect(warnSpy).not.toHaveBeenCalled();
+		expect(errorSpy).not.toHaveBeenCalled();
 	});
 });

--- a/packages/redis/__tests__/federation-tokens.test.mts
+++ b/packages/redis/__tests__/federation-tokens.test.mts
@@ -416,4 +416,46 @@ describe("OR-12 — redisFederationTokenStoreBuilder env-based encryption guard"
 		expect(warnSpy).not.toHaveBeenCalled();
 		expect(errorSpy).not.toHaveBeenCalled();
 	});
+
+	// I-1 (multi-agent-review M2): the lower-level public factory
+	// `createRedisFederationTokenStore` MUST run the same OR-12 production
+	// guard as the builder. Pre-fix the guard only ran in the builder, so a
+	// consumer calling the factory directly with `mode: "allow-plaintext"` in
+	// production shipped unencrypted refresh tokens.
+	it("createRedisFederationTokenStore (lower-level export) ALSO throws in production+allow-plaintext", () => {
+		process.env.NODE_ENV = "production";
+		delete process.env.FEDERATION_TOKENS_ALLOW_INSECURE;
+		const fake = createFakeRedis();
+		expect(() =>
+			createRedisFederationTokenStore({
+				client: fake,
+				encryption: { mode: "allow-plaintext" },
+			}),
+		).toThrow(/mode "allow-plaintext" is not allowed in NODE_ENV="production"/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// I-2 (multi-agent-review convergent — Claude + Codex P2): builder structural
+// validator must reject clients missing `compareAndDelete`. Pre-fix a custom
+// client missing this method passed the builder shape check then failed at
+// first lock release with an obscure runtime TypeError.
+// ---------------------------------------------------------------------------
+
+describe("redisFederationTokenStoreBuilder structural validator", () => {
+	it("rejects clients missing compareAndDelete with a clear message", () => {
+		const oldShapeClient = {
+			get: vi.fn(),
+			set: vi.fn(),
+			del: vi.fn(),
+			scanIterator: vi.fn(),
+			// compareAndDelete intentionally absent
+		};
+		expect(() =>
+			redisFederationTokenStoreBuilder(
+				{ client: oldShapeClient, encryption: { mode: "required", key: encryptionKey } },
+				{},
+			),
+		).toThrow(/missing required method.*compareAndDelete/);
+	});
 });

--- a/packages/redis/__tests__/internal/lock.test.mts
+++ b/packages/redis/__tests__/internal/lock.test.mts
@@ -9,6 +9,7 @@ import { createRedisLock, type RedisLockClient } from "../../src/internal/lock.m
 function makeFakeRedis(): RedisLockClient & {
 	data: Map<string, string>;
 	set: ReturnType<typeof vi.fn>;
+	compareAndDelete: ReturnType<typeof vi.fn>;
 } {
 	const data = new Map<string, string>();
 	const set = vi.fn(async (key: string, value: string, opts?: { PX?: number; NX?: boolean }) => {
@@ -16,11 +17,18 @@ function makeFakeRedis(): RedisLockClient & {
 		data.set(key, value);
 		return "OK";
 	});
+	const compareAndDelete = vi.fn(async (key: string, expected: string): Promise<boolean> => {
+		const stored = data.get(key);
+		if (stored !== undefined && stored === expected) {
+			data.delete(key);
+			return true;
+		}
+		return false;
+	});
 	return {
 		data,
 		set,
-		get: async (key: string) => data.get(key) ?? null,
-		del: async (key: string) => (data.delete(key) ? 1 : 0),
+		compareAndDelete,
 	};
 }
 

--- a/packages/redis/__tests__/ioredis.test.mts
+++ b/packages/redis/__tests__/ioredis.test.mts
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+// I-3 — Verify the EVALSHA + EVAL fallback path of
+// `makeIoredisClients(...).federationTokenStoreClient.compareAndDelete`. The
+// hot path uses `EVALSHA` with a precomputed SHA-1; on `NOSCRIPT` (cold
+// server-side script cache after `SCRIPT FLUSH` or cluster failover) the
+// adapter falls back to `EVAL`, which Redis implicitly loads into its
+// server-side cache so subsequent EVALSHA calls succeed.
+//
+// Uses a hand-rolled fake of the ioredis `Redis` shape (not testcontainers)
+// because the goal is to exercise the adapter's branching logic, not the
+// Lua atomicity (which is closed by construction at the Redis server).
+
+import type { Redis } from "ioredis";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { makeIoredisClients } from "../src/ioredis.mjs";
+
+interface FakeIoredis {
+	evalsha: ReturnType<typeof vi.fn>;
+	eval: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeIoredis(overrides: Partial<FakeIoredis> = {}): Redis {
+	const fake = {
+		evalsha: vi.fn(),
+		eval: vi.fn(),
+		// Stubs for everything else `makeIoredisClients` reads at construction time.
+		// The compareAndDelete tests below only exercise evalsha/eval; other
+		// methods are unused in the assertions.
+		set: vi.fn(),
+		get: vi.fn(),
+		del: vi.fn(),
+		hset: vi.fn(),
+		hvals: vi.fn(),
+		pexpireat: vi.fn(),
+		zadd: vi.fn(),
+		zrange: vi.fn(),
+		zrem: vi.fn(),
+		incr: vi.fn(),
+		expire: vi.fn(),
+		multi: vi.fn(),
+		watch: vi.fn(),
+		unwatch: vi.fn(),
+		duplicate: vi.fn(),
+		scanStream: vi.fn(),
+		script: vi.fn(),
+		...overrides,
+	};
+	return fake as unknown as Redis;
+}
+
+describe("makeIoredisClients federationTokenStoreClient.compareAndDelete", () => {
+	// Module-level `scriptCached` persists across tests in the same module —
+	// reset it implicitly by reusing the same fake state across the three
+	// tests in serial order: cold → warm → flush+cold.
+	afterEach(() => vi.restoreAllMocks());
+
+	it("first call falls through to EVAL (cold cache) and returns true on match", async () => {
+		const io = makeFakeIoredis({
+			evalsha: vi.fn().mockResolvedValue(1),
+			eval: vi.fn().mockResolvedValue(1),
+		});
+		const { federationTokenStoreClient } = makeIoredisClients(io);
+		const result = await federationTokenStoreClient.compareAndDelete("k", "v");
+
+		expect(result).toBe(true);
+		// Cold cache: EVAL is the path, not EVALSHA.
+		expect(io.eval).toHaveBeenCalledTimes(1);
+		// EVALSHA may be called once on the optimistic warm-path attempt only
+		// if `scriptCached` was already true from a prior test. The first
+		// real-world cold call is EVAL-only.
+	});
+
+	it("warm cache: subsequent calls use EVALSHA and skip EVAL", async () => {
+		const io = makeFakeIoredis({
+			evalsha: vi.fn().mockResolvedValue(0),
+			eval: vi.fn(),
+		});
+		const { federationTokenStoreClient } = makeIoredisClients(io);
+		// Module-level `scriptCached` is already true from the previous test.
+		const result = await federationTokenStoreClient.compareAndDelete("k", "wrong-token");
+
+		expect(result).toBe(false);
+		expect(io.evalsha).toHaveBeenCalledTimes(1);
+		expect(io.eval).not.toHaveBeenCalled();
+	});
+
+	it("NOSCRIPT on EVALSHA falls back to EVAL and re-warms the cache", async () => {
+		const noscriptError = new Error("NOSCRIPT No matching script. Please use EVAL.");
+		const io = makeFakeIoredis({
+			// First EVALSHA throws NOSCRIPT; the second (post-fallback) returns 1.
+			evalsha: vi
+				.fn()
+				.mockRejectedValueOnce(noscriptError)
+				.mockResolvedValueOnce(1),
+			eval: vi.fn().mockResolvedValue(1),
+		});
+		const { federationTokenStoreClient } = makeIoredisClients(io);
+
+		// First call: EVALSHA throws NOSCRIPT → fallback to EVAL → re-warm.
+		const r1 = await federationTokenStoreClient.compareAndDelete("k", "v");
+		expect(r1).toBe(true);
+		expect(io.evalsha).toHaveBeenCalledTimes(1);
+		expect(io.eval).toHaveBeenCalledTimes(1);
+
+		// Second call: cache flagged warm again → EVALSHA only, no EVAL.
+		const r2 = await federationTokenStoreClient.compareAndDelete("k", "v");
+		expect(r2).toBe(true);
+		expect(io.evalsha).toHaveBeenCalledTimes(2);
+		expect(io.eval).toHaveBeenCalledTimes(1);
+	});
+
+	it("non-NOSCRIPT errors from EVALSHA propagate (no silent fallback)", async () => {
+		const networkError = new Error("ECONNRESET: connection lost");
+		const io = makeFakeIoredis({
+			evalsha: vi.fn().mockRejectedValue(networkError),
+			eval: vi.fn(),
+		});
+		const { federationTokenStoreClient } = makeIoredisClients(io);
+
+		await expect(federationTokenStoreClient.compareAndDelete("k", "v")).rejects.toThrow(
+			/ECONNRESET/,
+		);
+		// Only ECONNRESET — must NOT fall through to EVAL on a non-NOSCRIPT error.
+		expect(io.eval).not.toHaveBeenCalled();
+	});
+});

--- a/packages/redis/__tests__/ioredis.test.mts
+++ b/packages/redis/__tests__/ioredis.test.mts
@@ -53,75 +53,105 @@ function makeFakeIoredis(overrides: Partial<FakeIoredis> = {}): Redis {
 }
 
 describe("makeIoredisClients federationTokenStoreClient.compareAndDelete", () => {
-	// Module-level `scriptCached` persists across tests in the same module —
-	// reset it implicitly by reusing the same fake state across the three
-	// tests in serial order: cold → warm → flush+cold.
+	// Each test warms the module-level `scriptCached` cache from cold within
+	// its own body so the suite is order-independent (running any single test
+	// via `vitest -t "..."` works in isolation). The first `compareAndDelete`
+	// call after module load — or after a prior NOSCRIPT path — runs EVAL;
+	// each subsequent call within the same test runs EVALSHA.
 	afterEach(() => vi.restoreAllMocks());
 
-	it("first call falls through to EVAL (cold cache) and returns true on match", async () => {
+	it("first call falls through to EVAL (cold path semantics) and returns true on match", async () => {
+		const io = makeFakeIoredis({
+			// EVALSHA may or may not be called first depending on whether
+			// `scriptCached` is true from a prior test. Both code paths
+			// must succeed. In a cold-path call the response is 1 (matched
+			// → key deleted).
+			evalsha: vi.fn().mockResolvedValue(1),
+			eval: vi.fn().mockResolvedValue(1),
+		});
+		const { federationTokenStoreClient } = makeIoredisClients(io);
+
+		const result = await federationTokenStoreClient.compareAndDelete("k", "v");
+		expect(result).toBe(true);
+		// One of EVAL or EVALSHA was called; total = 1. We don't assert on
+		// which because that depends on the prior `scriptCached` state.
+		expect(io.eval.mock.calls.length + io.evalsha.mock.calls.length).toBe(1);
+	});
+
+	it("after a warmup call the next call uses EVALSHA only (warm path)", async () => {
+		// Self-contained: don't depend on whether `scriptCached` is true at
+		// test start. Both EVALSHA and EVAL succeed for the warmup so the
+		// path taken doesn't matter; the assertion is only on the SECOND
+		// call's behavior (EVALSHA increments by 1, EVAL does not).
+		const io = makeFakeIoredis({
+			evalsha: vi.fn().mockResolvedValue(0),
+			eval: vi.fn().mockResolvedValue(1),
+		});
+		const { federationTokenStoreClient } = makeIoredisClients(io);
+
+		// Warmup: regardless of cold/warm initial state, scriptCached ends true.
+		await federationTokenStoreClient.compareAndDelete("k", "v");
+		const evalshaBefore = io.evalsha.mock.calls.length;
+		const evalBefore = io.eval.mock.calls.length;
+
+		// Second call: cache is now warm. Must take the EVALSHA path only.
+		const result = await federationTokenStoreClient.compareAndDelete("k", "wrong-token");
+
+		expect(result).toBe(false);
+		expect(io.evalsha.mock.calls.length).toBe(evalshaBefore + 1);
+		expect(io.eval.mock.calls.length).toBe(evalBefore);
+	});
+
+	it("NOSCRIPT on EVALSHA falls back to EVAL and re-warms the cache", async () => {
 		const io = makeFakeIoredis({
 			evalsha: vi.fn().mockResolvedValue(1),
 			eval: vi.fn().mockResolvedValue(1),
 		});
 		const { federationTokenStoreClient } = makeIoredisClients(io);
-		const result = await federationTokenStoreClient.compareAndDelete("k", "v");
 
-		expect(result).toBe(true);
-		// Cold cache: EVAL is the path, not EVALSHA.
-		expect(io.eval).toHaveBeenCalledTimes(1);
-		// EVALSHA may be called once on the optimistic warm-path attempt only
-		// if `scriptCached` was already true from a prior test. The first
-		// real-world cold call is EVAL-only.
-	});
+		// Warmup so `scriptCached === true` regardless of prior test state.
+		await federationTokenStoreClient.compareAndDelete("k", "v");
+		const evalAfterWarmup = io.eval.mock.calls.length;
 
-	it("warm cache: subsequent calls use EVALSHA and skip EVAL", async () => {
-		const io = makeFakeIoredis({
-			evalsha: vi.fn().mockResolvedValue(0),
-			eval: vi.fn(),
-		});
-		const { federationTokenStoreClient } = makeIoredisClients(io);
-		// Module-level `scriptCached` is already true from the previous test.
-		const result = await federationTokenStoreClient.compareAndDelete("k", "wrong-token");
-
-		expect(result).toBe(false);
-		expect(io.evalsha).toHaveBeenCalledTimes(1);
-		expect(io.eval).not.toHaveBeenCalled();
-	});
-
-	it("NOSCRIPT on EVALSHA falls back to EVAL and re-warms the cache", async () => {
+		// Swap EVALSHA to throw NOSCRIPT once, then succeed.
 		const noscriptError = new Error("NOSCRIPT No matching script. Please use EVAL.");
+		io.evalsha.mockReset().mockRejectedValueOnce(noscriptError).mockResolvedValue(1);
+
+		// Test call 1: EVALSHA throws NOSCRIPT → fallback to EVAL → re-warm.
+		const r1 = await federationTokenStoreClient.compareAndDelete("k", "v");
+		expect(r1).toBe(true);
+		expect(io.evalsha.mock.calls.length).toBe(1);
+		expect(io.eval.mock.calls.length).toBe(evalAfterWarmup + 1);
+
+		// Test call 2: cache flagged warm again → EVALSHA only, no NEW EVAL.
+		const r2 = await federationTokenStoreClient.compareAndDelete("k", "v");
+		expect(r2).toBe(true);
+		expect(io.evalsha.mock.calls.length).toBe(2);
+		expect(io.eval.mock.calls.length).toBe(evalAfterWarmup + 1);
+	});
+
+	it("non-NOSCRIPT errors from EVALSHA propagate (no silent fallback)", async () => {
+		// Self-contained: warm the cache with both EVALSHA and EVAL succeeding,
+		// then swap the EVALSHA mock to reject with a non-NOSCRIPT error and
+		// assert the next call propagates that error without falling through.
 		const io = makeFakeIoredis({
-			// First EVALSHA throws NOSCRIPT; the second (post-fallback) returns 1.
-			evalsha: vi.fn().mockRejectedValueOnce(noscriptError).mockResolvedValueOnce(1),
+			evalsha: vi.fn().mockResolvedValue(1),
 			eval: vi.fn().mockResolvedValue(1),
 		});
 		const { federationTokenStoreClient } = makeIoredisClients(io);
 
-		// First call: EVALSHA throws NOSCRIPT → fallback to EVAL → re-warm.
-		const r1 = await federationTokenStoreClient.compareAndDelete("k", "v");
-		expect(r1).toBe(true);
-		expect(io.evalsha).toHaveBeenCalledTimes(1);
-		expect(io.eval).toHaveBeenCalledTimes(1);
+		// Warmup ensures `scriptCached === true` regardless of prior test state.
+		await federationTokenStoreClient.compareAndDelete("k", "v");
+		const evalAfterWarmup = io.eval.mock.calls.length;
 
-		// Second call: cache flagged warm again → EVALSHA only, no EVAL.
-		const r2 = await federationTokenStoreClient.compareAndDelete("k", "v");
-		expect(r2).toBe(true);
-		expect(io.evalsha).toHaveBeenCalledTimes(2);
-		expect(io.eval).toHaveBeenCalledTimes(1);
-	});
-
-	it("non-NOSCRIPT errors from EVALSHA propagate (no silent fallback)", async () => {
+		// Swap EVALSHA to reject with ECONNRESET (not NOSCRIPT).
 		const networkError = new Error("ECONNRESET: connection lost");
-		const io = makeFakeIoredis({
-			evalsha: vi.fn().mockRejectedValue(networkError),
-			eval: vi.fn(),
-		});
-		const { federationTokenStoreClient } = makeIoredisClients(io);
+		io.evalsha.mockReset().mockRejectedValue(networkError);
 
 		await expect(federationTokenStoreClient.compareAndDelete("k", "v")).rejects.toThrow(
 			/ECONNRESET/,
 		);
-		// Only ECONNRESET — must NOT fall through to EVAL on a non-NOSCRIPT error.
-		expect(io.eval).not.toHaveBeenCalled();
+		// Critical assertion: EVAL is NOT called as a fallback for non-NOSCRIPT errors.
+		expect(io.eval.mock.calls.length).toBe(evalAfterWarmup);
 	});
 });

--- a/packages/redis/__tests__/ioredis.test.mts
+++ b/packages/redis/__tests__/ioredis.test.mts
@@ -92,10 +92,7 @@ describe("makeIoredisClients federationTokenStoreClient.compareAndDelete", () =>
 		const noscriptError = new Error("NOSCRIPT No matching script. Please use EVAL.");
 		const io = makeFakeIoredis({
 			// First EVALSHA throws NOSCRIPT; the second (post-fallback) returns 1.
-			evalsha: vi
-				.fn()
-				.mockRejectedValueOnce(noscriptError)
-				.mockResolvedValueOnce(1),
+			evalsha: vi.fn().mockRejectedValueOnce(noscriptError).mockResolvedValueOnce(1),
 			eval: vi.fn().mockResolvedValue(1),
 		});
 		const { federationTokenStoreClient } = makeIoredisClients(io);

--- a/packages/redis/__tests__/types.test.mts
+++ b/packages/redis/__tests__/types.test.mts
@@ -86,6 +86,15 @@ describe("makeIoredisClients return shape", () => {
 		>().toMatchTypeOf<FederationTokenStoreClient>();
 	});
 
+	// D-9: FederationTokenStoreClient declares atomic compare-and-delete used
+	// by the federation-tokens advisory lock release path. Custom client
+	// implementations must add this method.
+	it("FederationTokenStoreClient declares compareAndDelete: (key, expected) => Promise<boolean>", () => {
+		expectTypeOf<FederationTokenStoreClient["compareAndDelete"]>().toEqualTypeOf<
+			(key: string, expectedValue: string) => Promise<boolean>
+		>();
+	});
+
 	it("rateLimiterClient satisfies RateLimiterClient", () => {
 		expectTypeOf<IoredisClientsReturn["rateLimiterClient"]>().toMatchTypeOf<RateLimiterClient>();
 	});

--- a/packages/redis/src/clients.mts
+++ b/packages/redis/src/clients.mts
@@ -211,8 +211,9 @@ export interface SessionSidSortedSetClient {
 /**
  * Backing client for FederationTokenStore adapters. Declares `get`, `set`
  * (two overloads: PX form, and PX+NX form for atomic insert-only),
- * variadic `del`, and `scanIterator` for the cursor-based key scan used
- * by `deleteBySession`.
+ * variadic `del`, `scanIterator` for the cursor-based key scan used by
+ * `deleteBySession`, and `compareAndDelete` for atomic advisory-lock
+ * release.
  *
  * The plain-PX `set` overload always succeeds with `"OK"` per Redis
  * `SET key value PX ms` protocol; the PX+NX overload returns `"OK"` on
@@ -224,6 +225,27 @@ export interface FederationTokenStoreClient {
 	set(key: string, value: string, mode: "PX", ttlMs: number, condition: "NX"): Promise<"OK" | null>;
 	del(...keys: string[]): Promise<number>;
 	scanIterator(opts: { MATCH: string; COUNT?: number }): AsyncIterable<string>;
+	/**
+	 * Atomically compare the value stored at `key` to `expectedValue` and
+	 * delete the key only on match.
+	 *
+	 * This is the only safe lock-release primitive: a plain `del(key)` after a
+	 * separate `get(key)` has a race window between the two commands during
+	 * which a TTL-expired holder can evict a freshly-acquired lock owned by
+	 * another caller. Implementations MUST use a server-side atomic mechanism
+	 * — Lua `EVAL` on Redis standalone / Sentinel, or a transaction-equivalent
+	 * primitive on Cluster-mode deployments where `EVAL` is disabled.
+	 *
+	 * Built-in `makeIoredisClients()` implements this via a Lua compare-and-
+	 * delete script with `EVALSHA` caching and `EVAL` fallback on `NOSCRIPT`.
+	 *
+	 * @param key - The Redis key to check and conditionally delete.
+	 * @param expectedValue - The value the caller expects to find at `key`.
+	 * @returns `true` if the key was deleted (caller was the lock holder);
+	 *          `false` if the stored value did not match (caller is no longer
+	 *          the holder — a different process acquired the lock).
+	 */
+	compareAndDelete(key: string, expectedValue: string): Promise<boolean>;
 }
 
 // --- RateLimiterClient -----------------------------------------------------

--- a/packages/redis/src/federation-tokens.mts
+++ b/packages/redis/src/federation-tokens.mts
@@ -17,6 +17,52 @@ import { createRedisLock } from "./internal/lock.mjs";
 
 export type EncryptionConfig = { mode: "required"; key: Buffer } | { mode: "allow-plaintext" };
 
+/**
+ * NODE_ENV values treated as production for the purpose of OR-12's hard guard
+ * on `allow-plaintext` encryption mode. Federation tokens carry long-lived IdP
+ * refresh tokens; storing them unencrypted in production is a security risk.
+ */
+const PRODUCTION_ENVS = new Set(["production", "staging"]);
+
+/**
+ * OR-12 — refuse to construct a federation-token store with
+ * `mode = "allow-plaintext"` in production unless the operator explicitly
+ * sets `FEDERATION_TOKENS_ALLOW_INSECURE=1`. Logs a CRITICAL warning when the
+ * escape hatch is active. Dev/test (`NODE_ENV !== production|staging`) emits
+ * a soft `console.warn` but does not throw.
+ *
+ * Runs at factory time before the DI container is fully wired, so direct
+ * `console.*` is the appropriate emission channel (no Logger available yet).
+ */
+function validateEncryptionMode(mode: "required" | "allow-plaintext", nodeEnv: string): void {
+	if (mode === "required") return;
+	const isProduction = PRODUCTION_ENVS.has(nodeEnv);
+	const allowInsecure = process.env.FEDERATION_TOKENS_ALLOW_INSECURE === "1";
+
+	if (isProduction) {
+		if (allowInsecure) {
+			// Factory-time emission, no Logger available yet.
+			console.error(
+				`[federation-tokens] CRITICAL: running with mode="${mode}" in NODE_ENV="${nodeEnv}" ` +
+					"because FEDERATION_TOKENS_ALLOW_INSECURE=1. Federation tokens (IdP refresh tokens) " +
+					"are stored UNENCRYPTED. This is a security risk. Do NOT use in normal production.",
+			);
+			return;
+		}
+		throw new Error(
+			`[federation-tokens] mode "${mode}" is not allowed in NODE_ENV="${nodeEnv}". ` +
+				'Set mode to "required" and provide a 32-byte encryption key, OR set ' +
+				"FEDERATION_TOKENS_ALLOW_INSECURE=1 to override (NOT recommended for production).",
+		);
+	}
+
+	// Dev/test: warn but do not throw. Factory-time emission, no Logger available yet.
+	console.warn(
+		`[federation-tokens] WARNING: mode="${mode}" stores federation tokens (IdP refresh tokens) ` +
+			"unencrypted. Use only in development/test environments.",
+	);
+}
+
 export interface RedisFederationTokenStoreOptions {
 	client: FederationTokenStoreClient;
 	encryption: EncryptionConfig;
@@ -75,7 +121,6 @@ export function createRedisFederationTokenStore(
 	const lockKeyPrefix = `${prefix}lock:`;
 	const lock = createRedisLock({
 		client: {
-			get: (key) => opts.client.get(key),
 			set: (key, value, o) => {
 				// RedisLockClient uses options-object form; bridge to positional form.
 				if (o?.NX && o.PX !== undefined) {
@@ -84,9 +129,16 @@ export function createRedisFederationTokenStore(
 				if (o?.PX !== undefined) {
 					return opts.client.set(key, value, "PX", o.PX) as Promise<string | null>;
 				}
-				return Promise.resolve(null);
+				// CR-5 fix: unknown option shape is a programming error, not a silent
+				// no-op. The pre-D-9 silent `Promise.resolve(null)` fallback caused
+				// the lock acquire loop to spin until timeout when the bridge was
+				// passed a non-standard option shape.
+				throw new Error(
+					"FederationTokenStore lock bridge: unrecognized set() option shape. " +
+						"Expected { PX: number } or { PX: number, NX: true }.",
+				);
 			},
-			del: (key) => opts.client.del(key),
+			compareAndDelete: (key, expected) => opts.client.compareAndDelete(key, expected),
 		},
 		keyPrefix: lockKeyPrefix,
 	});
@@ -215,6 +267,11 @@ export const redisFederationTokenStoreBuilder: AdapterBuilder<FederationTokenSto
 		);
 	}
 	const mode = cfg.encryption?.mode ?? "required";
+	const nodeEnv = process.env.NODE_ENV ?? "development";
+	// OR-12: hard production guard (throws on plaintext in production unless
+	// FEDERATION_TOKENS_ALLOW_INSECURE=1). Validate before constructing the
+	// EncryptionConfig so the failure surfaces before any key parsing.
+	validateEncryptionMode(mode, nodeEnv);
 	let encryption: EncryptionConfig;
 	if (mode === "required") {
 		const rawKey = cfg.encryption?.key;
@@ -231,10 +288,6 @@ export const redisFederationTokenStoreBuilder: AdapterBuilder<FederationTokenSto
 		}
 		encryption = { mode: "required", key: keyBuf };
 	} else {
-		// eslint-disable-next-line no-console
-		console.warn(
-			"federationTokenStore.redis: running with encryption.mode = allow-plaintext. Do not use in production.",
-		);
 		encryption = { mode: "allow-plaintext" };
 	}
 	return createRedisFederationTokenStore({

--- a/packages/redis/src/federation-tokens.mts
+++ b/packages/redis/src/federation-tokens.mts
@@ -103,6 +103,12 @@ interface Envelope {
 export function createRedisFederationTokenStore(
 	opts: RedisFederationTokenStoreOptions,
 ): FederationTokenStoreBase & SupportsLock {
+	// OR-12: hard production guard MUST run before any encryption-key parsing
+	// so the same gate fires regardless of which entry point a consumer picks.
+	// `redisFederationTokenStoreBuilder` does its own pre-construction
+	// validation; this guard closes the gap when consumers call this lower-
+	// level factory directly (the OR-12 spec's M2 calibration delta).
+	validateEncryptionMode(opts.encryption.mode, process.env.NODE_ENV ?? "development");
 	if (opts.encryption.mode === "required" && opts.encryption.key.length !== 32) {
 		throw new Error("FederationTokenStore redis: encryption key must be 32 bytes");
 	}
@@ -258,12 +264,16 @@ export const redisFederationTokenStoreBuilder: AdapterBuilder<FederationTokenSto
 		throw new Error("federationTokenStore.redis: 'client' option is required");
 	}
 	const clientObj = cfg.client as Record<string, unknown>;
-	const requiredMethods = ["get", "set", "del", "scanIterator"] as const;
+	// `compareAndDelete` is required by the advisory-lock release path (D-9).
+	// Validate it here so a custom client missing the method fails at builder
+	// time with a clear message rather than at first lock release with an
+	// obscure `TypeError`.
+	const requiredMethods = ["get", "set", "del", "scanIterator", "compareAndDelete"] as const;
 	const missing = requiredMethods.filter((m) => typeof clientObj[m] !== "function");
 	if (missing.length > 0) {
 		throw new Error(
 			`federationTokenStore.redis: client is missing required method(s): ${missing.join(", ")}. ` +
-				`Pass a wrapper that implements get/set/del/scanIterator (e.g. makeIoredisClients(io).federationTokenStoreClient).`,
+				`Pass a wrapper that implements get/set/del/scanIterator/compareAndDelete (e.g. makeIoredisClients(io).federationTokenStoreClient).`,
 		);
 	}
 	const mode = cfg.encryption?.mode ?? "required";

--- a/packages/redis/src/internal/lock.mts
+++ b/packages/redis/src/internal/lock.mts
@@ -19,7 +19,7 @@ import type { AcquireLockOptions, LockResult, SupportsLock } from "@o3co/auth-pr
 
 /**
  * Minimal redis client shape the lock needs. Consumers can pass any client
- * that implements these three methods — node-redis, ioredis, fake clients in
+ * that implements these methods — node-redis, ioredis, fake clients in
  * tests, etc.
  *
  * ## Value-fidelity contract
@@ -28,11 +28,6 @@ import type { AcquireLockOptions, LockResult, SupportsLock } from "@o3co/auth-pr
  * assumes of the client; consumers wiring a non-standard client MUST preserve
  * them:
  *
- * - `get(key)` MUST return the exact string previously written by `set(key, value)`.
- *   No normalization, wrapping, or transformation. Clients that base64-encode
- *   values on write must base64-decode on read (most commercial redis clients
- *   do this transparently; homemade shims must mirror the behavior).
- *
  * - `set(key, value, { NX: true, PX: ttlMs })` MUST return a truthy value (the
  *   stored string or `"OK"`) when the key was created, and MUST return `null`
  *   when creation was skipped because the key already exists. The lock treats
@@ -40,14 +35,18 @@ import type { AcquireLockOptions, LockResult, SupportsLock } from "@o3co/auth-pr
  *
  * - `PX` is in **milliseconds** (matching the redis native option).
  *
+ * - `compareAndDelete(key, expectedValue)` MUST atomically delete the key only
+ *   when its stored value equals `expectedValue`. Implementations MUST NOT
+ *   degrade to a non-atomic GET+DEL pair under any condition — the race
+ *   window the spec closes (CR-1, OR-13, SF-4) reopens if so.
+ *
  * Breaking these invariants causes silent incorrectness: the release path
  * will fail its value-match check and never DEL, waiting for the TTL to
  * reclaim the key. Under load this manifests as lock starvation.
  */
 export interface RedisLockClient {
-	get(key: string): Promise<string | null>;
 	set(key: string, value: string, opts?: { PX?: number; NX?: boolean }): Promise<string | null>;
-	del(key: string): Promise<number>;
+	compareAndDelete(key: string, expectedValue: string): Promise<boolean>;
 }
 
 export interface RedisLockOptions {
@@ -61,20 +60,24 @@ const DEFAULT_WAIT_MS = 4_000;
 const POLL_INTERVAL_MS = 50;
 
 /**
- * Redis-backed advisory lock. Uses SET NX PX for acquire and compare-and-delete
- * for release — the release path fetches the current value and only issues DEL
- * when the value still matches the caller's acquire token, so a TTL-expired
- * caller cannot evict a subsequent holder.
+ * Redis-backed advisory lock. Uses SET NX PX for acquire and an atomic
+ * compare-and-delete for release — the release path runs a Lua script (or
+ * adapter-equivalent atomic operation) that compares the stored value to the
+ * caller's acquire token and only deletes the key when they match in a single
+ * server-side step.
  *
- * The compare-and-delete is GET + DEL — not atomic. A small race window exists
- * between the two commands, during which another process could acquire the
- * lock after our GET; our DEL would then evict them one poll-cycle early. The
- * window is ms-sized and the consequence is bounded — consumers that need
- * strict atomicity should upgrade to a Lua EVAL-based release.
+ * **Atomicity (D-9 / OR-13 / SF-4)**: there is no race window between checking
+ * and deleting the key. Pre-D-9 the release was GET+DEL — a TTL-expired holder
+ * could evict a freshly-acquired lock owned by a different process between
+ * the two round-trips. The atomic `compareAndDelete` closes that race.
  *
- * Plan line 837: "Upgrading to a Lua script would remove the race but adds
- * dependency on EVAL being available (which it is on all mainstream redis
- * versions). Defer unless pattern is reused heavily."
+ * Adapter responsibility: built-in `makeIoredisClients()` implements
+ * `compareAndDelete` via Lua `EVAL` (with `EVALSHA` caching). Custom
+ * `FederationTokenStoreClient` implementations MUST provide an atomic
+ * implementation; degrading to GET+DEL reopens the race. Cluster-mode
+ * deployments with Lua scripting disabled need an alternative atomic primitive.
+ *
+ * See `FederationTokenStoreClient.compareAndDelete` JSDoc for the contract.
  */
 export function createRedisLock(opts: RedisLockOptions): Pick<SupportsLock, "acquireLock"> {
 	const prefix = opts.keyPrefix ?? "ftlock:";
@@ -94,14 +97,12 @@ export function createRedisLock(opts: RedisLockOptions): Pick<SupportsLock, "acq
 					return {
 						acquired: true,
 						release: async () => {
-							// Compare-and-delete: only remove the entry when the stored
-							// value still matches our acquire token. Prevents evicting a
+							// Atomic compare-and-delete: deletes the key only when the
+							// stored value equals our acquire token. Prevents evicting a
 							// subsequently acquired lock after our TTL expired under a
-							// slow operation.
-							const current = await opts.client.get(key);
-							if (current === token) {
-								await opts.client.del(key);
-							}
+							// slow operation. Return value is intentionally not checked —
+							// `false` (caller no longer holds the lock) is a no-op outcome.
+							await opts.client.compareAndDelete(key, token);
 						},
 					};
 				}

--- a/packages/redis/src/ioredis.mts
+++ b/packages/redis/src/ioredis.mts
@@ -2,6 +2,7 @@
  * Copyright 2026 1o1 Co. Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  */
+import { createHash } from "node:crypto";
 import type { Redis } from "ioredis";
 import type {
 	ChallengeStoreClient,
@@ -32,15 +33,26 @@ end
 `.trim();
 
 /**
- * Module-level cache of the SHA-1 digest returned by `SCRIPT LOAD` for
- * `LUA_COMPARE_AND_DELETE`. Lazily populated by the first `EVALSHA`
- * fallback path. Module scope (not per-`makeIoredisClients` call) because
- * the script is constant — multiple ioredis clients in the same process
- * share the same SHA on the same Redis server. The fallback path resets
- * this to `null` on `NOSCRIPT` (e.g. after `SCRIPT FLUSH` or cluster
- * failover) and re-loads on the next call.
+ * Precomputed SHA-1 digest of `LUA_COMPARE_AND_DELETE`. Redis indexes its
+ * server-side script cache by SHA-1 of the bytewise script source, so this
+ * digest is deterministic and matches what `SCRIPT LOAD` would return. We
+ * compute it once at module load and skip the extra round-trip that a
+ * `SCRIPT LOAD` would cost on every cold-cache `EVAL` fallback.
  */
-let cachedLuaSha: string | null = null;
+const LUA_COMPARE_AND_DELETE_SHA = createHash("sha1").update(LUA_COMPARE_AND_DELETE).digest("hex");
+
+/**
+ * Module-level flag tracking whether the script is currently expected to be
+ * resident in the Redis server's script cache. `true` means the next call
+ * may use `EVALSHA`; `false` (e.g. after a `NOSCRIPT` error from
+ * `SCRIPT FLUSH` or cluster failover) means the next call must use `EVAL`,
+ * which implicitly re-loads the script and lets us flip back to `true`.
+ *
+ * Module scope (not per-`makeIoredisClients` call) because the script is
+ * constant: multiple ioredis clients in the same process share the same
+ * cache state on the same Redis server.
+ */
+let scriptCached = false;
 
 /**
  * Wrap a single ioredis connection into the 9 typed client wrappers
@@ -239,24 +251,26 @@ export function makeIoredisClients(io: Redis): {
 					for (const key of batch as string[]) yield key;
 				}
 			})(),
-		// D-9: atomic compare-and-delete via Lua. EVALSHA + cached SHA-1 on the
-		// hot path; falls back to EVAL on NOSCRIPT (cold cache, SCRIPT FLUSH,
-		// cluster failover) and re-loads the script for future calls.
+		// D-9: atomic compare-and-delete via Lua. EVALSHA on the hot path with a
+		// precomputed module-level SHA-1; on `NOSCRIPT` (cold cache after
+		// SCRIPT FLUSH or cluster failover) falls back to EVAL, which Redis
+		// implicitly loads into its server-side cache so the next EVALSHA hits.
 		async compareAndDelete(key, expectedValue) {
-			if (cachedLuaSha !== null) {
+			if (scriptCached) {
 				try {
-					const r = (await io.evalsha(cachedLuaSha, 1, key, expectedValue)) as number;
+					const r = (await io.evalsha(LUA_COMPARE_AND_DELETE_SHA, 1, key, expectedValue)) as number;
 					return r === 1;
 				} catch (err) {
 					if (!(err instanceof Error) || !err.message.includes("NOSCRIPT")) throw err;
-					cachedLuaSha = null;
+					scriptCached = false;
 					// Fall through to EVAL.
 				}
 			}
 			const r = (await io.eval(LUA_COMPARE_AND_DELETE, 1, key, expectedValue)) as number;
-			// Cache the SHA for the next call. `script("LOAD", ...)` returns
-			// the SHA-1 digest; future EVALSHA hits the server-side cache.
-			cachedLuaSha = (await io.script("LOAD", LUA_COMPARE_AND_DELETE)) as string;
+			// EVAL implicitly loads the script into Redis's server-side cache;
+			// future EVALSHA hits with the precomputed SHA. No extra SCRIPT LOAD
+			// round-trip required.
+			scriptCached = true;
 			return r === 1;
 		},
 	};

--- a/packages/redis/src/ioredis.mts
+++ b/packages/redis/src/ioredis.mts
@@ -19,6 +19,30 @@ import type {
 } from "./clients.mjs";
 
 /**
+ * Lua compare-and-delete script — atomic alternative to GET+DEL.
+ * Returns 1 when the key was deleted (caller's token matched), 0 otherwise.
+ * `KEYS[1]` = the lock key; `ARGV[1]` = the caller's acquire token.
+ */
+const LUA_COMPARE_AND_DELETE = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end
+`.trim();
+
+/**
+ * Module-level cache of the SHA-1 digest returned by `SCRIPT LOAD` for
+ * `LUA_COMPARE_AND_DELETE`. Lazily populated by the first `EVALSHA`
+ * fallback path. Module scope (not per-`makeIoredisClients` call) because
+ * the script is constant — multiple ioredis clients in the same process
+ * share the same SHA on the same Redis server. The fallback path resets
+ * this to `null` on `NOSCRIPT` (e.g. after `SCRIPT FLUSH` or cluster
+ * failover) and re-loads on the next call.
+ */
+let cachedLuaSha: string | null = null;
+
+/**
  * Wrap a single ioredis connection into the 9 typed client wrappers
  * needed by `@o3co/auth-provider-redis` adapters. Production consumers
  * use this factory in their composition root and spread the result into
@@ -215,6 +239,26 @@ export function makeIoredisClients(io: Redis): {
 					for (const key of batch as string[]) yield key;
 				}
 			})(),
+		// D-9: atomic compare-and-delete via Lua. EVALSHA + cached SHA-1 on the
+		// hot path; falls back to EVAL on NOSCRIPT (cold cache, SCRIPT FLUSH,
+		// cluster failover) and re-loads the script for future calls.
+		async compareAndDelete(key, expectedValue) {
+			if (cachedLuaSha !== null) {
+				try {
+					const r = (await io.evalsha(cachedLuaSha, 1, key, expectedValue)) as number;
+					return r === 1;
+				} catch (err) {
+					if (!(err instanceof Error) || !err.message.includes("NOSCRIPT")) throw err;
+					cachedLuaSha = null;
+					// Fall through to EVAL.
+				}
+			}
+			const r = (await io.eval(LUA_COMPARE_AND_DELETE, 1, key, expectedValue)) as number;
+			// Cache the SHA for the next call. `script("LOAD", ...)` returns
+			// the SHA-1 digest; future EVALSHA hits the server-side cache.
+			cachedLuaSha = (await io.script("LOAD", LUA_COMPARE_AND_DELETE)) as string;
+			return r === 1;
+		},
 	};
 
 	const rateLimiterClient: RateLimiterClient = {

--- a/packages/redis/vitest.config.mts
+++ b/packages/redis/vitest.config.mts
@@ -12,12 +12,13 @@ export default defineConfig({
 		typecheck: {
 			enabled: true,
 			tsconfig: "./tsconfig.json",
-			// Type-level assertions in __tests__/types.test.mts (per-purpose client
-			// shapes + ComponentMap declaration-merge invariants) must run through
-			// tsc rather than be silently treated as runtime no-ops. The default
-			// vitest typecheck pattern is `*.test-d.mts`; widen to include this
-			// runtime+typecheck hybrid.
-			include: ["__tests__/types.test.mts"],
+			// Type-level assertions in __tests__/types.test.mts (per-purpose
+			// client shapes + ComponentMap declaration-merge invariants) must
+			// run through tsc rather than be silently treated as runtime no-ops.
+			// `typecheck.include` REPLACES vitest's default pattern entirely, so
+			// re-include the default `*.test-d.*` glob in addition to the
+			// runtime+typecheck hybrid file.
+			include: ["**/*.test-d.?(c|m)[jt]s?(x)", "__tests__/types.test.mts"],
 		},
 	},
 });

--- a/packages/redis/vitest.config.mts
+++ b/packages/redis/vitest.config.mts
@@ -12,6 +12,12 @@ export default defineConfig({
 		typecheck: {
 			enabled: true,
 			tsconfig: "./tsconfig.json",
+			// Type-level assertions in __tests__/types.test.mts (per-purpose client
+			// shapes + ComponentMap declaration-merge invariants) must run through
+			// tsc rather than be silently treated as runtime no-ops. The default
+			// vitest typecheck pattern is `*.test-d.mts`; widen to include this
+			// runtime+typecheck hybrid.
+			include: ["__tests__/types.test.mts"],
 		},
 	},
 });


### PR DESCRIPTION
## Summary

Second PR of v0.5.1 Phase F batch F2. Two interlocking fixes in `@o3co/auth-provider-redis`:

- **D-9** — federation-tokens advisory lock release path is now an atomic Lua compare-and-delete (closes CR-1 partial / OR-13 / SF-4). Pre-fix the release was non-atomic GET+DEL with a race window during which a TTL-expired holder could evict a freshly-acquired lock owned by a different process.
- **OR-12** — redis federation-token store builder enforces a hard production guard for `encryption.mode = "allow-plaintext"` (closes CC-3 residual). Pre-fix the builder emitted only `console.warn` in production — IdP refresh tokens could ship unencrypted by misconfiguration.

Spec inputs:
- [`2026-05-05-d9-federation-lock-cas.md`](.claude/superpowers/specs/2026-05-05-d9-federation-lock-cas.md)
- [`2026-05-05-or12-federation-allow-plaintext-guard.md`](.claude/superpowers/specs/2026-05-05-or12-federation-allow-plaintext-guard.md)

## Changes

### D-9 — Lock CAS

- `FederationTokenStoreClient.compareAndDelete(key, expected): Promise<boolean>` added (**BREAKING** for custom client implementations).
- `internal/lock.mts` GET+DEL replaced with single `compareAndDelete(key, token)`. `RedisLockClient` shape narrowed to `{ set, compareAndDelete }` (internal, not re-exported).
- `ioredis.mts` `compareAndDelete` impl: precomputed Lua SHA-1 via `crypto.createHash`, EVALSHA on hot path, EVAL fallback on NOSCRIPT (re-warms server-side cache). Module-level `scriptCached: boolean` flag.
- `federation-tokens.mts` bridge: forwards `compareAndDelete`; replaces silent `Promise.resolve(null)` in the `set` shim with hard `throw` (CR-5 fix). Validator `requiredMethods` now includes `compareAndDelete`.

### OR-12 — Plaintext production guard

- Private `validateEncryptionMode(mode, nodeEnv)` in `federation-tokens.mts`. Wired into BOTH `redisFederationTokenStoreBuilder` AND `createRedisFederationTokenStore` (lower-level export) so neither entry point can bypass the guard.
- When `NODE_ENV ∈ {production, staging}` AND mode is non-`required`, throws unless `FEDERATION_TOKENS_ALLOW_INSECURE=1` opts in (with a CRITICAL `console.error`). Dev/test retains warn-only.

## Cluster-mode Lua caveat

The bundled `makeIoredisClients()` adapter targets Redis standalone + Sentinel mode (Lua EVAL enabled). AWS ElastiCache Cluster mode operators with Lua disabled need a custom `FederationTokenStoreClient` whose `compareAndDelete` uses an alternative atomic primitive. Documented in `packages/redis/README.md` Requirements bullet + `FederationTokenStoreClient.compareAndDelete` JSDoc.

## Multi-agent review

- 🔵 Claude initial: NEEDS WORK — 4 Important + 5 Minor.
- 🟠 Codex P2 (CONVERGENT with Claude I-2): missing `compareAndDelete` in builder structural validator.

**Fixed in commit `63257690`:**
- I-1 (OR-12 spec M2 delta) — `createRedisFederationTokenStore` now also runs guard
- I-2 (multi-reviewer convergent) — `requiredMethods` includes `compareAndDelete`
- I-3 (D-9 spec NOSCRIPT delta) — new `__tests__/ioredis.test.mts` (4 tests covering cold/warm/NOSCRIPT-fallback/non-NOSCRIPT-propagation)
- M-1 — precomputed SHA-1, eliminate redundant `SCRIPT LOAD` round-trip

**Deferred to Phase F+ follow-up:**
- I-4 — testcontainer-based CAS atomicity test (unit fakes verify the refactor; testcontainer test belongs in a separate spec). Atomicity claim currently by construction (Lua EVAL server-side single-threaded execution) + JSDoc + README.

Severity roll-up: **Critical=0 / Important=4 (3 fixed + 1 deferred) / Minor=5 (1 fixed + 4 advisory)**. No additional review round needed.

## Tests

`make test`: **1940 GREEN** across 10 packages (redis 242, was 236 → +6: 1 I-1 + 1 I-2 + 4 NOSCRIPT). Full TDD discipline (RED→GREEN per fix). Biome lint: clean.

## Closes

- **D-9** — full
- **OR-12** — full (closes CC-3 residual)
- Partially closes **CR-1** (lock release side; cleanup race still open per spec — CR-1 application-level pre-cleanup re-read deferred to Phase F+)

## Test plan

- [x] D-9 type assertion in `types.test.mts`
- [x] D-9 unit lock tests (release no-op on token mismatch, compareAndDelete sole release primitive)
- [x] D-9 NOSCRIPT fallback tests (4 mock-based)
- [x] OR-12 5 env-based tests (production+plaintext throws / staging+plaintext throws / production+escape-hatch / dev+plaintext warn / production+required silent)
- [x] OR-12 lower-level factory test (createRedisFederationTokenStore + production + plaintext)
- [x] Builder structural validator rejects clients missing compareAndDelete
- [x] Pre-existing internal/lock test fake updated to new shape
- [x] Pre-existing module test fake updated with compareAndDelete stub
- [x] Full make test 1940 GREEN
- [x] biome lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)