### PR TITLE
F6 PR1 — D-6 PB-2 client auth + GrantContext.authenticatedClient + public-client PKCE mandatory (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,89 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### BREAKING (Phase F — F6 PR1 D-6 PB-2 client authentication redesign, v0.5.1)
+
+- **`Client` interface gains `tokenEndpointAuthMethod`** (`@o3co/auth-provider-core`)
+  — REQUIRED discriminator with values
+  `"client_secret_basic" | "client_secret_post" | "none"` (RFC 6749 §2.3 / RFC 7591 §2).
+  Existing client configurations MUST add the field; `ClientEntrySchema` rejects
+  entries that omit it. `clientSecret` is now `string | undefined` (optional)
+  and a Zod `.superRefine` enforces "required iff method is `basic` / `post`,
+  forbidden iff method is `"none"`". All `Client` fields are now `readonly`.
+
+- **`/oauth/token` requires client authentication for every grant**: the
+  built-in route now wires `clientAuthMw` ahead of the grant dispatcher.
+  Calls without valid Basic credentials (or `client_id` body for public
+  clients) receive `401 invalid_client`. Public clients (`tokenEndpointAuthMethod
+  = "none"`) MUST send `client_id` in the form body and rely on PKCE/S256
+  for authenticity.
+
+- **PKCE/S256 is mandatory for public clients at `/authorize`** (RFC 9700
+  §2.1.1): public-client requests without `code_challenge` or with
+  `code_challenge_method != "S256"` are rejected via redirect-error
+  `invalid_request`. The operator-level `pkce.required` config is no longer
+  consulted for `"none"` clients.
+
+- **`GrantContext.authenticatedClient: AuthenticatedClient | null`** is
+  populated by `clientAuthMw` and consumed by the authorization-code and
+  refresh-token grants. Custom grant handlers MUST update their
+  `GrantContext` fixtures and rely on `ctx.authenticatedClient.clientId`
+  rather than `body.client_id` for any identity decision.
+
+- **Refresh-token grant binds RT to issuing client via `azp`**: the new
+  binding gate compares `(claims.azp ?? aud) === ctx.authenticatedClient.clientId`.
+  New tokens emit `azp` explicitly; legacy tokens (lacking `azp`) fall back
+  to `aud` once. Body `client_id` is no longer destructured.
+
+- **Authorization-code grant removes the in-grant `client_secret` check**
+  (RFC 6749 §2.3 belongs at the route, not the handler) and replaces every
+  raw-body `client_id` use that fed an identity sink (token `aud`/`azp`,
+  ID-token `aud`/`azp`, grant-policy `clientId`, session RP registration,
+  logout-metadata lookup) with `ctx.authenticatedClient.clientId`.
+  `body.client_secret` is no longer destructured.
+
+- **`clientAuthMw` enforces per-method transport (Codex M1)**: a client
+  configured for `"client_secret_basic"` cannot succeed via body credentials
+  (and vice versa) — wrong-transport attempts return `invalid_client`
+  regardless of credential validity. Basic-header + body-credential
+  conflict (Codex M4) is rejected with `invalid_client` before any
+  repository lookup.
+
+- **Token Exchange grant**: when dispatched via the standard `/token`
+  route, `clientAuthMw` runs ahead of the grant; the grant retains its
+  internal `client_secret_post` check as a no-op double-auth so consumers
+  who wire it onto custom routes keep the same authenticity guarantee.
+
+- **`InMemoryClientRepository.authenticate()` returns `null` for public
+  clients** (`tokenEndpointAuthMethod = "none"`) without throwing —
+  callers should dispatch to `findById` for public clients.
+
+#### Migration
+
+`config/clients.yaml`:
+
+```yaml
+# Confidential client (most common case)
+my-app:
+  tokenEndpointAuthMethod: "client_secret_basic"  # ADD THIS
+  clientSecret: "..."
+  # ... existing fields unchanged
+
+# Public client (SPA / mobile)
+my-spa:
+  tokenEndpointAuthMethod: "none"                 # ADD THIS
+  # clientSecret MUST be absent for "none"
+  allowedRedirectUris:
+    - "https://app.example/callback"
+  allowedScopes: ["openid", "profile"]
+```
+
+Confidential client requests to `/oauth/token` MUST send credentials via
+either HTTP Basic header or the body `client_id` + `client_secret` pair
+(matching the configured `tokenEndpointAuthMethod`). Public client requests
+MUST send `client_id` in the body and (at `/authorize`) include
+`code_challenge` + `code_challenge_method = "S256"`.
+
 ### Changed (Phase F — F4 PR2 standalone wiring batch + IH-10/17/18, v0.5.1)
 
 - **Single shared ioredis socket per replica** (`templates/standalone`):

--- a/packages/core/src/grants/types.mts
+++ b/packages/core/src/grants/types.mts
@@ -23,12 +23,30 @@ import type {
 	RefreshTokenFamilyRevocation,
 	RefreshTokenFamilyRotation,
 } from "../refresh-token-family/types.mjs";
+import type { TokenEndpointAuthMethod } from "../repositories/types.mjs";
 import type {
 	SessionFamilyIndex,
 	SessionFederationIndex,
 	SessionRPRegistry,
 	UserSessionStore,
 } from "../user-sessions/types.mjs";
+
+/**
+ * The client identity established by RFC 6749 §2.3 token-endpoint
+ * authentication middleware (`clientAuthMw`) before a grant handler is
+ * invoked.
+ *
+ * Every grant handler that gates on client identity (refresh, authorization
+ * code, token-exchange) MUST consult this slot rather than the raw request
+ * body — body parameters are attacker-controlled and may differ from the
+ * authenticated identity. `null` indicates the request did not pass through
+ * `clientAuthMw` (e.g., a custom route, or a unit test invoking the handler
+ * directly with a hand-built `GrantContext`).
+ */
+export interface AuthenticatedClient {
+	readonly clientId: string;
+	readonly tokenEndpointAuthMethod: TokenEndpointAuthMethod;
+}
 
 /**
  * Session data exposed to grant handlers.
@@ -56,6 +74,18 @@ export interface GrantContext {
 	metadata: Record<string, unknown>;
 	ip?: string;
 	userAgent?: string;
+	/**
+	 * The authenticated client established by `clientAuthMw` before grant
+	 * dispatch on `/token`. Grant handlers that bind tokens to client identity
+	 * (authorization code, refresh, token-exchange) MUST use this field rather
+	 * than `body.client_id` — the body is attacker-controlled and bypasses
+	 * RFC 6749 §2.3 authentication.
+	 *
+	 * `null` when the grant is invoked outside the standard `/token` route
+	 * (custom wiring, direct unit-test invocation). Handlers that rely on a
+	 * client identity SHOULD reject `null` with `invalid_client` 401.
+	 */
+	readonly authenticatedClient: AuthenticatedClient | null;
 }
 
 export interface GrantSuccess {

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -121,6 +121,7 @@ export {
 	type TokenResponse,
 } from "./grants/token.mjs";
 export type {
+	AuthenticatedClient,
 	GrantContext,
 	GrantDependencies,
 	GrantError,
@@ -254,7 +255,13 @@ export {
 export { loadYamlMap } from "./repositories/loadYamlMap.mjs";
 // Default repository factories
 export { createRepositoryFactories } from "./repositories/RepositoryFactory.mjs";
-export type { Client, Code, CodeData, User } from "./repositories/types.mjs";
+export type {
+	Client,
+	Code,
+	CodeData,
+	TokenEndpointAuthMethod,
+	User,
+} from "./repositories/types.mjs";
 export type { UserRepository } from "./repositories/UserRepository.mjs";
 export {
 	createSessionFamilyIndexFactory,

--- a/packages/core/src/repositories/ClientRepository.mts
+++ b/packages/core/src/repositories/ClientRepository.mts
@@ -19,7 +19,22 @@ import type { Client } from "./types.mjs";
 export type PublicClient = Omit<Client, "clientSecret">;
 
 export interface ClientRepository {
+	/**
+	 * Look up a client without authentication. Returns the client's public
+	 * fields (everything except `clientSecret`) or `null` when the client does
+	 * not exist. Used by `clientAuthMw` for the public-client (`tokenEndpoint-
+	 * AuthMethod === "none"`) path and by `/authorize` for redirect-URI /
+	 * scope validation that does not require credential authentication.
+	 */
 	findById(clientId: string): Promise<PublicClient | null>;
+	/**
+	 * Authenticate a confidential client by `clientId` + secret pair. Returns
+	 * the public projection on success, `null` when the client does not exist
+	 * or the secret does not match. Implementations MUST return `null` (and
+	 * SHOULD NOT throw) when called for a `tokenEndpointAuthMethod === "none"`
+	 * client — public clients have no secret to authenticate against, and
+	 * accepting any string would silently promote them to confidential.
+	 */
 	authenticate(clientId: string, secret: string): Promise<PublicClient | null>;
 }
 

--- a/packages/core/src/repositories/InMemoryClientRepository.mts
+++ b/packages/core/src/repositories/InMemoryClientRepository.mts
@@ -56,7 +56,13 @@ const httpUrlSchema = z
  */
 export const ClientEntrySchema = z
 	.object({
-		clientSecret: z.string().min(1),
+		// D-6 (v0.5.1): RFC 6749 §2.3 / RFC 7591 §2 client authentication method.
+		// Required — `clientSecret` is now optional and gated by the superRefine
+		// below so confidential clients still surface a startup error when the
+		// secret is missing, and public clients (`"none"`) cannot smuggle a
+		// secret in.
+		tokenEndpointAuthMethod: z.enum(["client_secret_basic", "client_secret_post", "none"]),
+		clientSecret: z.string().min(1).optional(),
 		allowedRedirectUris: z.array(z.string()).default([]),
 		allowedScopes: z.array(z.string()).default([]),
 		allowedAudiences: z.array(z.string()).default([]),
@@ -78,7 +84,32 @@ export const ClientEntrySchema = z
 		// NEW (TODO-F-6): Federation-token access opt-in. Default false — deny-by-default.
 		allowedAzpForFederationToken: z.boolean().optional().default(false),
 	})
-	.strict();
+	.strict()
+	.superRefine((data, ctx) => {
+		// D-6 (v0.5.1): the discriminator must select the right credential shape.
+		// Confidential clients (basic / post) must carry a secret; public clients
+		// (`"none"`) MUST NOT — accepting a secret on a `"none"` client would leave
+		// the credential in config where an operator could later assume the client
+		// had been promoted to confidential without changing the auth method.
+		const needsSecret =
+			data.tokenEndpointAuthMethod === "client_secret_basic" ||
+			data.tokenEndpointAuthMethod === "client_secret_post";
+		if (needsSecret && data.clientSecret === undefined) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message:
+					'clientSecret is required when tokenEndpointAuthMethod is "client_secret_basic" or "client_secret_post"',
+				path: ["clientSecret"],
+			});
+		}
+		if (!needsSecret && data.clientSecret !== undefined) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: 'clientSecret must not be set when tokenEndpointAuthMethod is "none"',
+				path: ["clientSecret"],
+			});
+		}
+	});
 
 export type ClientEntry = z.infer<typeof ClientEntrySchema>;
 
@@ -98,6 +129,7 @@ export class InMemoryClientRepository implements ClientRepository {
 		if (!entry) return null;
 		return {
 			clientId,
+			tokenEndpointAuthMethod: entry.tokenEndpointAuthMethod,
 			allowedRedirectUris: entry.allowedRedirectUris,
 			allowedScopes: entry.allowedScopes,
 			allowedAudiences: entry.allowedAudiences,
@@ -120,6 +152,16 @@ export class InMemoryClientRepository implements ClientRepository {
 		const entry = this.clients.get(clientId);
 		if (!entry) return null;
 
+		// D-6 (v0.5.1): public clients have no `clientSecret` to authenticate
+		// against. `clientAuthMw` already routes them through `findById` instead
+		// of `authenticate` — but this guard makes the contract structural rather
+		// than relying on every caller to dispatch correctly. Returning null
+		// (rather than throwing) keeps the failure indistinguishable from
+		// "wrong secret" so the timing surface stays uniform.
+		if (entry.tokenEndpointAuthMethod === "none" || entry.clientSecret === undefined) {
+			return null;
+		}
+
 		const stored = entry.clientSecret;
 		const isBcrypt = /^\$2[aby]\$/.test(stored);
 
@@ -136,6 +178,7 @@ export class InMemoryClientRepository implements ClientRepository {
 
 		return {
 			clientId,
+			tokenEndpointAuthMethod: entry.tokenEndpointAuthMethod,
 			allowedRedirectUris: entry.allowedRedirectUris,
 			allowedScopes: entry.allowedScopes,
 			allowedAudiences: entry.allowedAudiences,

--- a/packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts
+++ b/packages/core/src/repositories/__tests__/InMemoryClientRepository.test.mts
@@ -28,6 +28,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"test-app",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: "test-secret",
 							allowedRedirectUris: ["http://localhost:3000/callback"],
 							allowedScopes: ["read", "write"],
@@ -49,6 +50,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"test-app",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: "test-secret",
 							allowedRedirectUris: [],
 							allowedScopes: [],
@@ -59,6 +61,38 @@ describe("InMemoryClientRepository", () => {
 			const client = await repo.findById("nonexistent-client");
 			expect(client).toBeNull();
 		});
+
+		// D-6 (v0.5.1): findById exposes the configured authentication method on
+		// every PublicClient projection so downstream middleware (`clientAuthMw`)
+		// and grant handlers (`refreshToken`, `authorization`) can branch on it
+		// without re-fetching the client record.
+		it("D-6: returns tokenEndpointAuthMethod from findById", async () => {
+			const repo = new InMemoryClientRepository(
+				new Map([
+					[
+						"basic-client",
+						{
+							tokenEndpointAuthMethod: "client_secret_basic",
+							clientSecret: "s",
+							allowedRedirectUris: [],
+							allowedScopes: [],
+						},
+					],
+					[
+						"public-client",
+						{
+							tokenEndpointAuthMethod: "none",
+							allowedRedirectUris: [],
+							allowedScopes: [],
+						},
+					],
+				]),
+			);
+			const basic = await repo.findById("basic-client");
+			expect(basic?.tokenEndpointAuthMethod).toBe("client_secret_basic");
+			const pub = await repo.findById("public-client");
+			expect(pub?.tokenEndpointAuthMethod).toBe("none");
+		});
 	});
 
 	describe("logout metadata fields round-trip", () => {
@@ -68,6 +102,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"logout-client",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: "secret",
 							allowedRedirectUris: ["http://localhost:3000/callback"],
 							allowedScopes: ["openid"],
@@ -101,6 +136,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"no-logout-client",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: "secret",
 							allowedRedirectUris: [],
 							allowedScopes: [],
@@ -126,6 +162,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"explicit-false-client",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: "secret",
 							allowedRedirectUris: [],
 							allowedScopes: [],
@@ -149,6 +186,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"rp",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: "secret",
 							allowedRedirectUris: ["https://rp.example/cb"],
 							allowedScopes: ["openid"],
@@ -167,6 +205,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"rp",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: "secret",
 							allowedRedirectUris: ["https://rp.example/cb"],
 							allowedScopes: ["openid"],
@@ -184,6 +223,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"rp",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: "secret",
 							allowedRedirectUris: ["https://rp.example/cb"],
 							allowedScopes: ["openid"],
@@ -200,6 +240,7 @@ describe("InMemoryClientRepository", () => {
 	describe("ClientEntrySchema URI validation", () => {
 		it("rejects an invalid URL in backchannelLogoutUri", () => {
 			const result = ClientEntrySchema.safeParse({
+				tokenEndpointAuthMethod: "client_secret_basic",
 				clientSecret: "secret",
 				allowedRedirectUris: [],
 				allowedScopes: [],
@@ -211,6 +252,7 @@ describe("InMemoryClientRepository", () => {
 
 	describe("ClientEntrySchema URL scheme allowlist (F-5 XSS hardening)", () => {
 		const baseEntry = {
+			tokenEndpointAuthMethod: "client_secret_basic" as const,
 			clientSecret: "secret",
 			allowedRedirectUris: [],
 			allowedScopes: [],
@@ -258,6 +300,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"client-a",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: "s",
 							allowedRedirectUris: [],
 							allowedScopes: [],
@@ -275,6 +318,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"client-b",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: "s",
 							allowedRedirectUris: [],
 							allowedScopes: [],
@@ -293,6 +337,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"client-c",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: "correct-horse-battery-staple",
 							allowedRedirectUris: [],
 							allowedScopes: [],
@@ -313,6 +358,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"my-client",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: "plain-secret",
 							allowedRedirectUris: [],
 							allowedScopes: [],
@@ -332,6 +378,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"my-client",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: "plain-secret",
 							allowedRedirectUris: [],
 							allowedScopes: [],
@@ -349,6 +396,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"my-client",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: "plain-secret",
 							allowedRedirectUris: [],
 							allowedScopes: [],
@@ -367,6 +415,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"bcrypt-client",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: realHash,
 							allowedRedirectUris: [],
 							allowedScopes: [],
@@ -386,6 +435,7 @@ describe("InMemoryClientRepository", () => {
 					[
 						"bcrypt-client",
 						{
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: realHash,
 							allowedRedirectUris: [],
 							allowedScopes: [],
@@ -395,6 +445,162 @@ describe("InMemoryClientRepository", () => {
 			);
 			const client = await repo.authenticate("bcrypt-client", "wrong-secret");
 			expect(client).toBeNull();
+		});
+	});
+
+	// D-6 (v0.5.1): tokenEndpointAuthMethod discriminator + ClientEntrySchema
+	// superRefine. The schema is now the single source of truth for whether a
+	// client is confidential (basic/post — secret required) or public (none —
+	// secret forbidden). Historically these tests would have been split between
+	// ClientEntrySchema and InMemoryClientRepository, but the schema is invoked
+	// from the constructor so both surfaces share the same RED tests.
+	describe("D-6 tokenEndpointAuthMethod discriminator (RED Group A)", () => {
+		it("A-1: client_secret_basic without clientSecret throws at construction", () => {
+			expect(
+				() =>
+					new InMemoryClientRepository(
+						new Map([
+							[
+								"missing-secret",
+								{
+									tokenEndpointAuthMethod: "client_secret_basic",
+									allowedRedirectUris: [],
+									allowedScopes: [],
+								},
+							],
+						]),
+					),
+			).toThrow(/clientSecret is required/);
+		});
+
+		it("A-1b: client_secret_post without clientSecret throws at construction", () => {
+			expect(
+				() =>
+					new InMemoryClientRepository(
+						new Map([
+							[
+								"missing-secret-post",
+								{
+									tokenEndpointAuthMethod: "client_secret_post",
+									allowedRedirectUris: [],
+									allowedScopes: [],
+								},
+							],
+						]),
+					),
+			).toThrow(/clientSecret is required/);
+		});
+
+		it("A-2: tokenEndpointAuthMethod=none with clientSecret throws", () => {
+			expect(
+				() =>
+					new InMemoryClientRepository(
+						new Map([
+							[
+								"public-with-secret",
+								{
+									tokenEndpointAuthMethod: "none",
+									clientSecret: "secret",
+									allowedRedirectUris: [],
+									allowedScopes: [],
+								},
+							],
+						]),
+					),
+			).toThrow(/clientSecret must not be set/);
+		});
+
+		it("A-3: tokenEndpointAuthMethod=none without clientSecret succeeds", () => {
+			const repo = new InMemoryClientRepository(
+				new Map([
+					[
+						"public-spa",
+						{
+							tokenEndpointAuthMethod: "none",
+							allowedRedirectUris: ["https://app.example/cb"],
+							allowedScopes: ["openid"],
+						},
+					],
+				]),
+			);
+			expect(repo).toBeDefined();
+		});
+
+		it("A-4: authenticate() on a public client returns null (does not throw)", async () => {
+			const repo = new InMemoryClientRepository(
+				new Map([
+					[
+						"public-spa",
+						{
+							tokenEndpointAuthMethod: "none",
+							allowedRedirectUris: ["https://app.example/cb"],
+							allowedScopes: ["openid"],
+						},
+					],
+				]),
+			);
+			// Public clients have no secret. `authenticate()` MUST return null
+			// rather than throwing, so the timing surface stays uniform with the
+			// "wrong secret" path (which also returns null).
+			const result = await repo.authenticate("public-spa", "any-fake-secret");
+			expect(result).toBeNull();
+		});
+
+		it("A-5: findById() returns tokenEndpointAuthMethod on the PublicClient projection", async () => {
+			const repo = new InMemoryClientRepository(
+				new Map([
+					[
+						"basic-rp",
+						{
+							tokenEndpointAuthMethod: "client_secret_basic",
+							clientSecret: "s",
+							allowedRedirectUris: [],
+							allowedScopes: [],
+						},
+					],
+					[
+						"post-rp",
+						{
+							tokenEndpointAuthMethod: "client_secret_post",
+							clientSecret: "s",
+							allowedRedirectUris: [],
+							allowedScopes: [],
+						},
+					],
+					[
+						"public-rp",
+						{
+							tokenEndpointAuthMethod: "none",
+							allowedRedirectUris: [],
+							allowedScopes: [],
+						},
+					],
+				]),
+			);
+			expect((await repo.findById("basic-rp"))?.tokenEndpointAuthMethod).toBe(
+				"client_secret_basic",
+			);
+			expect((await repo.findById("post-rp"))?.tokenEndpointAuthMethod).toBe("client_secret_post");
+			expect((await repo.findById("public-rp"))?.tokenEndpointAuthMethod).toBe("none");
+		});
+
+		it("A-6: omitted tokenEndpointAuthMethod throws at construction (no silent default)", () => {
+			expect(
+				() =>
+					new InMemoryClientRepository(
+						new Map([
+							[
+								"unspecified",
+								{
+									clientSecret: "secret",
+									allowedRedirectUris: [],
+									allowedScopes: [],
+									// biome-ignore lint/suspicious/noExplicitAny: deliberately bypass the type system to verify runtime defence
+								} as any,
+							],
+						]),
+					),
+			).toThrow();
 		});
 	});
 });

--- a/packages/core/src/repositories/__tests__/createRepositoryFactories.test.mts
+++ b/packages/core/src/repositories/__tests__/createRepositoryFactories.test.mts
@@ -42,6 +42,7 @@ describe("createRepositoryFactories", () => {
 			const yamlPath = writeYaml(
 				"clients.yaml",
 				`my-client:
+  tokenEndpointAuthMethod: "client_secret_basic"
   clientSecret: "secret123"
   allowedRedirectUris:
     - "http://localhost:3000/callback"

--- a/packages/core/src/repositories/types.mts
+++ b/packages/core/src/repositories/types.mts
@@ -14,27 +14,51 @@
  * limitations under the License.
  */
 
+/**
+ * RFC 6749 §2.3 / RFC 7591 §2 client authentication method at the token endpoint.
+ *
+ * - `"client_secret_basic"`: HTTP Basic `Authorization` header (§2.3.1)
+ * - `"client_secret_post"`: form-encoded body parameters (§2.3.1)
+ * - `"none"`: public client (no secret; PKCE/S256 mandatory per RFC 9700 §2.1.1)
+ */
+export type TokenEndpointAuthMethod = "client_secret_basic" | "client_secret_post" | "none";
+
 export interface Client {
-	clientId: string;
-	clientSecret: string;
-	allowedRedirectUris: string[];
-	allowedScopes: string[];
+	readonly clientId: string;
+	/**
+	 * Token-endpoint authentication method. REQUIRED — the schema rejects
+	 * client entries that omit it; deployments upgrading from v0.5.0 must add
+	 * the field explicitly per the v0.5.1 migration guide.
+	 *
+	 * Public clients (`"none"`) MUST present PKCE/S256 at `/authorize`;
+	 * confidential clients (`"client_secret_basic"` / `"client_secret_post"`)
+	 * MUST present a `clientSecret` and use the matching transport at `/token`.
+	 */
+	readonly tokenEndpointAuthMethod: TokenEndpointAuthMethod;
+	/**
+	 * Required when `tokenEndpointAuthMethod` is `"client_secret_basic"` or
+	 * `"client_secret_post"`. MUST be absent (`undefined`) when the method is
+	 * `"none"`. The `ClientEntrySchema` superRefine enforces both directions.
+	 */
+	readonly clientSecret?: string;
+	readonly allowedRedirectUris: string[];
+	readonly allowedScopes: string[];
 	/**
 	 * Audience URIs that this client may request in Token Exchange (RFC 8693)
 	 * `audience` parameter. Empty or undefined means only the client's own
 	 * clientId is allowed as audience. Not used outside Token Exchange.
 	 */
-	allowedAudiences?: string[];
+	readonly allowedAudiences?: string[];
 	// NEW (TODO-F-5): Logout metadata.
-	postLogoutRedirectUris?: string[];
-	backchannelLogoutUri?: string;
+	readonly postLogoutRedirectUris?: string[];
+	readonly backchannelLogoutUri?: string;
 	// default: true (includes sid in logout_token) — intentional deviation from OIDC Back-Channel
 	// Logout 1.0 §2.2 spec default of false, to default to the safer behavior. See ClientEntrySchema.
-	backchannelLogoutSessionRequired?: boolean;
-	frontchannelLogoutUri?: string;
+	readonly backchannelLogoutSessionRequired?: boolean;
+	readonly frontchannelLogoutUri?: string;
 	// default: true (includes sid in frontchannel logout iframe URL) — intentional deviation from OIDC
 	// Front-Channel Logout 1.0 spec default of false, to default to the safer behavior. See ClientEntrySchema.
-	frontchannelLogoutSessionRequired?: boolean;
+	readonly frontchannelLogoutSessionRequired?: boolean;
 	// NEW (TODO-F-6): Federation-token access opt-in.
 	/**
 	 * When true, this client MAY call POST /oauth/federation/:name/token to
@@ -46,7 +70,7 @@ export interface Client {
 	 * radius. Opt-in prevents accidentally granting this power to a generic
 	 * OAuth client registration that only needs auth.
 	 */
-	allowedAzpForFederationToken?: boolean;
+	readonly allowedAzpForFederationToken?: boolean;
 }
 
 export interface User {

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -103,11 +103,21 @@ function buildGrant(
 	});
 }
 
-const ctx = (body: Record<string, unknown>): GrantContext => ({
+/**
+ * Default test context. The standalone-wiring path (no `clientAuthMw`) is
+ * exercised by leaving `authenticatedClient: null`; tests that need to verify
+ * the route-bound (`/oauth/token` after `clientAuthMw`) path override it.
+ */
+const ctx = (
+	body: Record<string, unknown>,
+	overrides: Partial<GrantContext> = {},
+): GrantContext => ({
 	body,
 	session: {},
 	issuer: ISSUER,
 	metadata: {},
+	authenticatedClient: null,
+	...overrides,
 });
 
 describe("createTokenExchangeGrant — request errors", () => {
@@ -927,5 +937,81 @@ describe("createTokenExchangeGrant — policy hook", () => {
 		);
 		expect(captured).not.toBeNull();
 		expect(captured?.resource).toEqual(["https://api.example.com"]);
+	});
+});
+
+// D-6 Codex post-review P2: when this grant runs behind `clientAuthMw` on
+// `/oauth/token`, the route already authenticated the client via Basic header
+// or body credentials and populated `ctx.authenticatedClient`. Trusting that
+// identity (and falling back to body credentials only when it is null) keeps
+// Basic-authenticated callers working AND retains the body-credential gate
+// for consumers wiring the grant onto a custom route.
+describe("createTokenExchangeGrant — D-6 ctx.authenticatedClient route-bound flow", () => {
+	const authedConfidential = {
+		clientId: "client-a",
+		tokenEndpointAuthMethod: "client_secret_basic" as const,
+	};
+
+	it("accepts a request with no body credentials when ctx.authenticatedClient is set (Basic auth at /token)", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx(
+				{
+					// no client_secret in body — Basic auth supplied it via clientAuthMw
+					client_id: "client-a",
+					subject_token: token,
+					subject_token_type: ACCESS_TOKEN_TYPE,
+				},
+				{ authenticatedClient: authedConfidential },
+			),
+		);
+		expect(result.status).toBe(200);
+	});
+
+	it("rejects when body.client_id differs from ctx.authenticatedClient.clientId (cross-client spoof)", async () => {
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx(
+				{
+					client_id: "spoofed-client", // ≠ authenticatedClient.clientId
+					subject_token: token,
+					subject_token_type: ACCESS_TOKEN_TYPE,
+				},
+				{ authenticatedClient: authedConfidential },
+			),
+		);
+		expect(result.status).toBe(400);
+		if (!("error" in result)) expect.fail("Expected error in result");
+		expect(result.error).toBe("invalid_request");
+		expect(result.errorDescription).toMatch(/client_id does not match/);
+	});
+
+	it("rejects public clients (`tokenEndpointAuthMethod: 'none'`) regardless of route", async () => {
+		// `clientAuthMw` admits public clients on `/oauth/token` (PKCE is
+		// the authenticity gate at `/oauth/authorize`), but Token Exchange
+		// has no PKCE and is confidential-only. The grant must refuse.
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx(
+				{
+					client_id: "spa-client",
+					subject_token: token,
+					subject_token_type: ACCESS_TOKEN_TYPE,
+				},
+				{
+					authenticatedClient: {
+						clientId: "spa-client",
+						tokenEndpointAuthMethod: "none",
+					},
+				},
+			),
+		);
+		expect(result.status).toBe(401);
+		if (!("error" in result)) expect.fail("Expected error in result");
+		expect(result.error).toBe("invalid_client");
+		expect(result.errorDescription).toMatch(/does not support public clients/);
 	});
 });

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -236,6 +236,32 @@ describe("createTokenExchangeGrant — request errors", () => {
 		});
 	});
 
+	it("Copilot review: standalone-wiring authenticate throw → 503 temporarily_unavailable (matches authenticated-client branch)", async () => {
+		// Standalone wiring (no `clientAuthMw`) — the in-grant `authenticate(...)`
+		// call must be guarded so a transient repository outage surfaces as a
+		// controlled 503 instead of an unhandled 500. This mirrors the
+		// authenticated-client branch's try/catch.
+		const throwingRepo: ClientRepository = {
+			findById: async () => null,
+			authenticate: async () => {
+				throw new Error("redis down");
+			},
+		};
+		const g = buildGrant({ clientRepository: throwingRepo });
+		const token = await signSelfIssuedAccessToken({});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(503);
+		if (!("error" in result)) expect.fail("Expected error in result");
+		expect(result.error).toBe("temporarily_unavailable");
+	});
+
 	it.each([
 		["number", 123],
 		["object", { a: 1 }],

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -969,6 +969,31 @@ describe("createTokenExchangeGrant — D-6 ctx.authenticatedClient route-bound f
 		expect(result.status).toBe(200);
 	});
 
+	it("accepts a Basic-auth request that omits body.client_id entirely (uses ctx.authenticatedClient.clientId)", async () => {
+		// Standard `Authorization: Basic <creds>` callers don't repeat
+		// `client_id` in the body. The grant must derive identity from
+		// `ctx.authenticatedClient` rather than rejecting the request.
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx(
+				{
+					subject_token: token,
+					subject_token_type: ACCESS_TOKEN_TYPE,
+				},
+				{ authenticatedClient: authedConfidential },
+			),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		// `azp` is bound to the authenticated client id.
+		const at = decodeJwt((result.tokens as { access_token: string }).access_token) as Record<
+			string,
+			unknown
+		>;
+		expect(at.azp).toBe("client-a");
+	});
+
 	it("rejects when body.client_id differs from ctx.authenticatedClient.clientId (cross-client spoof)", async () => {
 		const g = buildGrant();
 		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -1013,6 +1013,29 @@ describe("createTokenExchangeGrant — D-6 ctx.authenticatedClient route-bound f
 		expect(result.errorDescription).toMatch(/client_id does not match/);
 	});
 
+	it("rejects malformed body.client_id (string[]) instead of silently falling back to authenticated client", async () => {
+		// Codex P2: a repeated `client_id` form param produces `string[]`. The
+		// fallback path must NOT treat this as "absent" — otherwise an attacker
+		// could append a bogus client_id alongside a valid Basic header and
+		// bypass the cross-client equality check.
+		const g = buildGrant();
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx(
+				{
+					client_id: ["client-a", "spoof"], // malformed — repeated param
+					subject_token: token,
+					subject_token_type: ACCESS_TOKEN_TYPE,
+				},
+				{ authenticatedClient: authedConfidential },
+			),
+		);
+		expect(result.status).toBe(400);
+		if (!("error" in result)) expect.fail("Expected error in result");
+		expect(result.error).toBe("invalid_request");
+		expect(result.errorDescription).toMatch(/client_id must be a single string value/);
+	});
+
 	it("rejects public clients (`tokenEndpointAuthMethod: 'none'`) regardless of route", async () => {
 		// `clientAuthMw` admits public clients on `/oauth/token` (PKCE is
 		// the authenticity gate at `/oauth/authorize`), but Token Exchange

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -104,6 +104,23 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 			// Client authentication: confidential clients only. Reject when
 			// client_secret is omitted (see clientSecretRaw handling above for the
 			// rationale).
+			//
+			// D-6 note (v0.5.1): when this grant is dispatched from the standard
+			// `/token` route, `clientAuthMw` runs first and has already
+			// authenticated the client via the same `ClientRepository.authenticate`
+			// call below. The in-grant call is therefore a no-op double-auth in
+			// the route-bound flow. We retain it because:
+			// (a) the grant is a public OSS export — consumers may wire it onto a
+			//     custom route that bypasses `clientAuthMw`, where this remains
+			//     the only authenticity gate, and
+			// (b) this grant intentionally rejects public clients (`"none"`) at
+			//     this site, regardless of route configuration — a public client
+			//     calling Token Exchange with no `client_secret` falls through
+			//     here and gets `invalid_client`. Removing the check would let
+			//     `clientAuthMw`'s public-client path admit a request that has
+			//     no business reaching Token Exchange (which has no PKCE).
+			// `ctx.authenticatedClient` is intentionally NOT consulted: this grant
+			// owns its credential model and must remain self-contained.
 			if (clientSecret === null) {
 				return {
 					result: {

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -63,7 +63,26 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 			// the authenticated identity is the canonical source. We resolve the
 			// effective client id from the body first (matching standalone-wiring
 			// callers) and fall back to `ctx.authenticatedClient.clientId`.
-			const bodyClientId = typeof body.client_id === "string" ? body.client_id : null;
+			//
+			// Treat "present but not a single string" (e.g. `string[]` produced
+			// by a repeated query parameter) as malformed instead of silently
+			// falling back — otherwise an attacker could include a bogus
+			// `client_id` array to bypass the cross-client equality check below.
+			const bodyClientIdRaw = body.client_id;
+			let bodyClientId: string | null;
+			if (bodyClientIdRaw === undefined || bodyClientIdRaw === null) {
+				bodyClientId = null;
+			} else if (typeof bodyClientIdRaw === "string") {
+				bodyClientId = bodyClientIdRaw;
+			} else {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_request",
+						errorDescription: "client_id must be a single string value",
+					},
+				};
+			}
 			const clientId = bodyClientId ?? ctx.authenticatedClient?.clientId ?? null;
 			const clientSecretRaw = body.client_secret;
 			let clientSecret: string | null;

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -58,7 +58,13 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 			const subjectToken = typeof body.subject_token === "string" ? body.subject_token : null;
 			const subjectTokenType =
 				typeof body.subject_token_type === "string" ? body.subject_token_type : null;
-			const clientId = typeof body.client_id === "string" ? body.client_id : null;
+			// D-6 Codex post-review: when this grant runs through `/oauth/token`,
+			// Basic-authenticated callers don't repeat `client_id` in the body —
+			// the authenticated identity is the canonical source. We resolve the
+			// effective client id from the body first (matching standalone-wiring
+			// callers) and fall back to `ctx.authenticatedClient.clientId`.
+			const bodyClientId = typeof body.client_id === "string" ? body.client_id : null;
+			const clientId = bodyClientId ?? ctx.authenticatedClient?.clientId ?? null;
 			const clientSecretRaw = body.client_secret;
 			let clientSecret: string | null;
 			if (clientSecretRaw === undefined || clientSecretRaw === null) {
@@ -127,8 +133,10 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 				}
 				// Body-supplied client_id MUST match the authenticated identity —
 				// otherwise an attacker could authenticate as A and request a
-				// token exchange under B's allowlist.
-				if (clientId !== ctx.authenticatedClient.clientId) {
+				// token exchange under B's allowlist. Standard Basic-authenticated
+				// callers omit body `client_id` entirely; only verify equality
+				// when the body explicitly supplied one (`bodyClientId !== null`).
+				if (bodyClientId !== null && bodyClientId !== ctx.authenticatedClient.clientId) {
 					return {
 						result: {
 							status: 400,

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -23,6 +23,7 @@ import type {
 	GrantPolicyContext,
 	GrantPolicyDecision,
 	GrantPolicyRequest,
+	PublicClient,
 } from "@o3co/auth-provider-core";
 import { formatObject, generateToken, generateTokenResponse } from "@o3co/auth-provider-core";
 import { buildActClaim } from "./act.mjs";
@@ -101,36 +102,66 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 				};
 			}
 
-			// Client authentication: confidential clients only. Reject when
-			// client_secret is omitted (see clientSecretRaw handling above for the
-			// rationale).
+			// Client authentication. Token Exchange supports confidential clients
+			// only — public (`"none"`) clients are refused regardless of route.
 			//
-			// D-6 note (v0.5.1): when this grant is dispatched from the standard
-			// `/token` route, `clientAuthMw` runs first and has already
-			// authenticated the client via the same `ClientRepository.authenticate`
-			// call below. The in-grant call is therefore a no-op double-auth in
-			// the route-bound flow. We retain it because:
-			// (a) the grant is a public OSS export — consumers may wire it onto a
-			//     custom route that bypasses `clientAuthMw`, where this remains
-			//     the only authenticity gate, and
-			// (b) this grant intentionally rejects public clients (`"none"`) at
-			//     this site, regardless of route configuration — a public client
-			//     calling Token Exchange with no `client_secret` falls through
-			//     here and gets `invalid_client`. Removing the check would let
-			//     `clientAuthMw`'s public-client path admit a request that has
-			//     no business reaching Token Exchange (which has no PKCE).
-			// `ctx.authenticatedClient` is intentionally NOT consulted: this grant
-			// owns its credential model and must remain self-contained.
-			if (clientSecret === null) {
-				return {
-					result: {
-						status: 401,
-						error: "invalid_client",
-						errorDescription: "client_secret is required",
-					},
-				};
+			// D-6 (v0.5.1): when this grant is dispatched from the standard
+			// `/token` route, `clientAuthMw` has already authenticated the client
+			// (via Basic header OR body credentials) and populated
+			// `ctx.authenticatedClient`. We trust that identity over the body —
+			// without this branch, Basic-authenticated callers would fail here
+			// because `body.client_secret` is empty when credentials travel in
+			// the `Authorization` header. For consumers wiring this grant onto a
+			// custom route that bypasses `clientAuthMw`, the `else` branch keeps
+			// the original body-credential gate as the sole authenticity check.
+			let client: PublicClient | null;
+			if (ctx.authenticatedClient) {
+				if (ctx.authenticatedClient.tokenEndpointAuthMethod === "none") {
+					return {
+						result: {
+							status: 401,
+							error: "invalid_client",
+							errorDescription: "Token Exchange does not support public clients",
+						},
+					};
+				}
+				// Body-supplied client_id MUST match the authenticated identity —
+				// otherwise an attacker could authenticate as A and request a
+				// token exchange under B's allowlist.
+				if (clientId !== ctx.authenticatedClient.clientId) {
+					return {
+						result: {
+							status: 400,
+							error: "invalid_request",
+							errorDescription: "client_id does not match authenticated client",
+						},
+					};
+				}
+				try {
+					client = await clientRepository.findById(ctx.authenticatedClient.clientId);
+				} catch {
+					return {
+						result: {
+							status: 503,
+							error: "temporarily_unavailable",
+							errorDescription: "client repository unavailable",
+						},
+					};
+				}
+			} else {
+				// Standalone wiring: no `clientAuthMw` ahead of us, so verify
+				// the body-supplied secret directly.
+				if (clientSecret === null) {
+					return {
+						result: {
+							status: 401,
+							error: "invalid_client",
+							errorDescription: "client_secret is required",
+						},
+					};
+				}
+				client = await clientRepository.authenticate(clientId, clientSecret);
 			}
-			const client = await clientRepository.authenticate(clientId, clientSecret);
 			if (!client) {
 				return {
 					result: {

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -177,7 +177,10 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 				}
 			} else {
 				// Standalone wiring: no `clientAuthMw` ahead of us, so verify
-				// the body-supplied secret directly.
+				// the body-supplied secret directly. Repository failures are
+				// surfaced as a controlled 503 to match the authenticated-client
+				// branch — without this guard, a transient repository outage
+				// would propagate as an unhandled 500.
 				if (clientSecret === null) {
 					return {
 						result: {
@@ -187,7 +190,17 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 						},
 					};
 				}
-				client = await clientRepository.authenticate(clientId, clientSecret);
+				try {
+					client = await clientRepository.authenticate(clientId, clientSecret);
+				} catch {
+					return {
+						result: {
+							status: 503,
+							error: "temporarily_unavailable",
+							errorDescription: "client repository unavailable",
+						},
+					};
+				}
 			}
 			if (!client) {
 				return {

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -36,6 +36,15 @@ const validCode = {
 	redirect_uri: RP_URI,
 };
 
+// D-6 (v0.5.1): the authorization grant requires `ctx.authenticatedClient` to
+// be present and match `codeData.client_id`. Tests default to "client1" — the
+// same client_id baked into validCode — so existing scope/PKCE/policy tests
+// pass through the binding gate unchanged.
+const DEFAULT_AUTH_CLIENT = {
+	clientId: "client1",
+	tokenEndpointAuthMethod: "client_secret_basic" as const,
+};
+
 const mockConfig = {
 	oauth: {
 		jwt: { secret: "test-secret" },
@@ -101,6 +110,7 @@ describe("createAuthorizationGrant", () => {
 				session: { code: "abc", code_client_id: "client1" },
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -117,6 +127,7 @@ describe("createAuthorizationGrant", () => {
 				session: { code: "abc", code_client_id: "client1" },
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -132,6 +143,7 @@ describe("createAuthorizationGrant", () => {
 				session: { code: "abc", code_client_id: "client1" },
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -147,6 +159,7 @@ describe("createAuthorizationGrant", () => {
 				session: { code: "abc", code_client_id: "client1" },
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -169,6 +182,7 @@ describe("createAuthorizationGrant", () => {
 				},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result, sessionMutation } = await handler.handle(ctx);
@@ -213,6 +227,7 @@ describe("createAuthorizationGrant", () => {
 				},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -256,6 +271,7 @@ describe("createAuthorizationGrant", () => {
 				},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			});
 
 			expect(result.status).toBe(503);
@@ -278,6 +294,7 @@ describe("createAuthorizationGrant", () => {
 				},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			});
 			expect(result.status).toBe(200);
 		});
@@ -297,6 +314,7 @@ describe("createAuthorizationGrant", () => {
 				},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -329,6 +347,7 @@ describe("createAuthorizationGrant", () => {
 				},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -363,6 +382,7 @@ describe("createAuthorizationGrant", () => {
 				},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			});
 			expect(result.status).toBe(200);
 			if (!("tokens" in result)) throw new Error("expected tokens");
@@ -386,6 +406,7 @@ describe("createAuthorizationGrant", () => {
 				session: { code: "abc", code_client_id: "client1" },
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -409,6 +430,7 @@ describe("createAuthorizationGrant", () => {
 				session: { code: "abc", code_client_id: "client1" },
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -434,6 +456,7 @@ describe("createAuthorizationGrant", () => {
 				session: { code: "abc", code_client_id: "client1" },
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -462,6 +485,7 @@ describe("createAuthorizationGrant", () => {
 				session: { code: "abc", code_client_id: "client1" },
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -487,6 +511,7 @@ describe("createAuthorizationGrant", () => {
 				session: { code: "abc", code_client_id: "client1" },
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -541,6 +566,7 @@ describe("createAuthorizationGrant", () => {
 					session: { code: "abc", code_client_id: "client1" },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				};
 
 				const { result } = await handler.handle(ctx);
@@ -583,6 +609,7 @@ describe("createAuthorizationGrant", () => {
 					session: { code: "abc", code_client_id: "client1" },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				};
 
 				const { result } = await handler.handle(ctx);
@@ -612,6 +639,7 @@ describe("createAuthorizationGrant", () => {
 					},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				};
 
 				const { result } = await handler.handle(ctx);
@@ -637,6 +665,7 @@ describe("createAuthorizationGrant", () => {
 					},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				};
 
 				const { result } = await handler.handle(ctx);
@@ -663,6 +692,7 @@ describe("createAuthorizationGrant", () => {
 					},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				};
 
 				const { result } = await handler.handle(ctx);
@@ -688,6 +718,7 @@ describe("createAuthorizationGrant", () => {
 					session: { code: "abc", code_client_id: "client1" },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				};
 
 				const { result } = await handler.handle(ctx);
@@ -697,96 +728,69 @@ describe("createAuthorizationGrant", () => {
 			});
 		});
 
-		describe("A-3: client secret verification", () => {
-			it("returns invalid_client when client_secret is wrong for a confidential client", async () => {
-				const clientRepo: ClientRepository = {
-					findById: vi.fn().mockResolvedValue({
-						clientId: "client1",
-						allowedRedirectUris: [],
-						allowedScopes: [],
-					}),
-					authenticate: vi.fn().mockResolvedValue(null), // secret mismatch
-				};
-				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", ...validCode }), clientRepo);
+		// D-6 (v0.5.1): the in-grant `client_secret` check that lived here pre-
+		// v0.5.1 is removed. RFC 6749 §2.3 client authentication is now the
+		// responsibility of `clientAuthMw` at the route level — the grant
+		// handler trusts `ctx.authenticatedClient` and only verifies the
+		// canonical binding `codeData.client_id === authenticatedClient.clientId`.
+		// The integration-level coverage for credential validity lives in
+		// `clientAuth.test.mts` (Group B + Codex M1/M4) and the route-level
+		// `routes.test.mts` (Group C). The grant-level invariant tested here is
+		// just the binding gate.
+		describe("D-6 binding gate: codeData.client_id vs ctx.authenticatedClient.clientId", () => {
+			it("returns 401 invalid_client when ctx.authenticatedClient is null", async () => {
+				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", ...validCode }));
 				const handler = createAuthorizationGrant(deps);
-				const ctx: GrantContext = {
-					body: {
-						code: "abc",
-						client_id: "client1",
-						redirect_uri: RP_URI,
-						client_secret: "wrong-secret",
-					},
-					session: { code: "abc", code_client_id: "client1" },
+				const { result } = await handler.handle({
+					body: { code: "abc", redirect_uri: RP_URI },
+					session: {},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
-				};
-
-				const { result } = await handler.handle(ctx);
+					authenticatedClient: null,
+				});
 
 				expect(result.status).toBe(401);
-				expect("error" in result && result.error).toBe("invalid_client");
+				if (!("error" in result)) expect.fail("Expected error in result");
+				expect(result.error).toBe("invalid_client");
 			});
 
-			it("returns 200 when client_secret is correct", async () => {
-				const clientRepo: ClientRepository = {
-					findById: vi.fn().mockResolvedValue({
-						clientId: "client1",
-						allowedRedirectUris: [],
-						allowedScopes: [],
-					}),
-					authenticate: vi.fn().mockResolvedValue({
-						clientId: "client1",
-						allowedRedirectUris: [],
-						allowedScopes: [],
-					}),
-				};
-				const deps = makeDeps(
-					vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1", ...validCode }),
-					clientRepo,
-				);
+			it("returns 400 invalid_grant when authenticatedClient.clientId differs from codeData.client_id", async () => {
+				// codeData binds the code to "client1" (validCode); the authenticated
+				// client at /token is a different client. The binding gate must
+				// reject — accepting it would let any authenticated client redeem
+				// any code, which is the spoof vector PB-2 closes.
+				const deps = makeDeps(vi.fn().mockResolvedValue({ code: "abc", ...validCode }));
 				const handler = createAuthorizationGrant(deps);
-				const ctx: GrantContext = {
-					body: {
-						code: "abc",
-						client_id: "client1",
-						redirect_uri: RP_URI,
-						client_secret: "correct-secret",
+				const { result } = await handler.handle({
+					body: { code: "abc", redirect_uri: RP_URI },
+					session: {},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: {
+						clientId: "different-client",
+						tokenEndpointAuthMethod: "client_secret_basic",
 					},
-					session: { code: "abc", code_client_id: "client1" },
-					issuer: "localhost",
-					metadata: { ip: "127.0.0.1" },
-				};
+				});
 
-				const { result } = await handler.handle(ctx);
-
-				expect(result.status).toBe(200);
+				expect(result.status).toBe(400);
+				if (!("error" in result)) expect.fail("Expected error in result");
+				expect(result.error).toBe("invalid_grant");
+				expect(result.errorDescription).toBe("code was not issued to this client");
 			});
 
-			it("skips client secret check when client has no secret (public client - findById returns client but authenticate returns null with no secret provided)", async () => {
-				// Public client: no client_secret in request, findById succeeds
-				const clientRepo: ClientRepository = {
-					findById: vi.fn().mockResolvedValue({
-						clientId: "client1",
-						allowedRedirectUris: [],
-						allowedScopes: [],
-					}),
-					authenticate: vi.fn().mockResolvedValue(null),
-				};
+			it("returns 200 when authenticatedClient matches codeData.client_id (canonical happy path)", async () => {
 				const deps = makeDeps(
-					vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid-1", ...validCode }),
-					clientRepo,
+					vi.fn().mockResolvedValue({ code: "abc", sid: "test-sid", ...validCode }),
 				);
 				const handler = createAuthorizationGrant(deps);
-				const ctx: GrantContext = {
-					body: { code: "abc", client_id: "client1", redirect_uri: RP_URI }, // no client_secret
-					session: { code: "abc", code_client_id: "client1" },
+				const { result } = await handler.handle({
+					body: { code: "abc", redirect_uri: RP_URI },
+					session: { user: { id: "u1" } },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
-				};
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
+				});
 
-				const { result } = await handler.handle(ctx);
-
-				// Public client: no client_secret sent → skip verification
 				expect(result.status).toBe(200);
 			});
 		});
@@ -839,6 +843,7 @@ describe("createAuthorizationGrant", () => {
 					session: { code: "abc", code_client_id: "client1" },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				};
 
 				const { result } = await handler.handle(ctx);
@@ -871,6 +876,7 @@ describe("createAuthorizationGrant", () => {
 					session: { code: "abc", code_client_id: "client1" },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				};
 
 				const { result } = await handler.handle(ctx);
@@ -904,6 +910,7 @@ describe("createAuthorizationGrant", () => {
 					session: { code: "abc", code_client_id: "client1" },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				};
 
 				const { result } = await handler.handle(ctx);
@@ -999,6 +1006,7 @@ describe("createAuthorizationGrant", () => {
 					session: { code: "c1", code_client_id: "client1" },
 					issuer: "https://auth.example.com",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				});
 
 				expect(result.status).toBe(200);
@@ -1047,6 +1055,7 @@ describe("createAuthorizationGrant", () => {
 					session: { code: "c-noiss", code_client_id: "client1" },
 					// issuer intentionally omitted
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				});
 
 				expect(result.status).toBe(200);
@@ -1083,6 +1092,7 @@ describe("createAuthorizationGrant", () => {
 					session: { code: "c2", code_client_id: "client1" },
 					issuer: "https://auth.example.com",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				});
 
 				expect(result.status).toBe(200);
@@ -1108,6 +1118,7 @@ describe("createAuthorizationGrant", () => {
 					session: { code: "c3", code_client_id: "client1" },
 					issuer: "https://auth.example.com",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				});
 
 				expect(result.status).toBe(200);
@@ -1142,6 +1153,7 @@ describe("createAuthorizationGrant", () => {
 					session: { code: "abc", code_client_id: "client1", user: { id: "u1" } },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				};
 
 				const { result } = await handler.handle(ctx);
@@ -1170,6 +1182,7 @@ describe("createAuthorizationGrant", () => {
 					session: { code: "abc", code_client_id: "client1", user: { id: "u1" } },
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				};
 
 				const { result } = await handler.handle(ctx);
@@ -1206,6 +1219,7 @@ describe("createAuthorizationGrant", () => {
 					},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				};
 
 				const { result } = await handler.handle(ctx);
@@ -1231,6 +1245,7 @@ describe("createAuthorizationGrant", () => {
 					},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				});
 
 				expect(result.status).toBe(200);
@@ -1275,6 +1290,7 @@ describe("createAuthorizationGrant", () => {
 					},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				});
 
 				expect(result.status).toBe(400);
@@ -1300,6 +1316,7 @@ describe("createAuthorizationGrant", () => {
 					},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				});
 
 				expect(result.status).toBe(200);
@@ -1350,6 +1367,7 @@ describe("createAuthorizationGrant", () => {
 					},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				});
 
 				expect(result.status).toBe(200);
@@ -1394,6 +1412,7 @@ describe("createAuthorizationGrant", () => {
 					},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				});
 
 				expect(result.status).toBe(200);
@@ -1431,6 +1450,7 @@ describe("createAuthorizationGrant", () => {
 					},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				});
 
 				expect(result.status).toBe(400);
@@ -1464,6 +1484,7 @@ describe("createAuthorizationGrant", () => {
 					},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				});
 
 				expect(result.status).toBe(503);
@@ -1512,6 +1533,7 @@ describe("createAuthorizationGrant", () => {
 					},
 					issuer: "localhost",
 					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
 				});
 
 				expect(result.status).toBe(503);

--- a/packages/oauth/src/__tests__/hooks.test.mts
+++ b/packages/oauth/src/__tests__/hooks.test.mts
@@ -50,9 +50,34 @@ const mockConfig = {
 	},
 } as unknown as AppConfig;
 
+// D-6 (v0.5.1): every hit on /oauth/token now traverses `clientAuthMw` before
+// the registered grant handler runs. The mock client repository returns a
+// fixed "client1" / "secret1" pair so route-level integration tests can
+// authenticate by sending `Authorization: ${TEST_BASIC_AUTH}` and exercise the
+// rate-limit / audit / grant-policy paths under the new flow.
+const TEST_CLIENT_ID = "client1";
+const TEST_CLIENT_SECRET = "secret1";
+const TEST_BASIC_AUTH = `Basic ${Buffer.from(`${TEST_CLIENT_ID}:${TEST_CLIENT_SECRET}`).toString("base64")}`;
+
 const mockClientRepository: ClientRepository = {
-	findById: async () => null,
-	authenticate: async () => null,
+	findById: async (clientId) =>
+		clientId === TEST_CLIENT_ID
+			? {
+					clientId: TEST_CLIENT_ID,
+					tokenEndpointAuthMethod: "client_secret_basic",
+					allowedRedirectUris: ["https://rp.example/cb"],
+					allowedScopes: [],
+				}
+			: null,
+	authenticate: async (clientId, secret) =>
+		clientId === TEST_CLIENT_ID && secret === TEST_CLIENT_SECRET
+			? {
+					clientId: TEST_CLIENT_ID,
+					tokenEndpointAuthMethod: "client_secret_basic",
+					allowedRedirectUris: ["https://rp.example/cb"],
+					allowedScopes: [],
+				}
+			: null,
 };
 
 const mockCodeRepository: CodeRepository = {
@@ -127,7 +152,10 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 				})),
 			});
 
-			const res = await request(app).post("/oauth/token").send({ grant_type: "password" });
+			const res = await request(app)
+				.post("/oauth/token")
+				.set("Authorization", TEST_BASIC_AUTH)
+				.send({ grant_type: "password" });
 
 			expect(res.status).toBe(429);
 			expect(res.body.error).toBe("rate_limited");
@@ -146,7 +174,10 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 				})),
 			});
 
-			const res = await request(app).post("/oauth/token").send({ grant_type: "refresh_token" });
+			const res = await request(app)
+				.post("/oauth/token")
+				.set("Authorization", TEST_BASIC_AUTH)
+				.send({ grant_type: "refresh_token" });
 
 			expect(res.status).toBe(429);
 			expect(Number(res.headers["retry-after"])).toBeGreaterThan(0);
@@ -181,6 +212,7 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 
 			const res = await request(app)
 				.post("/oauth/token")
+				.set("Authorization", TEST_BASIC_AUTH)
 				.send({ grant_type: "unsupported_type_xyz" });
 
 			// 400 unsupported_grant_type — request was allowed through (fail-open)
@@ -223,6 +255,7 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 
 				const res = await request(app)
 					.post("/oauth/token")
+					.set("Authorization", TEST_BASIC_AUTH)
 					.send({ grant_type: "unsupported_type_xyz" });
 
 				// fail-open: 400 unsupported_grant_type from the route, NOT 503
@@ -254,6 +287,7 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 
 				const res = await request(app)
 					.post("/oauth/token")
+					.set("Authorization", TEST_BASIC_AUTH)
 					.send({ grant_type: "unsupported_type_xyz" });
 
 				expect(res.status).toBe(503);
@@ -277,6 +311,7 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 
 				const res = await request(app)
 					.post("/oauth/token")
+					.set("Authorization", TEST_BASIC_AUTH)
 					.send({ grant_type: "unsupported_type_xyz" });
 
 				expect(res.status).toBe(400); // unsupported_grant_type, not 503
@@ -303,6 +338,7 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 
 				const res = await request(app)
 					.post("/oauth/token")
+					.set("Authorization", TEST_BASIC_AUTH)
 					.send({ grant_type: "unsupported_type_xyz" });
 
 				expect(res.status).toBe(400); // unsupported_grant_type, not 503
@@ -320,6 +356,7 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 
 			const res = await request(app)
 				.post("/oauth/token")
+				.set("Authorization", TEST_BASIC_AUTH)
 				.send({ grant_type: "unsupported_type_xyz" });
 
 			// Not 429 — rate limiter allowed; 400 from unsupported_grant_type
@@ -339,7 +376,10 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 				},
 			};
 			const app = await buildApp({ rateLimiter });
-			await request(app).post("/oauth/token").send({ grant_type: "unsupported_xyz" });
+			await request(app)
+				.post("/oauth/token")
+				.set("Authorization", TEST_BASIC_AUTH)
+				.send({ grant_type: "unsupported_xyz" });
 			expect(observedKey).toBeDefined();
 			// Extract ip portion from key "token:ip:<ip>"
 			const keyIp = observedKey?.split(":").slice(2).join(":");
@@ -352,7 +392,10 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 			const { sink, events } = createSpyAuditSink();
 			const app = await buildApp({ auditSink: sink });
 
-			await request(app).post("/oauth/token").send({ grant_type: "unsupported_xyz" });
+			await request(app)
+				.post("/oauth/token")
+				.set("Authorization", TEST_BASIC_AUTH)
+				.send({ grant_type: "unsupported_xyz" });
 
 			expect(events.length).toBeGreaterThanOrEqual(1);
 			const ev = events.find((e) => e.type === "token.issued.failure");
@@ -362,7 +405,10 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 		it("does not throw when auditSink is undefined (no-op)", async () => {
 			const app = await buildApp({});
 
-			const res = await request(app).post("/oauth/token").send({ grant_type: "unsupported_xyz" });
+			const res = await request(app)
+				.post("/oauth/token")
+				.set("Authorization", TEST_BASIC_AUTH)
+				.send({ grant_type: "unsupported_xyz" });
 
 			expect(res.status).toBe(400);
 		});
@@ -719,6 +765,10 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 				},
 				issuer: "https://auth.example",
 				metadata: {},
+				authenticatedClient: {
+					clientId: "client-1",
+					tokenEndpointAuthMethod: "client_secret_basic",
+				},
 			});
 
 			if (!("tokens" in result)) throw new Error("expected tokens");

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -313,10 +313,11 @@ describe("createRefreshTokenGrant — refreshTokenFamilyRotation forwarding", ()
 		);
 
 		await handler.handle({
-			body: { refresh_token: rt.token, client_id: "client-1" },
+			body: { refresh_token: rt.token },
 			session: {},
 			issuer: "test-issuer",
 			metadata: {},
+			authenticatedClient: { clientId: "client-1", tokenEndpointAuthMethod: "client_secret_basic" },
 		});
 
 		expect(rotateSpy).toHaveBeenCalled();
@@ -401,6 +402,7 @@ describe("createAuthorizationGrant — userSessionStore forwarding", () => {
 			},
 			issuer: "localhost",
 			metadata: {},
+			authenticatedClient: { clientId: "client1", tokenEndpointAuthMethod: "client_secret_basic" },
 		});
 
 		expect(result.status).toBe(200);
@@ -453,6 +455,7 @@ describe("createAuthorizationGrant — grantPolicy forwarding", () => {
 			},
 			issuer: "localhost",
 			metadata: {},
+			authenticatedClient: { clientId: "client1", tokenEndpointAuthMethod: "client_secret_basic" },
 		});
 
 		// Pluck the refresh_token from the authorization code response
@@ -480,6 +483,7 @@ describe("createAuthorizationGrant — grantPolicy forwarding", () => {
 			session: {},
 			issuer: "localhost",
 			metadata: {},
+			authenticatedClient: { clientId: "client1", tokenEndpointAuthMethod: "client_secret_basic" },
 		});
 
 		expect(grantPolicy.evaluate).toHaveBeenCalled();
@@ -520,6 +524,7 @@ describe("createAuthorizationGrant — returns 400 for invalid code", () => {
 			session: { code: "different-code", code_client_id: "c1" },
 			issuer: "localhost",
 			metadata: {},
+			authenticatedClient: { clientId: "client1", tokenEndpointAuthMethod: "client_secret_basic" },
 		});
 
 		expect(result.status).toBe(400);

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -48,12 +48,26 @@ const mockDeps: GrantDependencies = {
 	keyStore,
 };
 
+// D-6 (v0.5.1): every test that hits the binding gate must supply both an
+// `aud` (or `azp`) on the signed RT and a matching `authenticatedClient` on
+// the GrantContext. We default both to "client1" so existing tests continue
+// to exercise the same scope/policy/family code paths without per-test
+// boilerplate; tests that need an explicit identity mismatch override the
+// `body.refresh_token` aud or the ctx authenticatedClient.
+const DEFAULT_CLIENT_ID = "client1";
+
 async function makeRefreshToken(overrides: Record<string, unknown> = {}): Promise<string> {
 	return new SignJWT({ sub: "u1", scope: "read write", ...overrides })
 		.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+		.setAudience(DEFAULT_CLIENT_ID)
 		.setExpirationTime("24h")
 		.sign(secretKey);
 }
+
+const DEFAULT_AUTH_CLIENT = {
+	clientId: DEFAULT_CLIENT_ID,
+	tokenEndpointAuthMethod: "client_secret_basic" as const,
+};
 
 describe("createRefreshTokenGrant", () => {
 	describe("handle", () => {
@@ -64,6 +78,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -79,6 +94,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -97,6 +113,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -104,7 +121,10 @@ describe("createRefreshTokenGrant", () => {
 			expect(result.status).toBe(400);
 		});
 
-		it("returns 400 when client_id does not match token audience", async () => {
+		it("D-6: returns 400 invalid_grant when authenticatedClient does not match RT azp/aud", async () => {
+			// Token is bound to "client1" via aud; authenticatedClient is a
+			// different client. The binding gate must reject — accepting it
+			// would let any authenticated client redeem any RT, defeating PB-2.
 			const token = await new SignJWT({ sub: "u1" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
 				.setAudience("client1")
@@ -112,15 +132,70 @@ describe("createRefreshTokenGrant", () => {
 				.sign(secretKey);
 			const handler = createRefreshTokenGrant(mockDeps);
 			const ctx: GrantContext = {
-				body: { refresh_token: token, client_id: "wrong-client" },
+				body: { refresh_token: token },
 				session: {},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: {
+					clientId: "different-client",
+					tokenEndpointAuthMethod: "client_secret_basic",
+				},
 			};
 
 			const { result } = await handler.handle(ctx);
 
 			expect(result.status).toBe(400);
+			if (!("error" in result)) expect.fail("Expected error in result");
+			expect(result.error).toBe("invalid_grant");
+			expect(result.errorDescription).toBe("refresh_token was not issued to this client");
+		});
+
+		it("D-6: returns 401 invalid_client when ctx.authenticatedClient is null", async () => {
+			// Direct grant invocation with no client auth — must be refused
+			// regardless of the RT contents.
+			const token = await makeRefreshToken();
+			const handler = createRefreshTokenGrant(mockDeps);
+			const { result } = await handler.handle({
+				body: { refresh_token: token },
+				session: {},
+				issuer: "localhost",
+				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: null,
+			});
+
+			expect(result.status).toBe(401);
+			if (!("error" in result)) expect.fail("Expected error in result");
+			expect(result.error).toBe("invalid_client");
+		});
+
+		it("D-6 R-legacy-azp: legacy RT (aud only, no azp) + matching authenticatedClient → 200, new RT emits azp", async () => {
+			// Pre-D-6 tokens carry only `aud`; the binding gate falls back to
+			// `aud === authenticatedClient.clientId`. The newly minted RT must
+			// emit `azp = authenticatedClient.clientId` so subsequent rotations
+			// no longer rely on the `aud` fallback.
+			const legacyToken = await new SignJWT({ sub: "u1", scope: "read" })
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setAudience("client1")
+				// note: no .azp claim (legacy)
+				.setExpirationTime("24h")
+				.sign(secretKey);
+			const handler = createRefreshTokenGrant(mockDeps);
+			const { result } = await handler.handle({
+				body: { refresh_token: legacyToken },
+				session: {},
+				issuer: "localhost",
+				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
+			});
+
+			expect(result.status).toBe(200);
+			if (!("tokens" in result)) expect.fail("Expected tokens in result");
+			const newRt = result.tokens.refresh_token as string;
+			const payload = JSON.parse(
+				Buffer.from(newRt.split(".")[1] ?? "", "base64url").toString("utf-8"),
+			) as Record<string, unknown>;
+			expect(payload.azp).toBe(DEFAULT_CLIENT_ID);
+			expect(payload.aud).toBe(DEFAULT_CLIENT_ID);
 		});
 
 		it("returns 200 with new access and refresh tokens on valid refresh token", async () => {
@@ -131,6 +206,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -155,6 +231,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -170,6 +247,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -189,6 +267,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -207,6 +286,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -226,6 +306,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -242,6 +323,7 @@ describe("createRefreshTokenGrant", () => {
 			// instead of typ: "rt+jwt" in the protected header.
 			const legacyToken = await new SignJWT({ type: "refresh", sub: "u1" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0" })
+				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.sign(secretKey);
 			const handler = createRefreshTokenGrant(mockDeps);
@@ -250,6 +332,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -261,6 +344,7 @@ describe("createRefreshTokenGrant", () => {
 		it("accepts legacy tokens without kid header", async () => {
 			const legacyToken = await new SignJWT({ sub: "u1" })
 				.setProtectedHeader({ alg: "HS256", typ: "rt+jwt" })
+				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.sign(secretKey);
 			const handler = createRefreshTokenGrant(mockDeps);
@@ -269,6 +353,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: { ip: "127.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -285,6 +370,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: {},
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { sessionMutation } = await handler.handle(ctx);
@@ -314,6 +400,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: {},
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -342,6 +429,7 @@ describe("createRefreshTokenGrant", () => {
 			// Token must include a jti so that previousJti !== null and rotate() is called
 			const token = await new SignJWT({ sub: "u1", scope: "read write" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.setJti("prev-jti-replay")
 				.sign(secretKey);
@@ -351,6 +439,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: {},
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -377,6 +466,7 @@ describe("createRefreshTokenGrant", () => {
 			};
 			const token = await new SignJWT({ sub: "u1", scope: "read write" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.setJti("prev-jti-503")
 				.sign(secretKey);
@@ -387,6 +477,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: {},
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			});
 
 			expect(result.status).toBe(503);
@@ -400,6 +491,7 @@ describe("createRefreshTokenGrant", () => {
 			// Token must include a jti so that previousJti !== null and rotate() is called
 			const token = await new SignJWT({ sub: "u1", scope: "read write" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.setJti("prev-jti-revoked")
 				.sign(secretKey);
@@ -409,6 +501,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: {},
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -441,6 +534,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: {},
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -469,6 +563,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: { ip: "10.0.0.1" },
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 				ip: "10.0.0.1",
 				userAgent: "test-agent/1.0",
 			};
@@ -493,6 +588,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: {},
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -519,6 +615,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: {},
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			};
 
 			const { result } = await handler.handle(ctx);
@@ -542,6 +639,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: {},
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			});
 
 			expect(result.status).toBe(503);
@@ -564,6 +662,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: {},
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			});
 
 			expect(result.status).toBe(200);
@@ -611,6 +710,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: {},
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			});
 
 			expect(result.status).toBe(200);
@@ -636,6 +736,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: {},
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			});
 
 			expect(result.status).toBe(400);
@@ -657,6 +758,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: {},
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			});
 
 			expect(result.status).toBe(503);
@@ -674,6 +776,7 @@ describe("createRefreshTokenGrant", () => {
 				session: {},
 				issuer: "localhost",
 				metadata: {},
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
 			});
 
 			expect(result.status).toBe(200);

--- a/packages/oauth/src/__tests__/routes.test.mts
+++ b/packages/oauth/src/__tests__/routes.test.mts
@@ -16,12 +16,16 @@
 
 import {
 	type AppConfig,
+	type AuditEvent,
+	type AuditSinkBase,
 	type ClientRepository,
 	type CodeRepository,
 	createSymmetricKeyStore,
+	type GrantHandler,
 	GrantRegistry,
 } from "@o3co/auth-provider-core";
-import type { Router } from "express";
+import express, { type Router } from "express";
+import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
 import { createOAuthRouter } from "#/routes.mjs";
 
@@ -30,6 +34,48 @@ const mockConfig = {
 		login: { url: "/login" },
 	},
 } as unknown as AppConfig;
+
+const fullConfig = {
+	oauth: { jwt: { issuer: "https://issuer.example" } },
+	rateLimit: { failMode: "open" as const },
+	endpoints: { login: { url: "/login" } },
+} as unknown as AppConfig;
+
+const TEST_CLIENT_ID = "client1";
+const TEST_CLIENT_SECRET = "secret1";
+const TEST_BASIC_AUTH = `Basic ${Buffer.from(`${TEST_CLIENT_ID}:${TEST_CLIENT_SECRET}`).toString("base64")}`;
+
+const integrationClientRepo: ClientRepository = {
+	findById: async (clientId) =>
+		clientId === TEST_CLIENT_ID
+			? {
+					clientId: TEST_CLIENT_ID,
+					tokenEndpointAuthMethod: "client_secret_basic",
+					allowedRedirectUris: [],
+					allowedScopes: [],
+				}
+			: null,
+	authenticate: async (clientId, secret) =>
+		clientId === TEST_CLIENT_ID && secret === TEST_CLIENT_SECRET
+			? {
+					clientId: TEST_CLIENT_ID,
+					tokenEndpointAuthMethod: "client_secret_basic",
+					allowedRedirectUris: [],
+					allowedScopes: [],
+				}
+			: null,
+};
+
+const integrationCodeRepo: CodeRepository = {
+	createCode: async () => ({
+		code: "code-x",
+		client_id: TEST_CLIENT_ID,
+		redirect_uri: "https://rp.example/cb",
+	}),
+	getByCode: async () => null,
+	consumeByCode: async () => null,
+	removeByCode: async () => {},
+};
 
 const mockExpress = {
 	Router: () =>
@@ -91,5 +137,131 @@ describe("createOAuthRouter", () => {
 
 		// The second arg (index 1) is the rate-limit middleware — it must be a function
 		expect(typeof introspectCall[1]).toBe("function");
+	});
+
+	// D-6 (v0.5.1) integration coverage: exercise the full /oauth/token pipeline
+	// end-to-end via supertest + a real express app. The mocked-router tests
+	// above only verify wiring; these tests cover the success-path token
+	// response, audit emit, and the 401 → `WWW-Authenticate: Bearer` branch.
+	describe("D-6 /oauth/token integration", () => {
+		async function buildApp(opts: {
+			grantHandler: GrantHandler;
+			grantType: string;
+			auditSink?: AuditSinkBase;
+		}) {
+			const app = express();
+			app.set("trust proxy", 1);
+			app.use(express.json());
+			app.use(express.urlencoded({ extended: false }));
+			const registry = new GrantRegistry();
+			registry.register(opts.grantType, opts.grantHandler);
+			const { router } = await createOAuthRouter(express, {
+				registry,
+				config: fullConfig,
+				clientRepository: integrationClientRepo,
+				codeRepository: integrationCodeRepo,
+				keyStore: createSymmetricKeyStore("test-secret-at-least-32-chars!!"),
+				auditSink: opts.auditSink,
+			});
+			app.use("/oauth", router);
+			return app;
+		}
+
+		it("success path: returns 200 + tokens + Cache-Control no-store + audit", async () => {
+			const events: AuditEvent[] = [];
+			const auditSink: AuditSinkBase = {
+				kind: "spy",
+				record: async (e) => {
+					events.push(e);
+				},
+			};
+			const stubGrant: GrantHandler = {
+				handle: async (_ctx) => ({
+					result: {
+						status: 200,
+						tokens: { access_token: "at.x.y", token_type: "Bearer", expires_in: 300 },
+					},
+				}),
+			};
+			const app = await buildApp({ grantHandler: stubGrant, grantType: "stub", auditSink });
+			const res = await request(app)
+				.post("/oauth/token")
+				.set("Authorization", TEST_BASIC_AUTH)
+				.type("form")
+				.send({ grant_type: "stub" });
+
+			expect(res.status).toBe(200);
+			expect(res.headers["cache-control"]).toBe("no-store");
+			expect(res.headers.pragma).toBe("no-cache");
+			expect(res.body.access_token).toBe("at.x.y");
+			// `clientId` in the audit event uses the authenticated identity, not body.
+			await new Promise((r) => setImmediate(r));
+			const issuedEvent = events.find((e) => e.type === "token.issued");
+			expect(issuedEvent).toBeDefined();
+			expect(issuedEvent?.clientId).toBe(TEST_CLIENT_ID);
+		});
+
+		it("error path with errorDescription + 401 sets WWW-Authenticate: Bearer + audit failure", async () => {
+			// A grant handler returning status 401 (e.g. ctx.authenticatedClient
+			// missing in a custom wiring) should route to the error branch with
+			// `WWW-Authenticate: Bearer` per RFC 6750 §3.
+			const events: AuditEvent[] = [];
+			const auditSink: AuditSinkBase = {
+				kind: "spy",
+				record: async (e) => {
+					events.push(e);
+				},
+			};
+			const stubGrant: GrantHandler = {
+				handle: async (_ctx) => ({
+					result: {
+						status: 401,
+						error: "invalid_client",
+						errorDescription: "stub denied",
+					},
+				}),
+			};
+			const app = await buildApp({ grantHandler: stubGrant, grantType: "stub", auditSink });
+			const res = await request(app)
+				.post("/oauth/token")
+				.set("Authorization", TEST_BASIC_AUTH)
+				.type("form")
+				.send({ grant_type: "stub" });
+
+			expect(res.status).toBe(401);
+			expect(res.headers["www-authenticate"]).toBe("Bearer");
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toBe("stub denied");
+			await new Promise((r) => setImmediate(r));
+			const failEvent = events.find((e) => e.type === "token.issued.failure");
+			expect(failEvent).toBeDefined();
+			expect(failEvent?.clientId).toBe(TEST_CLIENT_ID);
+		});
+
+		it("missing grant_type: returns 400 unsupported_grant_type + audit failure", async () => {
+			// Covers the early `if (typeof grant_type !== "string" ...)` branch.
+			const events: AuditEvent[] = [];
+			const auditSink: AuditSinkBase = {
+				kind: "spy",
+				record: async (e) => {
+					events.push(e);
+				},
+			};
+			const stubGrant: GrantHandler = {
+				handle: async () => ({
+					result: { status: 200, tokens: { access_token: "x", token_type: "Bearer" } },
+				}),
+			};
+			const app = await buildApp({ grantHandler: stubGrant, grantType: "stub", auditSink });
+			const res = await request(app)
+				.post("/oauth/token")
+				.set("Authorization", TEST_BASIC_AUTH)
+				.type("form")
+				.send({}); // no grant_type
+			expect(res.status).toBe(400);
+			expect(res.body.error).toBe("unsupported_grant_type");
+			await new Promise((r) => setImmediate(r));
+			expect(events.find((e) => e.type === "token.issued.failure")).toBeDefined();
+		});
 	});
 });

--- a/packages/oauth/src/__tests__/routes.test.mts
+++ b/packages/oauth/src/__tests__/routes.test.mts
@@ -201,10 +201,14 @@ describe("createOAuthRouter", () => {
 			expect(issuedEvent?.clientId).toBe(TEST_CLIENT_ID);
 		});
 
-		it("error path with errorDescription + 401 sets WWW-Authenticate: Bearer + audit failure", async () => {
+		it("error path with errorDescription + 401 does NOT inject WWW-Authenticate (Copilot review)", async () => {
 			// A grant handler returning status 401 (e.g. ctx.authenticatedClient
-			// missing in a custom wiring) should route to the error branch with
-			// `WWW-Authenticate: Bearer` per RFC 6750 §3.
+			// missing in a custom wiring) does NOT cause a `WWW-Authenticate:
+			// Bearer` challenge to be set on the token endpoint — RFC 6750 §3
+			// applies to protected resource servers, not authorization endpoints,
+			// and clobbering `clientAuthMw`'s upstream `WWW-Authenticate: Basic`
+			// challenge on auth failures would mislead callers into retrying with
+			// the wrong scheme.
 			const events: AuditEvent[] = [];
 			const auditSink: AuditSinkBase = {
 				kind: "spy",
@@ -229,7 +233,9 @@ describe("createOAuthRouter", () => {
 				.send({ grant_type: "stub" });
 
 			expect(res.status).toBe(401);
-			expect(res.headers["www-authenticate"]).toBe("Bearer");
+			// No WWW-Authenticate set by the route — clientAuthMw passed, the
+			// 401 came from the handler itself, and we do not impose Bearer here.
+			expect(res.headers["www-authenticate"]).toBeUndefined();
 			expect(res.body.error).toBe("invalid_client");
 			expect(res.body.error_description).toBe("stub denied");
 			await new Promise((r) => setImmediate(r));

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -68,16 +68,32 @@ export const createAuthorizationGrant = (
 			const {
 				code,
 				code_verifier = null,
-				client_id,
-				client_secret = null,
 				redirect_uri = null,
 			} = body as {
 				code?: string;
 				code_verifier?: string | null;
-				client_id?: string;
-				client_secret?: string | null;
+				// D-6: `client_id` / `client_secret` from body are no longer
+				// destructured — `clientAuthMw` populates `ctx.authenticatedClient`
+				// and the binding gate below verifies `codeData.client_id` against
+				// the authenticated identity.
 				redirect_uri?: string | null;
 			};
+
+			// D-6: client identity comes from RFC 6749 §2.3 token-endpoint
+			// authentication (clientAuthMw). A grant invocation that did not pass
+			// through that middleware (custom route, direct unit-test call) cannot
+			// be bound to a client and MUST be refused — the previous body-based
+			// `client_secret` check was superseded by route-level middleware.
+			if (!ctx.authenticatedClient) {
+				return {
+					result: {
+						status: 401,
+						error: "invalid_client",
+						errorDescription: "Client authentication is required",
+					},
+				};
+			}
+			const authenticatedClientId = ctx.authenticatedClient.clientId;
 
 			// D-1: presence-only check on `code`. The string itself is verified by
 			// `consumeByCode` (atomic getDel), which is the sole authenticity gate.
@@ -94,20 +110,10 @@ export const createAuthorizationGrant = (
 				};
 			}
 
-			// D-1: hoist client_id and redirect_uri presence checks ahead of
-			// consumeByCode so requests missing either reject without burning
-			// the (otherwise valid) code via the atomic getDel. The full
-			// equality checks against codeData.* still happen below — these
-			// hoisted checks only short-circuit the malformed-request path.
-			if (!client_id) {
-				return {
-					result: {
-						status: 400,
-						error: "invalid_grant",
-						errorDescription: "invalid client_id",
-					},
-				};
-			}
+			// D-1: hoist redirect_uri presence check ahead of consumeByCode so
+			// requests missing it reject without burning the (otherwise valid)
+			// code via the atomic getDel. The full equality check against
+			// codeData.redirect_uri still happens below.
 			if (!redirect_uri) {
 				return {
 					result: {
@@ -116,22 +122,6 @@ export const createAuthorizationGrant = (
 						errorDescription: "redirect_uri mismatch",
 					},
 				};
-			}
-
-			// A-3: Client secret verification (RFC 6749 §3.2.1)
-			// Only verify when client_secret is provided (confidential clients send it;
-			// public clients omit it). If provided, authenticate against the repository.
-			if (client_secret !== null && client_secret !== undefined) {
-				const authenticated = await clientRepository.authenticate(client_id, client_secret);
-				if (!authenticated) {
-					return {
-						result: {
-							status: 401,
-							error: "invalid_client",
-							errorDescription: "client authentication failed",
-						},
-					};
-				}
 			}
 
 			// Atomically consume code data from repository (replay attack prevention)
@@ -146,16 +136,16 @@ export const createAuthorizationGrant = (
 				};
 			}
 
-			// D-1: client_id binding moved from session.code_client_id to
-			// codeData.client_id. Custom impls predating v0.5.1 may emit a
-			// codeData without client_id — treat that as invalid_grant rather
-			// than crashing on undefined comparison.
-			if (client_id !== codeData.client_id) {
+			// D-6: canonical authority binding. The middleware authenticated the
+			// presenter; the code repository persisted the original `/authorize`
+			// caller. They must agree, otherwise an authenticated client could
+			// redeem a code issued to a different client.
+			if (codeData.client_id !== authenticatedClientId) {
 				return {
 					result: {
 						status: 400,
 						error: "invalid_grant",
-						errorDescription: "invalid client_id",
+						errorDescription: "code was not issued to this client",
 					},
 				};
 			}
@@ -297,10 +287,14 @@ export const createAuthorizationGrant = (
 			// generateToken carries a single `aud` claim; if policy narrowed to multiple
 			// audiences we flatten to the first. Multi-audience tokens are out of scope
 			// for the authorization code grant.
+			// D-6: default `aud` to the authenticated client (was raw body
+			// `client_id`). The binding gate above already proved the two are
+			// identical to `codeData.client_id`, so this rewrite is equivalent
+			// and removes the body-spoofable surface that Codex M2 flagged.
 			const audience =
 				grantedAudiencesFromCode && grantedAudiencesFromCode.length > 0
 					? grantedAudiencesFromCode[0]
-					: client_id;
+					: authenticatedClientId;
 
 			// CP-12: normalize empty scope array to null so the token response
 			// omits `scope` entirely instead of emitting `scope: ""` (which
@@ -319,7 +313,8 @@ export const createAuthorizationGrant = (
 					issuer,
 					audience,
 					subject: userId ?? null,
-					authorizedParty: client_id ?? null,
+					// D-6: `azp` is the authenticated client (was raw body `client_id`).
+					authorizedParty: authenticatedClientId,
 					scope: scopeClaim,
 					tokenType: "at+jwt",
 				},
@@ -332,7 +327,8 @@ export const createAuthorizationGrant = (
 					issuer,
 					audience,
 					subject: userId ?? null,
-					authorizedParty: client_id ?? null,
+					// D-6: `azp` is the authenticated client (was raw body `client_id`).
+					authorizedParty: authenticatedClientId,
 					scope: scopeClaim,
 					tokenType: "rt+jwt",
 				},
@@ -408,7 +404,11 @@ export const createAuthorizationGrant = (
 				// so a throw here returns a controlled 503 instead of propagating to the
 				// express default handler as an unhandled HTML 500.
 				try {
-					const clientRecord = await clientRepository.findById(client_id);
+					// D-6: logout-metadata lookup uses the authenticated client id
+					// (was raw body `client_id`). The two are guaranteed equal by
+					// the binding gate above, but reading from the authenticated
+					// slot keeps Codex M2's "no raw body for identity" invariant.
+					const clientRecord = await clientRepository.findById(authenticatedClientId);
 					// Composition-root invariant (A4 §3.4/§8): the bundled session-stores
 					// module wires all 4 sibling stores together. When deps.userSessionStore is
 					// present (outer guard), sessionFamilyIndex and sessionRPRegistry are also
@@ -420,7 +420,8 @@ export const createAuthorizationGrant = (
 					await deps.sessionRPRegistry!.registerRP(
 						sid,
 						{
-							clientId: client_id,
+							// D-6: RP record carries the authenticated client id.
+							clientId: authenticatedClientId,
 							backchannelLogoutUri: (clientRecord as Record<string, unknown> | null)
 								?.backchannelLogoutUri as string | undefined,
 							backchannelLogoutSessionRequired: (clientRecord as Record<string, unknown> | null)
@@ -466,8 +467,9 @@ export const createAuthorizationGrant = (
 			if (grantedScopes?.includes("openid") && userSession && sid && configuredIssuer) {
 				idToken = await generateIdToken({
 					sub: userSession.sub,
-					aud: client_id,
-					azp: client_id,
+					// D-6: id_token `aud` / `azp` bind to the authenticated client.
+					aud: authenticatedClientId,
+					azp: authenticatedClientId,
 					authTime: userSession.authTime,
 					...(nonce ? { nonce } : {}),
 					sid,

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -32,13 +32,10 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 	return {
 		async handle(ctx: GrantContext): Promise<GrantHandlerResult> {
 			const { body, issuer } = ctx;
-			const {
-				refresh_token: refreshTokenValue,
-				client_id,
-				scope: requestedScope,
-			} = body as {
+			const { refresh_token: refreshTokenValue, scope: requestedScope } = body as {
 				refresh_token?: string;
-				client_id?: string;
+				// D-6: `client_id` from body is no longer authoritative — `clientAuthMw`
+				// populates `ctx.authenticatedClient` and we read identity from there.
 				scope?: string;
 			};
 
@@ -51,6 +48,22 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 					},
 				};
 			}
+
+			// D-6: client identity comes from RFC 6749 §2.3 token-endpoint
+			// authentication (clientAuthMw). A grant invocation that did not pass
+			// through that middleware (custom route, direct unit-test call) cannot
+			// be bound to a client and MUST be refused — accepting it would
+			// re-introduce the body-spoofable flow that PB-2 closes.
+			if (!ctx.authenticatedClient) {
+				return {
+					result: {
+						status: 401,
+						error: "invalid_client",
+						errorDescription: "Client authentication is required",
+					},
+				};
+			}
+			const authenticatedClientId = ctx.authenticatedClient.clientId;
 
 			let tokenPayload: JWTPayload;
 			let typ: string | undefined;
@@ -84,31 +97,31 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				};
 			}
 
-			// Validate client_id matches audience if provided
+			// D-6: bind RT to its issuing client via `azp` (RFC 9068 §2.2). Pre-D-6
+			// tokens predate explicit `azp` issuance — for backward compat the
+			// gate falls back to `aud`. Tokens minted by post-D-6 issuers always
+			// emit `azp = ctx.authenticatedClient.clientId`, so once the legacy
+			// upgrade window closes the `aud` fallback is dead code.
 			const tokenAud = Array.isArray(tokenPayload.aud) ? tokenPayload.aud[0] : tokenPayload.aud;
-			if (client_id && tokenAud !== client_id) {
+			const claims = tokenPayload as Record<string, unknown>;
+			const tokenAzp =
+				typeof claims.azp === "string" && claims.azp.length > 0 ? claims.azp : tokenAud;
+			if (tokenAzp !== authenticatedClientId) {
 				return {
 					result: {
 						status: 400,
 						error: "invalid_grant",
-						errorDescription: "invalid client_id",
+						errorDescription: "refresh_token was not issued to this client",
 					},
 				};
 			}
 
-			const claims = tokenPayload as Record<string, unknown>;
 			// Read standard claims, with legacy fallback for pre-standardization tokens
 			const subjectStr =
 				typeof tokenPayload.sub === "string"
 					? tokenPayload.sub
 					: typeof (claims.user as Record<string, unknown> | undefined)?.id === "string"
 						? ((claims.user as Record<string, unknown>).id as string)
-						: undefined;
-			const azpStr =
-				typeof claims.azp === "string"
-					? (claims.azp as string)
-					: typeof (claims.client as Record<string, unknown> | undefined)?.id === "string"
-						? ((claims.client as Record<string, unknown>).id as string)
 						: undefined;
 			const scopeStr =
 				typeof claims.scope === "string"
@@ -146,7 +159,13 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			}
 
 			let finalScope = grantedScope;
-			let finalAudience: string | null = tokenAud ?? client_id ?? null;
+			// D-6: token aud/azp default to the authenticated client. `tokenAud`
+			// from the input refresh token is no longer authoritative for new-
+			// token issuance — the binding gate above already proves authenticated
+			// client matched the input azp/aud, so reusing
+			// `ctx.authenticatedClient.clientId` directly is equivalent and avoids
+			// a body-spoofable identity flow.
+			let finalAudience: string | null = authenticatedClientId;
 
 			if (deps.grantPolicy) {
 				// CP-18: fail-closed. grantPolicy is a security boundary (it
@@ -159,7 +178,9 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 					decision = await deps.grantPolicy.evaluate(
 						{
 							grantType: "refresh_token",
-							clientId: client_id,
+							// D-6: policy gate sees the authenticated client, not the
+							// raw body — same rationale as for token aud/azp.
+							clientId: authenticatedClientId,
 							subject: subjectStr,
 							requestedScope: requestedScope
 								? [...new Set(requestedScope.split(" ").filter(Boolean))]
@@ -260,7 +281,14 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 					issuer,
 					audience: finalAudience,
 					subject: subjectStr ?? null,
-					authorizedParty: azpStr ?? null,
+					// D-6: new token `azp` is the authenticated client. The legacy
+					// `claims.azp ?? claims.client.id` decoder was the only other
+					// code path that could populate this slot; both have been
+					// subsumed by the binding gate above (which proves the input
+					// token's azp/aud equalled `authenticatedClientId`), so reading
+					// from `ctx.authenticatedClient.clientId` is strictly equivalent
+					// and removes the body-spoofable surface.
+					authorizedParty: authenticatedClientId,
 					scope: scopeClaim,
 					tokenType: "at+jwt",
 				},
@@ -274,7 +302,9 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 					issuer,
 					audience: finalAudience,
 					subject: subjectStr ?? null,
-					authorizedParty: azpStr ?? null,
+					// D-6: same rationale as above — `azp` is bound to the
+					// authenticated client at issuance.
+					authorizedParty: authenticatedClientId,
 					scope: scopeClaim,
 					tokenType: "rt+jwt",
 				},

--- a/packages/oauth/src/middleware/__tests__/clientAuth.test.mts
+++ b/packages/oauth/src/middleware/__tests__/clientAuth.test.mts
@@ -338,6 +338,48 @@ describe("createClientAuthMiddleware (D-6 PB-2)", () => {
 			expect(res.body.error).toBe("invalid_client");
 			expect(res.body.error_description).toBeUndefined();
 		});
+
+		it("body-path: returns 401 fail-closed when authenticate throws — no WWW-Authenticate (body attempt)", async () => {
+			// Confidential client_secret_post + authenticate throws → rejectPlain
+			// (no Basic challenge — the caller never tried Basic).
+			const throwingRepo: ClientRepository = {
+				findById: async (id) =>
+					id === "alice" ? buildPublicClient(postConfidential("alice", "s3cret")) : null,
+				authenticate: async () => {
+					throw new Error("store unavailable");
+				},
+			};
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post("/test", createClientAuthMiddleware(throwingRepo), (_req, res) => res.end());
+			const res = await request(app)
+				.post("/test")
+				.type("form")
+				.send({ client_id: "alice", client_secret: "s3cret" });
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toBeUndefined();
+			// Body-path failure → no Basic challenge.
+			expect(res.headers["www-authenticate"]).toBeUndefined();
+		});
+
+		it("body-path: returns 401 Invalid client credentials when authenticate returns null", async () => {
+			// Confidential client_secret_post + wrong secret → authenticate
+			// returns null → rejectPlain "Invalid client credentials".
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([postConfidential("alice", "s3cret")])),
+				(_req, res) => res.end(),
+			);
+			const res = await request(app)
+				.post("/test")
+				.type("form")
+				.send({ client_id: "alice", client_secret: "wrong" });
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toBe("Invalid client credentials");
+			expect(res.headers["www-authenticate"]).toBeUndefined();
+		});
 	});
 
 	describe("Basic header parsing edge cases", () => {

--- a/packages/oauth/src/middleware/__tests__/clientAuth.test.mts
+++ b/packages/oauth/src/middleware/__tests__/clientAuth.test.mts
@@ -536,6 +536,24 @@ describe("createClientAuthMiddleware (D-6 PB-2)", () => {
 			expect(res.headers["www-authenticate"]).toBe('Basic realm="oauth"');
 		});
 
+		it("Copilot review: rejects unsafe realm characters and falls back to 'oauth'", async () => {
+			// `WWW-Authenticate: Basic realm="..."` is a quoted-string (RFC 7235
+			// §2.2 + RFC 7230). An issuer containing `"`, `\`, CR, LF, or other
+			// control bytes either produces a malformed header or opens a
+			// header-injection vector. The middleware validates the issuer and
+			// falls back to literal "oauth" on any unsafe character.
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([]), {
+					issuer: 'https://attacker.example/"\r\nSet-Cookie: x',
+				}),
+				(_req, res) => res.end(),
+			);
+			const res = await request(app).post("/test");
+			expect(res.headers["www-authenticate"]).toBe('Basic realm="oauth"');
+		});
+
 		it("backward-compat: accepts a Logger argument directly", async () => {
 			// F1 D-4 callers passed `Logger` as the second argument; the new signature
 			// takes an options object but keeps the legacy form working.

--- a/packages/oauth/src/middleware/__tests__/clientAuth.test.mts
+++ b/packages/oauth/src/middleware/__tests__/clientAuth.test.mts
@@ -14,224 +14,466 @@
  * limitations under the License.
  */
 
-import type { ClientRepository } from "@o3co/auth-provider-core";
+import type {
+	ClientRepository,
+	PublicClient,
+	TokenEndpointAuthMethod,
+} from "@o3co/auth-provider-core";
 import express from "express";
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
 import { createClientAuthMiddleware } from "../clientAuth.mjs";
 
-const fakePublicClient = (clientId: string) => ({
+interface FakeClient {
+	clientId: string;
+	tokenEndpointAuthMethod: TokenEndpointAuthMethod;
+	clientSecret?: string;
+}
+
+const buildPublicClient = (c: FakeClient): PublicClient => ({
+	clientId: c.clientId,
+	tokenEndpointAuthMethod: c.tokenEndpointAuthMethod,
+	allowedRedirectUris: [],
+	allowedScopes: [],
+});
+
+/**
+ * Test repository that supports both confidential (basic / post) and public
+ * (`"none"`) clients. After D-6, `clientAuthMw` calls `findById` to obtain the
+ * configured `tokenEndpointAuthMethod`, then `authenticate` for confidential
+ * clients only — so tests must populate both methods consistently.
+ */
+const fakeRepo = (clients: FakeClient[]): ClientRepository => {
+	const byId = new Map(clients.map((c) => [c.clientId, c]));
+	return {
+		findById: async (clientId) => {
+			const c = byId.get(clientId);
+			return c ? buildPublicClient(c) : null;
+		},
+		authenticate: async (clientId, secret) => {
+			const c = byId.get(clientId);
+			if (!c) return null;
+			if (c.tokenEndpointAuthMethod === "none") return null;
+			if (c.clientSecret !== secret) return null;
+			return buildPublicClient(c);
+		},
+	};
+};
+
+const basicConfidential = (clientId: string, secret: string): FakeClient => ({
 	clientId,
-	allowedRedirectUris: [] as string[],
-	allowedScopes: [] as string[],
+	tokenEndpointAuthMethod: "client_secret_basic",
+	clientSecret: secret,
 });
 
-const fakeRepo = (creds: Record<string, string>): ClientRepository => ({
-	findById: async () => null,
-	authenticate: async (id: string, secret: string) => {
-		if (creds[id] === secret) return fakePublicClient(id);
-		return null;
-	},
+const postConfidential = (clientId: string, secret: string): FakeClient => ({
+	clientId,
+	tokenEndpointAuthMethod: "client_secret_post",
+	clientSecret: secret,
 });
 
-describe("createClientAuthMiddleware", () => {
-	it("authenticates via HTTP Basic (RFC 6749 §2.3.1 preferred)", async () => {
-		const app = express().use(express.urlencoded({ extended: false }));
-		app.post("/test", createClientAuthMiddleware(fakeRepo({ alice: "s3cret" })), (req, res) => {
-			res.json({ client: req.oauthClient?.clientId });
+const publicClient = (clientId: string): FakeClient => ({
+	clientId,
+	tokenEndpointAuthMethod: "none",
+});
+
+describe("createClientAuthMiddleware (D-6 PB-2)", () => {
+	describe("group B-1..B-9 — confidential + public client paths", () => {
+		it("B-1: no credentials at all → 401 invalid_client + WWW-Authenticate", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post("/test", createClientAuthMiddleware(fakeRepo([])), (_req, res) => res.end());
+			const res = await request(app).post("/test").type("form").send({});
+			expect(res.status).toBe(401);
+			expect(res.headers["www-authenticate"]).toMatch(/^Basic realm=/);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toBe("Client authentication is required");
 		});
-		const basic = Buffer.from("alice:s3cret").toString("base64");
-		const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
-		expect(res.status).toBe(200);
-		expect(res.body.client).toBe("alice");
-	});
 
-	it("accepts form-encoded client_id/client_secret as a fallback", async () => {
-		const app = express().use(express.urlencoded({ extended: false }));
-		app.post("/test", createClientAuthMiddleware(fakeRepo({ alice: "s3cret" })), (req, res) => {
-			res.json({ client: req.oauthClient?.clientId });
+		it("B-2: valid Basic for a client_secret_basic client → next() with req.oauthClient set", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([basicConfidential("alice", "s3cret")])),
+				(req, res) => {
+					res.json({
+						client: req.oauthClient?.clientId,
+						method: req.oauthClient?.tokenEndpointAuthMethod,
+					});
+				},
+			);
+			const basic = Buffer.from("alice:s3cret").toString("base64");
+			const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
+			expect(res.status).toBe(200);
+			expect(res.body.client).toBe("alice");
+			expect(res.body.method).toBe("client_secret_basic");
 		});
-		const res = await request(app)
-			.post("/test")
-			.type("form")
-			.send({ client_id: "alice", client_secret: "s3cret" });
-		expect(res.status).toBe(200);
-		expect(res.body.client).toBe("alice");
-	});
 
-	it("returns 401 with WWW-Authenticate and error_description when credentials are missing", async () => {
-		const app = express().use(express.urlencoded({ extended: false }));
-		app.post("/test", createClientAuthMiddleware(fakeRepo({})), (_req, res) => res.end());
-		const res = await request(app).post("/test");
-		expect(res.status).toBe(401);
-		expect(res.headers["www-authenticate"]).toMatch(/^Basic realm=/);
-		expect(res.body.error).toBe("invalid_client");
-		expect(res.body.error_description).toBe("Client authentication is required");
-	});
-
-	it("returns 401 invalid_client with error_description when credentials do not match", async () => {
-		const app = express().use(express.urlencoded({ extended: false }));
-		app.post("/test", createClientAuthMiddleware(fakeRepo({ alice: "s3cret" })), (_req, res) =>
-			res.end(),
-		);
-		const res = await request(app)
-			.post("/test")
-			.type("form")
-			.send({ client_id: "alice", client_secret: "wrong" });
-		expect(res.status).toBe(401);
-		expect(res.body.error).toBe("invalid_client");
-		expect(res.body.error_description).toBe("Invalid client credentials");
-	});
-
-	it("prefers Basic over form-encoded when both are present", async () => {
-		const app = express().use(express.urlencoded({ extended: false }));
-		app.post("/test", createClientAuthMiddleware(fakeRepo({ alice: "s3cret" })), (req, res) => {
-			res.json({ client: req.oauthClient?.clientId });
+		it("B-3: wrong secret in Basic → 401 invalid_client + WWW-Authenticate", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([basicConfidential("alice", "s3cret")])),
+				(_req, res) => res.end(),
+			);
+			const basic = Buffer.from("alice:wrong").toString("base64");
+			const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
+			expect(res.status).toBe(401);
+			expect(res.headers["www-authenticate"]).toMatch(/^Basic realm=/);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toBe("Invalid client credentials");
 		});
-		const basic = Buffer.from("alice:s3cret").toString("base64");
-		const res = await request(app)
-			.post("/test")
-			.set("Authorization", `Basic ${basic}`)
-			.type("form")
-			.send({ client_id: "eve", client_secret: "pwned" });
-		expect(res.status).toBe(200);
-		expect(res.body.client).toBe("alice");
-	});
 
-	it("returns 401 malformed error_description on Basic header with no colon", async () => {
-		const app = express().use(express.urlencoded({ extended: false }));
-		app.post("/test", createClientAuthMiddleware(fakeRepo({ alice: "s3cret" })), (_req, res) =>
-			res.end(),
-		);
-		// Base64 of a string with no colon
-		const malformed = Buffer.from("nocolon").toString("base64");
-		const res = await request(app).post("/test").set("Authorization", `Basic ${malformed}`);
-		expect(res.status).toBe(401);
-		expect(res.body.error).toBe("invalid_client");
-		expect(res.body.error_description).toBe("Malformed client credentials");
-	});
-
-	it("returns 401 fail-closed when clientRepository.authenticate throws — no error_description", async () => {
-		const throwingRepo: ClientRepository = {
-			findById: async () => null,
-			authenticate: async () => {
-				throw new Error("store unavailable");
-			},
-		};
-		const app = express().use(express.urlencoded({ extended: false }));
-		app.post("/test", createClientAuthMiddleware(throwingRepo), (_req, res) => res.end());
-		const basic = Buffer.from("alice:s3cret").toString("base64");
-		const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
-		expect(res.status).toBe(401);
-		expect(res.body.error).toBe("invalid_client");
-		// Must NOT leak server-side detail to callers
-		expect(res.body.error_description).toBeUndefined();
-		expect(JSON.stringify(res.body)).not.toContain("store unavailable");
-	});
-
-	// Fix 5: Edge-case tests
-	it("returns 401 when client_id has empty secret (client_id:)", async () => {
-		const app = express().use(express.urlencoded({ extended: false }));
-		app.post("/test", createClientAuthMiddleware(fakeRepo({ alice: "" })), (_req, res) =>
-			res.end(),
-		);
-		// Basic header for "alice:" — empty secret should trip the guard
-		const basic = Buffer.from("alice:").toString("base64");
-		const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
-		expect(res.status).toBe(401);
-		expect(res.body.error).toBe("invalid_client");
-	});
-
-	it("splits on first colon only — client_id containing colon uses remainder as secret", async () => {
-		const authenticateSpy = vi.fn<ClientRepository["authenticate"]>().mockResolvedValue(null);
-		const spyRepo: ClientRepository = { authenticate: authenticateSpy, findById: vi.fn() };
-		const app = express().use(express.urlencoded({ extended: false }));
-		app.post("/test", createClientAuthMiddleware(spyRepo), (_req, res) => res.end());
-		// Base64 of "a:b:c:d" — clientId should be "a", secret "b:c:d"
-		const basic = Buffer.from("a:b:c:d").toString("base64");
-		const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
-		expect(res.status).toBe(401);
-		expect(authenticateSpy).toHaveBeenCalledWith("a", "b:c:d");
-	});
-
-	it("URL-decodes percent-encoded credentials from Basic header", async () => {
-		const authenticateSpy = vi
-			.fn<ClientRepository["authenticate"]>()
-			.mockResolvedValue(fakePublicClient("client_id@example"));
-		const spyRepo: ClientRepository = { authenticate: authenticateSpy, findById: vi.fn() };
-		const app = express().use(express.urlencoded({ extended: false }));
-		app.post("/test", createClientAuthMiddleware(spyRepo), (req, res) => {
-			res.json({ client: req.oauthClient?.clientId });
+		it("B-4: malformed Basic (no colon) → 401 invalid_client + WWW-Authenticate", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([basicConfidential("alice", "s3cret")])),
+				(_req, res) => res.end(),
+			);
+			const malformed = Buffer.from("nocolon").toString("base64");
+			const res = await request(app).post("/test").set("Authorization", `Basic ${malformed}`);
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toBe("Malformed client credentials");
 		});
-		// Base64 of "client_id%40example:secret%20with%20space"
-		const basic = Buffer.from("client_id%40example:secret%20with%20space").toString("base64");
-		const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
-		expect(res.status).toBe(200);
-		expect(authenticateSpy).toHaveBeenCalledWith("client_id@example", "secret with space");
-		expect(res.body.client).toBe("client_id@example");
-	});
 
-	it("returns 401 Client authentication is required when no credentials in body or header", async () => {
-		const app = express().use(express.urlencoded({ extended: false }));
-		app.post("/test", createClientAuthMiddleware(fakeRepo({})), (_req, res) => res.end());
-		// POST with no Authorization header, no client_id, no client_secret
-		const res = await request(app).post("/test").type("form").send({});
-		expect(res.status).toBe(401);
-		expect(res.body.error).toBe("invalid_client");
-		expect(res.body.error_description).toBe("Client authentication is required");
-	});
-
-	// Fix 5: RFC 6749 §2.3.1 — `+` in Basic credentials must decode to space (x-www-form-urlencoded)
-	it("Fix 5: Basic auth with + in credentials decodes to space (RFC 6749 §2.3.1 x-www-form-urlencoded)", async () => {
-		const authenticateSpy = vi
-			.fn<ClientRepository["authenticate"]>()
-			.mockResolvedValue(fakePublicClient("alice"));
-		const spyRepo: ClientRepository = { authenticate: authenticateSpy, findById: vi.fn() };
-		const app = express().use(express.urlencoded({ extended: false }));
-		app.post("/test", createClientAuthMiddleware(spyRepo), (req, res) => {
-			res.json({ client: req.oauthClient?.clientId });
+		it("B-5: form-encoded credentials for client_secret_post client → next()", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([postConfidential("alice", "s3cret")])),
+				(req, res) => res.json({ client: req.oauthClient?.clientId }),
+			);
+			const res = await request(app)
+				.post("/test")
+				.type("form")
+				.send({ client_id: "alice", client_secret: "s3cret" });
+			expect(res.status).toBe(200);
+			expect(res.body.client).toBe("alice");
 		});
-		// "alice:with+space" — `+` represents a literal space per x-www-form-urlencoded
-		const basic = Buffer.from("alice:with+space").toString("base64");
-		const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
-		expect(res.status).toBe(200);
-		expect(authenticateSpy).toHaveBeenCalledWith("alice", "with space");
-		expect(res.body.client).toBe("alice");
-	});
 
-	// Fix 6 (P2 Codex): RFC 7235 §2.1 — auth scheme name is case-insensitive
-	it("Fix P2: authenticates via lowercase 'basic' scheme (RFC 7235 §2.1 case-insensitive)", async () => {
-		const app = express().use(express.urlencoded({ extended: false }));
-		app.post("/test", createClientAuthMiddleware(fakeRepo({ alice: "s3cret" })), (req, res) => {
-			res.json({ client: req.oauthClient?.clientId });
+		it("B-6: public client supplies only client_id in body → next() with public method", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post("/test", createClientAuthMiddleware(fakeRepo([publicClient("spa")])), (req, res) => {
+				res.json({
+					client: req.oauthClient?.clientId,
+					method: req.oauthClient?.tokenEndpointAuthMethod,
+				});
+			});
+			const res = await request(app).post("/test").type("form").send({ client_id: "spa" });
+			expect(res.status).toBe(200);
+			expect(res.body.client).toBe("spa");
+			expect(res.body.method).toBe("none");
 		});
-		const creds = Buffer.from("alice:s3cret").toString("base64");
-		const res = await request(app).post("/test").set("Authorization", `basic ${creds}`);
-		expect(res.status).toBe(200);
-		expect(res.body.client).toBe("alice");
-	});
 
-	it("Fix P2: authenticates via uppercase 'BASIC' scheme (RFC 7235 §2.1 case-insensitive)", async () => {
-		const app = express().use(express.urlencoded({ extended: false }));
-		app.post("/test", createClientAuthMiddleware(fakeRepo({ alice: "s3cret" })), (req, res) => {
-			res.json({ client: req.oauthClient?.clientId });
+		it("B-7: confidential client called with body client_id only (no secret) → 401, no WWW-Authenticate (body attempt)", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([basicConfidential("alice", "s3cret")])),
+				(_req, res) => res.end(),
+			);
+			const res = await request(app).post("/test").type("form").send({ client_id: "alice" });
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+			// Body-only attempt → no Basic challenge in response.
+			expect(res.headers["www-authenticate"]).toBeUndefined();
 		});
-		const creds = Buffer.from("alice:s3cret").toString("base64");
-		const res = await request(app).post("/test").set("Authorization", `BASIC ${creds}`);
-		expect(res.status).toBe(200);
-		expect(res.body.client).toBe("alice");
+
+		it("B-8: unknown client → 401 invalid_client", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post("/test", createClientAuthMiddleware(fakeRepo([])), (_req, res) => res.end());
+			const res = await request(app).post("/test").type("form").send({ client_id: "ghost" });
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toBe("Unknown client");
+		});
+
+		it("B-9: Basic auth + body matching client_id (no body secret) → next() with Basic credentials used", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([basicConfidential("alice", "s3cret")])),
+				(req, res) => res.json({ client: req.oauthClient?.clientId }),
+			);
+			const basic = Buffer.from("alice:s3cret").toString("base64");
+			const res = await request(app)
+				.post("/test")
+				.set("Authorization", `Basic ${basic}`)
+				.type("form")
+				.send({ client_id: "alice" });
+			expect(res.status).toBe(200);
+			expect(res.body.client).toBe("alice");
+		});
 	});
 
-	// Fix 6: decodeURIComponent throw path
-	it("returns 401 Malformed client credentials when Basic header contains invalid percent-encoding", async () => {
-		const app = express().use(express.urlencoded({ extended: false }));
-		app.post("/test", createClientAuthMiddleware(fakeRepo({})), (_req, res) => res.end());
-		// "%zz" is invalid URL-encoding — decodeURIComponent will throw
-		// Buffer.from preserves the literal bytes through base64 round-trip
-		const basic = Buffer.from("%zz:x").toString("base64");
-		const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
-		expect(res.status).toBe(401);
-		expect(res.body.error).toBe("invalid_client");
-		expect(res.body.error_description).toBe("Malformed client credentials");
+	describe("Codex M4 — Basic+body conflict detection (B-10)", () => {
+		it("B-10a: Basic alice + body eve → 401 client_id mismatch", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(
+					fakeRepo([basicConfidential("alice", "s3cret"), basicConfidential("eve", "pwned")]),
+				),
+				(_req, res) => res.end(),
+			);
+			const basic = Buffer.from("alice:s3cret").toString("base64");
+			const res = await request(app)
+				.post("/test")
+				.set("Authorization", `Basic ${basic}`)
+				.type("form")
+				.send({ client_id: "eve", client_secret: "pwned" });
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toBe("client_id mismatch between Basic header and body");
+		});
+
+		it("B-10b: Basic alice:s3cret + body alice:wrong → 401 client_secret mismatch", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([basicConfidential("alice", "s3cret")])),
+				(_req, res) => res.end(),
+			);
+			const basic = Buffer.from("alice:s3cret").toString("base64");
+			const res = await request(app)
+				.post("/test")
+				.set("Authorization", `Basic ${basic}`)
+				.type("form")
+				.send({ client_id: "alice", client_secret: "wrong" });
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toBe(
+				"client_secret mismatch between Basic header and body",
+			);
+		});
+	});
+
+	describe("Codex M1 — per-method enforcement (B-method-1, B-method-2)", () => {
+		it("B-method-1: client configured 'client_secret_basic' rejects body credentials", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([basicConfidential("alice", "s3cret")])),
+				(_req, res) => res.end(),
+			);
+			const res = await request(app)
+				.post("/test")
+				.type("form")
+				.send({ client_id: "alice", client_secret: "s3cret" });
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toMatch(/tokenEndpointAuthMethod mismatch/);
+		});
+
+		it("B-method-2: client configured 'client_secret_post' rejects HTTP Basic credentials", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([postConfidential("alice", "s3cret")])),
+				(_req, res) => res.end(),
+			);
+			const basic = Buffer.from("alice:s3cret").toString("base64");
+			const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toMatch(/tokenEndpointAuthMethod mismatch/);
+			expect(res.headers["www-authenticate"]).toMatch(/^Basic realm=/);
+		});
+
+		it("B-method-3: confidential client called as if public (no secret) → mismatch", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([basicConfidential("confidential-rp", "s3cret")])),
+				(_req, res) => res.end(),
+			);
+			const res = await request(app)
+				.post("/test")
+				.type("form")
+				.send({ client_id: "confidential-rp" });
+			expect(res.status).toBe(401);
+			expect(res.body.error_description).toMatch(/Client authentication is required/);
+		});
+	});
+
+	describe("repository fail-closed", () => {
+		it("returns 401 fail-closed when findById throws — no error_description leak", async () => {
+			const throwingRepo: ClientRepository = {
+				findById: async () => {
+					throw new Error("store unavailable");
+				},
+				authenticate: async () => null,
+			};
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post("/test", createClientAuthMiddleware(throwingRepo), (_req, res) => res.end());
+			const basic = Buffer.from("alice:s3cret").toString("base64");
+			const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toBeUndefined();
+			expect(JSON.stringify(res.body)).not.toContain("store unavailable");
+		});
+
+		it("returns 401 fail-closed when authenticate throws — no error_description leak", async () => {
+			const throwingRepo: ClientRepository = {
+				findById: async (id) =>
+					id === "alice" ? buildPublicClient(basicConfidential("alice", "s3cret")) : null,
+				authenticate: async () => {
+					throw new Error("store unavailable");
+				},
+			};
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post("/test", createClientAuthMiddleware(throwingRepo), (_req, res) => res.end());
+			const basic = Buffer.from("alice:s3cret").toString("base64");
+			const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toBeUndefined();
+		});
+	});
+
+	describe("Basic header parsing edge cases", () => {
+		it("returns 401 when Basic credentials have empty secret (alice:)", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			// alice has tokenEndpointAuthMethod=basic but no secret matches "" — the
+			// authenticate path returns null; per-method gate accepts the basic
+			// transport since it was attempted.
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([basicConfidential("alice", "")])),
+				(_req, res) => res.end(),
+			);
+			const basic = Buffer.from("alice:").toString("base64");
+			const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+		});
+
+		it("splits on first colon only — secret may contain colons", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			const repo = fakeRepo([basicConfidential("a", "b:c:d")]);
+			const authSpy = vi.spyOn(repo, "authenticate");
+			app.post("/test", createClientAuthMiddleware(repo), (req, res) => {
+				res.json({ client: req.oauthClient?.clientId });
+			});
+			const basic = Buffer.from("a:b:c:d").toString("base64");
+			const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
+			expect(res.status).toBe(200);
+			expect(authSpy).toHaveBeenCalledWith("a", "b:c:d");
+			expect(res.body.client).toBe("a");
+		});
+
+		it("URL-decodes percent-encoded credentials from Basic header", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			const repo = fakeRepo([basicConfidential("client_id@example", "secret with space")]);
+			const authSpy = vi.spyOn(repo, "authenticate");
+			app.post("/test", createClientAuthMiddleware(repo), (req, res) => {
+				res.json({ client: req.oauthClient?.clientId });
+			});
+			const basic = Buffer.from("client_id%40example:secret%20with%20space").toString("base64");
+			const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
+			expect(res.status).toBe(200);
+			expect(authSpy).toHaveBeenCalledWith("client_id@example", "secret with space");
+			expect(res.body.client).toBe("client_id@example");
+		});
+
+		it("Basic auth with `+` decodes to space (RFC 6749 §2.3.1 x-www-form-urlencoded)", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			const repo = fakeRepo([basicConfidential("alice", "with space")]);
+			const authSpy = vi.spyOn(repo, "authenticate");
+			app.post("/test", createClientAuthMiddleware(repo), (req, res) => {
+				res.json({ client: req.oauthClient?.clientId });
+			});
+			const basic = Buffer.from("alice:with+space").toString("base64");
+			const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
+			expect(res.status).toBe(200);
+			expect(authSpy).toHaveBeenCalledWith("alice", "with space");
+		});
+
+		it("Authorization scheme is case-insensitive (lowercase 'basic')", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([basicConfidential("alice", "s3cret")])),
+				(req, res) => res.json({ client: req.oauthClient?.clientId }),
+			);
+			const creds = Buffer.from("alice:s3cret").toString("base64");
+			const res = await request(app).post("/test").set("Authorization", `basic ${creds}`);
+			expect(res.status).toBe(200);
+			expect(res.body.client).toBe("alice");
+		});
+
+		it("Authorization scheme is case-insensitive (uppercase 'BASIC')", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([basicConfidential("alice", "s3cret")])),
+				(req, res) => res.json({ client: req.oauthClient?.clientId }),
+			);
+			const creds = Buffer.from("alice:s3cret").toString("base64");
+			const res = await request(app).post("/test").set("Authorization", `BASIC ${creds}`);
+			expect(res.status).toBe(200);
+			expect(res.body.client).toBe("alice");
+		});
+
+		it("returns 401 Malformed when Basic header contains invalid percent-encoding", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post("/test", createClientAuthMiddleware(fakeRepo([])), (_req, res) => res.end());
+			// "%zz" is invalid URL-encoding — decodeURIComponent will throw
+			const basic = Buffer.from("%zz:x").toString("base64");
+			const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toBe("Malformed client credentials");
+		});
+	});
+
+	describe("issuer-driven WWW-Authenticate realm", () => {
+		it('emits realm="<issuer>" when issuer option is provided', async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([]), { issuer: "https://issuer.example" }),
+				(_req, res) => res.end(),
+			);
+			const res = await request(app).post("/test");
+			expect(res.headers["www-authenticate"]).toBe('Basic realm="https://issuer.example"');
+		});
+
+		it('falls back to realm="oauth" when issuer is unset', async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post("/test", createClientAuthMiddleware(fakeRepo([])), (_req, res) => res.end());
+			const res = await request(app).post("/test");
+			expect(res.headers["www-authenticate"]).toBe('Basic realm="oauth"');
+		});
+
+		it("backward-compat: accepts a Logger argument directly", async () => {
+			// F1 D-4 callers passed `Logger` as the second argument; the new signature
+			// takes an options object but keeps the legacy form working.
+			const calls: { ctx: unknown; msg?: string }[] = [];
+			const logger = {
+				debug: () => {},
+				info: () => {},
+				warn: (ctx: unknown, msg?: string) => {
+					calls.push({ ctx, msg });
+				},
+				error: () => {},
+				fatal: () => {},
+				child: () => logger,
+			};
+			const throwingRepo: ClientRepository = {
+				findById: async () => {
+					throw new Error("store down");
+				},
+				authenticate: async () => null,
+			};
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post("/test", createClientAuthMiddleware(throwingRepo, logger), (_req, res) => res.end());
+			const basic = Buffer.from("alice:s3cret").toString("base64");
+			const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
+			expect(res.status).toBe(401);
+			expect(calls.length).toBeGreaterThan(0);
+		});
 	});
 });

--- a/packages/oauth/src/middleware/__tests__/clientAuth.test.mts
+++ b/packages/oauth/src/middleware/__tests__/clientAuth.test.mts
@@ -152,14 +152,21 @@ describe("createClientAuthMiddleware (D-6 PB-2)", () => {
 			expect(res.body.client).toBe("alice");
 		});
 
-		it("B-6: public client supplies only client_id in body → next() with public method", async () => {
+		it("B-6: public client supplies only client_id in body → next() with public method (when allowPublicClients=true)", async () => {
+			// `/oauth/token` admits public clients (PKCE/S256 enforces authenticity
+			// at `/oauth/authorize`). Other routes leave `allowPublicClients` at
+			// the default `false` and would reject — see the dedicated P1 group.
 			const app = express().use(express.urlencoded({ extended: false }));
-			app.post("/test", createClientAuthMiddleware(fakeRepo([publicClient("spa")])), (req, res) => {
-				res.json({
-					client: req.oauthClient?.clientId,
-					method: req.oauthClient?.tokenEndpointAuthMethod,
-				});
-			});
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([publicClient("spa")]), { allowPublicClients: true }),
+				(req, res) => {
+					res.json({
+						client: req.oauthClient?.clientId,
+						method: req.oauthClient?.tokenEndpointAuthMethod,
+					});
+				},
+			);
 			const res = await request(app).post("/test").type("form").send({ client_id: "spa" });
 			expect(res.status).toBe(200);
 			expect(res.body.client).toBe("spa");
@@ -426,6 +433,45 @@ describe("createClientAuthMiddleware (D-6 PB-2)", () => {
 			expect(res.status).toBe(401);
 			expect(res.body.error).toBe("invalid_client");
 			expect(res.body.error_description).toBe("Malformed client credentials");
+		});
+	});
+
+	describe("P1 (Codex post-review): allowPublicClients gates the public-client path", () => {
+		it("default (allowPublicClients omitted) rejects public clients with 401 invalid_client", async () => {
+			// /oauth/introspect (RFC 7662 §2.1) and any non-/token route MUST
+			// reject public clients — knowledge of a client_id is not a credential.
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post("/test", createClientAuthMiddleware(fakeRepo([publicClient("spa")])), (_req, res) =>
+				res.end(),
+			);
+			const res = await request(app).post("/test").type("form").send({ client_id: "spa" });
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toMatch(/Public clients are not allowed/);
+		});
+
+		it("allowPublicClients: false also rejects (explicit form)", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([publicClient("spa")]), { allowPublicClients: false }),
+				(_req, res) => res.end(),
+			);
+			const res = await request(app).post("/test").type("form").send({ client_id: "spa" });
+			expect(res.status).toBe(401);
+			expect(res.body.error_description).toMatch(/Public clients are not allowed/);
+		});
+
+		it("allowPublicClients: true accepts public clients (used by /oauth/token only)", async () => {
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post(
+				"/test",
+				createClientAuthMiddleware(fakeRepo([publicClient("spa")]), { allowPublicClients: true }),
+				(req, res) => res.json({ client: req.oauthClient?.clientId }),
+			);
+			const res = await request(app).post("/test").type("form").send({ client_id: "spa" });
+			expect(res.status).toBe(200);
+			expect(res.body.client).toBe("spa");
 		});
 	});
 

--- a/packages/oauth/src/middleware/clientAuth.mts
+++ b/packages/oauth/src/middleware/clientAuth.mts
@@ -52,6 +52,18 @@ interface ClientAuthMiddlewareOptions {
 	 * `consoleLogger` so existing callers compile unchanged.
 	 */
 	logger?: Logger;
+	/**
+	 * Whether `tokenEndpointAuthMethod === "none"` (public) clients are
+	 * accepted on this route. Defaults to `false` because the only routes that
+	 * can soundly admit them are `/oauth/token` (where PKCE/S256 is the
+	 * authenticity gate, enforced separately at `/oauth/authorize`).
+	 *
+	 * RFC 7662 §2.1 requires that introspection callers be authenticated;
+	 * accepting a public client there would let anyone who knows a client_id
+	 * (a non-secret value) query token metadata. Routes other than `/token`
+	 * MUST leave this option at the default.
+	 */
+	allowPublicClients?: boolean;
 }
 
 /**
@@ -141,6 +153,7 @@ export function createClientAuthMiddleware(
 	const logger: Logger = opts.logger ?? consoleLogger;
 	const realm = opts.issuer && opts.issuer.length > 0 ? opts.issuer : "oauth";
 	const wwwAuth = `Basic realm="${realm}"`;
+	const allowPublicClients = opts.allowPublicClients === true;
 
 	function rejectBasic(res: Response, status: number, errorDescription?: string): void {
 		res.set("WWW-Authenticate", wwwAuth);
@@ -269,6 +282,15 @@ export function createClientAuthMiddleware(
 		}
 
 		if (client.tokenEndpointAuthMethod === "none") {
+			// Public-client routes are opt-in: only `/oauth/token` (where PKCE/S256
+			// is the authenticity gate enforced at `/authorize`) sets
+			// `allowPublicClients: true`. Other routes — `/oauth/introspect` per
+			// RFC 7662 §2.1, federation endpoints, etc. — must reject so a known
+			// public client_id (a non-secret value) cannot authorize requests.
+			if (!allowPublicClients) {
+				rejectPlain(res, 401, "Public clients are not allowed on this endpoint");
+				return;
+			}
 			req.oauthClient = client;
 			next();
 			return;

--- a/packages/oauth/src/middleware/clientAuth.mts
+++ b/packages/oauth/src/middleware/clientAuth.mts
@@ -19,8 +19,9 @@ import {
 	consoleLogger,
 	type Logger,
 	type PublicClient,
+	type TokenEndpointAuthMethod,
 } from "@o3co/auth-provider-core";
-import type { RequestHandler } from "express";
+import type { RequestHandler, Response } from "express";
 
 // Module augmentation: expose `req.oauthClient` for consumers who compose this
 // middleware onto their own routes and need the authenticated client downstream.
@@ -39,7 +40,19 @@ declare global {
 	}
 }
 
-const WWW_AUTH = 'Basic realm="oauth"';
+interface ClientAuthMiddlewareOptions {
+	/**
+	 * Issuer URL used to populate the `realm` parameter of `WWW-Authenticate:
+	 * Basic` headers per RFC 7235 §2.2. Defaults to `"oauth"` when unset so the
+	 * header still carries a syntactically valid realm.
+	 */
+	issuer?: string;
+	/**
+	 * Structured logger for repository-failure traces. Defaults to
+	 * `consoleLogger` so existing callers compile unchanged.
+	 */
+	logger?: Logger;
+}
 
 /**
  * Decodes an `application/x-www-form-urlencoded`-encoded string per RFC 6749 §2.3.1.
@@ -50,109 +63,260 @@ function formUrlDecode(s: string): string {
 	return decodeURIComponent(s.replace(/\+/g, " "));
 }
 
+interface BasicCreds {
+	clientId: string;
+	clientSecret: string;
+}
+
+type BasicParseResult =
+	| { kind: "absent" }
+	| { kind: "malformed" }
+	| { kind: "ok"; creds: BasicCreds };
+
+function parseBasicAuthHeader(authHeader: string | undefined): BasicParseResult {
+	if (typeof authHeader !== "string" || !/^basic\s+/i.test(authHeader)) {
+		return { kind: "absent" };
+	}
+	try {
+		const decoded = Buffer.from(authHeader.replace(/^basic\s+/i, ""), "base64").toString("utf8");
+		const idx = decoded.indexOf(":");
+		if (idx < 0) {
+			return { kind: "malformed" };
+		}
+		const clientId = formUrlDecode(decoded.slice(0, idx));
+		const clientSecret = formUrlDecode(decoded.slice(idx + 1));
+		return { kind: "ok", creds: { clientId, clientSecret } };
+	} catch {
+		// decodeURIComponent threw — malformed percent-encoding
+		return { kind: "malformed" };
+	}
+}
+
 /**
- * Creates RFC 6749 §2.3.1 client-authentication middleware for the /oauth/introspect
- * endpoint (and any other route requiring authenticated OAuth client access).
+ * Creates RFC 6749 §2.3.1 client-authentication middleware suitable for both
+ * `/oauth/introspect` and `/oauth/token`.
  *
- * Extracts client credentials from the request using:
- * 1. HTTP Basic authentication (preferred per RFC 6749 §2.3.1)
- * 2. Form-encoded `client_id` / `client_secret` body parameters (fallback)
+ * Authentication discriminator (RFC 6749 §2.3 / RFC 7591 §2):
  *
- * On success: sets `req.oauthClient` to the authenticated {@link PublicClient} and
- * calls `next()`. The built-in /introspect handler does not consume this field — it
- * is exposed for consumers who compose this middleware onto their own routes and need
- * the authenticated client's identity downstream.
+ * - `"client_secret_basic"` — credentials in HTTP Basic `Authorization` header.
+ * - `"client_secret_post"`  — credentials in form-encoded body parameters.
+ * - `"none"`                — public client; only `client_id` (in body) is
+ *   supplied. PKCE/S256 is mandated separately at `/authorize` (see `routes.mts`).
  *
- * On failure: responds with 401 + `WWW-Authenticate: Basic realm="oauth"` header
- * and `{ error: "invalid_client" }` body (RFC 6749 §5.2). A differentiated
- * `error_description` is included on most failure paths to aid client debugging;
- * the repository-throw path intentionally omits it to avoid leaking server-side
- * operational detail to callers.
+ * Enforcement (D-6 PB-2):
  *
- * @param clientRepository - used to look up the client by credential pair.
- * @param logger - structured logger for repository-failure traces. Defaults to
- *                 `consoleLogger` so existing callers compile unchanged.
- * @returns an express RequestHandler.
+ * 1. The configured `tokenEndpointAuthMethod` on the client record selects the
+ *    accepted transport. Wrong-transport attempts (e.g. `client_secret_post`
+ *    body sent to a `client_secret_basic` client) reject with `invalid_client`
+ *    400/401, matching RFC 6749 §5.2.
+ * 2. If both Basic and body credentials are present and the `client_id` (or
+ *    `client_secret`) values disagree, reject with `invalid_client` 401 —
+ *    prevents credential-confusion attacks where an attacker pins a victim's
+ *    Basic header and supplies their own body credentials, or vice versa.
+ * 3. `WWW-Authenticate: Basic realm="<issuer>"` is emitted only when the
+ *    failed attempt was Basic (per RFC 7235 §2.1 the header advertises a
+ *    challenge, and a `client_secret_post` client should not be told to retry
+ *    over Basic). Public-client failures emit no challenge for the same reason.
+ *
+ * On success: sets `req.oauthClient` to the authenticated {@link PublicClient}
+ * and calls `next()`.
+ *
+ * On failure: responds with 400/401, JSON body
+ * `{ error: "invalid_client", error_description?: string }`, and (when
+ * applicable) `WWW-Authenticate`. The repository-throw path intentionally omits
+ * `error_description` so that internal store details do not leak to callers.
  */
 export function createClientAuthMiddleware(
 	clientRepository: ClientRepository,
-	logger: Logger = consoleLogger,
+	loggerOrOptions: Logger | ClientAuthMiddlewareOptions = {},
 ): RequestHandler {
+	// Backward-compat: F1 D-4 callers passed the Logger directly. Accept either
+	// form to avoid forcing every call site to migrate at once. New call sites
+	// SHOULD pass the options object so they can supply `issuer` for the
+	// realm parameter.
+	const opts: ClientAuthMiddlewareOptions =
+		typeof loggerOrOptions === "object" && "warn" in loggerOrOptions
+			? { logger: loggerOrOptions as Logger }
+			: (loggerOrOptions as ClientAuthMiddlewareOptions);
+	const logger: Logger = opts.logger ?? consoleLogger;
+	const realm = opts.issuer && opts.issuer.length > 0 ? opts.issuer : "oauth";
+	const wwwAuth = `Basic realm="${realm}"`;
+
+	function rejectBasic(res: Response, status: number, errorDescription?: string): void {
+		res.set("WWW-Authenticate", wwwAuth);
+		const body: { error: string; error_description?: string } = { error: "invalid_client" };
+		if (errorDescription !== undefined) body.error_description = errorDescription;
+		res.status(status).json(body);
+	}
+
+	function rejectPlain(res: Response, status: number, errorDescription?: string): void {
+		const body: { error: string; error_description?: string } = { error: "invalid_client" };
+		if (errorDescription !== undefined) body.error_description = errorDescription;
+		res.status(status).json(body);
+	}
+
 	return async (req, res, next) => {
-		let clientId: string | undefined;
-		let clientSecret: string | undefined;
-		let malformedBasic = false;
+		const basic = parseBasicAuthHeader(req.headers.authorization);
 
-		// RFC 6749 §2.3.1: HTTP Basic is the preferred method.
-		const authHeader = req.headers.authorization;
-		if (typeof authHeader === "string" && /^basic\s+/i.test(authHeader)) {
-			try {
-				const decoded = Buffer.from(authHeader.replace(/^basic\s+/i, ""), "base64").toString(
-					"utf8",
-				);
-				const idx = decoded.indexOf(":");
-				if (idx > 0) {
-					clientId = formUrlDecode(decoded.slice(0, idx));
-					clientSecret = formUrlDecode(decoded.slice(idx + 1));
-				} else {
-					// No colon found — malformed credential pair
-					malformedBasic = true;
-				}
-			} catch {
-				// decodeURIComponent threw — malformed percent-encoding
-				malformedBasic = true;
-			}
-		}
-
-		// Form-encoded is an acceptable alternative per §2.3.1 — only use when Basic
-		// was absent or malformed (prevents credential confusion attacks).
-		if (clientId === undefined || clientSecret === undefined) {
-			if (!malformedBasic) {
-				const body = req.body as Record<string, unknown> | undefined;
-				if (body && typeof body.client_id === "string" && typeof body.client_secret === "string") {
-					clientId = body.client_id;
-					clientSecret = body.client_secret;
-				}
-			}
-		}
-
-		if (malformedBasic) {
-			res.set("WWW-Authenticate", WWW_AUTH);
-			res
-				.status(401)
-				.json({ error: "invalid_client", error_description: "Malformed client credentials" });
+		if (basic.kind === "malformed") {
+			rejectBasic(res, 401, "Malformed client credentials");
 			return;
 		}
 
-		if (!clientId || !clientSecret) {
-			res.set("WWW-Authenticate", WWW_AUTH);
-			res
-				.status(401)
-				.json({ error: "invalid_client", error_description: "Client authentication is required" });
+		// RFC 7617 §2: Basic auth with an empty secret is a malformed credential.
+		// `ClientEntrySchema` already rejects empty `clientSecret` at startup, so
+		// any production deployment that has wired `clientAuthMw` cannot emit one
+		// — but rejecting the empty case at the parser keeps the contract uniform
+		// with the v0.5.0 behaviour and avoids exposing an "empty == empty" path
+		// through `authenticate()` for misconfigured custom repositories.
+		if (basic.kind === "ok" && basic.creds.clientSecret.length === 0) {
+			rejectBasic(res, 401, "Malformed client credentials");
 			return;
 		}
 
+		const body = req.body as Record<string, unknown> | undefined;
+		const bodyClientId = typeof body?.client_id === "string" ? body.client_id : undefined;
+		const bodyClientSecret =
+			typeof body?.client_secret === "string" && body.client_secret.length > 0
+				? body.client_secret
+				: undefined;
+
+		// Codex M4: conflict detection. If both Basic and body identify a client,
+		// they MUST agree. Otherwise the request is ambiguous and an attacker
+		// could pin one identity in a header (typically less inspected by
+		// proxies) while sending another in the body.
+		if (
+			basic.kind === "ok" &&
+			bodyClientId !== undefined &&
+			basic.creds.clientId !== bodyClientId
+		) {
+			rejectBasic(res, 401, "client_id mismatch between Basic header and body");
+			return;
+		}
+		if (
+			basic.kind === "ok" &&
+			bodyClientSecret !== undefined &&
+			basic.creds.clientSecret !== bodyClientSecret
+		) {
+			rejectBasic(res, 401, "client_secret mismatch between Basic header and body");
+			return;
+		}
+
+		const clientId = basic.kind === "ok" ? basic.creds.clientId : bodyClientId;
+		if (!clientId) {
+			// Distinguish the no-credentials-at-all path from a malformed Basic.
+			// We always include WWW-Authenticate because Basic is a valid retry,
+			// matching prior v0.5.0 behavior for the /oauth/introspect users.
+			rejectBasic(res, 401, "Client authentication is required");
+			return;
+		}
+
+		// Codex M1 selector: which transport did the caller actually use? We
+		// have to derive this BEFORE looking up the client so the wrong-method
+		// branch can return without burning a credential lookup on a known-bad
+		// transport.
+		const usedMethod: TokenEndpointAuthMethod =
+			basic.kind === "ok"
+				? "client_secret_basic"
+				: bodyClientSecret !== undefined
+					? "client_secret_post"
+					: "none";
+
+		// Look up the client without authenticating yet — `findById` returns the
+		// same projection regardless of method, and we need the configured
+		// `tokenEndpointAuthMethod` to gate the credential check below. For
+		// `"client_secret_basic"` / `"client_secret_post"` clients we still call
+		// `authenticate()` afterward to verify the secret; for `"none"` clients
+		// the `findById` result is the final answer.
 		let client: PublicClient | null;
 		try {
-			client = await clientRepository.authenticate(clientId, clientSecret);
+			client = await clientRepository.findById(clientId);
 		} catch (err) {
 			// Fail-closed: repository unavailability must not grant access.
-			// Log server-side for operators; do NOT leak store details to callers.
-			logger.warn({ err }, "client credential lookup failed");
-			res.set("WWW-Authenticate", WWW_AUTH);
-			res.status(401).json({ error: "invalid_client" });
+			logger.warn({ err }, "client lookup failed");
+			if (basic.kind === "ok") {
+				rejectBasic(res, 401);
+			} else {
+				rejectPlain(res, 401);
+			}
 			return;
 		}
 
 		if (!client) {
-			res.set("WWW-Authenticate", WWW_AUTH);
-			res
-				.status(401)
-				.json({ error: "invalid_client", error_description: "Invalid client credentials" });
+			if (basic.kind === "ok") {
+				rejectBasic(res, 401, "Invalid client credentials");
+			} else {
+				rejectPlain(res, 401, "Unknown client");
+			}
 			return;
 		}
 
-		req.oauthClient = client;
+		// Codex M1: configured method must match the transport actually used.
+		// A `client_secret_basic` client cannot succeed via body auth, and vice
+		// versa — even with valid credentials. This makes the discriminator
+		// authoritative; without it the field would be partly documentary.
+		if (client.tokenEndpointAuthMethod !== usedMethod) {
+			const description =
+				usedMethod === "none"
+					? "Client authentication is required for confidential clients"
+					: `tokenEndpointAuthMethod mismatch: client is configured for "${client.tokenEndpointAuthMethod}"`;
+			if (basic.kind === "ok") {
+				rejectBasic(res, 401, description);
+			} else {
+				rejectPlain(res, 401, description);
+			}
+			return;
+		}
+
+		if (client.tokenEndpointAuthMethod === "none") {
+			req.oauthClient = client;
+			next();
+			return;
+		}
+
+		// Confidential path: verify the secret. `usedMethod` has already been
+		// validated against `client.tokenEndpointAuthMethod`, so we know which
+		// source (Basic vs body) supplied the secret.
+		const secret =
+			usedMethod === "client_secret_basic"
+				? // basic.kind === "ok" guaranteed when usedMethod === "client_secret_basic"
+					(basic as { kind: "ok"; creds: BasicCreds }).creds.clientSecret
+				: bodyClientSecret;
+		if (secret === undefined) {
+			// Defensive — should not happen because usedMethod selection requires
+			// at least one credential source. Surfacing a stable error message
+			// keeps the behaviour testable.
+			if (basic.kind === "ok") {
+				rejectBasic(res, 401, "Client authentication is required");
+			} else {
+				rejectPlain(res, 401, "Client authentication is required");
+			}
+			return;
+		}
+
+		let authenticated: PublicClient | null;
+		try {
+			authenticated = await clientRepository.authenticate(clientId, secret);
+		} catch (err) {
+			logger.warn({ err }, "client credential lookup failed");
+			if (basic.kind === "ok") {
+				rejectBasic(res, 401);
+			} else {
+				rejectPlain(res, 401);
+			}
+			return;
+		}
+
+		if (!authenticated) {
+			if (basic.kind === "ok") {
+				rejectBasic(res, 401, "Invalid client credentials");
+			} else {
+				rejectPlain(res, 401, "Invalid client credentials");
+			}
+			return;
+		}
+
+		req.oauthClient = authenticated;
 		next();
 	};
 }

--- a/packages/oauth/src/middleware/clientAuth.mts
+++ b/packages/oauth/src/middleware/clientAuth.mts
@@ -125,10 +125,14 @@ function parseBasicAuthHeader(authHeader: string | undefined): BasicParseResult 
  *    `client_secret`) values disagree, reject with `invalid_client` 401 —
  *    prevents credential-confusion attacks where an attacker pins a victim's
  *    Basic header and supplies their own body credentials, or vice versa.
- * 3. `WWW-Authenticate: Basic realm="<issuer>"` is emitted only when the
- *    failed attempt was Basic (per RFC 7235 §2.1 the header advertises a
- *    challenge, and a `client_secret_post` client should not be told to retry
- *    over Basic). Public-client failures emit no challenge for the same reason.
+ * 3. `WWW-Authenticate: Basic realm="<issuer>"` is emitted in two cases:
+ *    (a) the failed attempt was Basic (RFC 7235 §2.1 challenge advertisement),
+ *    and (b) no credentials were supplied at all (so the caller is told that
+ *    Basic is an accepted retry transport). It is NOT emitted on
+ *    `client_secret_post` failures or public-client rejections — those callers
+ *    should not be redirected to Basic. The `<issuer>` realm value is
+ *    validated against a safe character set; misconfigured issuers fall back
+ *    to the literal `oauth` realm.
  *
  * On success: sets `req.oauthClient` to the authenticated {@link PublicClient}
  * and calls `next()`.
@@ -151,7 +155,18 @@ export function createClientAuthMiddleware(
 			? { logger: loggerOrOptions as Logger }
 			: (loggerOrOptions as ClientAuthMiddlewareOptions);
 	const logger: Logger = opts.logger ?? consoleLogger;
-	const realm = opts.issuer && opts.issuer.length > 0 ? opts.issuer : "oauth";
+	// Copilot review: validate `issuer` against a safe character set before
+	// embedding it into the `WWW-Authenticate: Basic realm="..."` quoted-string.
+	// RFC 7235 §2.2 + RFC 7230 quoted-string rules require backslash-escaping of
+	// `"` and `\` and forbid CTL bytes; rather than emitting a malformed (or
+	// header-injecting) value when an operator misconfigures the issuer, we
+	// fall back to the literal "oauth" realm. URI-safe characters per RFC 3986
+	// (plus the few sub-delims commonly seen in absolute URIs) are accepted.
+	const SAFE_REALM_CHARS = /^[A-Za-z0-9._~:/?#@!$&'()*+,;=%-]+$/;
+	const realm =
+		opts.issuer && opts.issuer.length > 0 && SAFE_REALM_CHARS.test(opts.issuer)
+			? opts.issuer
+			: "oauth";
 	const wwwAuth = `Basic realm="${realm}"`;
 	const allowPublicClients = opts.allowPublicClients === true;
 

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -115,8 +115,19 @@ export const createOAuthRouter = async (
 	// challenges (RFC 7235 §2.2). When the operator has not configured a
 	// canonical issuer (or this router is constructed in a partial-config test
 	// fixture), the middleware falls back to the literal "oauth".
-	const clientAuthMw = createClientAuthMiddleware(clientRepository, {
-		issuer: (config as { oauth?: { jwt?: { issuer?: string } } }).oauth?.jwt?.issuer,
+	const issuerForRealm = (config as { oauth?: { jwt?: { issuer?: string } } }).oauth?.jwt?.issuer;
+	// `/oauth/token` MUST accept public clients (`tokenEndpointAuthMethod: "none"`)
+	// because PKCE/S256 at `/oauth/authorize` is their authenticity gate.
+	const tokenClientAuthMw = createClientAuthMiddleware(clientRepository, {
+		issuer: issuerForRealm,
+		logger,
+		allowPublicClients: true,
+	});
+	// `/oauth/introspect` MUST reject public clients per RFC 7662 §2.1 — a
+	// known client_id is a non-secret value and would otherwise let any party
+	// query token metadata. The default (`allowPublicClients: false`) applies.
+	const introspectClientAuthMw = createClientAuthMiddleware(clientRepository, {
+		issuer: issuerForRealm,
 		logger,
 	});
 
@@ -192,7 +203,7 @@ export const createOAuthRouter = async (
 				if (!(await checkRateLimit(req, res, "token"))) return;
 				next();
 			},
-			clientAuthMw,
+			tokenClientAuthMw,
 			async (req: Request, res: Response) => {
 				const { grant_type } = req.body;
 				const issuer = config.oauth.jwt.issuer ?? req.get("host");
@@ -309,7 +320,7 @@ export const createOAuthRouter = async (
 						return res.status(200).json({ active: false });
 					}
 				}
-				return clientAuthMw(req, res, next);
+				return introspectClientAuthMw(req, res, next);
 			},
 			async (req: Request, res: Response) => {
 				const { token } = req.body;

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -111,7 +111,14 @@ export const createOAuthRouter = async (
 	const router = express.Router();
 
 	// Construct once at router-creation time so the closure is not re-allocated per request.
-	const clientAuthMw = createClientAuthMiddleware(clientRepository, logger);
+	// `issuer` populates the `realm` parameter on `WWW-Authenticate: Basic`
+	// challenges (RFC 7235 §2.2). When the operator has not configured a
+	// canonical issuer (or this router is constructed in a partial-config test
+	// fixture), the middleware falls back to the literal "oauth".
+	const clientAuthMw = createClientAuthMiddleware(clientRepository, {
+		issuer: (config as { oauth?: { jwt?: { issuer?: string } } }).oauth?.jwt?.issuer,
+		logger,
+	});
 
 	async function checkRateLimit(req: Request, res: Response, tag: string): Promise<boolean> {
 		if (!rateLimiter) return true;
@@ -176,87 +183,108 @@ export const createOAuthRouter = async (
 	router
 		.use(express.json())
 		.use(express.urlencoded({ extended: false }))
-		.post("/token", async (req: Request, res: Response) => {
-			if (!(await checkRateLimit(req, res, "token"))) return;
-			const { grant_type } = req.body;
-			const issuer = config.oauth.jwt.issuer ?? req.get("host");
+		.post(
+			"/token",
+			// D-6 ordering: rate limit BEFORE client auth so repeated unauthenticated
+			// hits cannot escape rate limiting via the clientAuthMw rejection path
+			// (and so DoS amplification through repository lookups is bounded).
+			async (req: Request, res: Response, next) => {
+				if (!(await checkRateLimit(req, res, "token"))) return;
+				next();
+			},
+			clientAuthMw,
+			async (req: Request, res: Response) => {
+				const { grant_type } = req.body;
+				const issuer = config.oauth.jwt.issuer ?? req.get("host");
 
-			if (typeof grant_type !== "string" || grant_type === "") {
-				await emitAuditEvent(auditSink, {
-					timestamp: new Date(),
-					type: "token.issued.failure",
-					ip: req.ip,
-					userAgent: req.get("user-agent"),
-					details: { reason: "missing_grant_type" },
-				});
-				return res.status(400).json({
-					error: "unsupported_grant_type",
-					error_description: "grant_type must be a non-empty string",
-				});
-			}
-
-			const handler = registry.get(grant_type);
-			if (!handler) {
-				await emitAuditEvent(auditSink, {
-					timestamp: new Date(),
-					type: "token.issued.failure",
-					ip: req.ip,
-					userAgent: req.get("user-agent"),
-					details: { reason: "unsupported_grant_type", grant_type },
-				});
-				return res.status(400).json({
-					error: "unsupported_grant_type",
-					error_description: `grant_type "${grant_type}" is not supported`,
-				});
-			}
-
-			const ctx = {
-				body: req.body,
-				session: req.session,
-				issuer,
-				metadata: { ip: req.ip },
-				ip: req.ip,
-				userAgent: req.get("user-agent"),
-			};
-			const { result, sessionMutation } = await handler.handle(ctx);
-
-			if (sessionMutation?.clear) {
-				for (const key of sessionMutation.clear) {
-					(req.session as unknown as Record<string, unknown>)[key] = undefined;
+				if (typeof grant_type !== "string" || grant_type === "") {
+					await emitAuditEvent(auditSink, {
+						timestamp: new Date(),
+						type: "token.issued.failure",
+						ip: req.ip,
+						userAgent: req.get("user-agent"),
+						details: { reason: "missing_grant_type" },
+					});
+					return res.status(400).json({
+						error: "unsupported_grant_type",
+						error_description: "grant_type must be a non-empty string",
+					});
 				}
-			}
-			if (sessionMutation?.set) {
-				Object.assign(req.session, sessionMutation.set);
-			}
 
-			if ("tokens" in result) {
-				res.set("Cache-Control", "no-store");
-				res.set("Pragma", "no-cache");
-				await emitAuditEvent(auditSink, {
-					timestamp: new Date(),
-					type: "token.issued",
-					clientId: typeof req.body.client_id === "string" ? req.body.client_id : undefined,
+				const handler = registry.get(grant_type);
+				if (!handler) {
+					await emitAuditEvent(auditSink, {
+						timestamp: new Date(),
+						type: "token.issued.failure",
+						ip: req.ip,
+						userAgent: req.get("user-agent"),
+						details: { reason: "unsupported_grant_type", grant_type },
+					});
+					return res.status(400).json({
+						error: "unsupported_grant_type",
+						error_description: `grant_type "${grant_type}" is not supported`,
+					});
+				}
+
+				// D-6: `clientAuthMw` populates `req.oauthClient` after RFC 6749 §2.3
+				// authentication. Grant handlers consult `ctx.authenticatedClient`
+				// rather than the raw body so identity flows are not body-spoofable.
+				const ctx = {
+					body: req.body,
+					session: req.session,
+					issuer,
+					metadata: { ip: req.ip },
 					ip: req.ip,
 					userAgent: req.get("user-agent"),
-					details: { grant_type },
+					authenticatedClient: req.oauthClient
+						? {
+								clientId: req.oauthClient.clientId,
+								tokenEndpointAuthMethod: req.oauthClient.tokenEndpointAuthMethod,
+							}
+						: null,
+				};
+				const { result, sessionMutation } = await handler.handle(ctx);
+
+				if (sessionMutation?.clear) {
+					for (const key of sessionMutation.clear) {
+						(req.session as unknown as Record<string, unknown>)[key] = undefined;
+					}
+				}
+				if (sessionMutation?.set) {
+					Object.assign(req.session, sessionMutation.set);
+				}
+
+				if ("tokens" in result) {
+					res.set("Cache-Control", "no-store");
+					res.set("Pragma", "no-cache");
+					await emitAuditEvent(auditSink, {
+						timestamp: new Date(),
+						type: "token.issued",
+						// D-6: prefer the authenticated client over the raw body — body
+						// `client_id` is no longer authoritative once `clientAuthMw` runs.
+						clientId: req.oauthClient?.clientId,
+						ip: req.ip,
+						userAgent: req.get("user-agent"),
+						details: { grant_type },
+					});
+					return res.status(result.status).json(result.tokens);
+				}
+				const errorBody: Record<string, unknown> = { error: result.error };
+				if (result.errorDescription) errorBody.error_description = result.errorDescription;
+				if (result.status === 401) {
+					res.set("WWW-Authenticate", "Bearer");
+				}
+				await emitAuditEvent(auditSink, {
+					timestamp: new Date(),
+					type: "token.issued.failure",
+					clientId: req.oauthClient?.clientId,
+					ip: req.ip,
+					userAgent: req.get("user-agent"),
+					details: { grant_type, error: result.error },
 				});
-				return res.status(result.status).json(result.tokens);
-			}
-			const errorBody: Record<string, unknown> = { error: result.error };
-			if (result.errorDescription) errorBody.error_description = result.errorDescription;
-			if (result.status === 401) {
-				res.set("WWW-Authenticate", "Bearer");
-			}
-			await emitAuditEvent(auditSink, {
-				timestamp: new Date(),
-				type: "token.issued.failure",
-				clientId: typeof req.body.client_id === "string" ? req.body.client_id : undefined,
-				ip: req.ip,
-				userAgent: req.get("user-agent"),
-				details: { grant_type, error: result.error },
-			});
-			return res.status(result.status).json(errorBody);
-		})
+				return res.status(result.status).json(errorBody);
+			},
+		)
 		// RFC 7662: Token Introspection
 		.post(
 			"/introspect",
@@ -458,6 +486,37 @@ export const createOAuthRouter = async (
 				const supportedMethods: string[] = Array.isArray(pkceConfig?.supportedMethods)
 					? (pkceConfig.supportedMethods as string[])
 					: ["S256", "plain"];
+
+				// D-6 (RFC 9700 §2.1.1): PKCE/S256 is mandatory for public clients
+				// regardless of operator `pkce.required` config. Public clients have
+				// no transport-level credential at /token, so the only authenticity
+				// gate on the code redemption is the verifier — accepting `plain`
+				// or omitting PKCE entirely would let anyone with the issued code
+				// exchange it for tokens.
+				if (client.tokenEndpointAuthMethod === "none") {
+					if (typeof code_challenge !== "string" || !code_challenge) {
+						return redirectError(
+							redirect_uri,
+							"invalid_request",
+							"code_challenge is required for public clients",
+							toStr(state),
+						);
+					}
+					const requestedMethod = toStr(code_challenge_method);
+					// Public clients must explicitly select S256 — no defaulting to
+					// `plain` per the operator-configured `defaultMethod`. The check
+					// uses the raw query parameter so absence (= would silently pick
+					// up `defaultMethod`) is rejected as `plain` would be.
+					const effectivePublicMethod = requestedMethod ?? "plain";
+					if (effectivePublicMethod !== "S256") {
+						return redirectError(
+							redirect_uri,
+							"invalid_request",
+							'code_challenge_method must be "S256" for public clients',
+							toStr(state),
+						);
+					}
+				}
 
 				// B-8: PKCE required check at authorize endpoint
 				if (pkceRequired && (typeof code_challenge !== "string" || !code_challenge)) {

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -282,9 +282,14 @@ export const createOAuthRouter = async (
 				}
 				const errorBody: Record<string, unknown> = { error: result.error };
 				if (result.errorDescription) errorBody.error_description = result.errorDescription;
-				if (result.status === 401) {
-					res.set("WWW-Authenticate", "Bearer");
-				}
+				// Copilot review: do NOT inject `WWW-Authenticate: Bearer` here.
+				// The token endpoint is not a protected resource (RFC 6750 §3 applies to
+				// resource servers, not authorization endpoints), and `clientAuthMw`
+				// already set the appropriate `WWW-Authenticate: Basic realm="..."`
+				// challenge for client-auth failures upstream. Setting Bearer here
+				// clobbered that more-correct value for any grant returning 401
+				// (e.g., the new `ctx.authenticatedClient === null` branch). RFC 6749
+				// §5.2 token-endpoint error responses do not mandate WWW-Authenticate.
 				await emitAuditEvent(auditSink, {
 					timestamp: new Date(),
 					type: "token.issued.failure",

--- a/templates/standalone/config/clients.yaml.example
+++ b/templates/standalone/config/clients.yaml.example
@@ -1,14 +1,30 @@
 # Example client definitions loaded via loadYamlMap into InMemoryClientRepository.
 # Copy this file to clients.yaml and customize for your deployment.
 #
-# Secret format:
+# `tokenEndpointAuthMethod` is REQUIRED (RFC 6749 §2.3 / RFC 7591 §2):
+#   - "client_secret_basic": HTTP Basic Authorization header — recommended for confidential clients
+#   - "client_secret_post":  form-encoded body parameters
+#   - "none":                public client — no clientSecret; PKCE/S256 mandatory at /authorize
+#
+# Secret format (only for confidential clients — basic / post):
 #   - Plain text: "my-secret"
 #   - Bcrypt hash: "$2b$10$..." (generate with: node -e "require('bcrypt').hash('secret',10).then(console.log)")
 
 my-app:
+  tokenEndpointAuthMethod: "client_secret_basic"
   clientSecret: "$2b$10$REPLACE_WITH_BCRYPT_HASH"
   allowedRedirectUris:
     - "http://localhost:3000/callback"
   allowedScopes:
     - "read"
     - "write"
+
+# Public client example (e.g., a single-page app or mobile app):
+# my-spa:
+#   tokenEndpointAuthMethod: "none"
+#   # clientSecret MUST be absent for "none" clients.
+#   allowedRedirectUris:
+#     - "https://app.example/callback"
+#   allowedScopes:
+#     - "openid"
+#     - "profile"

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -89,11 +89,33 @@ const config: AppConfig = {
  * via the `oauth.code.adapter` switch in `buildModules`. The smoke test
  * config sets `oauth.code.adapter = "memory"`, so `inMemoryCodeRepositoryModule`
  * is added automatically and provides the slot.
+ *
+ * D-6 (v0.5.1): a single confidential client is registered so the
+ * `clientAuthMw` middleware in front of `/oauth/token` has a record to
+ * authenticate against. Smoke tests that hit `/oauth/token` send
+ * `Authorization: ${SMOKE_BASIC_AUTH}`.
  */
+const SMOKE_CLIENT_ID = "smoke-client";
+const SMOKE_CLIENT_SECRET = "smoke-secret";
+const SMOKE_BASIC_AUTH = `Basic ${Buffer.from(`${SMOKE_CLIENT_ID}:${SMOKE_CLIENT_SECRET}`).toString("base64")}`;
+
 const testRepositoriesModule = defineModule({
 	name: "test:repositories",
 	provides: {
-		clientRepository: () => new InMemoryClientRepository(new Map()),
+		clientRepository: () =>
+			new InMemoryClientRepository(
+				new Map([
+					[
+						SMOKE_CLIENT_ID,
+						{
+							tokenEndpointAuthMethod: "client_secret_basic" as const,
+							clientSecret: SMOKE_CLIENT_SECRET,
+							allowedRedirectUris: [],
+							allowedScopes: [],
+						},
+					],
+				]),
+			),
 		userRepository: () => new InMemoryUserRepository(new Map()),
 	},
 });
@@ -156,6 +178,7 @@ describe("standalone smoke test", () => {
 		handleRef = handle;
 		const res = await request(app)
 			.post("/oauth/token")
+			.set("Authorization", SMOKE_BASIC_AUTH)
 			.type("form")
 			.send({ grant_type: "unsupported" });
 		expect(res.status).toBe(400);
@@ -166,6 +189,7 @@ describe("standalone smoke test", () => {
 		handleRef = handle;
 		const res = await request(app)
 			.post("/oauth/token")
+			.set("Authorization", SMOKE_BASIC_AUTH)
 			.type("form")
 			.send({ grant_type: "unsupported" });
 		expect(res.status).toBe(400);

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -102,12 +102,12 @@ const SMOKE_BASIC_AUTH = `Basic ${Buffer.from(`${SMOKE_CLIENT_ID}:${SMOKE_CLIENT
 const testRepositoriesModule = defineModule({
 	name: "test:repositories",
 	provides: {
-		// `InMemoryClientRepository` constructor takes `Map<string, ClientEntry>`
-		// where `ClientEntry = z.infer<typeof ClientEntrySchema>` (output type) —
-		// fields with `.default(...)` are required in the output even though the
-		// input shape only requires the discriminator + secret. Tests supply the
-		// input shape and let the schema fill defaults at parse time, hence the
-		// cast at the construction boundary.
+		// `InMemoryClientRepository` constructor parameter `Map<string, ClientEntry>`
+		// uses `ClientEntry = z.infer<typeof ClientEntrySchema>` (the schema's
+		// OUTPUT type) — fields with `.default(...)` are non-optional in the
+		// output even though they are optional on input. The fixture supplies
+		// every field explicitly so the literal satisfies the output shape
+		// without requiring a cast.
 		clientRepository: () =>
 			new InMemoryClientRepository(
 				new Map([

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -102,16 +102,26 @@ const SMOKE_BASIC_AUTH = `Basic ${Buffer.from(`${SMOKE_CLIENT_ID}:${SMOKE_CLIENT
 const testRepositoriesModule = defineModule({
 	name: "test:repositories",
 	provides: {
+		// `InMemoryClientRepository` constructor takes `Map<string, ClientEntry>`
+		// where `ClientEntry = z.infer<typeof ClientEntrySchema>` (output type) —
+		// fields with `.default(...)` are required in the output even though the
+		// input shape only requires the discriminator + secret. Tests supply the
+		// input shape and let the schema fill defaults at parse time, hence the
+		// cast at the construction boundary.
 		clientRepository: () =>
 			new InMemoryClientRepository(
 				new Map([
 					[
 						SMOKE_CLIENT_ID,
 						{
-							tokenEndpointAuthMethod: "client_secret_basic" as const,
+							tokenEndpointAuthMethod: "client_secret_basic",
 							clientSecret: SMOKE_CLIENT_SECRET,
 							allowedRedirectUris: [],
 							allowedScopes: [],
+							allowedAudiences: [],
+							backchannelLogoutSessionRequired: true,
+							frontchannelLogoutSessionRequired: true,
+							allowedAzpForFederationToken: false,
 						},
 					],
 				]),


### PR DESCRIPTION
## Summary

F6 PR1 of v0.5.1 hotfix series — **BREAKING**. Closes RFC 6749 §2.3 client-authentication holes (PB-2) + closes Area-2-NEW-1 (discovery `"none"` was a future lie) + partial SF-7 (PKCE/S256 mandatory for public clients per RFC 9700).

Spec: `auth/.claude/superpowers/specs/2026-05-05-d6-pb2-client-schema-redesign.md`

### Core changes

- **`Client.tokenEndpointAuthMethod`** required discriminator (`"client_secret_basic" | "client_secret_post" | "none"`); `clientSecret` optional, `.superRefine` enforces "secret iff confidential, forbidden iff `none`"; all `Client` fields `readonly`.
- **`AuthenticatedClient` + `GrantContext.authenticatedClient`** — populated by `clientAuthMw`, consumed by grants (no more body-spoofable `body.client_id`).
- **`clientAuthMw` full refactor** — public-client path (Codex M0 `allowPublicClients` opt-in, `/token` only), per-method enforcement (Codex M1), Basic+body conflict detection (Codex M4), issuer-driven WWW-Authenticate realm.
- **`/oauth/token`** wires `clientAuthMw` ahead of grant dispatch; rate limit moved before client auth to bound DoS amplification through repository lookups.
- **`/oauth/authorize`** PKCE/S256 mandatory for `tokenEndpointAuthMethod === "none"` (RFC 9700 §2.1.1) — operator `pkce.required` config no longer consulted for public clients.
- **`refreshToken.mts`** ctx.authenticatedClient gate + replace ALL downstream raw-body sinks (Codex M3 — finalAudience, grantPolicy clientId, new AT+RT aud+azp, authorizedParty); binding gate `(claims.azp ?? aud) === authenticatedClient.clientId`; new tokens emit `azp` explicitly.
- **`authorization.mts`** removed in-grant client_secret block (RFC 6749 §2.3 belongs at the route); replaced ≥7 raw-body `client_id` identity sinks (Codex M2 — token aud/azp, ID-token aud/azp, grant-policy, RP registration, logout-metadata findById); canonical binding `codeData.client_id === authenticatedClient.clientId`.
- **Token Exchange grant** trusts `ctx.authenticatedClient` when present (Basic-auth callers don't repeat credentials in body); standalone wiring path retains body-credential gate. Public clients refused regardless of route.

### Codex review rounds

3 rounds of `codex review` between commits — final round Approved.

| # | Finding | Fix |
|---|---|---|
| R1 P1 | clientAuthMw shared with `/introspect` admitted public clients via `client_id` only (RFC 7662 §2.1 violation) | `allowPublicClients` opt-in option, `/token` sets true, `/introspect` default false |
| R1 P2 | Basic-auth Token Exchange broke (in-grant body-secret check) | Grant trusts `ctx.authenticatedClient` when present |
| R2 P1 | Round-1 Token Exchange fix still required body.client_id (earlier required-field guard rejects null) | Resolve `clientId = body.client_id ?? ctx.authenticatedClient?.clientId` |
| R3 P2 | Round-2 fix accepted malformed body.client_id (string[]) via silent null fallback | Reject with 400 invalid_request when present-but-not-a-string |

### Fixture migration

- 50+ `GrantContext` literals updated across `oauth/`, `oauth-token-exchange/` test files (added `authenticatedClient` field).
- `InMemoryClientRepository` test fixtures + create-app + standalone `clients.yaml.example` updated with `tokenEndpointAuthMethod`.
- Smoke test registers a confidential test client and sends Basic auth on `/oauth/token` calls.

### Test count

`a1d5dfee` baseline 2054 → HEAD 0cdc4ae4 ~2089 (+35 RED tests):

- Group A schema discriminator (7) — A-1..A-6
- Group B clientAuthMw paths (15+) — B-1..B-9, B-method-1..3, B-conflict, repository fail-closed, edge cases, issuer realm, allowPublicClients gate (3)
- D-6 binding-gate tests in `refreshToken.test.mts` + `authorization.test.mts`
- R-legacy-azp legacy aud-only RT path
- Token Exchange D-6 ctx.authenticatedClient flow (4) — Basic-auth happy path, body.client_id omitted, malformed array, public-client rejection

All 2089 tests green; biome clean (4 pre-existing warnings unchanged); typecheck clean across all packages.

### Migration

`config/clients.yaml` requires `tokenEndpointAuthMethod` per client. See CHANGELOG.md.

## Test plan

- [x] `pnpm -r run build` — all packages compile
- [x] `pnpm -r run test` — 2089 tests pass
- [x] `pnpm exec biome check packages/...` — no new warnings
- [x] Codex `review --commit HEAD` Approved
- [ ] Copilot review on PR (pending)
- [ ] Squash-merge to develop after Copilot ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)