### PR TITLE
feat(core,oauth,redis): D-1 Code/CodeData rewrite + session.code* gate removal (v0.5.1 F3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,73 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Breaking Changes (Phase F — D-1 Code/CodeData identity binding, v0.5.1)
+
+- **`CodeData.client_id` and `CodeData.redirect_uri` are now required fields**
+  (`@o3co/auth-provider-core`): `CodeRepository.createCode(...)` requires
+  `client_id: string` and `redirect_uri: string` on the params object. The
+  compile-time guard `Parameters<CodeRepository["createCode"]>[0]` makes
+  every implementation site fail typecheck when a field is added but not
+  destructured. Custom `CodeRepository` implementations must accept and
+  persist both fields.
+  **Migration**: callers building a `CodeData` literal must add `client_id`
+  and `redirect_uri`. The bundled `InMemoryCodeRepository` and
+  `RedisCodeRepository` are updated; consumer composition roots that wire a
+  custom repository must update its createCode signature.
+
+- **`/oauth/authorize` no longer writes `req.session.code`,
+  `req.session.code_client_id`, `req.session.code_redirect_uri`, or
+  `req.session.granted_scopes`** (`@o3co/auth-provider-oauth`): the four
+  session writes at the end of the GET `/authorize` handler are removed.
+  Identity binding is embedded in the code record (`Code.client_id` /
+  `Code.redirect_uri`) and is exchanged at `/token` exclusively via
+  `consumeByCode` (atomic single-use). Custom middleware that read these
+  session fields will no longer see them populated.
+  **Migration**: rewrite middleware that observed `req.session.code*` to
+  inspect the request body or the `codeRepository.getByCode` return value
+  instead.
+
+- **`/oauth/token` (authorization_code grant) drops the session-based
+  identity gates** (`@o3co/auth-provider-oauth`): the previous
+  `code !== session.code` and `client_id !== session.code_client_id`
+  checks are removed. `consumeByCode` is the sole authenticity gate;
+  `client_id` and `redirect_uri` are verified against `codeData.*` fields
+  populated at `/authorize` time. The `redirect_uri` binding (RFC 6749
+  §4.1.3) is now strictly enforced — when `codeData.redirect_uri` is
+  absent (legacy/corrupt records), the request is rejected with
+  `invalid_grant` rather than vacuously accepted.
+
+- **`sessionMutation.clear` shrinks** (`@o3co/auth-provider-oauth`): the
+  authorization grant's returned `sessionMutation.clear` list no longer
+  contains `code_client_id`, `code_redirect_uri`, or `granted_scopes`
+  (only `code` remains, to scrub residual values from sessions issued
+  before v0.5.1 ships).
+
+### Bug Fixes (Phase F — D-1, v0.5.1)
+
+- **Redis deployments with `userSessionStore` could not complete a single
+  authorization-code exchange** (`@o3co/auth-provider-redis`):
+  `RedisCodeRepository.createCode` silently discarded `sid`, `nonce`,
+  `redirect_uri`, `grantedScope`, and `grantedAudience`, causing every
+  `/token` exchange to fail with `invalid_grant: code record is missing
+  session identifier`. Fixed by persisting all fields in the Redis JSON
+  payload (closes IH-2 / TS-1 / TD-1).
+
+- **RFC 6749 §4.1.3 `redirect_uri` binding was silently skipped in Redis
+  deployments** (`@o3co/auth-provider-oauth`): when `codeData.redirect_uri`
+  was undefined (the IH-2 drop bug), the binding check at `/token` was
+  guarded by `if (storedRedirectUri)` and skipped entirely. The check is
+  now strict: absent or mismatched `redirect_uri` returns `invalid_grant`
+  (closes IH-4).
+
+- **Concurrent `/authorize` requests sharing an Express session could
+  race** (`@o3co/auth-provider-oauth`): two simultaneous `/authorize` calls
+  on the same session would clobber each other's `req.session.code`
+  last-write-wins, leaving the losing request's code orphaned in the
+  repository (unredeemable because the `code !== session.code` gate would
+  reject it). Fixed by removing the four `req.session.code*` writes and
+  binding identity to the code record (closes CR-2).
+
 ### Breaking Changes (Phase F — D-10 Redis 7.2 LTS minimum, v0.5.1)
 
 - **Redis 7.2 LTS minimum required** (`@o3co/auth-provider-redis`): the Redis-backed

--- a/packages/core/src/grants/types.mts
+++ b/packages/core/src/grants/types.mts
@@ -30,13 +30,22 @@ import type {
 	UserSessionStore,
 } from "../user-sessions/types.mjs";
 
+/**
+ * Session data exposed to grant handlers.
+ *
+ * D-1 (v0.5.1): identity binding for the authorization code grant moved out
+ * of this session bag and into the code record (`Code.client_id` /
+ * `Code.redirect_uri`). The previously exposed `code_client_id`,
+ * `code_redirect_uri`, and `granted_scopes` fields have been removed because
+ * `/authorize` no longer writes them and `/token` no longer reads them.
+ *
+ * `code` is retained because the authorization grant still clears it from
+ * sessions issued before v0.5.1 ships (see `sessionMutation.clear`).
+ */
 export interface SessionData {
 	user?: Record<string, unknown>;
 	client?: Record<string, unknown>;
 	code?: string;
-	code_client_id?: string;
-	code_redirect_uri?: string;
-	granted_scopes?: string[];
 	isAuthenticated?: boolean;
 }
 

--- a/packages/core/src/repositories/CodeRepository.mts
+++ b/packages/core/src/repositories/CodeRepository.mts
@@ -17,10 +17,17 @@
 import type { Code } from "./types.mjs";
 
 export interface CodeRepository {
+	/**
+	 * Issue an authorization code and persist all associated data atomically.
+	 * After `consumeByCode`, the code is single-use; `client_id` and
+	 * `redirect_uri` embedded in the record replace the session-based identity
+	 * binding removed in v0.5.1 (D-1 spec).
+	 */
 	createCode(params: {
+		client_id: string; // required (D-1)
+		redirect_uri: string; // required (D-1)
 		code_challenge?: string;
 		code_challenge_method?: string;
-		redirect_uri?: string;
 		expiresIn?: number;
 		grantedScope?: readonly string[];
 		grantedAudience?: readonly string[];
@@ -29,6 +36,11 @@ export interface CodeRepository {
 		sid?: string;
 	}): Promise<Code>;
 	getByCode(code: string): Promise<Code | null>;
+	/**
+	 * Atomically retrieve and delete the code record. This is the sole
+	 * authenticity gate for authorization code exchange. Returns null when the
+	 * code is unknown or has already been consumed (replay prevention).
+	 */
 	consumeByCode(code: string): Promise<Code | null>;
 	removeByCode(code: string): Promise<void>;
 }

--- a/packages/core/src/repositories/InMemoryCodeRepository.mts
+++ b/packages/core/src/repositories/InMemoryCodeRepository.mts
@@ -20,7 +20,6 @@ import type { Code } from "./types.mjs";
 
 interface StoredCode extends Code {
 	expiresAt: number;
-	redirect_uri?: string;
 	grantedScope?: readonly string[];
 	grantedAudience?: readonly string[];
 	// NEW (TODO-F-3): OIDC authorize → token round-trip state.
@@ -44,24 +43,15 @@ export class InMemoryCodeRepository implements CodeRepository {
 		}, 10_000);
 	}
 
-	async createCode(params: {
-		code_challenge?: string;
-		code_challenge_method?: string;
-		redirect_uri?: string;
-		expiresIn?: number;
-		grantedScope?: readonly string[];
-		grantedAudience?: readonly string[];
-		// NEW (TODO-F-3): OIDC authorize → token round-trip state.
-		nonce?: string;
-		sid?: string;
-	}): Promise<Code> {
+	async createCode(params: Parameters<CodeRepository["createCode"]>[0]): Promise<Code> {
 		const code = crypto.randomBytes(32).toString("base64url");
 		const expiresIn = params.expiresIn ?? this.defaultExpiresIn;
 		const stored: StoredCode = {
 			code,
+			client_id: params.client_id,
+			redirect_uri: params.redirect_uri,
 			code_challenge: params.code_challenge,
 			code_challenge_method: params.code_challenge_method,
-			redirect_uri: params.redirect_uri,
 			expiresIn,
 			expiresAt: Date.now() + expiresIn * 1000,
 			grantedScope: params.grantedScope,
@@ -72,9 +62,10 @@ export class InMemoryCodeRepository implements CodeRepository {
 		this.codes.set(code, stored);
 		return {
 			code,
+			client_id: params.client_id,
+			redirect_uri: params.redirect_uri,
 			code_challenge: params.code_challenge,
 			code_challenge_method: params.code_challenge_method,
-			redirect_uri: params.redirect_uri,
 			expiresIn,
 			grantedScope: params.grantedScope,
 			grantedAudience: params.grantedAudience,
@@ -92,9 +83,10 @@ export class InMemoryCodeRepository implements CodeRepository {
 		}
 		return {
 			code: stored.code,
+			client_id: stored.client_id,
+			redirect_uri: stored.redirect_uri,
 			code_challenge: stored.code_challenge,
 			code_challenge_method: stored.code_challenge_method,
-			redirect_uri: stored.redirect_uri,
 			expiresIn: stored.expiresIn,
 			grantedScope: stored.grantedScope,
 			grantedAudience: stored.grantedAudience,
@@ -110,9 +102,10 @@ export class InMemoryCodeRepository implements CodeRepository {
 		if (Date.now() >= stored.expiresAt) return null;
 		return {
 			code: stored.code,
+			client_id: stored.client_id,
+			redirect_uri: stored.redirect_uri,
 			code_challenge: stored.code_challenge,
 			code_challenge_method: stored.code_challenge_method,
-			redirect_uri: stored.redirect_uri,
 			expiresIn: stored.expiresIn,
 			grantedScope: stored.grantedScope,
 			grantedAudience: stored.grantedAudience,

--- a/packages/core/src/repositories/__tests__/InMemoryCodeRepository.test.mts
+++ b/packages/core/src/repositories/__tests__/InMemoryCodeRepository.test.mts
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 import { afterEach, describe, expect, it } from "vitest";
+import type { CodeRepository } from "#/repositories/CodeRepository.mjs";
 import { InMemoryCodeRepository } from "#/repositories/InMemoryCodeRepository.mjs";
 
 describe("InMemoryCodeRepository", () => {
 	let repo: InMemoryCodeRepository;
+
+	// Minimal valid params for v0.5.1+ (D-1: client_id and redirect_uri required).
+	const minimalParams = {
+		client_id: "test-client",
+		redirect_uri: "https://rp.example/cb",
+	};
 
 	afterEach(() => {
 		repo?.dispose();
@@ -26,7 +33,7 @@ describe("InMemoryCodeRepository", () => {
 	describe("createCode", () => {
 		it("creates a code with random string", async () => {
 			repo = new InMemoryCodeRepository();
-			const code = await repo.createCode({});
+			const code = await repo.createCode(minimalParams);
 
 			expect(code.code).toBeDefined();
 			expect(typeof code.code).toBe("string");
@@ -36,6 +43,7 @@ describe("InMemoryCodeRepository", () => {
 		it("stores code_challenge and code_challenge_method", async () => {
 			repo = new InMemoryCodeRepository();
 			const code = await repo.createCode({
+				...minimalParams,
 				code_challenge: "challenge123",
 				code_challenge_method: "S256",
 			});
@@ -46,7 +54,9 @@ describe("InMemoryCodeRepository", () => {
 
 		it("generates unique codes", async () => {
 			repo = new InMemoryCodeRepository();
-			const codes = await Promise.all(Array.from({ length: 10 }, () => repo.createCode({})));
+			const codes = await Promise.all(
+				Array.from({ length: 10 }, () => repo.createCode(minimalParams)),
+			);
 			const unique = new Set(codes.map((c) => c.code));
 			expect(unique.size).toBe(10);
 		});
@@ -55,7 +65,7 @@ describe("InMemoryCodeRepository", () => {
 	describe("getByCode", () => {
 		it("returns stored code", async () => {
 			repo = new InMemoryCodeRepository();
-			const created = await repo.createCode({ code_challenge: "ch" });
+			const created = await repo.createCode({ ...minimalParams, code_challenge: "ch" });
 			const found = await repo.getByCode(created.code);
 
 			expect(found).not.toBeNull();
@@ -74,7 +84,7 @@ describe("InMemoryCodeRepository", () => {
 	describe("consumeByCode", () => {
 		it("returns and removes the code atomically", async () => {
 			repo = new InMemoryCodeRepository();
-			const created = await repo.createCode({});
+			const created = await repo.createCode(minimalParams);
 			const consumed = await repo.consumeByCode(created.code);
 
 			expect(consumed).not.toBeNull();
@@ -96,7 +106,7 @@ describe("InMemoryCodeRepository", () => {
 	describe("removeByCode", () => {
 		it("removes a stored code", async () => {
 			repo = new InMemoryCodeRepository();
-			const created = await repo.createCode({});
+			const created = await repo.createCode(minimalParams);
 			await repo.removeByCode(created.code);
 
 			const found = await repo.getByCode(created.code);
@@ -113,6 +123,7 @@ describe("InMemoryCodeRepository", () => {
 		it("round-trips grantedScope and grantedAudience", async () => {
 			const repo = new InMemoryCodeRepository();
 			const created = await repo.createCode({
+				...minimalParams,
 				grantedScope: ["read"],
 				grantedAudience: ["https://api.example"],
 			});
@@ -126,7 +137,7 @@ describe("InMemoryCodeRepository", () => {
 	describe("expiration", () => {
 		it("expires codes after defaultExpiresIn", async () => {
 			repo = new InMemoryCodeRepository({ defaultExpiresIn: 0.05 }); // 50ms
-			const created = await repo.createCode({});
+			const created = await repo.createCode(minimalParams);
 
 			await new Promise((r) => setTimeout(r, 100));
 
@@ -136,7 +147,7 @@ describe("InMemoryCodeRepository", () => {
 
 		it("respects per-code expiresIn override", async () => {
 			repo = new InMemoryCodeRepository({ defaultExpiresIn: 10 });
-			const created = await repo.createCode({ expiresIn: 0.05 }); // 50ms
+			const created = await repo.createCode({ ...minimalParams, expiresIn: 0.05 }); // 50ms
 
 			await new Promise((r) => setTimeout(r, 100));
 
@@ -145,13 +156,58 @@ describe("InMemoryCodeRepository", () => {
 		});
 	});
 
+	// D-1 / TS-1: client_id and redirect_uri are required fields on CodeData and
+	// must be required on CodeRepository.createCode params. The compile-time
+	// guard via Parameters<CodeRepository["createCode"]>[0] surfaces missing
+	// required fields at every call site (including consumer custom impls).
+	//
+	// Pre-fix: redirect_uri is optional and client_id is absent entirely from the
+	// interface, so the @ts-expect-error directives below are unused → typecheck
+	// fails. Post-fix: both fields are required, so omitting either produces a
+	// TS error that the directive consumes → typecheck passes.
+	describe("D-1 / TS-1: createCode requires client_id and redirect_uri at compile time", () => {
+		it("compile-time guard: omitting client_id is a type error", async () => {
+			const repo = new InMemoryCodeRepository();
+			// @ts-expect-error client_id is required on CodeData (D-1)
+			const params: Parameters<CodeRepository["createCode"]>[0] = {
+				redirect_uri: "https://rp.example/cb",
+			};
+			const code = await repo.createCode(params);
+			expect(code.code).toBeDefined();
+			repo.dispose();
+		});
+
+		it("compile-time guard: omitting redirect_uri is a type error", async () => {
+			const repo = new InMemoryCodeRepository();
+			// @ts-expect-error redirect_uri is required on CodeData (D-1)
+			const params: Parameters<CodeRepository["createCode"]>[0] = {
+				client_id: "client-1",
+			};
+			const code = await repo.createCode(params);
+			expect(code.code).toBeDefined();
+			repo.dispose();
+		});
+
+		it("populated client_id and redirect_uri round-trip via getByCode", async () => {
+			const repo = new InMemoryCodeRepository();
+			const created = await repo.createCode({
+				client_id: "client-abc",
+				redirect_uri: "https://rp.example/cb",
+			});
+			const found = await repo.getByCode(created.code);
+			expect(found?.client_id).toBe("client-abc");
+			expect(found?.redirect_uri).toBe("https://rp.example/cb");
+			repo.dispose();
+		});
+	});
+
 	describe("TODO-F-3 extended fields (nonce / sid)", () => {
 		it("roundtrips nonce + sid + grantedScope via createCode → getByCode", async () => {
 			repo = new InMemoryCodeRepository();
 			const { code } = await repo.createCode({
+				...minimalParams,
 				code_challenge: "cc",
 				code_challenge_method: "S256",
-				redirect_uri: "https://rp/cb",
 				nonce: "n-abc",
 				sid: "sid-123",
 				grantedScope: ["openid", "profile"],
@@ -166,6 +222,7 @@ describe("InMemoryCodeRepository", () => {
 		it("consumeByCode returns the fields exactly once then removes them", async () => {
 			repo = new InMemoryCodeRepository();
 			const { code } = await repo.createCode({
+				...minimalParams,
 				sid: "sid-1",
 				nonce: "n-1",
 			});
@@ -178,7 +235,7 @@ describe("InMemoryCodeRepository", () => {
 
 		it("createCode without nonce/sid leaves them undefined (backward compat)", async () => {
 			repo = new InMemoryCodeRepository();
-			const { code } = await repo.createCode({ redirect_uri: "https://rp/cb" });
+			const { code } = await repo.createCode(minimalParams);
 			const r = await repo.getByCode(code);
 			expect(r?.nonce).toBeUndefined();
 			expect(r?.sid).toBeUndefined();

--- a/packages/core/src/repositories/__tests__/InMemoryCodeRepository.test.mts
+++ b/packages/core/src/repositories/__tests__/InMemoryCodeRepository.test.mts
@@ -165,27 +165,23 @@ describe("InMemoryCodeRepository", () => {
 	// interface, so the @ts-expect-error directives below are unused → typecheck
 	// fails. Post-fix: both fields are required, so omitting either produces a
 	// TS error that the directive consumes → typecheck passes.
+	//
+	// Type-only assertions: the directives are attached to typed-variable
+	// declarations rather than runtime call sites, so vitest's typecheck pass
+	// validates the contract without storing invalid records in the repository.
 	describe("D-1 / TS-1: createCode requires client_id and redirect_uri at compile time", () => {
-		it("compile-time guard: omitting client_id is a type error", async () => {
-			const repo = new InMemoryCodeRepository();
+		it("compile-time guard: omitting client_id is a type error", () => {
 			// @ts-expect-error client_id is required on CodeData (D-1)
-			const params: Parameters<CodeRepository["createCode"]>[0] = {
+			const _params: Parameters<CodeRepository["createCode"]>[0] = {
 				redirect_uri: "https://rp.example/cb",
 			};
-			const code = await repo.createCode(params);
-			expect(code.code).toBeDefined();
-			repo.dispose();
 		});
 
-		it("compile-time guard: omitting redirect_uri is a type error", async () => {
-			const repo = new InMemoryCodeRepository();
+		it("compile-time guard: omitting redirect_uri is a type error", () => {
 			// @ts-expect-error redirect_uri is required on CodeData (D-1)
-			const params: Parameters<CodeRepository["createCode"]>[0] = {
+			const _params: Parameters<CodeRepository["createCode"]>[0] = {
 				client_id: "client-1",
 			};
-			const code = await repo.createCode(params);
-			expect(code.code).toBeDefined();
-			repo.dispose();
 		});
 
 		it("populated client_id and redirect_uri round-trip via getByCode", async () => {

--- a/packages/core/src/repositories/__tests__/createRepositoryFactories.test.mts
+++ b/packages/core/src/repositories/__tests__/createRepositoryFactories.test.mts
@@ -117,7 +117,10 @@ describe("createRepositoryFactories", () => {
 		it("creates a code repository from memory config and supports createCode/getByCode", async () => {
 			const { codeFactory } = createRepositoryFactories();
 			const repo = await codeFactory.create({ type: "memory" });
-			const code = await repo.createCode({});
+			const code = await repo.createCode({
+				client_id: "test-client",
+				redirect_uri: "https://rp.example/cb",
+			});
 
 			expect(code.code).toBeDefined();
 			const fetched = await repo.getByCode(code.code);

--- a/packages/core/src/repositories/types.mts
+++ b/packages/core/src/repositories/types.mts
@@ -55,10 +55,24 @@ export interface User {
 	[key: string]: unknown;
 }
 
+/**
+ * Data persisted in the code record at /authorize time.
+ *
+ * `consumeByCode` (atomic single-use) is the sole authenticity gate; `client_id`
+ * and `redirect_uri` embedded in the record replace the session-based identity
+ * gates removed in v0.5.1 (see CHANGELOG and the D-1 spec at
+ * `auth/.claude/superpowers/specs/2026-05-05-d1-code-repository-rewrite.md`).
+ *
+ * Breaking change for custom CodeRepository implementations: `client_id` and
+ * `redirect_uri` are now required. The compile-time guard
+ * `Parameters<CodeRepository["createCode"]>[0]` makes any implementation that
+ * misses either field fail typecheck at the destructure site.
+ */
 export interface CodeData {
+	client_id: string; // required — replaces the session.code_client_id gate
+	redirect_uri: string; // required — closes IH-4 vacuous-pass (RFC 6749 §4.1.3)
 	code_challenge?: string;
 	code_challenge_method?: string;
-	redirect_uri?: string;
 	// NEW (TODO-F-3): OIDC authorize → token round-trip state.
 	// These fields are persisted at /authorize and read at /token.
 	nonce?: string;

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -8,7 +8,8 @@
 		"src/boot/**/*.mts",
 		"src/refresh-token-family/**/*.mts",
 		"src/user-sessions/**/*.mts",
-		"src/adapters/**/*.mts"
+		"src/adapters/**/*.mts",
+		"src/repositories/__tests__/InMemoryCodeRepository.test.mts"
 	],
 	"exclude": ["node_modules", "dist"]
 }

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -10,6 +10,11 @@
 		"src/user-sessions/**/*.mts",
 		"src/adapters/**/*.mts",
 		"src/repositories/__tests__/InMemoryCodeRepository.test.mts"
+		// D-1 FOLLOW-UP: this entry is a single file, not a `repositories/__tests__/**` glob,
+		// because `InMemoryClientRepository.test.mts` has 16 pre-existing TS errors
+		// (Map<...> shape mismatches) unrelated to D-1. Widen this to the glob
+		// once that file is cleaned up — track in the next core/repositories
+		// hygiene PR.
 	],
 	"exclude": ["node_modules", "dist"]
 }

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -10,6 +10,7 @@ export default defineConfig({
 				"src/boot/**/*.test.mts",
 				"src/refresh-token-family/**/*.test.mts",
 				"src/user-sessions/__tests__/**/*.test.mts",
+				"src/repositories/__tests__/InMemoryCodeRepository.test.mts",
 			],
 			tsconfig: "./tsconfig.test.json",
 		},

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -10,6 +10,12 @@ export default defineConfig({
 				"src/boot/**/*.test.mts",
 				"src/refresh-token-family/**/*.test.mts",
 				"src/user-sessions/__tests__/**/*.test.mts",
+				// D-1 FOLLOW-UP: explicit single-file include (not the
+				// `repositories/__tests__/**` glob) because
+				// `InMemoryClientRepository.test.mts` has 16 pre-existing TS
+				// errors unrelated to D-1. Widen to the glob once that file
+				// is cleaned up — track in the next core/repositories
+				// hygiene PR.
 				"src/repositories/__tests__/InMemoryCodeRepository.test.mts",
 			],
 			tsconfig: "./tsconfig.test.json",

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -28,6 +28,14 @@ import { decodeJwt } from "jose";
 import { describe, expect, it, vi } from "vitest";
 import { createAuthorizationGrant } from "#/grants/authorization.mjs";
 
+// D-1 / v0.5.1: codeData must carry client_id and redirect_uri (required fields).
+// `body.redirect_uri` must match codeData.redirect_uri or /token rejects.
+const RP_URI = "https://rp.example/cb";
+const validCode = {
+	client_id: "client1",
+	redirect_uri: RP_URI,
+};
+
 const mockConfig = {
 	oauth: {
 		jwt: { secret: "test-secret" },
@@ -135,7 +143,7 @@ describe("createAuthorizationGrant", () => {
 			const deps = makeDeps(vi.fn().mockResolvedValue(null));
 			const handler = createAuthorizationGrant(deps);
 			const ctx: GrantContext = {
-				body: { code: "abc", client_id: "client1" },
+				body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 				session: { code: "abc", code_client_id: "client1" },
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
@@ -147,10 +155,12 @@ describe("createAuthorizationGrant", () => {
 		});
 
 		it("returns 200 with access and refresh tokens on valid code exchange (no PKCE)", async () => {
-			const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" }));
+			const deps = makeDeps(
+				vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1", ...validCode }),
+			);
 			const handler = createAuthorizationGrant(deps);
 			const ctx: GrantContext = {
-				body: { code: "abc", client_id: "client1" },
+				body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 				session: {
 					code: "abc",
 					code_client_id: "client1",
@@ -172,11 +182,14 @@ describe("createAuthorizationGrant", () => {
 				expect(decoded.sub).toBe("u1");
 				expect((decoded as Record<string, unknown>).azp).toBe("client1");
 			}
-			// Session must be cleared
+			// D-1: only `code` remains in clear list. `code_client_id` and
+			// `granted_scopes` are no longer written by /authorize, so the
+			// /token grant no longer needs to clear them.
 			expect(sessionMutation).toBeDefined();
 			expect(sessionMutation?.clear).toContain("code");
-			expect(sessionMutation?.clear).toContain("code_client_id");
-			expect(sessionMutation?.clear).toContain("granted_scopes");
+			expect(sessionMutation?.clear).not.toContain("code_client_id");
+			expect(sessionMutation?.clear).not.toContain("code_redirect_uri");
+			expect(sessionMutation?.clear).not.toContain("granted_scopes");
 		});
 
 		it("registers initial rt+jwt via refreshTokenFamilyRotation.register (CP-2)", async () => {
@@ -186,12 +199,12 @@ describe("createAuthorizationGrant", () => {
 				rotate: vi.fn(async () => ({ outcome: "rotated" as const })),
 			};
 			const deps = {
-				...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" })),
+				...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1", ...validCode })),
 				refreshTokenFamilyRotation,
 			};
 			const handler = createAuthorizationGrant(deps);
 			const ctx: GrantContext = {
-				body: { code: "abc", client_id: "client1" },
+				body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 				session: {
 					code: "abc",
 					code_client_id: "client1",
@@ -228,13 +241,13 @@ describe("createAuthorizationGrant", () => {
 				rotate: vi.fn(async () => ({ outcome: "rotated" as const })),
 			};
 			const deps = {
-				...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" })),
+				...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1", ...validCode })),
 				refreshTokenFamilyRotation: throwingRotation,
 			};
 			const handler = createAuthorizationGrant(deps);
 
 			const { result } = await handler.handle({
-				body: { code: "abc", client_id: "client1" },
+				body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 				session: {
 					code: "abc",
 					code_client_id: "client1",
@@ -251,10 +264,12 @@ describe("createAuthorizationGrant", () => {
 		});
 
 		it("skips initial-register when no refreshTokenFamilyRotation is configured (CP-2 graceful)", async () => {
-			const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" }));
+			const deps = makeDeps(
+				vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1", ...validCode }),
+			);
 			const handler = createAuthorizationGrant(deps);
 			const { result } = await handler.handle({
-				body: { code: "abc", client_id: "client1" },
+				body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 				session: {
 					code: "abc",
 					code_client_id: "client1",
@@ -268,10 +283,12 @@ describe("createAuthorizationGrant", () => {
 		});
 
 		it("issues an initial rt+jwt carrying a new family_id (C-3)", async () => {
-			const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" }));
+			const deps = makeDeps(
+				vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1", ...validCode }),
+			);
 			const handler = createAuthorizationGrant(deps);
 			const ctx: GrantContext = {
-				body: { code: "abc", client_id: "client1" },
+				body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 				session: {
 					code: "abc",
 					code_client_id: "client1",
@@ -298,10 +315,12 @@ describe("createAuthorizationGrant", () => {
 
 		it("omits scope from token response when granted scopes is empty (CP-12)", async () => {
 			// Code has neither grantedScope nor session.granted_scopes.
-			const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" }));
+			const deps = makeDeps(
+				vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1", ...validCode }),
+			);
 			const handler = createAuthorizationGrant(deps);
 			const ctx: GrantContext = {
-				body: { code: "abc", client_id: "client1" },
+				body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 				session: {
 					code: "abc",
 					code_client_id: "client1",
@@ -327,13 +346,15 @@ describe("createAuthorizationGrant", () => {
 			const deps = makeDeps(
 				vi.fn().mockResolvedValue({
 					code: "abc",
+					client_id: "client1",
+					redirect_uri: RP_URI,
 					sid: "test-sid-1",
 					grantedScope: [] as readonly string[],
 				}),
 			);
 			const handler = createAuthorizationGrant(deps);
 			const { result } = await handler.handle({
-				body: { code: "abc", client_id: "client1" },
+				body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 				session: {
 					code: "abc",
 					code_client_id: "client1",
@@ -353,13 +374,15 @@ describe("createAuthorizationGrant", () => {
 			const deps = makeDeps(
 				vi.fn().mockResolvedValue({
 					code: "abc",
+					client_id: "client1",
+					redirect_uri: RP_URI,
 					code_challenge: "challenge",
 					code_challenge_method: "S256",
 				}),
 			);
 			const handler = createAuthorizationGrant(deps);
 			const ctx: GrantContext = {
-				body: { code: "abc", client_id: "client1" },
+				body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 				session: { code: "abc", code_client_id: "client1" },
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
@@ -374,6 +397,8 @@ describe("createAuthorizationGrant", () => {
 			const deps = makeDeps(
 				vi.fn().mockResolvedValue({
 					code: "abc",
+					client_id: "client1",
+					redirect_uri: RP_URI,
 					code_challenge: "challenge",
 					code_challenge_method: "S256",
 				}),
@@ -395,6 +420,8 @@ describe("createAuthorizationGrant", () => {
 			const deps = makeDeps(
 				vi.fn().mockResolvedValue({
 					code: "abc",
+					client_id: "client1",
+					redirect_uri: RP_URI,
 					code_challenge: "wrong-challenge",
 					code_challenge_method: "S256",
 				}),
@@ -403,7 +430,7 @@ describe("createAuthorizationGrant", () => {
 			// Valid format verifier that won't match the challenge
 			const verifier = "a".repeat(43);
 			const ctx: GrantContext = {
-				body: { code: "abc", client_id: "client1", code_verifier: verifier },
+				body: { code: "abc", client_id: "client1", redirect_uri: RP_URI, code_verifier: verifier },
 				session: { code: "abc", code_client_id: "client1" },
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
@@ -422,6 +449,8 @@ describe("createAuthorizationGrant", () => {
 			const deps = makeDeps(
 				vi.fn().mockResolvedValue({
 					code: "abc",
+					client_id: "client1",
+					redirect_uri: RP_URI,
 					sid: "test-sid-1",
 					code_challenge: challenge,
 					code_challenge_method: "S256",
@@ -429,7 +458,7 @@ describe("createAuthorizationGrant", () => {
 			);
 			const handler = createAuthorizationGrant(deps);
 			const ctx: GrantContext = {
-				body: { code: "abc", client_id: "client1", code_verifier: verifier },
+				body: { code: "abc", client_id: "client1", redirect_uri: RP_URI, code_verifier: verifier },
 				session: { code: "abc", code_client_id: "client1" },
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
@@ -445,6 +474,8 @@ describe("createAuthorizationGrant", () => {
 			const deps = makeDeps(
 				vi.fn().mockResolvedValue({
 					code: "abc",
+					client_id: "client1",
+					redirect_uri: RP_URI,
 					sid: "test-sid-1",
 					code_challenge: verifier,
 					code_challenge_method: "plain",
@@ -452,7 +483,7 @@ describe("createAuthorizationGrant", () => {
 			);
 			const handler = createAuthorizationGrant(deps);
 			const ctx: GrantContext = {
-				body: { code: "abc", client_id: "client1", code_verifier: verifier },
+				body: { code: "abc", client_id: "client1", redirect_uri: RP_URI, code_verifier: verifier },
 				session: { code: "abc", code_client_id: "client1" },
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
@@ -488,6 +519,8 @@ describe("createAuthorizationGrant", () => {
 					codeRepository: {
 						consumeByCode: vi.fn().mockResolvedValue({
 							code: "abc",
+							client_id: "client1",
+							redirect_uri: RP_URI,
 							code_challenge: verifier,
 							code_challenge_method: "plain",
 						}),
@@ -499,7 +532,12 @@ describe("createAuthorizationGrant", () => {
 				};
 				const handler = createAuthorizationGrant(deps);
 				const ctx: GrantContext = {
-					body: { code: "abc", client_id: "client1", code_verifier: verifier },
+					body: {
+						code: "abc",
+						client_id: "client1",
+						redirect_uri: RP_URI,
+						code_verifier: verifier,
+					},
 					session: { code: "abc", code_client_id: "client1" },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
@@ -522,6 +560,8 @@ describe("createAuthorizationGrant", () => {
 					codeRepository: {
 						consumeByCode: vi.fn().mockResolvedValue({
 							code: "abc",
+							client_id: "client1",
+							redirect_uri: RP_URI,
 							sid: "test-sid-1",
 							code_challenge: challenge,
 							code_challenge_method: "S256",
@@ -534,7 +574,12 @@ describe("createAuthorizationGrant", () => {
 				};
 				const handler = createAuthorizationGrant(deps);
 				const ctx: GrantContext = {
-					body: { code: "abc", client_id: "client1", code_verifier: verifier },
+					body: {
+						code: "abc",
+						client_id: "client1",
+						redirect_uri: RP_URI,
+						code_verifier: verifier,
+					},
 					session: { code: "abc", code_client_id: "client1" },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
@@ -546,11 +591,15 @@ describe("createAuthorizationGrant", () => {
 			});
 		});
 
+		// A-2 redirect_uri binding — D-1 made redirect_uri a required field on
+		// CodeData; the previous "vacuous-pass when not stored" behavior (IH-4)
+		// is closed. session.code_redirect_uri fallback is removed.
 		describe("A-2: redirect_uri binding", () => {
 			it("returns invalid_grant when stored redirect_uri does not match body redirect_uri", async () => {
 				const deps = makeDeps(
 					vi.fn().mockResolvedValue({
 						code: "abc",
+						client_id: "client1",
 						redirect_uri: "https://example.com/callback",
 					}),
 				);
@@ -560,7 +609,6 @@ describe("createAuthorizationGrant", () => {
 					session: {
 						code: "abc",
 						code_client_id: "client1",
-						code_redirect_uri: "https://example.com/callback",
 					},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
@@ -576,16 +624,16 @@ describe("createAuthorizationGrant", () => {
 				const deps = makeDeps(
 					vi.fn().mockResolvedValue({
 						code: "abc",
+						client_id: "client1",
 						redirect_uri: "https://example.com/callback",
 					}),
 				);
 				const handler = createAuthorizationGrant(deps);
 				const ctx: GrantContext = {
-					body: { code: "abc", client_id: "client1" },
+					body: { code: "abc", client_id: "client1" /* no redirect_uri */ },
 					session: {
 						code: "abc",
 						code_client_id: "client1",
-						code_redirect_uri: "https://example.com/callback",
 					},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
@@ -602,6 +650,7 @@ describe("createAuthorizationGrant", () => {
 					vi.fn().mockResolvedValue({
 						code: "abc",
 						sid: "test-sid-1",
+						client_id: "client1",
 						redirect_uri: "https://example.com/callback",
 					}),
 				);
@@ -611,7 +660,6 @@ describe("createAuthorizationGrant", () => {
 					session: {
 						code: "abc",
 						code_client_id: "client1",
-						code_redirect_uri: "https://example.com/callback",
 					},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
@@ -622,16 +670,21 @@ describe("createAuthorizationGrant", () => {
 				expect(result.status).toBe(200);
 			});
 
-			it("returns 200 when no redirect_uri was stored (redirect_uri not required in authorize)", async () => {
+			it("D-1 / IH-4: rejects when codeData has no redirect_uri (was: vacuous-pass returns 200)", async () => {
+				// Pre-v0.5.1 this returned 200 because the redirect_uri binding
+				// check was guarded by `if (storedRedirectUri)`. Post-D-1
+				// codeData.redirect_uri is required and the check is unconditional.
 				const deps = makeDeps(
 					vi.fn().mockResolvedValue({
 						code: "abc",
 						sid: "test-sid-1",
+						client_id: "client1",
+						// redirect_uri intentionally omitted to model legacy/corrupt records.
 					}),
 				);
 				const handler = createAuthorizationGrant(deps);
 				const ctx: GrantContext = {
-					body: { code: "abc", client_id: "client1" },
+					body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 					session: { code: "abc", code_client_id: "client1" },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
@@ -639,7 +692,8 @@ describe("createAuthorizationGrant", () => {
 
 				const { result } = await handler.handle(ctx);
 
-				expect(result.status).toBe(200);
+				expect(result.status).toBe(400);
+				expect("error" in result && result.error).toBe("invalid_grant");
 			});
 		});
 
@@ -653,10 +707,15 @@ describe("createAuthorizationGrant", () => {
 					}),
 					authenticate: vi.fn().mockResolvedValue(null), // secret mismatch
 				};
-				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc" }), clientRepo);
+				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", ...validCode }), clientRepo);
 				const handler = createAuthorizationGrant(deps);
 				const ctx: GrantContext = {
-					body: { code: "abc", client_id: "client1", client_secret: "wrong-secret" },
+					body: {
+						code: "abc",
+						client_id: "client1",
+						redirect_uri: RP_URI,
+						client_secret: "wrong-secret",
+					},
 					session: { code: "abc", code_client_id: "client1" },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
@@ -682,12 +741,17 @@ describe("createAuthorizationGrant", () => {
 					}),
 				};
 				const deps = makeDeps(
-					vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" }),
+					vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1", ...validCode }),
 					clientRepo,
 				);
 				const handler = createAuthorizationGrant(deps);
 				const ctx: GrantContext = {
-					body: { code: "abc", client_id: "client1", client_secret: "correct-secret" },
+					body: {
+						code: "abc",
+						client_id: "client1",
+						redirect_uri: RP_URI,
+						client_secret: "correct-secret",
+					},
 					session: { code: "abc", code_client_id: "client1" },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
@@ -709,12 +773,12 @@ describe("createAuthorizationGrant", () => {
 					authenticate: vi.fn().mockResolvedValue(null),
 				};
 				const deps = makeDeps(
-					vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1" }),
+					vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1", ...validCode }),
 					clientRepo,
 				);
 				const handler = createAuthorizationGrant(deps);
 				const ctx: GrantContext = {
-					body: { code: "abc", client_id: "client1" }, // no client_secret
+					body: { code: "abc", client_id: "client1", redirect_uri: RP_URI }, // no client_secret
 					session: { code: "abc", code_client_id: "client1" },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
@@ -753,6 +817,8 @@ describe("createAuthorizationGrant", () => {
 					codeRepository: {
 						consumeByCode: vi.fn().mockResolvedValue({
 							code: "abc",
+							client_id: "client1",
+							redirect_uri: RP_URI,
 							code_challenge: verifier,
 							code_challenge_method: "plain",
 						}),
@@ -764,7 +830,12 @@ describe("createAuthorizationGrant", () => {
 				};
 				const handler = createAuthorizationGrant(deps);
 				const ctx: GrantContext = {
-					body: { code: "abc", client_id: "client1", code_verifier: verifier },
+					body: {
+						code: "abc",
+						client_id: "client1",
+						redirect_uri: RP_URI,
+						code_verifier: verifier,
+					},
 					session: { code: "abc", code_client_id: "client1" },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
@@ -784,6 +855,8 @@ describe("createAuthorizationGrant", () => {
 					codeRepository: {
 						consumeByCode: vi.fn().mockResolvedValue({
 							code: "abc",
+							client_id: "client1",
+							redirect_uri: RP_URI,
 							// no code_challenge_method
 						}),
 						createCode: vi.fn(),
@@ -794,7 +867,7 @@ describe("createAuthorizationGrant", () => {
 				};
 				const handler = createAuthorizationGrant(deps);
 				const ctx: GrantContext = {
-					body: { code: "abc", client_id: "client1" },
+					body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 					session: { code: "abc", code_client_id: "client1" },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
@@ -814,6 +887,8 @@ describe("createAuthorizationGrant", () => {
 					codeRepository: {
 						consumeByCode: vi.fn().mockResolvedValue({
 							code: "abc",
+							client_id: "client1",
+							redirect_uri: RP_URI,
 							sid: "test-sid-1",
 							// no code_challenge_method
 						}),
@@ -825,7 +900,7 @@ describe("createAuthorizationGrant", () => {
 				};
 				const handler = createAuthorizationGrant(deps);
 				const ctx: GrantContext = {
-					body: { code: "abc", client_id: "client1" },
+					body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 					session: { code: "abc", code_client_id: "client1" },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
@@ -907,6 +982,8 @@ describe("createAuthorizationGrant", () => {
 					...makeDepsWithIssuer(
 						vi.fn().mockResolvedValue({
 							code: "c1",
+							client_id: "client1",
+							redirect_uri: RP_URI,
 							sid: "sid-1",
 							nonce: "client-nonce",
 							grantedScope: ["openid", "email"],
@@ -918,7 +995,7 @@ describe("createAuthorizationGrant", () => {
 				};
 				const handler = createAuthorizationGrant(deps);
 				const { result } = await handler.handle({
-					body: { code: "c1", client_id: "client1" },
+					body: { code: "c1", client_id: "client1", redirect_uri: RP_URI },
 					session: { code: "c1", code_client_id: "client1" },
 					issuer: "https://auth.example.com",
 					metadata: { ip: "127.0.0.1" },
@@ -953,6 +1030,8 @@ describe("createAuthorizationGrant", () => {
 					...makeDeps(
 						vi.fn().mockResolvedValue({
 							code: "c-noiss",
+							client_id: "client1",
+							redirect_uri: RP_URI,
 							sid: "sid-noiss",
 							grantedScope: ["openid", "email"],
 							nonce: "client-nonce",
@@ -964,7 +1043,7 @@ describe("createAuthorizationGrant", () => {
 				};
 				const handler = createAuthorizationGrant(deps);
 				const { result } = await handler.handle({
-					body: { code: "c-noiss", client_id: "client1" },
+					body: { code: "c-noiss", client_id: "client1", redirect_uri: RP_URI },
 					session: { code: "c-noiss", code_client_id: "client1" },
 					// issuer intentionally omitted
 					metadata: { ip: "127.0.0.1" },
@@ -988,6 +1067,8 @@ describe("createAuthorizationGrant", () => {
 					...makeDepsWithIssuer(
 						vi.fn().mockResolvedValue({
 							code: "c2",
+							client_id: "client1",
+							redirect_uri: RP_URI,
 							sid: "sid-2",
 							grantedScope: ["profile", "email"],
 						}),
@@ -998,7 +1079,7 @@ describe("createAuthorizationGrant", () => {
 				};
 				const handler = createAuthorizationGrant(deps);
 				const { result } = await handler.handle({
-					body: { code: "c2", client_id: "client1" },
+					body: { code: "c2", client_id: "client1", redirect_uri: RP_URI },
 					session: { code: "c2", code_client_id: "client1" },
 					issuer: "https://auth.example.com",
 					metadata: { ip: "127.0.0.1" },
@@ -1015,13 +1096,15 @@ describe("createAuthorizationGrant", () => {
 				const deps = makeDepsWithIssuer(
 					vi.fn().mockResolvedValue({
 						code: "c3",
+						client_id: "client1",
+						redirect_uri: RP_URI,
 						sid: "sid-3",
 						grantedScope: ["openid"],
 					}),
 				);
 				const handler = createAuthorizationGrant(deps);
 				const { result } = await handler.handle({
-					body: { code: "c3", client_id: "client1" },
+					body: { code: "c3", client_id: "client1", redirect_uri: RP_URI },
 					session: { code: "c3", code_client_id: "client1" },
 					issuer: "https://auth.example.com",
 					metadata: { ip: "127.0.0.1" },
@@ -1034,12 +1117,112 @@ describe("createAuthorizationGrant", () => {
 			});
 		});
 
+		// D-1 / IH-4 / IH-2: identity gates move from the Express session to the
+		// code record. consumeByCode (atomic getDel on a single Redis node)
+		// becomes the sole authenticity gate; client_id and redirect_uri are
+		// verified against codeData fields populated at /authorize time.
+		describe("D-1: identity gates derive from codeData not session", () => {
+			it("IH-4: rejects when both body.redirect_uri AND codeData.redirect_uri are missing (vacuous-pass closure)", async () => {
+				// Per Codex calibration: include session.code / session.code_client_id
+				// matching the body so the early session gates would otherwise let
+				// this through, and exercise the new strict redirect_uri check directly.
+				const deps = makeDeps(
+					vi.fn().mockResolvedValue({
+						code: "abc",
+						client_id: "client1",
+						redirect_uri: RP_URI,
+						sid: "test-sid-1",
+						// redirect_uri intentionally absent — pre-fix this is the Redis
+						// drop scenario where IH-4 vacuous-pass would skip the check.
+					}),
+				);
+				const handler = createAuthorizationGrant(deps);
+				const ctx: GrantContext = {
+					body: { code: "abc", client_id: "client1" /* no redirect_uri */ },
+					session: { code: "abc", code_client_id: "client1", user: { id: "u1" } },
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+				};
+
+				const { result } = await handler.handle(ctx);
+
+				expect(result.status).toBe(400);
+				expect("error" in result && result.error).toBe("invalid_grant");
+			});
+
+			it("IH-4: rejects when body.redirect_uri is supplied but codeData.redirect_uri is missing", async () => {
+				const deps = makeDeps(
+					vi.fn().mockResolvedValue({
+						code: "abc",
+						client_id: "client1",
+						redirect_uri: RP_URI,
+						sid: "test-sid-1",
+						// redirect_uri intentionally absent on the codeData side.
+					}),
+				);
+				const handler = createAuthorizationGrant(deps);
+				const ctx: GrantContext = {
+					body: {
+						code: "abc",
+						client_id: "client1",
+						redirect_uri: "https://attacker.example/steal",
+					},
+					session: { code: "abc", code_client_id: "client1", user: { id: "u1" } },
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+				};
+
+				const { result } = await handler.handle(ctx);
+
+				expect(result.status).toBe(400);
+				expect("error" in result && result.error).toBe("invalid_grant");
+			});
+
+			it("IH-2: client_id check derives from codeData.client_id, not session.code_client_id", async () => {
+				// Per Codex calibration: set session.code_client_id to MATCH the body
+				// so the pre-fix session-based gate (`client_id !== session.code_client_id`)
+				// would let the request through. The new gate must reject because
+				// codeData.client_id differs from the body's client_id.
+				const deps = makeDeps(
+					vi.fn().mockResolvedValue({
+						code: "abc",
+						sid: "test-sid-1",
+						client_id: "real-client",
+						redirect_uri: "https://rp.example/cb",
+					}),
+				);
+				const handler = createAuthorizationGrant(deps);
+				const ctx: GrantContext = {
+					body: {
+						code: "abc",
+						client_id: "spoofed-client",
+						redirect_uri: "https://rp.example/cb",
+					},
+					session: {
+						code: "abc",
+						// matches body.client_id — pre-fix session gate passes.
+						code_client_id: "spoofed-client",
+						user: { id: "u1" },
+					},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+				};
+
+				const { result } = await handler.handle(ctx);
+
+				expect(result.status).toBe(400);
+				expect("error" in result && result.error).toBe("invalid_grant");
+			});
+		});
+
 		describe("TODO-F-3: family_id + sid claims, RP registration", () => {
 			it("happy path: access_token and refresh_token both carry family_id and sid claims (F-3-1)", async () => {
-				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "session-abc" }));
+				const deps = makeDeps(
+					vi.fn().mockResolvedValue({ code: "abc", sid: "session-abc", ...validCode }),
+				);
 				const handler = createAuthorizationGrant(deps);
 				const { result } = await handler.handle({
-					body: { code: "abc", client_id: "client1" },
+					body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 					session: {
 						code: "abc",
 						code_client_id: "client1",
@@ -1079,12 +1262,12 @@ describe("createAuthorizationGrant", () => {
 					async delete() {},
 				};
 				const deps = {
-					...makeDeps(vi.fn().mockResolvedValue({ code: "abc" /* no sid */ })),
+					...makeDeps(vi.fn().mockResolvedValue({ code: "abc", ...validCode } /* no sid */)),
 					userSessionStore,
 				};
 				const handler = createAuthorizationGrant(deps);
 				const { result } = await handler.handle({
-					body: { code: "abc", client_id: "client1" },
+					body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 					session: {
 						code: "abc",
 						code_client_id: "client1",
@@ -1103,10 +1286,12 @@ describe("createAuthorizationGrant", () => {
 			it("backward compat — no userSessionStore + no sid → grant succeeds without sid claim (F-3-2-compat)", async () => {
 				// Deployments that have not wired userSessionStore do not write sid at login
 				// time and must continue to work. No store → sid not required.
-				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc" /* no sid */ }));
+				const deps = makeDeps(
+					vi.fn().mockResolvedValue({ code: "abc", ...validCode } /* no sid */),
+				);
 				const handler = createAuthorizationGrant(deps);
 				const { result } = await handler.handle({
-					body: { code: "abc", client_id: "client1" },
+					body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 					session: {
 						code: "abc",
 						code_client_id: "client1",
@@ -1149,14 +1334,14 @@ describe("createAuthorizationGrant", () => {
 				const sessionFamilyIndex = makeSessionFamilyIndex({ addFamilyId: addFamilyIdSpy });
 				const sessionRPRegistry = makeSessionRPRegistry({ registerRP: registerRPSpy });
 				const deps = {
-					...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "session-xyz" })),
+					...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "session-xyz", ...validCode })),
 					userSessionStore,
 					sessionFamilyIndex,
 					sessionRPRegistry,
 				};
 				const handler = createAuthorizationGrant(deps);
 				const { result } = await handler.handle({
-					body: { code: "abc", client_id: "client1" },
+					body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 					session: {
 						code: "abc",
 						code_client_id: "client1",
@@ -1195,10 +1380,12 @@ describe("createAuthorizationGrant", () => {
 
 			it("backward compat: issues tokens without userSessionStore (F-3-4)", async () => {
 				// No userSessionStore in deps — grant must succeed without linkFamily/registerRP.
-				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "session-abc" }));
+				const deps = makeDeps(
+					vi.fn().mockResolvedValue({ code: "abc", sid: "session-abc", ...validCode }),
+				);
 				const handler = createAuthorizationGrant(deps);
 				const { result } = await handler.handle({
-					body: { code: "abc", client_id: "client1" },
+					body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 					session: {
 						code: "abc",
 						code_client_id: "client1",
@@ -1228,12 +1415,14 @@ describe("createAuthorizationGrant", () => {
 					async delete() {},
 				};
 				const deps = {
-					...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "session-gone" })),
+					...makeDeps(
+						vi.fn().mockResolvedValue({ code: "abc", sid: "session-gone", ...validCode }),
+					),
 					userSessionStore,
 				};
 				const handler = createAuthorizationGrant(deps);
 				const { result } = await handler.handle({
-					body: { code: "abc", client_id: "client1" },
+					body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 					session: {
 						code: "abc",
 						code_client_id: "client1",
@@ -1261,12 +1450,12 @@ describe("createAuthorizationGrant", () => {
 					async delete() {},
 				};
 				const deps = {
-					...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "session-abc" })),
+					...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "session-abc", ...validCode })),
 					userSessionStore,
 				};
 				const handler = createAuthorizationGrant(deps);
 				const { result } = await handler.handle({
-					body: { code: "abc", client_id: "client1" },
+					body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 					session: {
 						code: "abc",
 						code_client_id: "client1",
@@ -1305,7 +1494,7 @@ describe("createAuthorizationGrant", () => {
 				};
 				const deps = {
 					...makeDeps(
-						vi.fn().mockResolvedValue({ code: "abc", sid: "session-abc" }),
+						vi.fn().mockResolvedValue({ code: "abc", sid: "session-abc", ...validCode }),
 						throwingClientRepo,
 					),
 					userSessionStore,
@@ -1314,7 +1503,7 @@ describe("createAuthorizationGrant", () => {
 				};
 				const handler = createAuthorizationGrant(deps);
 				const { result } = await handler.handle({
-					body: { code: "abc", client_id: "client1" },
+					body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
 					session: {
 						code: "abc",
 						code_client_id: "client1",

--- a/packages/oauth/src/__tests__/hooks.test.mts
+++ b/packages/oauth/src/__tests__/hooks.test.mts
@@ -536,6 +536,7 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 			// but the session got tampered to ["write"]. Code must win.
 			const persistedCode: Code = {
 				code: "code-xyz",
+				client_id: "client-1",
 				redirect_uri: "https://example.test/cb",
 				grantedScope: ["read"],
 				sid: "test-sid-1",

--- a/packages/oauth/src/__tests__/hooks.test.mts
+++ b/packages/oauth/src/__tests__/hooks.test.mts
@@ -48,7 +48,12 @@ const mockClientRepository: ClientRepository = {
 };
 
 const mockCodeRepository: CodeRepository = {
-	createCode: async () => ({ code: "test-code" }),
+	// D-1: Code requires client_id + redirect_uri.
+	createCode: async () => ({
+		code: "test-code",
+		client_id: "client1",
+		redirect_uri: "https://rp.example/cb",
+	}),
 	getByCode: async () => null,
 	consumeByCode: async () => null,
 	removeByCode: async () => {},
@@ -254,7 +259,12 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 				authenticate: async () => null,
 			};
 			const codeRepo: CodeRepository = {
-				createCode: async () => ({ code: "auth-code-1" }),
+				// D-1: Code requires client_id + redirect_uri.
+				createCode: async () => ({
+					code: "auth-code-1",
+					client_id: "client1",
+					redirect_uri: "https://rp.example/cb",
+				}),
 				getByCode: async () => null,
 				consumeByCode: async () => null,
 				removeByCode: async () => {},
@@ -311,8 +321,11 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 			const codeRepo: CodeRepository = {
 				createCode: async (params) => {
 					opts.captureCode?.(params);
+					// D-1: echo identity fields from params so the returned Code
+					// satisfies the new required shape.
 					return {
 						code: "code-1",
+						client_id: params.client_id,
 						redirect_uri: params.redirect_uri,
 						grantedScope: params.grantedScope,
 						grantedAudience: params.grantedAudience,

--- a/packages/oauth/src/__tests__/introspectCascade.test.mts
+++ b/packages/oauth/src/__tests__/introspectCascade.test.mts
@@ -55,7 +55,12 @@ const mockClientRepository: ClientRepository = {
 };
 
 const mockCodeRepository: CodeRepository = {
-	createCode: async () => ({ code: "test-code" }),
+	// D-1: Code requires client_id + redirect_uri.
+	createCode: async () => ({
+		code: "test-code",
+		client_id: "client1",
+		redirect_uri: "https://rp.example/cb",
+	}),
 	getByCode: async () => null,
 	consumeByCode: async () => null,
 	removeByCode: async () => {},

--- a/packages/oauth/src/__tests__/module.test.mts
+++ b/packages/oauth/src/__tests__/module.test.mts
@@ -49,7 +49,12 @@ const fakeClientRepository: ClientRepository = {
 };
 
 const fakeCodeRepository: CodeRepository = {
-	createCode: async () => ({ code: "fake-code" }),
+	// D-1: Code requires client_id + redirect_uri.
+	createCode: async () => ({
+		code: "fake-code",
+		client_id: "client1",
+		redirect_uri: "https://rp.example/cb",
+	}),
 	getByCode: async () => null,
 	consumeByCode: async () => null,
 	removeByCode: async () => {},

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -47,7 +47,12 @@ const fakeClientRepository: ClientRepository = {
 };
 
 const fakeCodeRepository: CodeRepository = {
-	createCode: async () => ({ code: "fake-code" }),
+	// D-1: Code requires client_id + redirect_uri.
+	createCode: async () => ({
+		code: "fake-code",
+		client_id: "client1",
+		redirect_uri: "https://rp.example/cb",
+	}),
 	getByCode: async () => null,
 	consumeByCode: async () => null,
 	removeByCode: async () => {},
@@ -129,7 +134,9 @@ async function buildAuthorizeApp(opts: {
 	const codeRepo: CodeRepository = {
 		createCode: async (params) => {
 			opts.captureCode(params);
-			return { code: "auth-code" };
+			// D-1: echo back the required identity fields from params so the
+			// returned `Code` satisfies the new shape (client_id + redirect_uri).
+			return { code: "auth-code", client_id: params.client_id, redirect_uri: params.redirect_uri };
 		},
 		getByCode: async () => null,
 		consumeByCode: async () => null,

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -105,6 +105,7 @@ const authorizeClientRepo: ClientRepository = {
 async function buildAuthorizeApp(opts: {
 	sessionFields: Record<string, unknown>;
 	captureCode: (params: Parameters<CodeRepository["createCode"]>[0]) => void;
+	captureSession?: (session: Record<string, unknown>) => void;
 }) {
 	const app = express();
 	app.use(express.json());
@@ -112,11 +113,16 @@ async function buildAuthorizeApp(opts: {
 
 	// Inline session substitute — minimal surface needed by the /authorize route.
 	app.use((req, _res, next) => {
-		(req as unknown as { session: Record<string, unknown> }).session = {
+		const session: Record<string, unknown> = {
 			isAuthenticated: true,
 			user: { id: "user-1" },
 			...opts.sessionFields,
 		};
+		(req as unknown as { session: Record<string, unknown> }).session = session;
+		// CR-2: capture the session reference so the test can inspect post-route mutations.
+		// The /authorize route writes req.session.code* synchronously before res.redirect,
+		// so the captured reference reflects the route's writes after the request resolves.
+		opts.captureSession?.(session);
 		next();
 	});
 
@@ -339,7 +345,12 @@ describe("createAuthorizationGrant — userSessionStore forwarding", () => {
 			removeBySid: vi.fn(async () => {}),
 		};
 		const keyStore = createSymmetricKeyStore("test-secret-at-least-32-chars!!");
-		const consumeByCode = vi.fn().mockResolvedValue({ code: "auth-code", sid: "sid-wired" });
+		const consumeByCode = vi.fn().mockResolvedValue({
+			code: "auth-code",
+			sid: "sid-wired",
+			client_id: "client1",
+			redirect_uri: "https://rp.example/cb",
+		});
 
 		const deps: GrantDependencies & {
 			codeRepository: CodeRepository;
@@ -370,7 +381,11 @@ describe("createAuthorizationGrant — userSessionStore forwarding", () => {
 
 		const handler = createAuthorizationGrant(deps);
 		const { result } = await handler.handle({
-			body: { code: "auth-code", client_id: "client1" },
+			body: {
+				code: "auth-code",
+				client_id: "client1",
+				redirect_uri: "https://rp.example/cb",
+			},
 			session: {
 				code: "auth-code",
 				code_client_id: "client1",
@@ -555,5 +570,96 @@ describe("authorize persists OIDC round-trip state on code record (TODO-F-3)", (
 		expect(captured?.nonce).toBeUndefined();
 		// sid is still captured even without nonce
 		expect(captured?.sid).toBe("sid-1");
+	});
+});
+
+// D-1 / CR-2: /authorize MUST embed the identity binding in the code record,
+// not in the Express session. Pre-fix, four session writes (req.session.code,
+// req.session.code_client_id, req.session.code_redirect_uri,
+// req.session.granted_scopes) at routes.mts:572-575 created a last-write-wins
+// race when concurrent /authorize requests shared a session — the losing
+// request's code was orphaned in the repository because session.code had been
+// overwritten by the winning request and the /token gate would reject it.
+//
+// Per spec Codex calibration: prefer structural assertion (session writes are
+// gone) as a regression guard alongside the functional check (createCode is
+// called with client_id + redirect_uri).
+describe("D-1 / CR-2: /authorize binds identity to code record, not Express session", () => {
+	it("does NOT write code, code_client_id, code_redirect_uri, granted_scopes to req.session", async () => {
+		let capturedCode: Parameters<CodeRepository["createCode"]>[0] | undefined;
+		let capturedSession: Record<string, unknown> | undefined;
+
+		const app = await buildAuthorizeApp({
+			sessionFields: { sid: "sid-cr2" },
+			captureCode: (p) => {
+				capturedCode = p;
+			},
+			captureSession: (s) => {
+				capturedSession = s;
+			},
+		});
+
+		await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "client-1",
+			redirect_uri: "https://example.test/cb",
+			scope: "openid profile",
+		});
+
+		// The route must have called createCode with the identity binding embedded.
+		expect(capturedCode).toBeDefined();
+		expect(capturedCode?.client_id).toBe("client-1");
+		expect(capturedCode?.redirect_uri).toBe("https://example.test/cb");
+
+		// And the session must NOT carry any code* identity binding — otherwise
+		// concurrent /authorize requests could race on session.code overwrite.
+		expect(capturedSession).toBeDefined();
+		expect(capturedSession).not.toHaveProperty("code");
+		expect(capturedSession).not.toHaveProperty("code_client_id");
+		expect(capturedSession).not.toHaveProperty("code_redirect_uri");
+		expect(capturedSession).not.toHaveProperty("granted_scopes");
+	});
+
+	it("two concurrent /authorize requests sharing a session both produce a code with intact identity binding", async () => {
+		// Functional verification: with no session writes, two concurrent
+		// authorize calls cannot clobber each other. Both createCode calls
+		// receive distinct client_id + redirect_uri arguments and the captured
+		// session shows neither overwrote the other.
+		const capturedCodes: Parameters<CodeRepository["createCode"]>[0][] = [];
+		const capturedSessions: Record<string, unknown>[] = [];
+
+		const app = await buildAuthorizeApp({
+			sessionFields: { sid: "sid-concurrent" },
+			captureCode: (p) => {
+				capturedCodes.push(p);
+			},
+			captureSession: (s) => {
+				capturedSessions.push(s);
+			},
+		});
+
+		await Promise.all([
+			request(app).get("/oauth/authorize").query({
+				response_type: "code",
+				client_id: "client-1",
+				redirect_uri: "https://example.test/cb",
+			}),
+			request(app).get("/oauth/authorize").query({
+				response_type: "code",
+				client_id: "client-1",
+				redirect_uri: "https://example.test/cb",
+			}),
+		]);
+
+		expect(capturedCodes).toHaveLength(2);
+		for (const params of capturedCodes) {
+			expect(params.client_id).toBe("client-1");
+			expect(params.redirect_uri).toBe("https://example.test/cb");
+		}
+		// Neither captured session should carry a code identity binding.
+		for (const session of capturedSessions) {
+			expect(session).not.toHaveProperty("code");
+			expect(session).not.toHaveProperty("code_client_id");
+		}
 	});
 });

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -94,16 +94,26 @@ export const createAuthorizationGrant = (
 				};
 			}
 
-			// D-1: hoist client_id presence check ahead of consumeByCode so a
-			// missing client_id rejects symmetrically for confidential and public
-			// clients without burning the (otherwise valid) code via the atomic
-			// getDel inside consumeByCode.
+			// D-1: hoist client_id and redirect_uri presence checks ahead of
+			// consumeByCode so requests missing either reject without burning
+			// the (otherwise valid) code via the atomic getDel. The full
+			// equality checks against codeData.* still happen below — these
+			// hoisted checks only short-circuit the malformed-request path.
 			if (!client_id) {
 				return {
 					result: {
 						status: 400,
 						error: "invalid_grant",
 						errorDescription: "invalid client_id",
+					},
+				};
+			}
+			if (!redirect_uri) {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_grant",
+						errorDescription: "redirect_uri mismatch",
 					},
 				};
 			}
@@ -154,8 +164,10 @@ export const createAuthorizationGrant = (
 			// D-1: codeData.redirect_uri is now always populated (required field).
 			// The previous `?? session.code_redirect_uri` fallback hid the IH-4
 			// vacuous-pass bug where Redis silently dropped redirect_uri and the
-			// check was skipped entirely. Now strictly enforced.
-			if (!redirect_uri || redirect_uri !== codeData.redirect_uri) {
+			// check was skipped entirely. Now strictly enforced. The presence
+			// check on `redirect_uri` is hoisted above consumeByCode; this site
+			// only verifies the equality binding.
+			if (redirect_uri !== codeData.redirect_uri) {
 				return {
 					result: {
 						status: 400,

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -79,7 +79,12 @@ export const createAuthorizationGrant = (
 				redirect_uri?: string | null;
 			};
 
-			if (!code || code !== session.code) {
+			// D-1: presence-only check on `code`. The string itself is verified by
+			// `consumeByCode` (atomic getDel), which is the sole authenticity gate.
+			// The previous `code !== session.code` cross-check was redundant
+			// defense-in-depth that introduced the CR-2 last-write-wins race when
+			// two /authorize requests shared an Express session.
+			if (!code) {
 				return {
 					result: {
 						status: 400,
@@ -89,20 +94,19 @@ export const createAuthorizationGrant = (
 				};
 			}
 
-			if (!client_id || client_id !== session.code_client_id) {
-				return {
-					result: {
-						status: 400,
-						error: "invalid_grant",
-						errorDescription: "invalid client_id",
-					},
-				};
-			}
-
 			// A-3: Client secret verification (RFC 6749 §3.2.1)
 			// Only verify when client_secret is provided (confidential clients send it;
 			// public clients omit it). If provided, authenticate against the repository.
 			if (client_secret !== null && client_secret !== undefined) {
+				if (!client_id) {
+					return {
+						result: {
+							status: 400,
+							error: "invalid_grant",
+							errorDescription: "invalid client_id",
+						},
+					};
+				}
 				const authenticated = await clientRepository.authenticate(client_id, client_secret);
 				if (!authenticated) {
 					return {
@@ -127,26 +131,40 @@ export const createAuthorizationGrant = (
 				};
 			}
 
-			// A-2: redirect_uri binding (RFC 6749 §4.1.3)
-			// If redirect_uri was stored at authorization time, it MUST be present and match.
-			const storedRedirectUri = codeData.redirect_uri ?? session.code_redirect_uri;
-			if (storedRedirectUri) {
-				if (!redirect_uri || redirect_uri !== storedRedirectUri) {
-					return {
-						result: {
-							status: 400,
-							error: "invalid_grant",
-							errorDescription: "redirect_uri mismatch",
-						},
-					};
-				}
+			// D-1: client_id binding moved from session.code_client_id to
+			// codeData.client_id. Custom impls predating v0.5.1 may emit a
+			// codeData without client_id — treat that as invalid_grant rather
+			// than crashing on undefined comparison.
+			if (!client_id || client_id !== codeData.client_id) {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_grant",
+						errorDescription: "invalid client_id",
+					},
+				};
 			}
 
-			// C-2: prefer narrowed values persisted on Code at /authorize time; fall back
-			// to session for pre-C-2 codes and tests that bypass the authorize endpoint.
-			// Do NOT re-run grantPolicy here — evaluate-once-at-authorize is the contract.
-			const grantedScopes: readonly string[] | undefined =
-				codeData.grantedScope ?? session.granted_scopes;
+			// A-2: redirect_uri binding (RFC 6749 §4.1.3)
+			// D-1: codeData.redirect_uri is now always populated (required field).
+			// The previous `?? session.code_redirect_uri` fallback hid the IH-4
+			// vacuous-pass bug where Redis silently dropped redirect_uri and the
+			// check was skipped entirely. Now strictly enforced.
+			if (!redirect_uri || redirect_uri !== codeData.redirect_uri) {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_grant",
+						errorDescription: "redirect_uri mismatch",
+					},
+				};
+			}
+
+			// C-2 / D-1: only the values persisted on Code at /authorize time are
+			// authoritative. The session.granted_scopes fallback is removed along
+			// with the four /authorize session writes. Do NOT re-run grantPolicy
+			// here — evaluate-once-at-authorize is the contract.
+			const grantedScopes: readonly string[] | undefined = codeData.grantedScope;
 			const grantedAudiencesFromCode = codeData.grantedAudience;
 
 			// B-8: PKCE required check at token endpoint
@@ -449,7 +467,10 @@ export const createAuthorizationGrant = (
 					tokens: generateTokenResponse({ accessToken, refreshToken, idToken }),
 				},
 				sessionMutation: {
-					clear: ["code", "code_client_id", "code_redirect_uri", "granted_scopes"],
+					// D-1: /authorize no longer writes session.code* in v0.5.1; the
+					// `code` key remains in the clear list to scrub residual values
+					// from sessions issued before v0.5.1 ships.
+					clear: ["code"],
 				},
 			};
 		},

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -94,19 +94,24 @@ export const createAuthorizationGrant = (
 				};
 			}
 
+			// D-1: hoist client_id presence check ahead of consumeByCode so a
+			// missing client_id rejects symmetrically for confidential and public
+			// clients without burning the (otherwise valid) code via the atomic
+			// getDel inside consumeByCode.
+			if (!client_id) {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_grant",
+						errorDescription: "invalid client_id",
+					},
+				};
+			}
+
 			// A-3: Client secret verification (RFC 6749 §3.2.1)
 			// Only verify when client_secret is provided (confidential clients send it;
 			// public clients omit it). If provided, authenticate against the repository.
 			if (client_secret !== null && client_secret !== undefined) {
-				if (!client_id) {
-					return {
-						result: {
-							status: 400,
-							error: "invalid_grant",
-							errorDescription: "invalid client_id",
-						},
-					};
-				}
 				const authenticated = await clientRepository.authenticate(client_id, client_secret);
 				if (!authenticated) {
 					return {
@@ -135,7 +140,7 @@ export const createAuthorizationGrant = (
 			// codeData.client_id. Custom impls predating v0.5.1 may emit a
 			// codeData without client_id — treat that as invalid_grant rather
 			// than crashing on undefined comparison.
-			if (!client_id || client_id !== codeData.client_id) {
+			if (client_id !== codeData.client_id) {
 				return {
 					result: {
 						status: 400,
@@ -467,9 +472,12 @@ export const createAuthorizationGrant = (
 					tokens: generateTokenResponse({ accessToken, refreshToken, idToken }),
 				},
 				sessionMutation: {
-					// D-1: /authorize no longer writes session.code* in v0.5.1; the
-					// `code` key remains in the clear list to scrub residual values
-					// from sessions issued before v0.5.1 ships.
+					// D-1: /authorize no longer writes session.code* in v0.5.1.
+					// `code` is the only key still cleared here because the
+					// authorization grant doesn't read the other v0.4.x keys
+					// (`code_client_id`, `code_redirect_uri`, `granted_scopes`)
+					// at all anymore — they age out with the session TTL on
+					// rolling-deploy nodes that still have stale values.
 					clear: ["code"],
 				},
 			};

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -44,14 +44,17 @@ import * as logoutRoute from "./routes/logout.mjs";
 import * as userinfo from "./routes/userinfo.mjs";
 
 // Session data type augmentation
+//
+// D-1 (v0.5.1): `code_client_id`, `code_redirect_uri`, `granted_scopes` were
+// removed because /authorize no longer writes identity binding into the
+// session — `Code.client_id` and `Code.redirect_uri` carry it instead. `code`
+// is retained because the /token grant clears it from in-flight pre-v0.5.1
+// sessions (see authorization.mts `sessionMutation.clear`).
 declare module "express-session" {
 	interface SessionData {
 		client?: Record<string, unknown>;
 		user?: Record<string, unknown>;
 		code?: string;
-		code_client_id?: string;
-		code_redirect_uri?: string;
-		granted_scopes?: string[];
 		isAuthenticated?: boolean;
 		/** UserSession ID — set by the federation callback hook or local login (`POST /session/login`) and preserved across session regeneration. */
 		sid?: string;
@@ -555,9 +558,10 @@ export const createOAuthRouter = async (
 				let issue: Awaited<ReturnType<typeof codeRepository.createCode>>;
 				try {
 					issue = await codeRepository.createCode({
+						client_id, // D-1: identity binding embedded in the code record (replaces session.code_client_id)
+						redirect_uri, // D-1: required field (closes IH-4 vacuous-pass)
 						code_challenge: toStr(code_challenge),
 						code_challenge_method: resolvedMethod,
-						redirect_uri,
 						grantedScope: scopeForPersist,
 						grantedAudience: audienceForPersist,
 						// NEW (TODO-F-3): OIDC round-trip state on the code record.
@@ -573,10 +577,11 @@ export const createOAuthRouter = async (
 					);
 				}
 
-				req.session.code = issue.code;
-				req.session.code_client_id = client_id;
-				req.session.code_redirect_uri = redirect_uri;
-				req.session.granted_scopes = grantedScopes.length > 0 ? [...grantedScopes] : undefined;
+				// D-1 / CR-2: identity binding lives in the code record only — no
+				// session writes. Concurrent /authorize requests sharing a session
+				// previously raced on `req.session.code` last-write-wins; the
+				// losing request's code became unredeemable. consumeByCode (atomic
+				// getDel on a single Redis node) is now the sole authenticity gate.
 
 				const url = new URL(redirect_uri);
 				url.searchParams.append("code", issue.code);

--- a/packages/redis/__tests__/code-repository.test.mts
+++ b/packages/redis/__tests__/code-repository.test.mts
@@ -131,6 +131,29 @@ describe("RedisCodeRepository", () => {
 			const result = await repo.getByCode("corrupted");
 			expect(result).toBeNull();
 		});
+
+		// D-1: pre-v0.5.1 records persisted via the old createCode path lacked
+		// `client_id` / `redirect_uri` because RedisCodeRepository.createCode
+		// silently dropped both. parseCodeValue treats such records as corrupt
+		// (returns null + structured error log) so the strict identity gates
+		// in /token never see `client_id: undefined` or `redirect_uri: undefined`.
+		it("treats pre-v0.5.1 records lacking client_id and redirect_uri as corrupt", async () => {
+			store.set(`${KEY_PREFIX}legacy-1`, JSON.stringify({ code_challenge: "x" }));
+			expect(await repo.getByCode("legacy-1")).toBeNull();
+		});
+
+		it("treats records with non-string client_id as corrupt", async () => {
+			store.set(
+				`${KEY_PREFIX}legacy-2`,
+				JSON.stringify({ client_id: 123, redirect_uri: "https://rp/cb" }),
+			);
+			expect(await repo.getByCode("legacy-2")).toBeNull();
+		});
+
+		it("treats records with missing redirect_uri as corrupt even if client_id is present", async () => {
+			store.set(`${KEY_PREFIX}legacy-3`, JSON.stringify({ client_id: "client-1" }));
+			expect(await repo.getByCode("legacy-3")).toBeNull();
+		});
 	});
 
 	describe("consumeByCode", () => {

--- a/packages/redis/__tests__/code-repository.test.mts
+++ b/packages/redis/__tests__/code-repository.test.mts
@@ -46,6 +46,12 @@ const createMockRedis = () => ({
 describe("RedisCodeRepository", () => {
 	let repo: RedisCodeRepository;
 
+	// Minimal valid params for v0.5.1+ (D-1: client_id and redirect_uri required).
+	const minimalParams = {
+		client_id: "test-client",
+		redirect_uri: "https://rp.example/cb",
+	};
+
 	beforeEach(async () => {
 		store.clear();
 		const redis = createMockRedis();
@@ -55,7 +61,7 @@ describe("RedisCodeRepository", () => {
 
 	describe("createCode", () => {
 		it("generates a code string and stores it", async () => {
-			const result = await repo.createCode({});
+			const result = await repo.createCode(minimalParams);
 
 			expect(typeof result.code).toBe("string");
 			expect(result.code.length).toBeGreaterThan(0);
@@ -65,6 +71,7 @@ describe("RedisCodeRepository", () => {
 
 		it("returns code with code_challenge and code_challenge_method", async () => {
 			const result = await repo.createCode({
+				...minimalParams,
 				code_challenge: "abc123",
 				code_challenge_method: "S256",
 			});
@@ -75,6 +82,7 @@ describe("RedisCodeRepository", () => {
 
 		it("stores code_challenge and code_challenge_method in Redis", async () => {
 			const result = await repo.createCode({
+				...minimalParams,
 				code_challenge: "challenge-value",
 				code_challenge_method: "S256",
 			});
@@ -87,12 +95,12 @@ describe("RedisCodeRepository", () => {
 		});
 
 		it("uses default expiresIn when not provided", async () => {
-			const result = await repo.createCode({});
+			const result = await repo.createCode(minimalParams);
 			expect(result.expiresIn).toBe(600);
 		});
 
 		it("uses provided expiresIn", async () => {
-			const result = await repo.createCode({ expiresIn: 300 });
+			const result = await repo.createCode({ ...minimalParams, expiresIn: 300 });
 			expect(result.expiresIn).toBe(300);
 		});
 	});
@@ -100,6 +108,7 @@ describe("RedisCodeRepository", () => {
 	describe("getByCode", () => {
 		it("returns stored code data", async () => {
 			const created = await repo.createCode({
+				...minimalParams,
 				code_challenge: "test-challenge",
 				code_challenge_method: "S256",
 			});
@@ -127,6 +136,7 @@ describe("RedisCodeRepository", () => {
 	describe("consumeByCode", () => {
 		it("returns code data and removes it atomically", async () => {
 			const created = await repo.createCode({
+				...minimalParams,
 				code_challenge: "consume-test",
 				code_challenge_method: "S256",
 			});
@@ -145,7 +155,7 @@ describe("RedisCodeRepository", () => {
 		});
 
 		it("second consume returns null (replay prevention)", async () => {
-			const created = await repo.createCode({});
+			const created = await repo.createCode(minimalParams);
 			const first = await repo.consumeByCode(created.code);
 			expect(first).not.toBeNull();
 
@@ -156,7 +166,7 @@ describe("RedisCodeRepository", () => {
 
 	describe("removeByCode", () => {
 		it("removes a stored code", async () => {
-			const created = await repo.createCode({ code_challenge: "c" });
+			const created = await repo.createCode({ ...minimalParams, code_challenge: "c" });
 			expect(store.has(`${KEY_PREFIX}${created.code}`)).toBe(true);
 
 			await repo.removeByCode(created.code);
@@ -165,6 +175,72 @@ describe("RedisCodeRepository", () => {
 
 		it("does not throw for unknown code", async () => {
 			await expect(repo.removeByCode("nonexistent")).resolves.toBeUndefined();
+		});
+	});
+
+	// D-1 / TD-1 / IH-2 / TS-1: extended-fields round-trip
+	// Pre-fix RedisCodeRepository.createCode silently drops every field except
+	// code_challenge / code_challenge_method / expiresIn (sid / nonce / redirect_uri /
+	// grantedScope / grantedAudience). Production deployments using Redis +
+	// userSessionStore could not complete a single authorization-code exchange
+	// because codeData.sid was always undefined.
+	describe("D-1 extended fields round-trip", () => {
+		it("persists and returns client_id, redirect_uri via consumeByCode", async () => {
+			const result = await repo.createCode({
+				client_id: "client-abc",
+				redirect_uri: "https://rp.example/cb",
+			});
+			const consumed = await repo.consumeByCode(result.code);
+			expect(consumed?.client_id).toBe("client-abc");
+			expect(consumed?.redirect_uri).toBe("https://rp.example/cb");
+		});
+
+		it("persists and returns sid, nonce, grantedScope, grantedAudience via consumeByCode", async () => {
+			const result = await repo.createCode({
+				client_id: "client-abc",
+				redirect_uri: "https://rp.example/cb",
+				sid: "sid-xyz",
+				nonce: "nonce-abc",
+				grantedScope: ["openid", "profile"],
+				grantedAudience: ["api.example"],
+			});
+			const consumed = await repo.consumeByCode(result.code);
+			expect(consumed?.sid).toBe("sid-xyz");
+			expect(consumed?.nonce).toBe("nonce-abc");
+			expect(consumed?.grantedScope).toEqual(["openid", "profile"]);
+			expect(consumed?.grantedAudience).toEqual(["api.example"]);
+		});
+
+		it("persists all fields in the Redis JSON payload (storage-level assertion)", async () => {
+			const result = await repo.createCode({
+				client_id: "client-abc",
+				redirect_uri: "https://rp.example/cb",
+				sid: "sid-xyz",
+				nonce: "nonce-abc",
+				grantedScope: ["openid"],
+			});
+			const raw = store.get(`${KEY_PREFIX}${result.code}`) as string;
+			expect(raw).toBeDefined();
+			const parsed = JSON.parse(raw);
+			expect(parsed.client_id).toBe("client-abc");
+			expect(parsed.redirect_uri).toBe("https://rp.example/cb");
+			expect(parsed.sid).toBe("sid-xyz");
+			expect(parsed.nonce).toBe("nonce-abc");
+			expect(parsed.grantedScope).toEqual(["openid"]);
+		});
+
+		it("getByCode also returns all extended fields", async () => {
+			const result = await repo.createCode({
+				client_id: "client-abc",
+				redirect_uri: "https://rp.example/cb",
+				sid: "sid-xyz",
+				nonce: "nonce-abc",
+			});
+			const found = await repo.getByCode(result.code);
+			expect(found?.client_id).toBe("client-abc");
+			expect(found?.redirect_uri).toBe("https://rp.example/cb");
+			expect(found?.sid).toBe("sid-xyz");
+			expect(found?.nonce).toBe("nonce-abc");
 		});
 	});
 });

--- a/packages/redis/src/code-repository.mts
+++ b/packages/redis/src/code-repository.mts
@@ -181,6 +181,15 @@ export class RedisCodeRepository implements CodeRepository {
 				);
 				return null;
 			}
+			// Defensive type guards on optional array fields. The `as
+			// StoredCodePayload` cast trusts JSON shape; without these, a
+			// corrupted record with `grantedScope: "not-an-array"` would
+			// propagate a non-array up to downstream gates (scope filter / aud
+			// narrowing) that assume `readonly string[]`. Drop on shape mismatch
+			// rather than throw — the strict `/token` gates downstream will
+			// then reject naturally on the missing claim.
+			const grantedScope = Array.isArray(p.grantedScope) ? p.grantedScope : undefined;
+			const grantedAudience = Array.isArray(p.grantedAudience) ? p.grantedAudience : undefined;
 			return {
 				code,
 				client_id: p.client_id,
@@ -190,8 +199,8 @@ export class RedisCodeRepository implements CodeRepository {
 				nonce: p.nonce,
 				sid: p.sid,
 				expiresIn: p.expiresIn,
-				grantedScope: p.grantedScope,
-				grantedAudience: p.grantedAudience,
+				grantedScope,
+				grantedAudience,
 			};
 		} catch (err) {
 			const codeHash = crypto.createHash("sha256").update(code).digest("hex").slice(0, 16);

--- a/packages/redis/src/code-repository.mts
+++ b/packages/redis/src/code-repository.mts
@@ -45,6 +45,28 @@ interface RedisClientWithQuit extends RedisClient {
 	quit(): Promise<void>;
 }
 
+/**
+ * Shape persisted as JSON in Redis for each authorization code (D-1).
+ *
+ * Mirrors `Parameters<CodeRepository["createCode"]>[0]` plus a private
+ * `expiresIn` echo so reads can reconstruct the original record. The
+ * destructure of `createCode` MUST stay in sync with this shape — adding
+ * a field to `CodeData` requires destructuring it AND extending this
+ * interface, otherwise the Redis path silently drops it (which was the
+ * IH-2 / TS-1 / TD-1 production bug v0.5.1 closes).
+ */
+interface StoredCodePayload {
+	client_id: string;
+	redirect_uri: string;
+	code_challenge?: string;
+	code_challenge_method?: string;
+	nonce?: string;
+	sid?: string;
+	expiresIn?: number;
+	grantedScope?: string[];
+	grantedAudience?: string[];
+}
+
 export class RedisCodeRepository implements CodeRepository {
 	private redis: RedisClient;
 	private defaultExpiresIn: number;
@@ -98,23 +120,30 @@ export class RedisCodeRepository implements CodeRepository {
 	}
 
 	async createCode({
+		client_id,
+		redirect_uri,
 		code_challenge,
 		code_challenge_method,
+		nonce,
+		sid,
 		expiresIn = this.defaultExpiresIn,
-	}: {
-		code_challenge?: string;
-		code_challenge_method?: string;
-		expiresIn?: number;
-	}): Promise<Code> {
+		grantedScope,
+		grantedAudience,
+	}: Parameters<CodeRepository["createCode"]>[0]): Promise<Code> {
 		const code = crypto.randomBytes(32).toString("base64url");
-
-		await this.redis.set(
-			KEY_PREFIX + code,
-			JSON.stringify({ code_challenge, code_challenge_method }),
-			{ EX: expiresIn },
-		);
-
-		return { code, code_challenge, code_challenge_method, expiresIn };
+		const payload: StoredCodePayload = {
+			client_id,
+			redirect_uri,
+			code_challenge,
+			code_challenge_method,
+			nonce,
+			sid,
+			expiresIn,
+			grantedScope: grantedScope ? [...grantedScope] : undefined,
+			grantedAudience: grantedAudience ? [...grantedAudience] : undefined,
+		};
+		await this.redis.set(KEY_PREFIX + code, JSON.stringify(payload), { EX: expiresIn });
+		return { code, ...payload };
 	}
 
 	async getByCode(code: string): Promise<Code | null> {
@@ -134,7 +163,36 @@ export class RedisCodeRepository implements CodeRepository {
 	private parseCodeValue(code: string, value: string | null): Code | null {
 		if (!value) return null;
 		try {
-			return { ...JSON.parse(value), code } as Code;
+			// The cast trusts the stored format — `StoredCodePayload` is a private
+			// internal type that exactly mirrors what `createCode` serializes; no
+			// external writer touches this key namespace.
+			const p = JSON.parse(value) as StoredCodePayload;
+			// Pre-v0.5.1 codes lack `client_id` / `redirect_uri` (the IH-2 / TS-1
+			// production drop bug). Treat them as corrupt — the strict identity
+			// gates in /token would reject them anyway, but failing here keeps the
+			// failure mode aligned with the corrupted-JSON branch and prevents
+			// `client_id: undefined` from leaking into downstream gates as a
+			// runtime null.
+			if (typeof p.client_id !== "string" || typeof p.redirect_uri !== "string") {
+				const codeHash = crypto.createHash("sha256").update(code).digest("hex").slice(0, 16);
+				this.logger.error(
+					{ codeHash },
+					"RedisCodeRepository: legacy/corrupted code record missing required identity fields",
+				);
+				return null;
+			}
+			return {
+				code,
+				client_id: p.client_id,
+				redirect_uri: p.redirect_uri,
+				code_challenge: p.code_challenge,
+				code_challenge_method: p.code_challenge_method,
+				nonce: p.nonce,
+				sid: p.sid,
+				expiresIn: p.expiresIn,
+				grantedScope: p.grantedScope,
+				grantedAudience: p.grantedAudience,
+			};
 		} catch (err) {
 			const codeHash = crypto.createHash("sha256").update(code).digest("hex").slice(0, 16);
 			this.logger.error({ err, codeHash }, "RedisCodeRepository: corrupted data for code");


### PR DESCRIPTION
## Summary

Phase F batch F3 — closes Decision **D-1 (CC-1)**. Single isolated PR per dep graph §3 F3.

**Closes 5 audit findings** in one structural change:
- **IH-2** — `RedisCodeRepository.createCode` silently dropped `sid` / `nonce` / `redirect_uri` / `grantedScope` / `grantedAudience` (Redis + OIDC was non-functional)
- **TS-1** — `parseCodeValue` cast `as Code` masked the missing fields from TypeScript
- **TD-1** — Redis test never round-tripped extended fields
- **IH-4** — RFC 6749 §4.1.3 `redirect_uri` binding was guarded by `if (storedRedirectUri)` and silently skipped when both `codeData.redirect_uri` and `session.code_redirect_uri` were undefined
- **CR-2** — concurrent `/authorize` requests sharing a session raced on `req.session.code` last-write-wins

## Design

`CodeData` now requires `client_id: string` and `redirect_uri: string`. The compile-time guard `Parameters<CodeRepository["createCode"]>[0]` makes any implementation that misses either field fail typecheck at the destructure site. `RedisCodeRepository` persists every field via a private `StoredCodePayload` interface and reconstructs the `Code` via explicit field-by-field extraction (no spread / cast). The pre-v0.5.1 in-flight code records (lacking `client_id`/`redirect_uri`) are treated as corrupt by `parseCodeValue` (returns null + logs structured error). `Array.isArray` guards on `grantedScope`/`grantedAudience` close the JSON-shape trust gap.

`/oauth/authorize` no longer writes `req.session.code` / `code_client_id` / `code_redirect_uri` / `granted_scopes` — identity binding is embedded in the code record. `/oauth/token` (authorization_code grant) drops the session-based identity gates and verifies `client_id` + `redirect_uri` against `codeData.*` fields populated at `/authorize` time. `consumeByCode` (Redis `getDel` atomic single-use) is the sole authenticity gate. The `client_id` presence check is hoisted ahead of `consumeByCode` so missing-id rejects symmetrically for confidential and public clients without burning the code.

## Breaking Changes (v0.5.1)

Documented in CHANGELOG. Custom `CodeRepository` implementations must update their `createCode` signature. Custom middleware that read `req.session.code*` will no longer see those fields populated. The canonical core `SessionData` interface no longer advertises `code_client_id` / `code_redirect_uri` / `granted_scopes` (only `code` remains, retained for in-flight pre-v0.5.1 session scrubbing).

## Tests

29 new RED→GREEN tests across core / redis / oauth packages:
- 4× `redis/code-repository.test.mts` — round-trip of all extended fields (TD-1)
- 3× `core/InMemoryCodeRepository.test.mts` — `@ts-expect-error` type guards (TS-1) + round-trip
- 3× `oauth/authorization.test.mts` — IH-4 redirect_uri rejection + IH-2 client_id-from-codeData gate
- 2× `oauth/oauthAuthorization.test.mts` — CR-2 structural session-write absence + functional concurrent-codes
- Plus comprehensive fixture updates across 8 test files

`make test` clean: **1984 / 1984 passing** (was 1955 → +29 D-1 tests).

biome lint: clean on all modified files.

## Test plan

- [x] All packages green via `make test` (create-app 66 / core 1095 / foundation 10 / oauth-token-exchange 84 / oauth 293 / session 150+1 todo / redis 246 / federation-google 11 / federation-github 20 / templates/standalone 9 = **1984 total**)
- [x] biome lint clean on every modified file (verified individually)
- [x] tsc clean across workspace
- [x] Verification greps per spec §Verification:
  - `grep -r "session\.code_client_id\|session\.code_redirect_uri\|session\.granted_scopes" packages/oauth/src/` (excl tests) → only comments in change history
  - `grep -n "req\.session\.code\s*=" packages/oauth/src/routes.mts` → zero hits
- [x] Multi-agent review (Claude code-reviewer + Codex review --base develop) — all Important findings addressed in second commit

## Spec + cross-references

- Spec: `auth/.claude/superpowers/specs/2026-05-05-d1-code-repository-rewrite.md`
- Phase F dep graph: `auth/.claude/audit/2026-05-06-phase-f-dependency-graph.md` §3 F3
- Handoff: `auth/.claude/handoff/2026-05-06-phase-f-f3-handoff.md`

## Cross-spec implications

- D-6 (Wave 4 PB-2, F6 batch) builds on this Code/CodeData shape; reconciliation is documented in spec §"Cross-spec implications" — D-6 must NOT revive `session.code_client_id`.
- F4 (D-2 v2 standalone composition root), F5 (OR-9 RedisCodeRepository client injection), F6 (CR-4 TOCTOU re-check) all depend on the new shape landing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)