### PR TITLE
feat(core,redis,foundation): F5 PR2 — TS-safety batch + TS-3 (TS-M1/M2/2/6/3) (v0.5.1)

### DIFF
--- a/packages/core/src/refresh-token-family/__tests__/errors.test.mts
+++ b/packages/core/src/refresh-token-family/__tests__/errors.test.mts
@@ -59,12 +59,26 @@ describe("RefreshTokenStorageError", () => {
 		}
 	});
 
-	it("reason union has exactly 3 members", () => {
+	it("reason union has exactly 4 members (TS-M1 added 'corrupt-data')", () => {
 		const all: RefreshTokenStorageErrorReason[] = [
 			"duplicate-family",
 			"expired-at-issue",
 			"conflict-exhausted",
+			"corrupt-data",
 		];
-		expect(all).toHaveLength(3);
+		expect(all).toHaveLength(4);
+	});
+
+	// TS-M1 (Wave 5g): the new `corrupt-data` reason is emitted by
+	// `RedisRefreshTokenFamilyStore.deserialize()` on JSON.parse failure,
+	// missing required fields, wrong field types, or unknown extra fields
+	// (`.strict()` schema). The redis-side parse path is exercised in
+	// `packages/redis/__tests__/refresh-token-family.test.mts`; this test
+	// only confirms the union member is constructable.
+	it("accepts corrupt-data reason (TS-M1)", () => {
+		const err = new RefreshTokenStorageError({ reason: "corrupt-data" });
+		expect(err.reason).toBe("corrupt-data");
+		expect(err.name).toBe("RefreshTokenStorageError");
+		expect(err.message).toBe("RefreshTokenStorageError: corrupt-data");
 	});
 });

--- a/packages/core/src/refresh-token-family/errors.mts
+++ b/packages/core/src/refresh-token-family/errors.mts
@@ -23,13 +23,19 @@
  *   at call time; the storage layer fails closed.
  * - `conflict-exhausted`: updateFamily's CAS retry budget exhausted under
  *   sustained contention; load-shedding signal.
+ * - `corrupt-data`: stored value failed Zod schema validation on
+ *   deserialization (truncated JSON, missing required fields, wrong
+ *   field types, or unknown fields from a schema migration). The
+ *   family is treated as non-existent/unreadable; callers must NOT
+ *   trust the partial value. Per TS-M1 (Wave 5g).
  *
- * Per A3 §5.4.
+ * Per A3 §5.4 + TS-M1.
  */
 export type RefreshTokenStorageErrorReason =
 	| "duplicate-family"
 	| "expired-at-issue"
-	| "conflict-exhausted";
+	| "conflict-exhausted"
+	| "corrupt-data";
 
 /**
  * Single error class for `RefreshTokenFamilyStore` domain failures.

--- a/packages/foundation/src/repositories/HttpUserRepository.mts
+++ b/packages/foundation/src/repositories/HttpUserRepository.mts
@@ -16,6 +16,27 @@
 
 import type { User, UserRepository } from "@o3co/auth-provider-core";
 
+/**
+ * Runtime guard for the upstream user-service response. The previous
+ * `(await res.json()) as User` was a compile-time cast only — a malformed
+ * upstream payload (`{ status: "ok" }`, schema migration, tampered
+ * response) silently produced a `User` with `undefined` required fields,
+ * leaking `sub: undefined` into the authentication flow.
+ *
+ * The guard accepts any object with string `id` and `username`,
+ * preserving the index-signature `[key: string]: unknown` extras that
+ * `User` allows. Empty strings pass — bcrypt compare and downstream
+ * gates prevent empty-credential authentication in practice; tightening
+ * to `.min(1)` is a Phase F follow-up if needed.
+ *
+ * Per TS-2 (Wave 5g).
+ */
+function isUser(v: unknown): v is User {
+	if (typeof v !== "object" || v === null) return false;
+	const o = v as Record<string, unknown>;
+	return typeof o.id === "string" && typeof o.username === "string";
+}
+
 export class HttpUserRepository implements UserRepository {
 	private authenticateUrl: string;
 	private authenticateByTokenUrl: string;
@@ -56,7 +77,15 @@ export class HttpUserRepository implements UserRepository {
 			});
 
 			if (res.ok) {
-				return (await res.json()) as User;
+				const parsed: unknown = await res.json();
+				if (!isUser(parsed)) {
+					// Upstream returned 2xx with an unexpected shape — this is an
+					// "upstream is broken" case, not a "user not found" case, so
+					// throw rather than return null. The thrown error propagates
+					// as a 500 to the client (correct: upstream-service failure).
+					throw new Error(`HttpUserRepository: upstream ${url} returned an invalid User shape`);
+				}
+				return parsed;
 			}
 
 			if (res.status === 401 || res.status === 403) {

--- a/packages/foundation/src/repositories/__tests__/HttpUserRepository.test.mts
+++ b/packages/foundation/src/repositories/__tests__/HttpUserRepository.test.mts
@@ -105,4 +105,61 @@ describe("HttpUserRepository", () => {
 			expect(user).toBeNull();
 		});
 	});
+
+	// TS-2 (Wave 5g): pre-fix, `(await res.json()) as User` was a compile-time
+	// cast only. A 200 response with an unexpected body shape silently
+	// produced a `User` whose required fields were `undefined`, leaking
+	// `sub: undefined` into the authentication flow. The new `isUser`
+	// runtime guard rejects such shapes by throwing — an "upstream broken"
+	// failure is distinct from "user not found" (401).
+	describe("TS-2: upstream response shape validation", () => {
+		it("throws when upstream 200 returns an object missing required fields", async () => {
+			server.use(
+				http.post(`${BASE_URL}/user/authenticate`, () => {
+					return HttpResponse.json({ status: "ok" }, { status: 200 });
+				}),
+			);
+			await expect(repo.authenticate("alice@example.com", "pass")).rejects.toThrow(
+				/invalid User shape/,
+			);
+		});
+
+		it("throws when upstream 200 returns non-string id", async () => {
+			server.use(
+				http.post(`${BASE_URL}/user/authenticate`, () => {
+					return HttpResponse.json({ id: 123, username: "alice" }, { status: 200 });
+				}),
+			);
+			await expect(repo.authenticate("alice@example.com", "pass")).rejects.toThrow(
+				/invalid User shape/,
+			);
+		});
+
+		it("throws when upstream 200 returns null body", async () => {
+			server.use(
+				http.post(`${BASE_URL}/user/authenticate`, () => {
+					return HttpResponse.json(null, { status: 200 });
+				}),
+			);
+			await expect(repo.authenticate("alice@example.com", "pass")).rejects.toThrow(
+				/invalid User shape/,
+			);
+		});
+
+		it("accepts valid User shape with extra fields (index-signature passthrough)", async () => {
+			server.use(
+				http.post(`${BASE_URL}/user/authenticate`, () => {
+					return HttpResponse.json(
+						{ id: "u1", username: "alice", email: "a@x", role: "admin" },
+						{ status: 200 },
+					);
+				}),
+			);
+			const user = await repo.authenticate("alice@example.com", "pass");
+			expect(user?.id).toBe("u1");
+			expect(user?.username).toBe("alice");
+			// Extra fields preserved via the `User` index signature.
+			expect((user as Record<string, unknown>).email).toBe("a@x");
+		});
+	});
 });

--- a/packages/redis/__tests__/builders-validation.test.mts
+++ b/packages/redis/__tests__/builders-validation.test.mts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from "vitest";
+import { redisChallengeStoreBuilder } from "../src/challenges.mjs";
+import type { ChallengeStoreClient, ReplaySeenSetClient } from "../src/clients.mjs";
+import { redisReplaySeenSetBuilder } from "../src/replay-seen-set.mjs";
+
+// TS-M2 (Wave 5g): boot-time guard tests for the builder-pattern entry
+// points used by AdapterFactory wiring. The real factory invokes the
+// builder with the merged config slice; if the slice is missing `client`,
+// the prior behavior was to construct a store and crash on first Redis op
+// with a cryptic `Cannot read properties of undefined`.
+
+const noopChallengeClient: ChallengeStoreClient = {
+	set: async () => "OK",
+	pttl: async () => -2,
+	del: async () => 0,
+};
+
+const noopReplayClient: ReplaySeenSetClient = {
+	set: async () => "OK",
+	exists: async () => 0,
+};
+
+describe("TS-M2: redisChallengeStoreBuilder — client guard", () => {
+	it("throws when 'client' option is missing (config = {})", () => {
+		expect(() =>
+			redisChallengeStoreBuilder({} as never, { lifecycle: undefined } as never),
+		).toThrow("redisChallengeStoreBuilder: 'client' option is required");
+	});
+
+	it("succeeds when 'client' is present", () => {
+		const store = redisChallengeStoreBuilder(
+			{ client: noopChallengeClient } as never,
+			{ lifecycle: undefined } as never,
+		);
+		expect(store).toBeDefined();
+		expect(store.kind).toBe("redis");
+	});
+});
+
+describe("TS-M2: redisReplaySeenSetBuilder — client guard", () => {
+	it("throws when 'client' option is missing (config = {})", () => {
+		expect(() => redisReplaySeenSetBuilder({} as never, { lifecycle: undefined } as never)).toThrow(
+			"redisReplaySeenSetBuilder: 'client' option is required",
+		);
+	});
+
+	it("succeeds when 'client' is present", () => {
+		const store = redisReplaySeenSetBuilder(
+			{ client: noopReplayClient } as never,
+			{ lifecycle: undefined } as never,
+		);
+		expect(store).toBeDefined();
+		expect(store.kind).toBe("redis");
+	});
+});

--- a/packages/redis/__tests__/refresh-token-family-validation.test.mts
+++ b/packages/redis/__tests__/refresh-token-family-validation.test.mts
@@ -132,6 +132,41 @@ describe("TS-M1: RedisRefreshTokenFamilyStore.findFamily — corrupt-data valida
 		expect((err as RefreshTokenStorageError).reason).toBe("corrupt-data");
 	});
 
+	// Per Copilot review on PR #123: `expiresAtMs` is now
+	// `z.number().int().positive().finite()` rather than the looser
+	// `z.number()`. Each of these previously-accepted bad values must now
+	// surface as `corrupt-data`. Note: `Infinity` / `NaN` cannot survive
+	// `JSON.stringify` (they serialize to `null`); operator-injected raw
+	// JSON containing those tokens is invalid JSON and would already trip
+	// the parse-failure branch. The cases below cover values that DO
+	// JSON-roundtrip but were silently accepted by the looser schema.
+	it.each([
+		["expiresAtMs zero", 0],
+		["expiresAtMs negative", -1],
+		["expiresAtMs fractional (1.5)", 1.5],
+		["expiresAtMs fractional (Date.now()+0.5)", Date.now() + 0.5],
+	])("throws corrupt-data when %s passes JSON.parse but fails the tightened schema", async (_label, badValue) => {
+		const store = new Map<string, string>([
+			[
+				`${keyPrefix}fam-tight`,
+				JSON.stringify({
+					familyId: "fam-tight",
+					activeJti: "j1",
+					revoked: false,
+					expiresAtMs: badValue,
+				}),
+			],
+		]);
+		const pttls = new Map<string, number>([[`${keyPrefix}fam-tight`, 60_000]]);
+		const repo = createRedisRefreshTokenFamilyStore({
+			client: makeMockClient(store, pttls),
+			keyPrefix,
+		});
+
+		const err = await repo.findFamily("fam-tight").catch((e: unknown) => e);
+		expect((err as RefreshTokenStorageError).reason).toBe("corrupt-data");
+	});
+
 	it("returns the family normally for a valid envelope (regression guard)", async () => {
 		const expiresAtMs = Date.now() + 60_000;
 		const store = new Map<string, string>([

--- a/packages/redis/__tests__/refresh-token-family-validation.test.mts
+++ b/packages/redis/__tests__/refresh-token-family-validation.test.mts
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { RefreshTokenStorageError } from "@o3co/auth-provider-core";
+import { describe, expect, it } from "vitest";
+import type {
+	DisposableRefreshTokenFamilyClient,
+	RefreshTokenFamilyClient,
+	RefreshTokenFamilyMultiClient,
+} from "../src/clients.mjs";
+import {
+	createRedisRefreshTokenFamilyStore,
+	redisRefreshTokenFamilyStoreBuilder,
+} from "../src/refresh-token-family.mjs";
+
+// Lightweight in-memory mock — only `get` / `pttl` are exercised by the
+// `findFamily` corrupt-data tests below. The other methods are stubs that
+// return shapes wide enough for the type contract; tests do not invoke
+// them.
+const makeMockClient = (
+	store: Map<string, string>,
+	pttls: Map<string, number>,
+): RefreshTokenFamilyClient => {
+	const noopMulti: RefreshTokenFamilyMultiClient = {
+		set: () => noopMulti,
+		exec: async () => [],
+	};
+	const self: RefreshTokenFamilyClient = {
+		set: async () => "OK",
+		get: async (k) => store.get(k) ?? null,
+		pttl: async (k) => pttls.get(k) ?? -2,
+		watch: async () => "OK",
+		unwatch: async () => "OK",
+		multi: () => noopMulti,
+		duplicate: (): DisposableRefreshTokenFamilyClient =>
+			Object.assign(
+				{ ...self },
+				{
+					[Symbol.asyncDispose]: async () => {},
+				},
+			),
+	};
+	return self;
+};
+
+describe("TS-M1: RedisRefreshTokenFamilyStore.findFamily — corrupt-data validation", () => {
+	const keyPrefix = "rtfam:";
+
+	it("throws RefreshTokenStorageError({reason:'corrupt-data'}) for truncated JSON in Redis", async () => {
+		const store = new Map<string, string>([[`${keyPrefix}fam-1`, "{truncated"]]);
+		const pttls = new Map<string, number>([[`${keyPrefix}fam-1`, 60_000]]);
+		const repo = createRedisRefreshTokenFamilyStore({
+			client: makeMockClient(store, pttls),
+			keyPrefix,
+		});
+
+		await expect(repo.findFamily("fam-1")).rejects.toBeInstanceOf(RefreshTokenStorageError);
+		const err = await repo.findFamily("fam-1").catch((e: unknown) => e);
+		expect((err as RefreshTokenStorageError).reason).toBe("corrupt-data");
+	});
+
+	it("throws corrupt-data for envelope missing required fields", async () => {
+		const store = new Map<string, string>([
+			// activeJti, revoked, expiresAtMs all absent
+			[`${keyPrefix}fam-2`, JSON.stringify({ familyId: "fam-2" })],
+		]);
+		const pttls = new Map<string, number>([[`${keyPrefix}fam-2`, 60_000]]);
+		const repo = createRedisRefreshTokenFamilyStore({
+			client: makeMockClient(store, pttls),
+			keyPrefix,
+		});
+
+		const err = await repo.findFamily("fam-2").catch((e: unknown) => e);
+		expect(err).toBeInstanceOf(RefreshTokenStorageError);
+		expect((err as RefreshTokenStorageError).reason).toBe("corrupt-data");
+	});
+
+	it("throws corrupt-data for wrong field type (revoked: 'yes' instead of boolean)", async () => {
+		const store = new Map<string, string>([
+			[
+				`${keyPrefix}fam-3`,
+				JSON.stringify({
+					familyId: "fam-3",
+					activeJti: "j1",
+					revoked: "yes",
+					expiresAtMs: Date.now() + 60_000,
+				}),
+			],
+		]);
+		const pttls = new Map<string, number>([[`${keyPrefix}fam-3`, 60_000]]);
+		const repo = createRedisRefreshTokenFamilyStore({
+			client: makeMockClient(store, pttls),
+			keyPrefix,
+		});
+
+		const err = await repo.findFamily("fam-3").catch((e: unknown) => e);
+		expect((err as RefreshTokenStorageError).reason).toBe("corrupt-data");
+	});
+
+	it("throws corrupt-data for unknown extra field (.strict() rejects schema drift)", async () => {
+		const store = new Map<string, string>([
+			[
+				`${keyPrefix}fam-4`,
+				JSON.stringify({
+					familyId: "fam-4",
+					activeJti: "j1",
+					revoked: false,
+					expiresAtMs: Date.now() + 60_000,
+					unknownFutureField: "value",
+				}),
+			],
+		]);
+		const pttls = new Map<string, number>([[`${keyPrefix}fam-4`, 60_000]]);
+		const repo = createRedisRefreshTokenFamilyStore({
+			client: makeMockClient(store, pttls),
+			keyPrefix,
+		});
+
+		const err = await repo.findFamily("fam-4").catch((e: unknown) => e);
+		expect((err as RefreshTokenStorageError).reason).toBe("corrupt-data");
+	});
+
+	it("returns the family normally for a valid envelope (regression guard)", async () => {
+		const expiresAtMs = Date.now() + 60_000;
+		const store = new Map<string, string>([
+			[
+				`${keyPrefix}fam-ok`,
+				JSON.stringify({
+					familyId: "fam-ok",
+					activeJti: "j1",
+					revoked: false,
+					expiresAtMs,
+				}),
+			],
+		]);
+		const pttls = new Map<string, number>([[`${keyPrefix}fam-ok`, 60_000]]);
+		const repo = createRedisRefreshTokenFamilyStore({
+			client: makeMockClient(store, pttls),
+			keyPrefix,
+		});
+
+		const fam = await repo.findFamily("fam-ok");
+		expect(fam).not.toBeNull();
+		expect(fam?.familyId).toBe("fam-ok");
+		expect(fam?.activeJti).toBe("j1");
+		expect(fam?.revoked).toBe(false);
+	});
+});
+
+describe("TS-6: redisRefreshTokenFamilyStoreBuilder — client guard", () => {
+	it("throws when 'client' option is missing (config = {})", () => {
+		expect(() =>
+			redisRefreshTokenFamilyStoreBuilder({} as never, { lifecycle: undefined } as never),
+		).toThrow("redisRefreshTokenFamilyStoreBuilder: 'client' option is required");
+	});
+
+	it("succeeds when 'client' is present", () => {
+		const client = makeMockClient(new Map(), new Map());
+		const store = redisRefreshTokenFamilyStoreBuilder(
+			{ client } as never,
+			{ lifecycle: undefined } as never,
+		);
+		expect(store).toBeDefined();
+		expect(store.kind).toBe("redis");
+	});
+});

--- a/packages/redis/__tests__/userSessionStore-validation.test.mts
+++ b/packages/redis/__tests__/userSessionStore-validation.test.mts
@@ -55,7 +55,7 @@ describe("TS-3: RedisUserSessionStore.get — corrupt envelope validation", () =
 		expect(result?.sub).toBe("user-1");
 	});
 
-	it("returns null and logs json_parse warn on malformed JSON", async () => {
+	it("returns null and logs json_parse warn on malformed JSON (object-first call shape)", async () => {
 		const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
 		const client = makeMockClient();
 		const store = createRedisUserSessionStore({ client, keyPrefix, logger });
@@ -63,9 +63,11 @@ describe("TS-3: RedisUserSessionStore.get — corrupt envelope validation", () =
 
 		const result = await store.get("sid-bad");
 		expect(result).toBeNull();
+		// Object-first per the D-4 Logger interface: structured fields are the
+		// 1st arg, the human-readable message is the 2nd arg.
 		expect(logger.warn).toHaveBeenCalledWith(
-			expect.any(String),
 			expect.objectContaining({ sid: "sid-bad", reason: "json_parse" }),
+			expect.any(String),
 		);
 	});
 
@@ -90,6 +92,24 @@ describe("TS-3: RedisUserSessionStore.get — corrupt envelope validation", () =
 			"claims is array (not object)",
 			{ ...validEnvelope, claims: [] as unknown as Record<string, unknown> },
 		],
+		// Per Copilot review on PR #123: timestamps must be safe integers in
+		// the JS Date valid range. The previous `Number.isFinite` check
+		// accepted very large finite numbers (`Number.MAX_VALUE`, `2 ** 60`,
+		// fractional ms) that lose precision through `new Date(ms)` and
+		// could either propagate `Invalid Date` or appear effectively-never-
+		// expiring against `expiresAtMs <= Date.now()`.
+		[
+			"expiresAtMs > MAX_DATE_MS (8.64e15)",
+			{ ...validEnvelope, expiresAtMs: 8_640_000_000_000_001 as unknown as number },
+		],
+		[
+			"expiresAtMs unsafe-integer above 2^53",
+			{ ...validEnvelope, expiresAtMs: Number.MAX_VALUE as unknown as number },
+		],
+		["expiresAtMs fractional", { ...validEnvelope, expiresAtMs: 1.5 as unknown as number }],
+		["expiresAtMs negative", { ...validEnvelope, expiresAtMs: -1 as unknown as number }],
+		["authTimeMs unsafe-integer", { ...validEnvelope, authTimeMs: (2 ** 60) as unknown as number }],
+		["createdAtMs fractional", { ...validEnvelope, createdAtMs: 1.5 as unknown as number }],
 	])("returns null and logs shape_invalid warn for %s", async (_label, corrupt) => {
 		const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
 		const client = makeMockClient();
@@ -98,9 +118,11 @@ describe("TS-3: RedisUserSessionStore.get — corrupt envelope validation", () =
 
 		const result = await store.get("sid-corrupt");
 		expect(result).toBeNull();
+		// Object-first per the D-4 Logger interface: structured fields are the
+		// 1st arg, the human-readable message is the 2nd arg.
 		expect(logger.warn).toHaveBeenCalledWith(
-			expect.any(String),
 			expect.objectContaining({ sid: "sid-corrupt", reason: "shape_invalid" }),
+			expect.any(String),
 		);
 	});
 

--- a/packages/redis/__tests__/userSessionStore-validation.test.mts
+++ b/packages/redis/__tests__/userSessionStore-validation.test.mts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { UserSessionStoreClient } from "../src/clients.mjs";
+import { createRedisUserSessionStore } from "../src/userSessionStore.mjs";
+
+// Lightweight in-memory mock with a `seed()` helper to inject corrupt
+// payloads directly into the Redis store. Matches the exactly-what-we-test
+// surface: only `get` is exercised by these tests.
+const makeMockClient = (): UserSessionStoreClient & {
+	seed: (key: string, raw: string) => void;
+} => {
+	const store = new Map<string, string>();
+	const set = ((..._args: unknown[]) => Promise.resolve("OK" as const)) as never;
+	return {
+		set,
+		get: async (k: string) => store.get(k) ?? null,
+		del: async (k: string) => (store.delete(k) ? 1 : 0),
+		seed: (key, raw) => store.set(key, raw),
+	};
+};
+
+const validEnvelope = {
+	sid: "sid-1",
+	sub: "user-1",
+	authTimeMs: Date.now(),
+	createdAtMs: Date.now(),
+	expiresAtMs: Date.now() + 60_000,
+	claims: { iss: "https://auth.example" },
+};
+
+describe("TS-3: RedisUserSessionStore.get — corrupt envelope validation", () => {
+	const keyPrefix = "sess:";
+
+	it("returns the session for a valid envelope (regression guard)", async () => {
+		const client = makeMockClient();
+		const store = createRedisUserSessionStore({ client, keyPrefix });
+		client.seed(`${keyPrefix}sid-1`, JSON.stringify(validEnvelope));
+		const result = await store.get("sid-1");
+		expect(result).not.toBeNull();
+		expect(result?.sid).toBe("sid-1");
+		expect(result?.sub).toBe("user-1");
+	});
+
+	it("returns null and logs json_parse warn on malformed JSON", async () => {
+		const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+		const client = makeMockClient();
+		const store = createRedisUserSessionStore({ client, keyPrefix, logger });
+		client.seed(`${keyPrefix}sid-bad`, "{not-valid-json}}");
+
+		const result = await store.get("sid-bad");
+		expect(result).toBeNull();
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({ sid: "sid-bad", reason: "json_parse" }),
+		);
+	});
+
+	// Parametric coverage: each missing/invalid field individually causes
+	// `get()` to return null and emit a `shape_invalid` warn. An
+	// implementation that only validated `expiresAtMs` would still fail
+	// these — preventing the regression where `expiresAtMs: undefined`
+	// silently bypassed the expiry filter.
+	it.each([
+		["sid missing", { ...validEnvelope, sid: undefined as unknown as string }],
+		["sub missing", { ...validEnvelope, sub: undefined as unknown as string }],
+		["authTimeMs missing", { ...validEnvelope, authTimeMs: undefined as unknown as number }],
+		["createdAtMs missing", { ...validEnvelope, createdAtMs: undefined as unknown as number }],
+		["expiresAtMs missing", { ...validEnvelope, expiresAtMs: undefined as unknown as number }],
+		[
+			"expiresAtMs non-numeric",
+			{ ...validEnvelope, expiresAtMs: "not-a-number" as unknown as number },
+		],
+		["expiresAtMs null", { ...validEnvelope, expiresAtMs: null as unknown as number }],
+		["claims null", { ...validEnvelope, claims: null as unknown as Record<string, unknown> }],
+		[
+			"claims is array (not object)",
+			{ ...validEnvelope, claims: [] as unknown as Record<string, unknown> },
+		],
+	])("returns null and logs shape_invalid warn for %s", async (_label, corrupt) => {
+		const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+		const client = makeMockClient();
+		const store = createRedisUserSessionStore({ client, keyPrefix, logger });
+		client.seed(`${keyPrefix}sid-corrupt`, JSON.stringify(corrupt));
+
+		const result = await store.get("sid-corrupt");
+		expect(result).toBeNull();
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({ sid: "sid-corrupt", reason: "shape_invalid" }),
+		);
+	});
+
+	it("returns null without logger when no logger is injected (optional-chain semantics)", async () => {
+		const client = makeMockClient();
+		const store = createRedisUserSessionStore({ client, keyPrefix });
+		client.seed(`${keyPrefix}sid-corrupt`, "{not-valid-json}");
+		const result = await store.get("sid-corrupt");
+		expect(result).toBeNull();
+		// No assertion on logger — simply not crashing without one is the
+		// success criterion.
+	});
+});

--- a/packages/redis/src/challenges.mts
+++ b/packages/redis/src/challenges.mts
@@ -89,7 +89,13 @@ export function createRedisChallengeStore(opts: RedisChallengeStoreOptions): Cha
  *   factory.create({ type: "redis", client, keyPrefix: "chal:" });
  */
 export const redisChallengeStoreBuilder: AdapterBuilder<ChallengeStore> = (config, _ctx) => {
-	const c = config as { client: ChallengeStoreClient; keyPrefix?: string };
+	const c = config as { client?: ChallengeStoreClient; keyPrefix?: string };
+	// TS-M2 (Wave 5g): structural guard. Mirrors the
+	// `redisFederationTokenStoreBuilder` pattern — fail at boot rather than
+	// at first Redis op with a cryptic `Cannot read properties of undefined`.
+	if (!c.client) {
+		throw new Error("redisChallengeStoreBuilder: 'client' option is required");
+	}
 	return createRedisChallengeStore({
 		client: c.client,
 		keyPrefix: c.keyPrefix ?? "chal:",

--- a/packages/redis/src/refresh-token-family.mts
+++ b/packages/redis/src/refresh-token-family.mts
@@ -66,7 +66,15 @@ const SerializedFamilySchema = z
 		familyId: z.string(),
 		activeJti: z.string(),
 		revoked: z.boolean(),
-		expiresAtMs: z.number(),
+		// `expiresAtMs` is a positive epoch-ms integer. The looser `z.number()`
+		// would have accepted `Infinity` and fractional values, neither of
+		// which is a valid stored epoch — `Infinity` would defeat the
+		// `pttl <= 0` expiry gate (effectively "never expires") and
+		// fractional values cannot survive a `new Date(ms)` round-trip
+		// without precision loss. Tightened so corrupt operator-injected
+		// values trip `corrupt-data` rather than silently passing.
+		// Per Copilot review on PR #123.
+		expiresAtMs: z.number().int().positive().finite(),
 	})
 	.strict();
 

--- a/packages/redis/src/refresh-token-family.mts
+++ b/packages/redis/src/refresh-token-family.mts
@@ -48,8 +48,49 @@ interface SerializedFamily {
 const serialize = (fam: RefreshTokenFamily): string =>
 	JSON.stringify(fam satisfies SerializedFamily);
 
-const deserialize = (raw: string): RefreshTokenFamily =>
-	Object.freeze(JSON.parse(raw) as SerializedFamily);
+/**
+ * Runtime schema for `SerializedFamily`. `.strict()` rejects extra fields so
+ * a future schema migration that adds keys is detected as `corrupt-data`
+ * rather than silently dropped. Forward-compat callers that need to
+ * tolerate extra fields across rolling deploys can wrap the store; the
+ * default fail-closed posture is the safer choice.
+ *
+ * Per TS-M1 (Wave 5g): `JSON.parse(raw) as SerializedFamily` is a
+ * compile-time cast only. A corrupt or schema-migrated value would
+ * silently propagate `undefined` required fields into the rotation logic
+ * — `fam.activeJti` comparisons against `undefined` are always false,
+ * masking either a crash or a security bypass.
+ */
+const SerializedFamilySchema = z
+	.object({
+		familyId: z.string(),
+		activeJti: z.string(),
+		revoked: z.boolean(),
+		expiresAtMs: z.number(),
+	})
+	.strict();
+
+/**
+ * Parse + validate a stored family JSON. Throws
+ * `RefreshTokenStorageError({ reason: "corrupt-data" })` on either parse
+ * failure or shape failure — callers (`findFamily`, `updateFamily`)
+ * expect either a result or a `RefreshTokenStorageError`, so a raw
+ * `ZodError` would be an unexpected generic error type leaking past the
+ * adapter contract.
+ */
+const deserialize = (raw: string): RefreshTokenFamily => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (cause) {
+		throw new RefreshTokenStorageError({ reason: "corrupt-data", cause });
+	}
+	const result = SerializedFamilySchema.safeParse(parsed);
+	if (!result.success) {
+		throw new RefreshTokenStorageError({ reason: "corrupt-data", cause: result.error });
+	}
+	return Object.freeze(result.data satisfies SerializedFamily);
+};
 
 /**
  * Redis-backed RefreshTokenFamilyStore.
@@ -214,10 +255,19 @@ export const redisRefreshTokenFamilyStoreBuilder: AdapterBuilder<RefreshTokenFam
 	_ctx,
 ) => {
 	const c = config as {
-		client: RefreshTokenFamilyClient;
+		client?: RefreshTokenFamilyClient;
 		keyPrefix?: string;
 		casRetryLimit?: number;
 	};
+	// TS-6 (Wave 5g): structural guard. Without this, a misconfigured DI
+	// graph (`client: undefined`) propagates to first-Redis-call time as a
+	// cryptic `TypeError: Cannot read properties of undefined (reading
+	// 'set')`. Failing fast at builder-invocation makes the boot-time
+	// configuration error obvious and aligns with the
+	// `redisFederationTokenStoreBuilder` precedent.
+	if (!c.client) {
+		throw new Error("redisRefreshTokenFamilyStoreBuilder: 'client' option is required");
+	}
 	return createRedisRefreshTokenFamilyStore({
 		client: c.client,
 		keyPrefix: c.keyPrefix ?? "rtfam:",

--- a/packages/redis/src/replay-seen-set.mts
+++ b/packages/redis/src/replay-seen-set.mts
@@ -82,7 +82,13 @@ export function createRedisReplaySeenSet(opts: RedisReplaySeenSetOptions): Repla
  *   factory.create({ type: "redis", client, keyPrefix: "replay:" });
  */
 export const redisReplaySeenSetBuilder: AdapterBuilder<ReplaySeenSet> = (config, _ctx) => {
-	const c = config as { client: ReplaySeenSetClient; keyPrefix?: string };
+	const c = config as { client?: ReplaySeenSetClient; keyPrefix?: string };
+	// TS-M2 (Wave 5g): structural guard. Mirrors the
+	// `redisFederationTokenStoreBuilder` pattern — boot-time failure on
+	// missing client instead of cryptic runtime crash.
+	if (!c.client) {
+		throw new Error("redisReplaySeenSetBuilder: 'client' option is required");
+	}
 	return createRedisReplaySeenSet({
 		client: c.client,
 		keyPrefix: c.keyPrefix ?? "replay:",

--- a/packages/redis/src/userSessionStore.mts
+++ b/packages/redis/src/userSessionStore.mts
@@ -47,20 +47,45 @@ interface Envelope {
 }
 
 /**
+ * Maximum representable date in milliseconds (`new Date(8_640_000_000_000_000)`
+ * is the upper bound of valid JavaScript Date values per ECMA-262 §21.4.1.1).
+ * Values outside `[0, MAX_DATE_MS]` cannot survive a `new Date(ms)` round-trip
+ * — they produce `Invalid Date` whose `getTime()` returns `NaN`.
+ */
+const MAX_DATE_MS = 8_640_000_000_000_000;
+
+/**
+ * Per-field timestamp predicate: must be a non-negative safe integer within
+ * the `Date` valid range. Using `Number.isSafeInteger` (vs the looser
+ * `Number.isFinite`) closes a stricter form of the TS-3 expiry-bypass:
+ * very large finite numbers (e.g. `Number.MAX_VALUE` or any value > 2^53)
+ * lose precision and may produce `Invalid Date` via `new Date(ms)`. The
+ * comparison `expiresAtMs <= Date.now()` could then evaluate to `false`
+ * against an effectively-never-expiring envelope, again silently bypassing
+ * the gate. Per Copilot review on PR #123.
+ *
+ * Negative values are rejected because session timestamps are always
+ * positive epoch milliseconds; a negative value would map to a pre-1970
+ * Date, which is structurally meaningless for OAuth session lifecycle.
+ */
+const isValidTimestamp = (x: unknown): x is number =>
+	typeof x === "number" && Number.isSafeInteger(x) && x >= 0 && x <= MAX_DATE_MS;
+
+/**
  * Hand-rolled type predicate for `Envelope`. Lighter than Zod for the
  * storage layer and matches the Wave 5g `ts-safety-batch` convention.
  *
- * `Number.isFinite` rejects `NaN`, `Infinity`, `-Infinity`, and non-number
- * types in one check — the original `expiresAtMs <= Date.now()` comparison
- * silently returned `false` for `undefined`/`NaN`, bypassing the expiry
- * filter and propagating `Invalid Date` into the returned `UserSession`.
+ * Timestamp validation uses `isValidTimestamp` (safe integer + Date-range
+ * bounded). The original `expiresAtMs <= Date.now()` comparison silently
+ * returned `false` for `undefined`/`NaN`, bypassing the expiry filter and
+ * propagating `Invalid Date` into the returned `UserSession`.
  *
  * `claims` must be a plain object — `[]` and `null` both fail the
  * `typeof === "object"` plus index-signature contract. Callers that need
  * to support `claims: null` should change the predicate explicitly; the
  * fail-closed default is the safer posture for a security-critical path.
  *
- * Per TS-3 (Wave 5j).
+ * Per TS-3 (Wave 5j) + Copilot review on PR #123 (timestamp tightening).
  */
 const isValidEnvelope = (v: unknown): v is Envelope => {
 	if (typeof v !== "object" || v === null) return false;
@@ -68,12 +93,9 @@ const isValidEnvelope = (v: unknown): v is Envelope => {
 	return (
 		typeof e.sid === "string" &&
 		typeof e.sub === "string" &&
-		typeof e.authTimeMs === "number" &&
-		Number.isFinite(e.authTimeMs) &&
-		typeof e.createdAtMs === "number" &&
-		Number.isFinite(e.createdAtMs) &&
-		typeof e.expiresAtMs === "number" &&
-		Number.isFinite(e.expiresAtMs) &&
+		isValidTimestamp(e.authTimeMs) &&
+		isValidTimestamp(e.createdAtMs) &&
+		isValidTimestamp(e.expiresAtMs) &&
 		typeof e.claims === "object" &&
 		e.claims !== null &&
 		!Array.isArray(e.claims)
@@ -151,19 +173,23 @@ export function createRedisUserSessionStore(opts: RedisUserSessionStoreOptions):
 			let parsed: unknown;
 			try {
 				parsed = JSON.parse(raw);
-			} catch {
-				opts.logger?.warn(`user_session_corrupt_envelope: JSON.parse failed for sid=${sid}`, {
-					sid,
-					reason: "json_parse",
-				});
+			} catch (cause) {
+				// Object-first call shape per the D-4 Logger interface — keeps
+				// `sid` / `reason` reliably emitted as structured fields across
+				// `Logger` implementations (pino, console, custom). Per Copilot
+				// review on PR #123.
+				opts.logger?.warn(
+					{ sid, reason: "json_parse", cause },
+					"user_session_corrupt_envelope: JSON.parse failed",
+				);
 				return null;
 			}
 
 			if (!isValidEnvelope(parsed)) {
-				opts.logger?.warn(`user_session_corrupt_envelope: shape invalid for sid=${sid}`, {
-					sid,
-					reason: "shape_invalid",
-				});
+				opts.logger?.warn(
+					{ sid, reason: "shape_invalid" },
+					"user_session_corrupt_envelope: shape invalid",
+				);
 				return null;
 			}
 

--- a/packages/redis/src/userSessionStore.mts
+++ b/packages/redis/src/userSessionStore.mts
@@ -16,6 +16,7 @@
 
 import type {
 	CreateUserSessionInput,
+	Logger,
 	UserSession,
 	UserSessionClaims,
 	UserSessionStore,
@@ -25,6 +26,15 @@ import type { UserSessionStoreClient } from "./clients.mjs";
 export interface RedisUserSessionStoreOptions {
 	readonly client: UserSessionStoreClient;
 	readonly keyPrefix: string;
+	/**
+	 * Optional structured logger consumed by `get()` when a stored
+	 * envelope fails JSON.parse or shape validation (TS-3). Optional
+	 * chaining is used so callers that don't inject a logger get the
+	 * same fail-closed `null` return without an emitted warn. Phase F
+	 * will add a `consoleLogger` fallback once the D-4 ComponentMap
+	 * `logger` slot lands and module wiring threads it through.
+	 */
+	readonly logger?: Logger;
 }
 
 interface Envelope {
@@ -35,6 +45,40 @@ interface Envelope {
 	expiresAtMs: number;
 	claims: Record<string, unknown>;
 }
+
+/**
+ * Hand-rolled type predicate for `Envelope`. Lighter than Zod for the
+ * storage layer and matches the Wave 5g `ts-safety-batch` convention.
+ *
+ * `Number.isFinite` rejects `NaN`, `Infinity`, `-Infinity`, and non-number
+ * types in one check — the original `expiresAtMs <= Date.now()` comparison
+ * silently returned `false` for `undefined`/`NaN`, bypassing the expiry
+ * filter and propagating `Invalid Date` into the returned `UserSession`.
+ *
+ * `claims` must be a plain object — `[]` and `null` both fail the
+ * `typeof === "object"` plus index-signature contract. Callers that need
+ * to support `claims: null` should change the predicate explicitly; the
+ * fail-closed default is the safer posture for a security-critical path.
+ *
+ * Per TS-3 (Wave 5j).
+ */
+const isValidEnvelope = (v: unknown): v is Envelope => {
+	if (typeof v !== "object" || v === null) return false;
+	const e = v as Partial<Envelope>;
+	return (
+		typeof e.sid === "string" &&
+		typeof e.sub === "string" &&
+		typeof e.authTimeMs === "number" &&
+		Number.isFinite(e.authTimeMs) &&
+		typeof e.createdAtMs === "number" &&
+		Number.isFinite(e.createdAtMs) &&
+		typeof e.expiresAtMs === "number" &&
+		Number.isFinite(e.expiresAtMs) &&
+		typeof e.claims === "object" &&
+		e.claims !== null &&
+		!Array.isArray(e.claims)
+	);
+};
 
 const toEnvelope = (input: CreateUserSessionInput, createdAtMs: number): Envelope => ({
 	sid: input.sid,
@@ -96,9 +140,35 @@ export function createRedisUserSessionStore(opts: RedisUserSessionStoreOptions):
 		async get(sid) {
 			const raw = await opts.client.get(k(sid));
 			if (raw === null) return null;
-			const env = JSON.parse(raw) as Envelope;
-			if (env.expiresAtMs <= Date.now()) return null;
-			return fromEnvelope(env);
+
+			// TS-3 (Wave 5j): the previous `JSON.parse(raw) as Envelope` was a
+			// compile-time cast only. A corrupt envelope with `expiresAtMs:
+			// undefined` made `expiresAtMs <= Date.now()` evaluate to `false`
+			// (NaN comparison), bypassing the expiry filter and returning a
+			// session with `Invalid Date` fields. Treat any parse / shape
+			// failure as fail-closed (return null) and emit a structured
+			// warn for operator observability.
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(raw);
+			} catch {
+				opts.logger?.warn(`user_session_corrupt_envelope: JSON.parse failed for sid=${sid}`, {
+					sid,
+					reason: "json_parse",
+				});
+				return null;
+			}
+
+			if (!isValidEnvelope(parsed)) {
+				opts.logger?.warn(`user_session_corrupt_envelope: shape invalid for sid=${sid}`, {
+					sid,
+					reason: "shape_invalid",
+				});
+				return null;
+			}
+
+			if (parsed.expiresAtMs <= Date.now()) return null;
+			return fromEnvelope(parsed);
 		},
 		async delete(sid) {
 			await opts.client.del(k(sid));


### PR DESCRIPTION
## Summary

Closes **TS-M1 + TS-M2 + TS-2 + TS-6 + TS-3** of the v0.5.1 hotfix. Five findings cluster around the same root cause: unsafe TypeScript casts from `unknown` to typed shapes, with no runtime validation. All allow corrupt, malformed, or misconfigured data to bypass the type system and propagate as silently wrong values.

### TS-M1 — RedisRefreshTokenFamilyStore deserialize Zod validation

`Object.freeze(JSON.parse(raw) as SerializedFamily)` was a compile-time cast only. A corrupt or schema-migrated value silently produced a `RefreshTokenFamily` with `undefined` required fields; downstream rotation logic operated on `undefined activeJti` (comparisons always false), masking either a crash or a security bypass.

- New `SerializedFamilySchema` Zod schema with `.strict()` to reject schema drift.
- `deserialize` now `safeParse`s and throws `RefreshTokenStorageError({ reason: "corrupt-data" })` on parse or shape failure (not raw `ZodError`, preserving the adapter contract).
- New `corrupt-data` member added to `RefreshTokenStorageErrorReason`.

### TS-M2 — challenge + replay-seen-set builder client guards

A misconfigured DI graph (`client: undefined`) propagated to first-Redis-call time as `TypeError: Cannot read properties of undefined`. Both builders now throw at builder-invocation time. Mirrors the precedent set by `redisFederationTokenStoreBuilder`.

### TS-2 — HttpUserRepository response shape validation

`(await res.json()) as User` was a compile-time cast. A 200 response with a malformed body silently produced a `User` with `undefined` required fields, leaking `sub: undefined` into the authentication flow. New `isUser` runtime type guard checking string `id` and `username`. Throws on 200 + invalid shape ("upstream broken" is distinct from 401 "user not found").

### TS-6 — RedisRefreshTokenFamilyStore builder client guard

Same pattern as TS-M2 — boot-time guard.

### TS-3 — RedisUserSessionStore corrupt envelope validation

`JSON.parse(raw) as Envelope` + `env.expiresAtMs <= Date.now()` returned `false` for `undefined`/`NaN` (NaN comparison) — corrupt envelopes silently bypassed the expiry gate and `fromEnvelope` propagated `Invalid Date` for `authTime` / `createdAt` / `expiresAt`. Security impact: corrupt envelope returned as live session.

- New `isValidEnvelope` hand-rolled type predicate (`Number.isFinite` rejects `NaN`/`Infinity`/non-number types; rejects `null` and array `claims`).
- `get()` rewritten with try/catch around `JSON.parse` and shape predicate. Both failure paths return `null` (fail-closed) and emit a structured `logger?.warn(...)` with `sid` + `reason`.
- New optional `logger?: Logger` on `RedisUserSessionStoreOptions`. Phase F adds `consoleLogger` fallback once the D-4 ComponentMap `logger` slot is wired through `redisSessionStoresModule`.

## Migration

- **Operators with corrupt Redis data**: previously-silent `RefreshTokenFamily` corruption now throws `RefreshTokenStorageError({ reason: "corrupt-data" })` on `findFamily`/`updateFamily`. Monitor `redis_parse_failed` log entries after upgrade.
- **HttpUserRepository upstream changes**: 200 responses must include string `id` and `username`. Schema-migrated upstreams that drop these fields now error rather than silently propagating `undefined`.
- **RedisUserSessionStore corrupt envelopes**: previously returned a session with `Invalid Date` fields; now returns `null` and emits `user_session_corrupt_envelope` warn. Operators may see more null returns from Redis stores that hold pre-v0.5 data.
- **Misconfigured Redis builders**: previously crashed on first request with cryptic `Cannot read properties of undefined`; now fail at composition-root initialization with a clear error message.

## Test plan

- [x] Build clean (10 packages compile)
- [x] Tests: 2006 → ~2032 (+26: redis +23, foundation +4, core +2)
- [x] Biome lint 0 errors
- [x] Codex review: **No issues identified**
- [ ] Copilot review pending (auto-attached on PR open)

## Cross-spec references

- TS-safety batch spec: `auth/.claude/superpowers/specs/2026-05-05-ts-safety-batch.md`
- TS-3 spec: `auth/.claude/superpowers/specs/2026-05-05-ts3-user-session-envelope-validation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)