### PR TITLE
feat(core,oauth,redis,standalone): F5 PR1 — OR-9 RedisCodeRepository module + OR-5 rate-limit fail-mode (v0.5.1)

### DIFF
--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -38,6 +38,14 @@ oauth {
     authorization_code { enabled = true, enabled = ${?OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED} }
     refresh_token { enabled = true, enabled = ${?OAUTH_GRANTS_REFRESH_TOKEN_ENABLED} }
   }
+  # OR-9: adapter switch for the OAuth authorization-code repository.
+  # Multi-replica production MUST set this to "redis" — the memory adapter
+  # loses codes on restart and across replicas. Default `"memory"` matches
+  # the existing core behavior.
+  code {
+    adapter = "memory"
+    adapter = ${?OAUTH_CODE_ADAPTER}
+  }
 }
 
 session {
@@ -63,6 +71,12 @@ session {
 
 rateLimit {
   login { windowMs = 900000, limit = 20 }
+  # OR-5: fail-mode policy for the OAuth-endpoint rate limiter when its
+  # backend errors. "open" preserves fail-open behavior + adds `logger.error`
+  # emission. "closed" returns HTTP 503 — recommended for security-sensitive
+  # deployments where rate limiting is a load-shedding hard requirement.
+  failMode = "open"
+  failMode = ${?RATE_LIMIT_FAIL_MODE}
 }
 
 federations {

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -40,10 +40,16 @@ oauth {
   }
   # OR-9: adapter switch for the OAuth authorization-code repository.
   # Multi-replica production MUST set this to "redis" — the memory adapter
-  # loses codes on restart and across replicas. Default `"memory"` matches
-  # the existing core behavior.
+  # loses codes on restart and across replicas.
+  #
+  # No default literal here on purpose: the legacy `repositories.code.type`
+  # fallback in `buildModules` only runs when `oauth.code.adapter` is
+  # absent, so a baked-in default would make the legacy override path dead
+  # code for any deployment that inherits this core HOCON. Operators who
+  # want to opt into the new switch set `OAUTH_CODE_ADAPTER` (or override
+  # in their own config layer); pre-OR-9 deployments that still rely on
+  # `CLIENT_CODE_TYPE=redis` keep working through the deprecation window.
   code {
-    adapter = "memory"
     adapter = ${?OAUTH_CODE_ADAPTER}
   }
 }

--- a/packages/core/src/__tests__/config-composition.test.mts
+++ b/packages/core/src/__tests__/config-composition.test.mts
@@ -187,6 +187,7 @@ describe("fullSectionsSchema endpoints optionality", () => {
 		const sessionModuleConfig = {
 			rateLimit: {
 				login: { windowMs: 60000, limit: 10 },
+				failMode: "open" as const,
 			},
 			endpoints: {
 				login: { url: "/login" },
@@ -233,6 +234,7 @@ describe("AppConfigSchema backward compatibility", () => {
 			},
 			rateLimit: {
 				login: { windowMs: 60000, limit: 10 },
+				failMode: "open",
 			},
 			federations: {
 				google: { enabled: false },

--- a/packages/core/src/config/__tests__/schema-open-type.test.mts
+++ b/packages/core/src/config/__tests__/schema-open-type.test.mts
@@ -128,6 +128,7 @@ describe("schema open type", () => {
 			},
 			rateLimit: {
 				login: { windowMs: 900000, limit: 20 },
+				failMode: "open",
 			},
 			federations: {},
 			// Legacy key — must fail. The renamed key `repositories` is absent.
@@ -293,6 +294,7 @@ describe("schema nested repositories", () => {
 		it("rateLimit.login uses windowMs, not windowSeconds", () => {
 			const result = fullSectionsSchema.shape.rateLimit.parse({
 				login: { windowMs: 900000, limit: 20 },
+				failMode: "open",
 			});
 			expect(result.login.windowMs).toBe(900000);
 			expect(result.login.limit).toBe(20);
@@ -300,6 +302,7 @@ describe("schema nested repositories", () => {
 			expect(() =>
 				fullSectionsSchema.shape.rateLimit.parse({
 					login: { windowSeconds: 900, limit: 20 },
+					failMode: "open",
 				}),
 			).toThrow();
 		});

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -327,7 +327,15 @@ export const fullSectionsSchema = z.object({
 	redisCodeRepository: z
 		.object({
 			keyPrefix: z.string().optional(),
-			defaultExpiresIn: z.coerce.number().optional(),
+			// `defaultExpiresIn` is the Redis PX TTL (seconds) for OAuth
+			// authorization codes. Constrained to a positive integer: a bad
+			// env-var override (`CLIENT_CODE_DEFAULT_EXPIRES_IN=0`, `="-1"`,
+			// non-numeric) fails AppConfigSchema parse at boot rather than
+			// silently propagating to a Redis PX call that errors per
+			// request. Mirrored at the module configSchema level + at the
+			// `RedisCodeRepository` constructor for defense in depth.
+			// Per Copilot review on PR #122.
+			defaultExpiresIn: z.coerce.number().int().positive().optional(),
 		})
 		.optional(),
 });

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -123,6 +123,17 @@ export const CoreConfigSchema = z.object({
 			expiresIn: z.coerce.number(),
 		}),
 		grants: z.object({}).passthrough(),
+		// OR-9 (Wave 5d): adapter switch for the OAuth authorization-code
+		// repository. Multi-replica deployments MUST set this to `"redis"`;
+		// the in-memory variant loses codes on restart and across replicas.
+		// Default `"memory"` lives in HOCON per ADR; presence-only here
+		// (`.optional()`) so token-only deployments that omit `oauth.code`
+		// entirely still validate against this base schema.
+		code: z
+			.object({
+				adapter: z.enum(["memory", "redis"]),
+			})
+			.optional(),
 	}),
 });
 
@@ -206,6 +217,13 @@ export const fullSectionsSchema = z.object({
 	 */
 	rateLimit: z.object({
 		login: rateLimitSchema,
+		// OR-5: fail-mode policy for the OAuth-endpoint rate limiter when
+		// the limiter backend itself errors. `"open"` (default in HOCON)
+		// preserves existing fail-open behavior + adds `logger.error`
+		// emission so operators see the outage even when the audit sink
+		// is also down. `"closed"` returns HTTP 503 + logs — recommended
+		// for security-sensitive deployments. No `.default()` per ADR.
+		failMode: z.enum(["open", "closed"]),
 	}),
 	federations: z.record(z.string(), federationEntrySchema),
 	repositories: z.object({
@@ -291,6 +309,19 @@ export const fullSectionsSchema = z.object({
 		.object({
 			keyPrefix: z.string().optional(),
 			casRetryLimit: z.coerce.number().optional(),
+		})
+		.optional(),
+	// OR-9 (Wave 5d): module-internal config for `redisCodeRepositoryModule`.
+	// MUST be declared here (in `fullSectionsSchema`) so `AppConfigSchema.parse(...)`
+	// in `app.mts` preserves operator overrides
+	// (`CLIENT_CODE_KEY_PREFIX` / `CLIENT_CODE_DEFAULT_EXPIRES_IN`) before
+	// the module's `configSchema` runs at boot time. Same gotcha as D-2 v2's
+	// `redisRefreshTokenFamilyStore` block above. Defaults stay in
+	// `application.conf`; this entry is presence-only (both fields optional).
+	redisCodeRepository: z
+		.object({
+			keyPrefix: z.string().optional(),
+			defaultExpiresIn: z.coerce.number().optional(),
 		})
 		.optional(),
 });

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -126,12 +126,18 @@ export const CoreConfigSchema = z.object({
 		// OR-9 (Wave 5d): adapter switch for the OAuth authorization-code
 		// repository. Multi-replica deployments MUST set this to `"redis"`;
 		// the in-memory variant loses codes on restart and across replicas.
-		// Default `"memory"` lives in HOCON per ADR; presence-only here
-		// (`.optional()`) so token-only deployments that omit `oauth.code`
-		// entirely still validate against this base schema.
+		//
+		// `adapter` is `.optional()` (not required-when-code-is-present)
+		// because the core HOCON binds it to `${?OAUTH_CODE_ADAPTER}` with
+		// no literal default — when the env var is unset, HOCON still
+		// produces an empty `oauth.code = {}` block. Requiring `adapter`
+		// here would reject that valid "no override" state. The
+		// `buildModules` legacy `repositories.code.type = "redis"` fallback
+		// only fires when `adapter` is undefined, so leaving it optional
+		// is what keeps the deprecation window real.
 		code: z
 			.object({
-				adapter: z.enum(["memory", "redis"]),
+				adapter: z.enum(["memory", "redis"]).optional(),
 			})
 			.optional(),
 	}),

--- a/packages/core/src/testing/fixtures/valid-config.mts
+++ b/packages/core/src/testing/fixtures/valid-config.mts
@@ -98,6 +98,7 @@ export function makeValidFullSections() {
 		},
 		rateLimit: {
 			login: { windowMs: 900000, limit: 20 },
+			failMode: "open",
 		},
 		federations: {},
 		repositories: {

--- a/packages/oauth/src/__tests__/hooks.test.mts
+++ b/packages/oauth/src/__tests__/hooks.test.mts
@@ -24,18 +24,26 @@ import {
 	createSymmetricKeyStore,
 	type GrantPolicyHookBase,
 	GrantRegistry,
+	type Logger,
 	type RateLimiterBase,
 } from "@o3co/auth-provider-core";
 import express from "express";
 import request from "supertest";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createOAuthRouter } from "#/routes.mjs";
 
+// OR-5: `checkRateLimit` reads `config.rateLimit.failMode` in the catch
+// path. The mock config carries `failMode: "open"` to exercise the
+// default behavior; closed-mode tests below override `rateLimit` per-test.
 const mockConfig = {
 	oauth: {
 		jwt: { issuer: "https://auth.example" },
 		accessToken: { expiresIn: 3600 },
 		refreshToken: { expiresIn: 86400 },
+	},
+	rateLimit: {
+		login: { windowMs: 60_000, limit: 100 },
+		failMode: "open",
 	},
 	endpoints: {
 		login: { url: "/login" },
@@ -83,7 +91,12 @@ function createSpyAuditSink(): { sink: AuditSinkBase; events: AuditEvent[] } {
 	};
 }
 
-async function buildApp(overrides: { rateLimiter?: RateLimiterBase; auditSink?: AuditSinkBase }) {
+async function buildApp(overrides: {
+	rateLimiter?: RateLimiterBase;
+	auditSink?: AuditSinkBase;
+	logger?: Logger;
+	config?: AppConfig;
+}) {
 	const app = express();
 	// Ensure req.ip is consistently populated so the RateLimiter hook sees it
 	app.set("trust proxy", 1);
@@ -92,7 +105,7 @@ async function buildApp(overrides: { rateLimiter?: RateLimiterBase; auditSink?: 
 
 	const { router } = await createOAuthRouter(express, {
 		registry: new GrantRegistry(),
-		config: mockConfig,
+		config: overrides.config ?? mockConfig,
 		clientRepository: mockClientRepository,
 		codeRepository: mockCodeRepository,
 		keyStore: createSymmetricKeyStore("test-secret-at-least-32-chars!!"),
@@ -178,6 +191,126 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 			const ev = events.find((e) => e.type === "rate_limit.unavailable");
 			expect(ev).toBeDefined();
 			expect((ev?.details as { error?: string } | undefined)?.error).toContain("redis down");
+		});
+
+		// OR-5: fail-mode policy + logger emission. Pre-OR-5 the limiter
+		// outage was silent (audit sink was the only path, and a Redis-backed
+		// audit sink also drops during the same outage). The new logger
+		// emission ensures operators see the outage regardless of audit sink
+		// status; `failMode = "closed"` adds 503 enforcement on top.
+		describe("OR-5: failMode policy + logger emission", () => {
+			const makeMockLogger = (): Logger & { error: ReturnType<typeof vi.fn> } => ({
+				debug: vi.fn(),
+				info: vi.fn(),
+				warn: vi.fn(),
+				error: vi.fn(),
+			});
+
+			const brokenRateLimiter: RateLimiterBase = {
+				kind: "broken",
+				async check() {
+					throw new Error("redis down");
+				},
+			};
+
+			it("failMode='open' + limiter throws → request allowed + logger.error('rate_limiter_failed_open')", async () => {
+				const logger = makeMockLogger();
+				const app = await buildApp({
+					rateLimiter: brokenRateLimiter,
+					logger,
+					// mockConfig already has failMode: "open"
+				});
+
+				const res = await request(app)
+					.post("/oauth/token")
+					.send({ grant_type: "unsupported_type_xyz" });
+
+				// fail-open: 400 unsupported_grant_type from the route, NOT 503
+				expect(res.status).toBe(400);
+				expect(logger.error).toHaveBeenCalledWith(
+					expect.objectContaining({
+						error: expect.stringContaining("redis down"),
+						mode: "open",
+						tag: "token",
+					}),
+					"rate_limiter_failed_open",
+				);
+			});
+
+			it("failMode='closed' + limiter throws → 503 service_unavailable + logger.error('rate_limiter_failed_closed')", async () => {
+				const logger = makeMockLogger();
+				const closedConfig = {
+					...(mockConfig as unknown as Record<string, unknown>),
+					rateLimit: {
+						login: { windowMs: 60_000, limit: 100 },
+						failMode: "closed",
+					},
+				} as unknown as AppConfig;
+				const app = await buildApp({
+					rateLimiter: brokenRateLimiter,
+					logger,
+					config: closedConfig,
+				});
+
+				const res = await request(app)
+					.post("/oauth/token")
+					.send({ grant_type: "unsupported_type_xyz" });
+
+				expect(res.status).toBe(503);
+				expect(res.body.error).toBe("service_unavailable");
+				expect(logger.error).toHaveBeenCalledWith(
+					expect.objectContaining({
+						error: expect.stringContaining("redis down"),
+						mode: "closed",
+						tag: "token",
+					}),
+					"rate_limiter_failed_closed",
+				);
+			});
+
+			it("failMode='open' + limiter succeeds and allows → no logger.error call (success path is silent)", async () => {
+				const logger = makeMockLogger();
+				const app = await buildApp({
+					rateLimiter: createStubRateLimiter(() => ({ allowed: true })),
+					logger,
+				});
+
+				const res = await request(app)
+					.post("/oauth/token")
+					.send({ grant_type: "unsupported_type_xyz" });
+
+				expect(res.status).toBe(400); // unsupported_grant_type, not 503
+				expect(logger.error).not.toHaveBeenCalledWith(
+					expect.anything(),
+					expect.stringMatching(/^rate_limiter_failed_/),
+				);
+			});
+
+			it("failMode='closed' + limiter succeeds and allows → no logger.error call (failMode only affects error path)", async () => {
+				const logger = makeMockLogger();
+				const closedConfig = {
+					...(mockConfig as unknown as Record<string, unknown>),
+					rateLimit: {
+						login: { windowMs: 60_000, limit: 100 },
+						failMode: "closed",
+					},
+				} as unknown as AppConfig;
+				const app = await buildApp({
+					rateLimiter: createStubRateLimiter(() => ({ allowed: true })),
+					logger,
+					config: closedConfig,
+				});
+
+				const res = await request(app)
+					.post("/oauth/token")
+					.send({ grant_type: "unsupported_type_xyz" });
+
+				expect(res.status).toBe(400); // unsupported_grant_type, not 503
+				expect(logger.error).not.toHaveBeenCalledWith(
+					expect.anything(),
+					expect.stringMatching(/^rate_limiter_failed_/),
+				);
+			});
 		});
 
 		it("does not block requests when rateLimiter allows", async () => {

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -127,9 +127,22 @@ export const createOAuthRouter = async (
 				userAgent: req.get("user-agent"),
 			});
 		} catch (cause) {
-			// Fail-open: if the limiter backend is unavailable we prefer to serve
-			// the auth flow over 5xx-ing every request. Operators see the outage
-			// via the audit event below and via their limiter's own telemetry.
+			// OR-5: the previous implementation was silent fail-open with a
+			// fire-and-forget audit event. The audit sink is typically Redis-
+			// backed too, so during a Redis outage the audit emission also
+			// silently drops — operators saw nothing while rate limiting was
+			// down for hours. The `failMode` policy below makes the behavior
+			// configurable, and the `logger.error` call ensures operators see
+			// the outage regardless of audit-sink status.
+			const failMode = config.rateLimit.failMode;
+			const errorMessage = cause instanceof Error ? cause.message : String(cause);
+			logger.error(
+				{ error: errorMessage, mode: failMode, tag, ip },
+				failMode === "open" ? "rate_limiter_failed_open" : "rate_limiter_failed_closed",
+			);
+			// Belt-and-suspenders: keep the audit event for ops dashboards
+			// that consume it. The logger call above is the operator-visible
+			// path; the audit event is the structured pipeline path.
 			emitAuditEvent(auditSink, {
 				timestamp: new Date(),
 				type: "rate_limit.unavailable",
@@ -137,9 +150,16 @@ export const createOAuthRouter = async (
 				userAgent: req.get("user-agent"),
 				details: {
 					tag,
-					error: cause instanceof Error ? cause.message : String(cause),
+					error: errorMessage,
 				},
 			});
+			if (failMode === "closed") {
+				res.status(503).json({
+					error: "service_unavailable",
+					error_description: "Rate limiter temporarily unavailable",
+				});
+				return false;
+			}
 			return true;
 		}
 		if (!decision.allowed) {

--- a/packages/redis/__tests__/code-repository.test.mts
+++ b/packages/redis/__tests__/code-repository.test.mts
@@ -21,13 +21,17 @@ const KEY_PREFIX = "oauth:code:";
 // In-memory store simulating Redis
 const store = new Map<string, string>();
 
+import type { CodeRepositoryClient } from "../src/clients.mjs";
 import { RedisCodeRepository } from "../src/code-repository.mjs";
 
-const createMockRedis = () => ({
-	connect: vi.fn().mockResolvedValue(undefined),
+// OR-9: the public `RedisCodeRepository` constructor accepts a typed
+// `CodeRepositoryClient` wrapper, not a node-redis client. The mock satisfies
+// only that interface — `set/get/getDel/del` — and ignores the `mode`/`ttlMs`
+// arguments which the in-memory store doesn't honor.
+const createMockClient = (): CodeRepositoryClient => ({
 	set: vi.fn().mockImplementation((key: string, value: string) => {
 		store.set(key, value);
-		return Promise.resolve("OK");
+		return Promise.resolve("OK" as const);
 	}),
 	get: vi.fn().mockImplementation((key: string) => {
 		return Promise.resolve(store.get(key) ?? null);
@@ -45,6 +49,7 @@ const createMockRedis = () => ({
 
 describe("RedisCodeRepository", () => {
 	let repo: RedisCodeRepository;
+	let client: CodeRepositoryClient;
 
 	// Minimal valid params for v0.5.1+ (D-1: client_id and redirect_uri required).
 	const minimalParams = {
@@ -52,11 +57,10 @@ describe("RedisCodeRepository", () => {
 		redirect_uri: "https://rp.example/cb",
 	};
 
-	beforeEach(async () => {
+	beforeEach(() => {
 		store.clear();
-		const redis = createMockRedis();
-		repo = new RedisCodeRepository(redis);
-		await repo.initialize();
+		client = createMockClient();
+		repo = new RedisCodeRepository(client);
 	});
 
 	describe("createCode", () => {
@@ -198,6 +202,68 @@ describe("RedisCodeRepository", () => {
 
 		it("does not throw for unknown code", async () => {
 			await expect(repo.removeByCode("nonexistent")).resolves.toBeUndefined();
+		});
+	});
+
+	// OR-9 (Wave 5d): external client + ioredis migration. The constructor
+	// accepts a `CodeRepositoryClient` typed wrapper instead of constructing
+	// its own node-redis client. PX expiry is in milliseconds; keyPrefix and
+	// defaultExpiresIn flow through the options object.
+	describe("OR-9 external client", () => {
+		it("calls client.set with PX mode and ttlMs = expiresIn * 1000", async () => {
+			await repo.createCode({ ...minimalParams, expiresIn: 300 });
+			expect(client.set).toHaveBeenCalledWith(
+				expect.stringMatching(/^oauth:code:/),
+				expect.any(String),
+				"PX",
+				300_000,
+			);
+		});
+
+		it("uses the default expiry (600s = 600000ms) when expiresIn is omitted", async () => {
+			await repo.createCode(minimalParams);
+			expect(client.set).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.any(String),
+				"PX",
+				600_000,
+			);
+		});
+
+		it("honors a custom keyPrefix option", async () => {
+			const customClient = createMockClient();
+			const customRepo = new RedisCodeRepository(customClient, { keyPrefix: "tenant-a:code:" });
+			const result = await customRepo.createCode(minimalParams);
+			expect(customClient.set).toHaveBeenCalledWith(
+				`tenant-a:code:${result.code}`,
+				expect.any(String),
+				"PX",
+				expect.any(Number),
+			);
+		});
+
+		it("honors a custom defaultExpiresIn option", async () => {
+			const customClient = createMockClient();
+			const customRepo = new RedisCodeRepository(customClient, { defaultExpiresIn: 120 });
+			const result = await customRepo.createCode(minimalParams);
+			expect(result.expiresIn).toBe(120);
+			expect(customClient.set).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.any(String),
+				"PX",
+				120_000,
+			);
+		});
+
+		it("has no dispose / [Symbol.asyncDispose] method (consumer manages client lifecycle, D-5 v2)", () => {
+			// Regression guard: the consumer (composition root) owns the
+			// ioredis socket via `standaloneRedisClientsModule` and registers
+			// its own `lifecycleRegistrar.register(io.quit)`. The repository
+			// is purely a typed wrapper; introducing a dispose() here would
+			// double-quit the shared socket.
+			const r = repo as unknown as Record<string, unknown>;
+			expect(r.dispose).toBeUndefined();
+			expect(r[Symbol.asyncDispose as unknown as string]).toBeUndefined();
 		});
 	});
 

--- a/packages/redis/__tests__/code-repository.test.mts
+++ b/packages/redis/__tests__/code-repository.test.mts
@@ -265,6 +265,28 @@ describe("RedisCodeRepository", () => {
 			expect(r.dispose).toBeUndefined();
 			expect(r[Symbol.asyncDispose as unknown as string]).toBeUndefined();
 		});
+
+		// Defense-in-depth: the module configSchema rejects non-positive
+		// integers at boot, but direct constructor callers must also fail
+		// loudly so the failure mode is identical regardless of wiring path.
+		// Per Copilot review on PR #122.
+		it.each([
+			["zero", 0],
+			["negative", -1],
+			["fractional", 1.5],
+			["NaN", Number.NaN],
+			["Infinity", Number.POSITIVE_INFINITY],
+		])("constructor throws RangeError when defaultExpiresIn is %s", (_label, badValue) => {
+			const c = createMockClient();
+			expect(() => new RedisCodeRepository(c, { defaultExpiresIn: badValue })).toThrow(RangeError);
+		});
+
+		it("constructor accepts undefined defaultExpiresIn (falls back to 600s default)", async () => {
+			const c = createMockClient();
+			const r = new RedisCodeRepository(c, {});
+			const result = await r.createCode(minimalParams);
+			expect(result.expiresIn).toBe(600);
+		});
 	});
 
 	// D-1 / TD-1 / IH-2 / TS-1: extended-fields round-trip

--- a/packages/redis/src/clients.mts
+++ b/packages/redis/src/clients.mts
@@ -259,6 +259,26 @@ export interface RateLimiterClient {
 	expire(key: string, seconds: number): Promise<number>;
 }
 
+// --- CodeRepositoryClient --------------------------------------------------
+
+/**
+ * Backing client for CodeRepository adapters. Declares only the four Redis
+ * commands `RedisCodeRepository` consumes: `set` with PX expiry (always
+ * succeeds with `"OK"`), unconditional `get`, atomic `getDel` (Redis 6.2+),
+ * and unconditional `del`.
+ *
+ * Per OR-9 (Wave 5d). The repository is rewritten in v0.5.1 to consume an
+ * externally-provided typed wrapper instead of constructing its own
+ * node-redis client; aligns with the per-purpose client convention
+ * established by D-2 v2 and consumed via `bootstrapComponents`.
+ */
+export interface CodeRepositoryClient {
+	set(key: string, value: string, mode: "PX", ttlMs: number): Promise<"OK">;
+	get(key: string): Promise<string | null>;
+	getDel(key: string): Promise<string | null>;
+	del(key: string): Promise<number>;
+}
+
 // ---------------------------------------------------------------------------
 // ComponentMap augmentations: backing-client slots consumed by redis adapters.
 //
@@ -278,5 +298,6 @@ declare module "@o3co/auth-provider-core" {
 		readonly sessionFederationIndexClient?: SessionSidSortedSetClient;
 		readonly federationTokenStoreClient?: FederationTokenStoreClient;
 		readonly rateLimiterClient?: RateLimiterClient;
+		readonly codeRepositoryClient?: CodeRepositoryClient;
 	}
 }

--- a/packages/redis/src/code-repository.mts
+++ b/packages/redis/src/code-repository.mts
@@ -20,30 +20,14 @@ import {
 	type Code,
 	type CodeRepository,
 	consoleLogger,
+	defineModule,
 	type Logger,
-	type PathResolver,
 } from "@o3co/auth-provider-core";
+import { z } from "zod";
+import type { CodeRepositoryClient } from "./clients.mjs";
 
-const KEY_PREFIX = "oauth:code:";
-
-// Minimal interface for the redis client methods we use.
-// Avoids importing the full "redis" types at the module level.
-interface RedisClient {
-	connect(): Promise<void>;
-	get(key: string): Promise<string | null>;
-	set(key: string, value: string, options?: { EX?: number }): Promise<unknown>;
-	getDel(key: string): Promise<string | null>;
-	del(key: string): Promise<number>;
-}
-
-// Quit shape lives on the concrete node-redis client returned by `createClient`
-// but is intentionally NOT part of the public `RedisClient` interface (which
-// stays minimal per `feedback_no_vendor_in_interface`). The cast in
-// `[Symbol.asyncDispose]` reaches the runtime quit() method via the private
-// `redis` field — no interface widening needed.
-interface RedisClientWithQuit extends RedisClient {
-	quit(): Promise<void>;
-}
+const DEFAULT_KEY_PREFIX = "oauth:code:";
+const DEFAULT_EXPIRES_IN_SECONDS = 600;
 
 /**
  * Shape persisted as JSON in Redis for each authorization code (D-1).
@@ -67,56 +51,31 @@ interface StoredCodePayload {
 	grantedAudience?: string[];
 }
 
+/**
+ * Options accepted by the public `RedisCodeRepository` constructor.
+ *
+ * Per OR-9 (Wave 5d): the connection lifecycle is owned by the consumer
+ * (composition root); the repository only consumes the typed
+ * `CodeRepositoryClient` wrapper. No internal client construction, no
+ * `quit()` call, no `[Symbol.asyncDispose]`.
+ */
+export interface RedisCodeRepositoryOptions {
+	readonly keyPrefix?: string;
+	readonly defaultExpiresIn?: number;
+	readonly logger?: Logger;
+}
+
 export class RedisCodeRepository implements CodeRepository {
-	private redis: RedisClient;
-	private defaultExpiresIn: number;
-	private logger: Logger;
-	// D-5: idempotence flag — `[Symbol.asyncDispose]` fallback in the boot
-	// planner AND the LifecycleRegistrar drain both target the same instance,
-	// so `dispose()` may be called twice. The second call must be a no-op
-	// instead of issuing a second `quit()` against a closed client (which
-	// throws `ClientClosedError` on node-redis v5).
-	private disposed = false;
+	private readonly client: CodeRepositoryClient;
+	private readonly keyPrefix: string;
+	private readonly defaultExpiresIn: number;
+	private readonly logger: Logger;
 
-	constructor(redis: RedisClient, defaultExpiresIn = 600, logger: Logger = consoleLogger) {
-		this.redis = redis;
-		this.defaultExpiresIn = defaultExpiresIn;
-		this.logger = logger;
-	}
-
-	static async create(
-		config: Record<string, unknown>,
-		pathResolver?: PathResolver,
-		logger: Logger = consoleLogger,
-	): Promise<RedisCodeRepository> {
-		if (typeof config.endpointUri !== "string") {
-			throw new Error('RedisCodeRepository requires "endpointUri" in config');
-		}
-
-		const { createClient } = pathResolver
-			? ((await import(pathResolver("redis"))) as typeof import("redis"))
-			: await import("redis");
-
-		const redis = createClient({
-			url: config.endpointUri,
-			password: typeof config.password === "string" ? config.password : undefined,
-			socket: {
-				reconnectStrategy: (retries: number) => {
-					const jitter = Math.floor(Math.random() * 200);
-					const delay = Math.min(2 ** retries * 50, 2000);
-					return delay + jitter;
-				},
-			},
-		});
-		const defaultExpiresIn =
-			typeof config.defaultExpiresIn === "number" ? config.defaultExpiresIn : undefined;
-		const repo = new RedisCodeRepository(redis as unknown as RedisClient, defaultExpiresIn, logger);
-		await repo.initialize();
-		return repo;
-	}
-
-	async initialize(): Promise<void> {
-		await this.redis.connect();
+	constructor(client: CodeRepositoryClient, opts: RedisCodeRepositoryOptions = {}) {
+		this.client = client;
+		this.keyPrefix = opts.keyPrefix ?? DEFAULT_KEY_PREFIX;
+		this.defaultExpiresIn = opts.defaultExpiresIn ?? DEFAULT_EXPIRES_IN_SECONDS;
+		this.logger = opts.logger ?? consoleLogger;
 	}
 
 	async createCode({
@@ -142,22 +101,23 @@ export class RedisCodeRepository implements CodeRepository {
 			grantedScope: grantedScope ? [...grantedScope] : undefined,
 			grantedAudience: grantedAudience ? [...grantedAudience] : undefined,
 		};
-		await this.redis.set(KEY_PREFIX + code, JSON.stringify(payload), { EX: expiresIn });
+		// PX expiry is in milliseconds; HOCON expiresIn is in seconds.
+		await this.client.set(this.keyPrefix + code, JSON.stringify(payload), "PX", expiresIn * 1000);
 		return { code, ...payload };
 	}
 
 	async getByCode(code: string): Promise<Code | null> {
-		const value = await this.redis.get(KEY_PREFIX + code);
+		const value = await this.client.get(this.keyPrefix + code);
 		return this.parseCodeValue(code, value);
 	}
 
 	async consumeByCode(code: string): Promise<Code | null> {
-		const value = await this.redis.getDel(KEY_PREFIX + code);
+		const value = await this.client.getDel(this.keyPrefix + code);
 		return this.parseCodeValue(code, value);
 	}
 
 	async removeByCode(code: string): Promise<void> {
-		await this.redis.del(KEY_PREFIX + code);
+		await this.client.del(this.keyPrefix + code);
 	}
 
 	private parseCodeValue(code: string, value: string | null): Code | null {
@@ -208,69 +168,76 @@ export class RedisCodeRepository implements CodeRepository {
 			return null;
 		}
 	}
-
-	/**
-	 * Disconnect the underlying Redis client (D-5 / OR-2). The
-	 * `redisCodeRepositoryBuilder` registers this with `BuilderContext.lifecycle`
-	 * so `AppHandle.dispose()` drains the connection automatically. The cast
-	 * reaches the runtime `quit()` method on the concrete node-redis client
-	 * without widening the minimal `RedisClient` interface (per
-	 * `feedback_no_vendor_in_interface`).
-	 */
-	async [Symbol.asyncDispose](): Promise<void> {
-		if (this.disposed) return;
-		this.disposed = true;
-		// Runtime guard: the public `RedisClient` interface does NOT declare
-		// `quit()` (kept minimal per `feedback_no_vendor_in_interface`), but
-		// the concrete node-redis client returned by `createClient()` always
-		// provides it. Custom `RedisClient` implementations passed via the
-		// public constructor MUST also implement `quit()` for D-5 lifecycle
-		// integration to work — fail loudly with a clear message instead of
-		// throwing an opaque `client.quit is not a function` TypeError.
-		const client = this.redis as Partial<RedisClientWithQuit>;
-		if (typeof client.quit !== "function") {
-			throw new Error(
-				"RedisCodeRepository.dispose(): underlying redis client does not implement quit(). " +
-					"Custom RedisClient implementations passed to the constructor must provide a `quit(): Promise<void>` " +
-					"method for D-5 lifecycle integration.",
-			);
-		}
-		await client.quit();
-	}
-
-	/**
-	 * Alias for `[Symbol.asyncDispose]` for call sites that cannot use
-	 * `await using`. Returns the same Promise.
-	 */
-	dispose(): Promise<void> {
-		return this[Symbol.asyncDispose]();
-	}
 }
 
 /**
- * AdapterFactory builder. Consumer wires:
- *   factory.register("redis", redisCodeRepositoryBuilder);
+ * @deprecated since v0.5.1 (OR-9). Use `redisCodeRepositoryModule` (DI module
+ * pattern) instead. The builder now expects `{ client, keyPrefix?,
+ * defaultExpiresIn? }` (the same shape the module passes internally) — the
+ * pre-v0.5.1 `{ endpointUri }` shape is no longer supported. Removed in v0.6.
  *
- * `config` shape: `{ endpointUri: string; password?: string; defaultExpiresIn?: number }`.
- *
- * The repository is constructed and connected lazily on first call to
- * `factory.create(...)`. The redis client lifetime is owned by the repo
- * instance: D-5 wired the builder to `ctx.lifecycle?.register(...)` so
- * `AppHandle.dispose()` drains `repo.dispose()` (which calls `quit()` on the
- * underlying client) automatically. Call sites that cannot use `await using`
- * may invoke `repo.dispose()` directly.
- *
- * Module pattern wrapper for `codeRepository` slot is intentionally NOT
- * provided in v0.5.0 — see Phase 10 plan §1 / Q4 (deferred to a separate
- * "legacy-slot module-parity" PR).
+ * Migration: stop calling `factory.register("redis", redisCodeRepositoryBuilder)`;
+ * instead include `redisCodeRepositoryModule` in the manifest and provide the
+ * `codeRepositoryClient` slot from `makeIoredisClients()`.
  */
-export const redisCodeRepositoryBuilder: AdapterBuilder<CodeRepository> = async (config, ctx) => {
-	if (typeof config.endpointUri !== "string") {
-		throw new Error('RedisCodeRepository requires "endpointUri" in config');
+export const redisCodeRepositoryBuilder: AdapterBuilder<CodeRepository> = (config, _ctx) => {
+	const c = config as {
+		client?: CodeRepositoryClient;
+		keyPrefix?: string;
+		defaultExpiresIn?: number;
+	};
+	if (!c.client) {
+		throw new Error(
+			"redisCodeRepositoryBuilder: 'client' option is required (legacy { endpointUri } " +
+				"shape removed in v0.5.1). Use redisCodeRepositoryModule with a codeRepositoryClient " +
+				"slot from makeIoredisClients() instead.",
+		);
 	}
-	const repo = await RedisCodeRepository.create(config);
-	ctx.lifecycle?.register(async () => {
-		await repo.dispose();
+	consoleLogger.warn(
+		"redisCodeRepositoryBuilder is deprecated; use redisCodeRepositoryModule (will be removed in v0.6).",
+	);
+	return new RedisCodeRepository(c.client, {
+		keyPrefix: c.keyPrefix,
+		defaultExpiresIn: c.defaultExpiresIn,
 	});
-	return repo;
 };
+
+/**
+ * `defineModule` manifest for the Redis CodeRepository (OR-9 / Wave 5d).
+ *
+ * Static composition path. The legacy `redisCodeRepositoryBuilder` still
+ * exists for one release cycle but is deprecated — operators wiring redis
+ * codes should switch to this module + provide `codeRepositoryClient` from
+ * `makeIoredisClients()`.
+ *
+ * configSchema: top-level key `redisCodeRepository` (module-namespaced per
+ * master roadmap §3.5). No `.default()` per ADR — defaults live in
+ * `application.conf`. The constructor falls back to its built-in defaults
+ * (`oauth:code:` / 600s) when both HOCON and operator overrides omit a
+ * field; mirrors the `?? DEFAULT_*` pattern in the constructor body.
+ */
+export const redisCodeRepositoryModule = defineModule({
+	name: "redis-code-repository",
+	requires: ["codeRepositoryClient", "config"] as const,
+	configSchema: z.object({
+		redisCodeRepository: z
+			.object({
+				keyPrefix: z.string().optional(),
+				defaultExpiresIn: z.coerce.number().optional(),
+			})
+			.optional(),
+	}),
+	provides: {
+		codeRepository: (deps) => {
+			const cfg = (
+				deps.config as {
+					redisCodeRepository?: { keyPrefix?: string; defaultExpiresIn?: number };
+				}
+			).redisCodeRepository;
+			return new RedisCodeRepository(deps.codeRepositoryClient, {
+				keyPrefix: cfg?.keyPrefix,
+				defaultExpiresIn: cfg?.defaultExpiresIn,
+			});
+		},
+	},
+});

--- a/packages/redis/src/code-repository.mts
+++ b/packages/redis/src/code-repository.mts
@@ -74,7 +74,22 @@ export class RedisCodeRepository implements CodeRepository {
 	constructor(client: CodeRepositoryClient, opts: RedisCodeRepositoryOptions = {}) {
 		this.client = client;
 		this.keyPrefix = opts.keyPrefix ?? DEFAULT_KEY_PREFIX;
-		this.defaultExpiresIn = opts.defaultExpiresIn ?? DEFAULT_EXPIRES_IN_SECONDS;
+		// Direct-construction guard: the module configSchema already rejects
+		// non-positive integers, but consumers calling
+		// `new RedisCodeRepository(client, { defaultExpiresIn: 0 })`
+		// directly would otherwise sail past validation and hit Redis with
+		// a bad PX argument. Reject at construction time with a clear
+		// message so the failure mode is the same regardless of wiring path.
+		// Per Copilot review on PR #122.
+		const expiresIn = opts.defaultExpiresIn;
+		if (expiresIn !== undefined) {
+			if (!Number.isInteger(expiresIn) || expiresIn <= 0) {
+				throw new RangeError(
+					`RedisCodeRepository: defaultExpiresIn must be a positive integer (seconds), got ${expiresIn}`,
+				);
+			}
+		}
+		this.defaultExpiresIn = expiresIn ?? DEFAULT_EXPIRES_IN_SECONDS;
 		this.logger = opts.logger ?? consoleLogger;
 	}
 
@@ -223,7 +238,13 @@ export const redisCodeRepositoryModule = defineModule({
 		redisCodeRepository: z
 			.object({
 				keyPrefix: z.string().optional(),
-				defaultExpiresIn: z.coerce.number().optional(),
+				// `defaultExpiresIn` controls the Redis PX TTL (seconds) for
+				// authorization codes. Constrained to a positive integer so a
+				// bad env-var override (`CLIENT_CODE_DEFAULT_EXPIRES_IN=0`,
+				// `="-1"`, or `="abc"`) fails Zod validation at boot rather
+				// than producing a non-positive PX argument that Redis rejects
+				// at first /authorize call. Per Copilot review on PR #122.
+				defaultExpiresIn: z.coerce.number().int().positive().optional(),
 			})
 			.optional(),
 	}),

--- a/packages/redis/src/index.mts
+++ b/packages/redis/src/index.mts
@@ -47,11 +47,18 @@ export type {
 // into the consumer's TS dependency closure. Per Phase 10 addendum +
 // Copilot review #102.
 // ---------------------------------------------------------------------------
-// CodeRepository (Phase 10 Q4).
-// Relocated from @o3co/auth-provider-foundation. Module pattern intentionally
-// omitted in v0.5.0 (see plan §1 / Q4).
+// CodeRepository (Phase 10 Q4 / OR-9 Wave 5d).
+// Relocated from @o3co/auth-provider-foundation. v0.5.1 OR-9 added the module
+// pattern + migrated to ioredis-typed `CodeRepositoryClient`; the legacy
+// builder is retained one release cycle as deprecated and now requires the
+// new `{ client, keyPrefix?, defaultExpiresIn? }` shape.
 // ---------------------------------------------------------------------------
-export { RedisCodeRepository, redisCodeRepositoryBuilder } from "./code-repository.mjs";
+export {
+	RedisCodeRepository,
+	type RedisCodeRepositoryOptions,
+	redisCodeRepositoryBuilder,
+	redisCodeRepositoryModule,
+} from "./code-repository.mjs";
 // ---------------------------------------------------------------------------
 // FederationTokenStore (Phase 10 Q1+Q5).
 // Adapter relocated from core; module pattern added for declarative wiring

--- a/packages/redis/src/index.mts
+++ b/packages/redis/src/index.mts
@@ -29,6 +29,7 @@ export {
 // ---------------------------------------------------------------------------
 export type {
 	ChallengeStoreClient,
+	CodeRepositoryClient,
 	DisposableRefreshTokenFamilyClient,
 	FederationTokenStoreClient,
 	RateLimiterClient,

--- a/packages/redis/src/ioredis.mts
+++ b/packages/redis/src/ioredis.mts
@@ -6,6 +6,7 @@ import { createHash } from "node:crypto";
 import type { Redis } from "ioredis";
 import type {
 	ChallengeStoreClient,
+	CodeRepositoryClient,
 	DisposableRefreshTokenFamilyClient,
 	FederationTokenStoreClient,
 	RateLimiterClient,
@@ -92,6 +93,7 @@ export function makeIoredisClients(io: Redis): {
 	sessionFederationIndexClient: SessionSidSortedSetClient;
 	federationTokenStoreClient: FederationTokenStoreClient;
 	rateLimiterClient: RateLimiterClient;
+	codeRepositoryClient: CodeRepositoryClient;
 } {
 	const challengeStoreClient: ChallengeStoreClient = {
 		set: (k, v, _mode, ttl, _cond) => io.set(k, v, "PX", ttl, "NX") as Promise<"OK" | null>,
@@ -280,6 +282,17 @@ export function makeIoredisClients(io: Redis): {
 		expire: (k, s) => io.expire(k, s),
 	};
 
+	// OR-9: code-repository client. Codes are short-TTL (60-600s) high-volume
+	// records; the four-method surface (`set`/`get`/`getDel`/`del`) maps
+	// directly to ioredis primitives. Shares the same socket as the other
+	// per-purpose clients.
+	const codeRepositoryClient: CodeRepositoryClient = {
+		set: (k, v, _mode, ttlMs) => io.set(k, v, "PX", ttlMs) as Promise<"OK">,
+		get: (k) => io.get(k),
+		getDel: (k) => io.getdel(k),
+		del: (k) => io.del(k),
+	};
+
 	return {
 		challengeStoreClient,
 		replaySeenSetClient,
@@ -290,5 +303,6 @@ export function makeIoredisClients(io: Redis): {
 		sessionFederationIndexClient: sortedSetClient,
 		federationTokenStoreClient,
 		rateLimiterClient,
+		codeRepositoryClient,
 	};
 }

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -208,8 +208,12 @@ redisRefreshTokenFamilyStore {
 # codes from colliding with tenant B's under the default `oauth:code:`
 # prefix (MIN-3 advisory).
 redisCodeRepository {
-  # keyPrefix = "oauth:code:"
-  # keyPrefix = ${?CLIENT_CODE_KEY_PREFIX}
+  # No literal default for keyPrefix — the RedisCodeRepository constructor
+  # falls back to `oauth:code:` when this field is absent. Operators that
+  # need multi-tenant isolation set CLIENT_CODE_KEY_PREFIX (e.g.
+  # `tenant-a:code:`); leaving the env var unset keeps the constructor
+  # default intact via HOCON's `${?VAR}` "absent if unset" semantics.
+  keyPrefix = ${?CLIENT_CODE_KEY_PREFIX}
   defaultExpiresIn = 600
   defaultExpiresIn = ${?CLIENT_CODE_DEFAULT_EXPIRES_IN}
 }

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -45,6 +45,17 @@ oauth {
     }
     refresh_token { enabled = true, enabled = ${?OAUTH_GRANTS_REFRESH_TOKEN_ENABLED} }
   }
+  # OR-9: adapter switch for the OAuth authorization-code repository. When
+  # set to "redis", the standalone composition root wires
+  # `redisCodeRepositoryModule` against the shared ioredis socket
+  # (`standaloneRedisClientsModule`). Memory-only deployments lose codes on
+  # restart and across replicas — multi-replica production MUST use "redis".
+  # Supersedes the legacy `repositories.code.type` switch (kept below for
+  # one release cycle for backward compat).
+  code {
+    adapter = "redis"
+    adapter = ${?OAUTH_CODE_ADAPTER}
+  }
 }
 
 session {
@@ -78,6 +89,11 @@ session {
 #       `rateLimiter.adapter = "memory" | "redis"` (see below).
 rateLimit {
   login { windowMs = 900000, limit = 20 }
+  # OR-5: fail-mode for the OAuth-endpoint rate limiter when the limiter
+  # backend errors. "open" = allow + `logger.error`. "closed" = HTTP 503
+  # + `logger.error` (recommended for security-sensitive deployments).
+  failMode = "open"
+  failMode = ${?RATE_LIMIT_FAIL_MODE}
 }
 
 federations {
@@ -179,6 +195,23 @@ redisRefreshTokenFamilyStore {
   keyPrefix = ${?REFRESH_TOKEN_FAMILY_STORE_KEY_PREFIX}
   casRetryLimit = 3
   casRetryLimit = ${?REFRESH_TOKEN_FAMILY_STORE_CAS_RETRY_LIMIT}
+}
+
+# OR-9 (Wave 5d): module-internal config for `redisCodeRepositoryModule`.
+# Consumed when `oauth.code.adapter = "redis"`. The shared ioredis socket
+# (`standaloneRedisClientsModule`) provides the `codeRepositoryClient`
+# slot; this section governs only key namespacing and the default
+# expiry-in-seconds the repository uses when /authorize doesn't supply one.
+#
+# Multi-tenant deployments override `keyPrefix` to isolate tenants in the
+# same Redis instance — e.g. `keyPrefix = "tenant-a:code:"` keeps tenant A's
+# codes from colliding with tenant B's under the default `oauth:code:`
+# prefix (MIN-3 advisory).
+redisCodeRepository {
+  # keyPrefix = "oauth:code:"
+  # keyPrefix = ${?CLIENT_CODE_KEY_PREFIX}
+  defaultExpiresIn = 600
+  defaultExpiresIn = ${?CLIENT_CODE_DEFAULT_EXPIRES_IN}
 }
 
 refreshTokenFamilyStore {

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -21,14 +21,13 @@ import {
 	defineModule,
 	generateToken,
 	InMemoryClientRepository,
-	InMemoryCodeRepository,
 	InMemoryUserRepository,
 	memoryRefreshTokenFamilyStoreModule,
 	registerBuiltinKeyStores,
 } from "@o3co/auth-provider-core";
 import express from "express";
 import request from "supertest";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildModules } from "../buildModules.mjs";
 
 const config: AppConfig = {
@@ -48,6 +47,11 @@ const config: AppConfig = {
 		accessToken: { expiresIn: 3600 },
 		refreshToken: { expiresIn: 86400 },
 		grants: {},
+		// OR-9: explicit memory adapter for the smoke test. The legacy
+		// `repositories.code.type` fallback would also pick memory here,
+		// but the explicit setting documents the intent and avoids
+		// console.warn deprecation noise in the test output.
+		code: { adapter: "memory" as const },
 	},
 	session: {
 		secret: "test-session-secret",
@@ -59,6 +63,7 @@ const config: AppConfig = {
 	},
 	rateLimit: {
 		login: { windowMs: 60000, limit: 10 },
+		failMode: "open",
 	},
 	federations: {
 		google: { enabled: false },
@@ -78,13 +83,18 @@ const config: AppConfig = {
  * Test-only repository module — bypasses the file-system-backed repositories
  * that `repositoriesModule` provides in production. Smoke tests use in-memory
  * empty repositories to verify the boot pipeline shape, not the data layer.
+ *
+ * Post-OR-9 (Wave 5d): `codeRepository` is no longer provided here — it is
+ * wired by `inMemoryCodeRepositoryModule` (or `redisCodeRepositoryModule`)
+ * via the `oauth.code.adapter` switch in `buildModules`. The smoke test
+ * config sets `oauth.code.adapter = "memory"`, so `inMemoryCodeRepositoryModule`
+ * is added automatically and provides the slot.
  */
 const testRepositoriesModule = defineModule({
 	name: "test:repositories",
 	provides: {
 		clientRepository: () => new InMemoryClientRepository(new Map()),
 		userRepository: () => new InMemoryUserRepository(new Map()),
-		codeRepository: () => new InMemoryCodeRepository(),
 	},
 });
 
@@ -266,6 +276,84 @@ describe("standalone smoke test", () => {
 			expect(names).toContain("redisSessionStores");
 			expect(names).not.toContain("standalone:stores");
 			expect(names).toContain("standalone:redis-clients");
+		});
+	});
+
+	// OR-9 (Wave 5d): adapter switch for the OAuth code repository. Closes
+	// the deferred Phase 10 module-pattern wrapper for `codeRepository`. The
+	// memory branch wires `inMemoryCodeRepositoryModule`; the redis branch
+	// wires `redisCodeRepositoryModule` against the shared ioredis socket
+	// (same `standaloneRedisClientsModule` as the RT family / rate limiter).
+	describe("OR-9: code-repository adapter wiring", () => {
+		it("buildModules wires inMemoryCodeRepositoryModule by default (oauth.code.adapter = 'memory')", () => {
+			const modules = buildModules(config, {
+				keyStoreModule: testKeyStoreModule,
+				repositoriesModule: testRepositoriesModule,
+				refreshTokenFamilyModules: [memoryRefreshTokenFamilyStoreModule],
+			});
+			const names = modules.map((m) => m.name);
+			expect(names).toContain("standalone:in-memory-code-repository");
+			expect(names).not.toContain("redis-code-repository");
+		});
+
+		it("buildModules switches to redisCodeRepositoryModule when oauth.code.adapter = 'redis'", () => {
+			const redisCodeConfig = {
+				...config,
+				oauth: { ...config.oauth, code: { adapter: "redis" as const } },
+			};
+			const modules = buildModules(redisCodeConfig, {
+				keyStoreModule: testKeyStoreModule,
+				repositoriesModule: testRepositoriesModule,
+				refreshTokenFamilyModules: [memoryRefreshTokenFamilyStoreModule],
+			});
+			const names = modules.map((m) => m.name);
+			expect(names).toContain("redis-code-repository");
+			expect(names).not.toContain("standalone:in-memory-code-repository");
+			// adapter = "redis" pulls in the shared ioredis socket so the
+			// `codeRepositoryClient` slot is satisfied.
+			expect(names).toContain("standalone:redis-clients");
+		});
+
+		it("buildModules honors legacy repositories.code.type='redis' with deprecation warn when oauth.code.adapter is absent", () => {
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			try {
+				const legacyConfig = {
+					...config,
+					oauth: { ...config.oauth, code: undefined },
+					repositories: {
+						...config.repositories,
+						code: { type: "redis" as const, defaultExpiresIn: 600 },
+					},
+				};
+				const modules = buildModules(legacyConfig, {
+					keyStoreModule: testKeyStoreModule,
+					repositoriesModule: testRepositoriesModule,
+					refreshTokenFamilyModules: [memoryRefreshTokenFamilyStoreModule],
+				});
+				const names = modules.map((m) => m.name);
+				expect(names).toContain("redis-code-repository");
+				expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("repositories.code.type"));
+			} finally {
+				warnSpy.mockRestore();
+			}
+		});
+
+		it("buildModules has only ONE codeRepository provider in the manifest (no slot collision)", () => {
+			// Regression guard: `repositoriesModule` must NOT provide
+			// `codeRepository` post-OR-9 — the slot is owned by
+			// `inMemoryCodeRepositoryModule` or `redisCodeRepositoryModule`
+			// exclusively, selected via `oauth.code.adapter`.
+			const modules = buildModules(config, {
+				keyStoreModule: testKeyStoreModule,
+				// Use the production repositoriesModule (not the test override)
+				// so we exercise its post-OR-9 provides-shape.
+				refreshTokenFamilyModules: [memoryRefreshTokenFamilyStoreModule],
+			});
+			const codeRepoProviders = modules.filter((m) =>
+				Object.keys(m.provides ?? {}).includes("codeRepository"),
+			);
+			expect(codeRepoProviders).toHaveLength(1);
+			expect(codeRepoProviders[0]?.name).toBe("standalone:in-memory-code-repository");
 		});
 	});
 

--- a/templates/standalone/src/buildModules.mts
+++ b/templates/standalone/src/buildModules.mts
@@ -27,6 +27,7 @@ import {
 	oauthSessionModule,
 } from "@o3co/auth-provider-oauth";
 import {
+	redisCodeRepositoryModule,
 	redisRateLimiterModule,
 	redisRefreshTokenFamilyStoreModule,
 	redisSessionStoresModule,
@@ -35,6 +36,7 @@ import { sessionModule, sessionStoreModule } from "@o3co/auth-provider-session";
 import {
 	federationTokenStoreModule,
 	googleFederationConfigModule,
+	inMemoryCodeRepositoryModule,
 	inMemorySessionStoresModule,
 	keyStoreModule,
 	repositoriesModule,
@@ -81,17 +83,38 @@ export function buildModules(config: AppConfig, overrides: BuildModulesOverrides
 	const googleEnabled =
 		(config.federations?.google as { enabled?: boolean } | undefined)?.enabled === true;
 
-	// Wave 5d (IH-14 + OR-M1 + OR-4): adapter-driven branching for the
-	// OAuth-endpoint rate limiter and the user-session-store family. The RT
-	// family store always uses Redis in the production manifest (D-2 v2 /
-	// OR-1) unless `overrides.refreshTokenFamilyModules` swaps it out. When
-	// EITHER consumer adapter is `"redis"` (or the RT family override
-	// includes a Redis-backed store module), the shared
-	// `standaloneRedisClientsModule` is added once and provides every
-	// per-purpose ComponentMap slot from a single ioredis socket per
-	// replica. Memory-only deployments skip it.
+	// Wave 5d (IH-14 + OR-M1 + OR-4) + OR-9: adapter-driven branching for
+	// the OAuth-endpoint rate limiter, the user-session-store family, AND
+	// the OAuth code repository. The RT family store always uses Redis in
+	// the production manifest (D-2 v2 / OR-1) unless
+	// `overrides.refreshTokenFamilyModules` swaps it out. When ANY consumer
+	// adapter is `"redis"` (or the RT family override includes a
+	// Redis-backed store module), the shared `standaloneRedisClientsModule`
+	// is added once and provides every per-purpose ComponentMap slot from a
+	// single ioredis socket per replica. Memory-only deployments skip it.
 	const rateLimiterAdapter = config.rateLimiter?.adapter ?? "memory";
 	const userSessionStoresAdapter = config.userSessionStores?.adapter ?? "memory";
+
+	// OR-9: effective code-repo adapter. `oauth.code.adapter` is the
+	// authoritative switch; the legacy `repositories.code.type = "redis"`
+	// path is honored for one release with a deprecation warn so existing
+	// operators relying on `CLIENT_CODE_TYPE=redis` env-var overrides keep
+	// working until they migrate. Removed in v0.6.
+	const oauthCodeAdapter = config.oauth?.code?.adapter;
+	const legacyCodeType = (config.repositories?.code as { type?: string } | undefined)?.type;
+	let codeRepositoryAdapter: "memory" | "redis";
+	if (oauthCodeAdapter !== undefined) {
+		codeRepositoryAdapter = oauthCodeAdapter;
+	} else if (legacyCodeType === "redis") {
+		console.warn(
+			'[buildModules] `repositories.code.type = "redis"` is deprecated; use ' +
+				'`oauth.code.adapter = "redis"` instead (will be removed in v0.6).',
+		);
+		codeRepositoryAdapter = "redis";
+	} else {
+		codeRepositoryAdapter = "memory";
+	}
+
 	const refreshTokenFamilyModules: readonly Module[] = overrides.refreshTokenFamilyModules ?? [
 		redisRefreshTokenFamilyStoreModule,
 	];
@@ -106,7 +129,8 @@ export function buildModules(config: AppConfig, overrides: BuildModulesOverrides
 	const usingRedisAnywhere =
 		refreshTokenFamilyUsesRedis ||
 		rateLimiterAdapter === "redis" ||
-		userSessionStoresAdapter === "redis";
+		userSessionStoresAdapter === "redis" ||
+		codeRepositoryAdapter === "redis";
 
 	// Federation-token store is always wired; only the 4 user-session
 	// stores switch on the adapter. Pre-Wave-5d the redis branch dropped
@@ -121,6 +145,15 @@ export function buildModules(config: AppConfig, overrides: BuildModulesOverrides
 
 	const rateLimiterModules: Module[] =
 		rateLimiterAdapter === "redis" ? [redisRateLimiterModule] : [memoryRateLimiterModule];
+
+	// OR-9: code-repository module — mutually exclusive memory/redis pair.
+	// Same pattern as sessionStoresModules + rateLimiterModules. The two
+	// modules provide the same `codeRepository` slot; including both would
+	// be a boot-time slot collision.
+	const codeRepositoryModules: Module[] =
+		codeRepositoryAdapter === "redis"
+			? [redisCodeRepositoryModule]
+			: [inMemoryCodeRepositoryModule];
 
 	return [
 		// D-5: sessionStoreModule wires the express-session middleware into the
@@ -149,6 +182,8 @@ export function buildModules(config: AppConfig, overrides: BuildModulesOverrides
 		...sessionStoresModules,
 		// OAuth-endpoint rate limiter: redis (shared counters) or memory.
 		...rateLimiterModules,
+		// OAuth code repository: redis (multi-replica) or memory (single-instance).
+		...codeRepositoryModules,
 		// RT family store: redis by default (closes OR-1); override path
 		// swaps to `[memoryRefreshTokenFamilyStoreModule]` for unit tests.
 		...refreshTokenFamilyModules,

--- a/templates/standalone/src/modules.mts
+++ b/templates/standalone/src/modules.mts
@@ -31,10 +31,7 @@ import {
 } from "@o3co/auth-provider-core";
 import type { GoogleProviderConfig } from "@o3co/auth-provider-federation-google";
 import { registerBuiltinAdapters } from "@o3co/auth-provider-foundation";
-import {
-	redisCodeRepositoryBuilder,
-	redisFederationTokenStoreBuilder,
-} from "@o3co/auth-provider-redis";
+import { redisFederationTokenStoreBuilder } from "@o3co/auth-provider-redis";
 import { makeIoredisClients } from "@o3co/auth-provider-redis/ioredis";
 import { extractFederationSection } from "@o3co/auth-provider-session";
 // Named import is required here, not default. Under `module: "nodenext"`
@@ -91,16 +88,21 @@ export const keyStoreModule: Module = defineModule({
 });
 
 /**
- * Repositories module — provides client / user / code repositories from
+ * Repositories module — provides client / user repositories from
  * `config.repositories.*` slices using the built-in adapter factories.
+ *
+ * Pre-OR-9 this module also provided `codeRepository` — split out into
+ * `inMemoryCodeRepositoryModule` (memory branch) / `redisCodeRepositoryModule`
+ * (redis branch, from `@o3co/auth-provider-redis`) so the
+ * `oauth.code.adapter` switch can wire mutually-exclusive providers without
+ * a slot collision. Same pattern as the Wave-5d userSessionStores split.
  */
 export const repositoriesModule: Module = defineModule({
 	name: "standalone:repositories",
 	requires: ["config"] as const,
 	// D-5 / OR-2 / IH-11: forward `lifecycleRegistrar` into the repository
-	// factories so the redis/memory CodeRepository builders can register their
-	// disposal callbacks (RedisCodeRepository.quit() and the InMemory GC
-	// interval, respectively). Without this, builders' `ctx.lifecycle?.register`
+	// factories so client/user adapters can register disposal callbacks
+	// (e.g. file-watch closers). Without this, builders' `ctx.lifecycle?.register`
 	// is a no-op and the leaks remain.
 	optional: ["lifecycleRegistrar"] as const,
 	provides: {
@@ -126,16 +128,39 @@ export const repositoriesModule: Module = defineModule({
 				),
 			);
 		},
+	},
+});
+
+/**
+ * In-memory CodeRepository module — wired by `buildModules` only when
+ * `oauth.code.adapter = "memory"`. The redis branch swaps in
+ * `redisCodeRepositoryModule` from `@o3co/auth-provider-redis` (mutually
+ * exclusive — both modules provide the same `codeRepository` slot).
+ *
+ * Per OR-9 (Wave 5d) split: pre-OR-9 the codeRepository slot was provided
+ * inside `repositoriesModule` via the AdapterFactory pattern; that path
+ * coupled the slot to `repositories.code.type` which is now superseded by
+ * `oauth.code.adapter`.
+ */
+export const inMemoryCodeRepositoryModule: Module = defineModule({
+	name: "standalone:in-memory-code-repository",
+	requires: ["config"] as const,
+	optional: ["lifecycleRegistrar"] as const,
+	provides: {
 		codeRepository: async ({ config, lifecycleRegistrar }) => {
 			const ctx = { lifecycle: lifecycleRegistrar };
 			const { userFactory, codeFactory } = createRepositoryFactories(ctx);
 			registerBuiltinAdapters({ userFactory });
-			codeFactory.register("redis", redisCodeRepositoryBuilder);
-			return codeFactory.create(
-				flattenAdapterConfig(
-					(config as AppConfig).repositories.code as { type: string } & Record<string, unknown>,
-				),
+			// codeFactory.register("memory", ...) is wired by registerBuiltinAdapters
+			// indirectly; the memory builder is the default registered shape. The
+			// flattened slice MAY still have `type = "redis"` when only the legacy
+			// `repositories.code.type` is set — buildModules' adapter resolution
+			// already chose memory by the time we get here, so override the type
+			// explicitly to keep this module robust against legacy HOCON shapes.
+			const slice = flattenAdapterConfig(
+				(config as AppConfig).repositories.code as { type: string } & Record<string, unknown>,
 			);
+			return codeFactory.create({ ...slice, type: "memory" });
 		},
 	},
 });
@@ -264,6 +289,15 @@ export const standaloneRedisClientsModule: Module = defineModule({
 		},
 		rateLimiterClient: async ({ config, lifecycleRegistrar }) => {
 			return getOrCreateClients(config as AppConfig, lifecycleRegistrar).rateLimiterClient;
+		},
+		// OR-9: code-repository client wired off the same shared ioredis
+		// socket. `redisCodeRepositoryModule` consumes this slot when
+		// `oauth.code.adapter = "redis"`. Codes are short-TTL (60-600s)
+		// high-volume — sharing the connection avoids opening a separate
+		// socket while the per-purpose typed wrapper keeps the Redis
+		// command surface consumed by RedisCodeRepository explicit.
+		codeRepositoryClient: async ({ config, lifecycleRegistrar }) => {
+			return getOrCreateClients(config as AppConfig, lifecycleRegistrar).codeRepositoryClient;
 		},
 	},
 });

--- a/templates/standalone/src/modules.mts
+++ b/templates/standalone/src/modules.mts
@@ -149,14 +149,18 @@ export const inMemoryCodeRepositoryModule: Module = defineModule({
 	provides: {
 		codeRepository: async ({ config, lifecycleRegistrar }) => {
 			const ctx = { lifecycle: lifecycleRegistrar };
-			const { userFactory, codeFactory } = createRepositoryFactories(ctx);
-			registerBuiltinAdapters({ userFactory });
-			// codeFactory.register("memory", ...) is wired by registerBuiltinAdapters
-			// indirectly; the memory builder is the default registered shape. The
-			// flattened slice MAY still have `type = "redis"` when only the legacy
-			// `repositories.code.type` is set — buildModules' adapter resolution
-			// already chose memory by the time we get here, so override the type
-			// explicitly to keep this module robust against legacy HOCON shapes.
+			const { codeFactory } = createRepositoryFactories(ctx);
+			// `codeFactory.register("memory", ...)` is wired automatically by
+			// `createRepositoryFactories` itself (see core/repositories/RepositoryFactory.mts).
+			// `registerBuiltinAdapters` from `@o3co/auth-provider-foundation` only
+			// registers the HTTP user adapter on `userFactory`; it does NOT touch
+			// `codeFactory`, so calling it here would be misleading and unnecessary.
+			//
+			// The flattened slice MAY still have `type = "redis"` when only the
+			// legacy `repositories.code.type` is set — `buildModules`' adapter
+			// resolution already chose memory by the time we get here, so
+			// override the type explicitly to keep this module robust against
+			// legacy HOCON shapes.
 			const slice = flattenAdapterConfig(
 				(config as AppConfig).repositories.code as { type: string } & Record<string, unknown>,
 			);


### PR DESCRIPTION
## Summary

Closes **OR-9** + **OR-5** of the v0.5.1 hotfix. Combined into one PR because both touch `packages/core/src/config/application.schema.mts` and would otherwise produce merge conflicts (per Phase F dep graph §3 F5).

### OR-9 — RedisCodeRepository accepts external ioredis client

Migrates `RedisCodeRepository` off node-redis onto an externally-provided typed `CodeRepositoryClient` wrapper, aligning with the per-purpose client convention established by D-2 v2. The standalone composition root provides the slot off the shared `standaloneRedisClientsModule` ioredis socket.

- New `CodeRepositoryClient` interface in `packages/redis/src/clients.mts` + ComponentMap augmentation. `makeIoredisClients()` returns a 10th per-purpose typed client.
- `RedisCodeRepository` constructor: `(client: CodeRepositoryClient, opts?: { keyPrefix?, defaultExpiresIn?, logger? })`. Static `.create()` and `[Symbol.asyncDispose]` removed (consumer manages client lifecycle per D-5 v2). PX expiry now in milliseconds.
- New `redisCodeRepositoryModule` (defineModule pattern). Legacy `redisCodeRepositoryBuilder` retained one cycle as deprecated; `{ endpointUri }` shape removed.
- `oauth.code.adapter: "memory" | "redis"` config switch. `fullSectionsSchema.redisCodeRepository.{keyPrefix,defaultExpiresIn}` added so AppConfig parse preserves operator overrides (F4 PR1 gotcha #1: AppConfigSchema strip on undeclared keys).
- Standalone `repositoriesModule` split: `codeRepository` extracted into new `inMemoryCodeRepositoryModule` (mutually exclusive with `redisCodeRepositoryModule`).
- `buildModules` honors `oauth.code.adapter` first; falls back to legacy `repositories.code.type = "redis"` with one-cycle deprecation warn.
- Standalone HOCON: `oauth.code.adapter = "redis"` + multi-tenant `keyPrefix` env binding (Codex M5 / MIN-3).

### OR-5 — rate-limit fail-mode policy + logger emission

Pre-OR-5 the `checkRateLimit` catch path was silent fail-open: it emitted a fire-and-forget `rate_limit.unavailable` audit event and returned true. The audit sink is typically Redis-backed too — operators saw nothing while rate limiting was down for hours.

- `rateLimit.failMode: "open" | "closed"` added to `fullSectionsSchema.rateLimit` (no `.default()` per ADR).
- `checkRateLimit` catch block emits `logger.error` with structured context + outage tag (`rate_limiter_failed_open` / `rate_limiter_failed_closed`). Audit event preserved for ops dashboards. `failMode = "closed"` returns HTTP 503 + log.
- `logger` was already threaded into `createOAuthRouter`; no new wiring required.

### Codex review fixups (2nd commit)

Codex review flagged two P2 issues, both addressed in `ffd430cf`:

1. Legacy `repositories.code.type` fallback was dead code because core HOCON baked `oauth.code.adapter = "memory"` as default. Fixed: env-var-only binding (`adapter = ${?OAUTH_CODE_ADAPTER}`) so the legacy fallback fires when no operator override is set. Schema relaxed to `adapter` `.optional()` within the (already-optional) `oauth.code` block to accept the empty `{}` produced by HOCON when env var is unset.
2. Standalone `redisCodeRepository.keyPrefix` env binding was commented out, so `CLIENT_CODE_KEY_PREFIX` had no path to the constructor. Fixed by uncommenting the binding line.

## Breaking changes

- `RedisCodeRepository.create({ endpointUri })` removed. Migration: open ioredis externally, pass to `new RedisCodeRepository(client, opts)`.
- `redisCodeRepositoryBuilder` shape changed from `{ endpointUri }` to `{ client, ... }`. Migration: switch to `redisCodeRepositoryModule` + `bootstrapComponents.codeRepositoryClient` (e.g. from `makeIoredisClients()`).

## Test plan

- [x] Build clean (all 10 packages compile)
- [x] All 2019 tests pass (was 2006; +13: redis +5 OR-9, standalone +4 OR-9, oauth +4 OR-5)
- [x] Biome lint 0 errors (existing 18 warnings unchanged)
- [x] Smoke test verifies memory branch, redis branch, legacy fallback, and slot-collision regression guard
- [x] Codex review applied + addressed
- [ ] Copilot review pending (auto-attached on PR open)

## Cross-spec references

- Spec: `auth/.claude/superpowers/specs/2026-05-05-or9-redis-code-repository-client.md`
- Spec: `auth/.claude/superpowers/specs/2026-05-05-or5-rate-limit-fail-mode.md`
- Handoff: `auth/.claude/handoff/2026-05-06-phase-f-f5-handoff.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)