### PR TITLE
test(oauth): F6 PR1 D-6 PB-2 patch coverage boost (89.26% → 99.04%)

### DIFF
--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -821,5 +821,13 @@ describe("D-6 (RFC 9700 §2.1.1): /authorize public-client PKCE/S256 mandatory",
 		expect(location.searchParams.get("error")).toBeNull();
 		expect(captured?.client_id).toBe("public-app");
 		expect(captured?.redirect_uri).toBe("https://spa.example.test/cb");
+		// The /authorize gate is only the first half of the public-client
+		// protection. The verifier check at /token requires the challenge to
+		// have been persisted on the Code record — if a future refactor drops
+		// either field from `createCode`, the public-client gate would still
+		// pass requests through but `/token` would have no verifier to check
+		// against. Asserting persistence here closes that regression window.
+		expect(captured?.code_challenge).toBe(VALID_S256_CHALLENGE);
+		expect(captured?.code_challenge_method).toBe("S256");
 	});
 });

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -682,6 +682,13 @@ describe("D-1 / CR-2: /authorize binds identity to code record, not Express sess
 // allow anyone with the code to redeem it. The route must enforce these even
 // when operator config sets `pkce.required = false`.
 describe("D-6 (RFC 9700 §2.1.1): /authorize public-client PKCE/S256 mandatory", () => {
+	// Canonical RFC 7636 example pair — a 43-char base64url-encoded SHA-256
+	// digest of `dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk`. Using a
+	// spec-valid challenge here means a future PKCE syntax check (e.g.,
+	// "must be 43-128 chars from [A-Z][a-z][0-9]-._~") would not break
+	// these tests — only the gate logic they target.
+	const VALID_S256_CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
 	const publicClientRepo: ClientRepository = {
 		findById: async () => ({
 			clientId: "public-app",
@@ -757,7 +764,7 @@ describe("D-6 (RFC 9700 §2.1.1): /authorize public-client PKCE/S256 mandatory",
 			client_id: "public-app",
 			redirect_uri: "https://spa.example.test/cb",
 			state: "state-plain",
-			code_challenge: "abc123",
+			code_challenge: VALID_S256_CHALLENGE,
 			code_challenge_method: "plain",
 		});
 		expect(res.status).toBe(302);
@@ -779,7 +786,7 @@ describe("D-6 (RFC 9700 §2.1.1): /authorize public-client PKCE/S256 mandatory",
 			client_id: "public-app",
 			redirect_uri: "https://spa.example.test/cb",
 			state: "state-omit",
-			code_challenge: "abc123",
+			code_challenge: VALID_S256_CHALLENGE,
 			// no code_challenge_method → routes.mts treats absence as "plain"
 		});
 		expect(res.status).toBe(302);
@@ -803,7 +810,7 @@ describe("D-6 (RFC 9700 §2.1.1): /authorize public-client PKCE/S256 mandatory",
 			redirect_uri: "https://spa.example.test/cb",
 			state: "state-ok",
 			scope: "openid profile",
-			code_challenge: "abc123",
+			code_challenge: VALID_S256_CHALLENGE,
 			code_challenge_method: "S256",
 		});
 		expect(res.status).toBe(302);

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -675,3 +675,144 @@ describe("D-1 / CR-2: /authorize binds identity to code record, not Express sess
 		}
 	});
 });
+
+// D-6 (RFC 9700 §2.1.1): for public clients (`tokenEndpointAuthMethod === "none"`)
+// PKCE/S256 is the ONLY authenticity gate on the code redemption — Basic/Post
+// client auth is not available, so accepting `plain` or no code_challenge would
+// allow anyone with the code to redeem it. The route must enforce these even
+// when operator config sets `pkce.required = false`.
+describe("D-6 (RFC 9700 §2.1.1): /authorize public-client PKCE/S256 mandatory", () => {
+	const publicClientRepo: ClientRepository = {
+		findById: async () => ({
+			clientId: "public-app",
+			tokenEndpointAuthMethod: "none",
+			allowedRedirectUris: ["https://spa.example.test/cb"],
+			allowedScopes: ["openid", "profile"],
+		}),
+		authenticate: async () => null,
+	};
+
+	async function buildPublicAuthorizeApp(opts: {
+		captureCode?: (params: Parameters<CodeRepository["createCode"]>[0]) => void;
+	}) {
+		const app = express();
+		app.use(express.json());
+		app.use(express.urlencoded({ extended: false }));
+		app.use((req, _res, next) => {
+			(req as unknown as { session: Record<string, unknown> }).session = {
+				isAuthenticated: true,
+				user: { id: "user-1" },
+			};
+			next();
+		});
+
+		const codeRepo: CodeRepository = {
+			createCode: async (params) => {
+				opts.captureCode?.(params);
+				return {
+					code: "auth-code-public",
+					client_id: params.client_id,
+					redirect_uri: params.redirect_uri,
+				};
+			},
+			getByCode: async () => null,
+			consumeByCode: async () => null,
+			removeByCode: async () => {},
+		};
+
+		const { router } = await createOAuthRouter(express, {
+			registry: new GrantRegistry(),
+			config: authorizeConfig,
+			clientRepository: publicClientRepo,
+			codeRepository: codeRepo,
+			keyStore: createSymmetricKeyStore("test-secret-at-least-32-chars!!"),
+		});
+		app.use("/oauth", router);
+		return app;
+	}
+
+	it("rejects public client when code_challenge is missing → invalid_request redirect", async () => {
+		const app = await buildPublicAuthorizeApp({});
+		const res = await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "public-app",
+			redirect_uri: "https://spa.example.test/cb",
+			state: "state-abc",
+			// no code_challenge
+		});
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers.location);
+		expect(location.origin + location.pathname).toBe("https://spa.example.test/cb");
+		expect(location.searchParams.get("error")).toBe("invalid_request");
+		expect(location.searchParams.get("error_description")).toBe(
+			"code_challenge is required for public clients",
+		);
+		expect(location.searchParams.get("state")).toBe("state-abc");
+	});
+
+	it('rejects public client when code_challenge_method is "plain" → invalid_request redirect', async () => {
+		const app = await buildPublicAuthorizeApp({});
+		const res = await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "public-app",
+			redirect_uri: "https://spa.example.test/cb",
+			state: "state-plain",
+			code_challenge: "abc123",
+			code_challenge_method: "plain",
+		});
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers.location);
+		expect(location.searchParams.get("error")).toBe("invalid_request");
+		expect(location.searchParams.get("error_description")).toBe(
+			'code_challenge_method must be "S256" for public clients',
+		);
+		expect(location.searchParams.get("state")).toBe("state-plain");
+	});
+
+	it("rejects public client when code_challenge_method is omitted (defaults to plain) → invalid_request redirect", async () => {
+		// Omitting code_challenge_method MUST NOT silently fall back to the
+		// operator-configured `defaultMethod` for public clients. The check uses
+		// the raw query parameter so absence is rejected the same as `plain`.
+		const app = await buildPublicAuthorizeApp({});
+		const res = await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "public-app",
+			redirect_uri: "https://spa.example.test/cb",
+			state: "state-omit",
+			code_challenge: "abc123",
+			// no code_challenge_method → routes.mts treats absence as "plain"
+		});
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers.location);
+		expect(location.searchParams.get("error")).toBe("invalid_request");
+		expect(location.searchParams.get("error_description")).toBe(
+			'code_challenge_method must be "S256" for public clients',
+		);
+	});
+
+	it("accepts public client with S256 + code_challenge → 302 redirect with code (happy path)", async () => {
+		let captured: Parameters<CodeRepository["createCode"]>[0] | undefined;
+		const app = await buildPublicAuthorizeApp({
+			captureCode: (p) => {
+				captured = p;
+			},
+		});
+		const res = await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "public-app",
+			redirect_uri: "https://spa.example.test/cb",
+			state: "state-ok",
+			scope: "openid profile",
+			code_challenge: "abc123",
+			code_challenge_method: "S256",
+		});
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers.location);
+		expect(location.origin + location.pathname).toBe("https://spa.example.test/cb");
+		expect(location.searchParams.get("code")).toBe("auth-code-public");
+		expect(location.searchParams.get("state")).toBe("state-ok");
+		expect(location.searchParams.get("error")).toBeNull();
+		expect(captured?.client_id).toBe("public-app");
+		expect(captured?.redirect_uri).toBe("https://spa.example.test/cb");
+	});
+});

--- a/packages/oauth/src/__tests__/routes.test.mts
+++ b/packages/oauth/src/__tests__/routes.test.mts
@@ -269,5 +269,96 @@ describe("createOAuthRouter", () => {
 			await new Promise((r) => setImmediate(r));
 			expect(events.find((e) => e.type === "token.issued.failure")).toBeDefined();
 		});
+
+		it("sessionMutation.clear and .set: route propagates both to req.session", async () => {
+			// Grants returning `sessionMutation` (e.g., session-bound flows that
+			// need to clear ephemeral state and write a new sid) rely on the
+			// /token route applying both `clear` and `set` on the request session
+			// before responding. Without this propagation, downstream routes would
+			// observe stale session state.
+			let observedSession: Record<string, unknown> | undefined;
+			const sessionGrant: GrantHandler = {
+				handle: async () => ({
+					result: {
+						status: 200,
+						tokens: { access_token: "at.x", token_type: "Bearer", expires_in: 60 },
+					},
+					sessionMutation: {
+						clear: ["clearMe"],
+						set: { setMe: "newValue" },
+					},
+				}),
+			};
+
+			const app = express();
+			app.set("trust proxy", 1);
+			app.use(express.json());
+			app.use(express.urlencoded({ extended: false }));
+			app.use((req, _res, next) => {
+				const session: Record<string, unknown> = {
+					clearMe: "old",
+					existingKey: "stays",
+				};
+				(req as unknown as { session: Record<string, unknown> }).session = session;
+				observedSession = session;
+				next();
+			});
+
+			const registry = new GrantRegistry();
+			registry.register("session-mutating", sessionGrant);
+			const { router } = await createOAuthRouter(express, {
+				registry,
+				config: fullConfig,
+				clientRepository: integrationClientRepo,
+				codeRepository: integrationCodeRepo,
+				keyStore: createSymmetricKeyStore("test-secret-at-least-32-chars!!"),
+			});
+			app.use("/oauth", router);
+
+			const res = await request(app)
+				.post("/oauth/token")
+				.set("Authorization", TEST_BASIC_AUTH)
+				.type("form")
+				.send({ grant_type: "session-mutating" });
+
+			expect(res.status).toBe(200);
+			// `clear` sets the property to undefined (route does not delete).
+			expect(observedSession?.clearMe).toBeUndefined();
+			expect(observedSession?.setMe).toBe("newValue");
+			expect(observedSession?.existingKey).toBe("stays");
+		});
+	});
+
+	describe("D-6 /oauth/introspect non-Bearer fallback", () => {
+		// When /introspect is called WITHOUT a `Bearer` Authorization header, the
+		// route hands off to `introspectClientAuthMw` (RFC 7662 §2.1) — the same
+		// confidential-client auth used for /token. This exercises the fallback
+		// branch + the post-auth body-token-missing branch (200 { active: false }).
+		async function buildIntrospectApp() {
+			const app = express();
+			app.set("trust proxy", 1);
+			app.use(express.json());
+			app.use(express.urlencoded({ extended: false }));
+			const { router } = await createOAuthRouter(express, {
+				registry: new GrantRegistry(),
+				config: fullConfig,
+				clientRepository: integrationClientRepo,
+				codeRepository: integrationCodeRepo,
+				keyStore: createSymmetricKeyStore("test-secret-at-least-32-chars!!"),
+			});
+			app.use("/oauth", router);
+			return app;
+		}
+
+		it("Basic auth + missing token returns 200 { active: false } via client-auth fallback", async () => {
+			const app = await buildIntrospectApp();
+			const res = await request(app)
+				.post("/oauth/introspect")
+				.set("Authorization", TEST_BASIC_AUTH)
+				.type("form")
+				.send({}); // no token field
+			expect(res.status).toBe(200);
+			expect(res.body).toEqual({ active: false });
+		});
 	});
 });

--- a/packages/oauth/src/middleware/__tests__/clientAuth.test.mts
+++ b/packages/oauth/src/middleware/__tests__/clientAuth.test.mts
@@ -380,6 +380,45 @@ describe("createClientAuthMiddleware (D-6 PB-2)", () => {
 			expect(res.body.error_description).toBe("Invalid client credentials");
 			expect(res.headers["www-authenticate"]).toBeUndefined();
 		});
+
+		it("body-path: returns 401 fail-closed when findById throws — no WWW-Authenticate (body attempt)", async () => {
+			// Body-only client_id + findById throws → rejectPlain. The Basic-path
+			// version (line 266) is covered above; this exercises the matching
+			// rejectPlain branch when no Authorization header was supplied.
+			const throwingRepo: ClientRepository = {
+				findById: async () => {
+					throw new Error("store unavailable");
+				},
+				authenticate: async () => null,
+			};
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post("/test", createClientAuthMiddleware(throwingRepo), (_req, res) => res.end());
+			const res = await request(app)
+				.post("/test")
+				.type("form")
+				.send({ client_id: "alice", client_secret: "s3cret" });
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toBeUndefined();
+			expect(res.headers["www-authenticate"]).toBeUndefined();
+			expect(JSON.stringify(res.body)).not.toContain("store unavailable");
+		});
+
+		it("Basic header + unknown client → 401 Invalid client credentials with WWW-Authenticate", async () => {
+			// Basic auth used with a client_id that the repository does not know.
+			// Per RFC 6749 §5.2, Basic-attempt failures must include the Basic
+			// challenge; the description ("Invalid client credentials") is
+			// indistinguishable from "wrong secret" so an attacker cannot enumerate
+			// valid client_ids by message.
+			const app = express().use(express.urlencoded({ extended: false }));
+			app.post("/test", createClientAuthMiddleware(fakeRepo([])), (_req, res) => res.end());
+			const basic = Buffer.from("ghost:s3cret").toString("base64");
+			const res = await request(app).post("/test").set("Authorization", `Basic ${basic}`);
+			expect(res.status).toBe(401);
+			expect(res.body.error).toBe("invalid_client");
+			expect(res.body.error_description).toBe("Invalid client credentials");
+			expect(res.headers["www-authenticate"]).toMatch(/^Basic realm=/);
+		});
 	});
 
 	describe("Basic header parsing edge cases", () => {


### PR DESCRIPTION
## Summary

PR #124 (D-6 PB-2) merged with `codecov/patch` failing at 89.26% — 19 lines short of the 90% threshold. The check is informational on develop, but the F6 PR1 surface includes the security-critical public-client PKCE/S256 mandatory gate (RFC 9700 §2.1.1) which had **zero integration test coverage**. This PR closes that gap before F6 PR2 lands more code on top.

**Test-only PR. No production code changed. No CHANGELOG entry.**

## Coverage delta (F6 PR1 surface)

| File | Before | After |
|------|--------|-------|
| `routes.mts`                  | ~83% | **100%** |
| `middleware/clientAuth.mts`   | ~93% | 98%* |
| `grants/authorization.mts`    | 100% | 100% |
| `grants/refreshToken.mts`     | 100% | 100% |
| **PR-surface total**          | **89.26%** | **99.04%** |

\* Remaining 5 lines (`clientAuth.mts:326-331`) are dismissed — see below.

## Tests added (8)

### `oauthAuthorization.test.mts` — public-client PKCE/S256 gate (4 tests)

The largest gap. Covers `routes.mts:506-535` end-to-end:

- missing `code_challenge` → `invalid_request` redirect
- `code_challenge_method="plain"` → `invalid_request` redirect
- `code_challenge_method` omitted (would default to plain) → `invalid_request` redirect
- S256 + valid `code_challenge` → 302 with code (happy path; verifies `createCode` receives correct binding)

**Why important**: this is the ONLY authenticity check on public-client code redemption — no Basic/Post auth available at `/token`. Missing coverage was a meaningful regression risk for the F6 PR1 security guarantee.

### `routes.test.mts` — token route loose ends (2 tests)

- `sessionMutation.clear` and `.set` propagation (`routes.mts:259-265`): pre-populates session, has stub grant return both `clear` and `set`, asserts observed session reflects the mutations.
- `/oauth/introspect` non-Bearer fallback (`routes.mts:328`): Basic auth + missing token → 200 `{ active: false }` via `introspectClientAuthMw`.

### `clientAuth.test.mts` — fail-closed counterparts (2 tests)

- Body-path `findById` throws → `rejectPlain` (no `WWW-Authenticate`, no `error_description` leak). Counterpart of the existing Basic-path fail-closed test.
- Basic header + unknown client → `rejectBasic` with `WWW-Authenticate` + `"Invalid client credentials"`. Counterpart of the existing body-path `"Unknown client"` test. RFC 6749 §5.2 requires the Basic challenge on Basic-attempt failures, and the description must not enumerate.

## Dismissed lines

`clientAuth.mts:322-331` — `secret === undefined` defensive branch.

```
Dismiss reason: [x] Contract-based
  `usedMethod` selection at clientAuth.mts:248-251 maps to one of three
  values from credential presence:
    - "client_secret_basic"  ⇐ basic.kind === "ok"
    - "client_secret_post"   ⇐ bodyClientSecret !== undefined
    - "none"                 ⇐ neither (returns at line 305-308)
  When line 322 is reached, usedMethod ≠ "none" (otherwise the public-client
  branch would have returned), so at least one of basic.creds.clientSecret
  or bodyClientSecret was non-undefined when usedMethod was selected.
  Therefore `secret === undefined` at line 322 is structurally unreachable.

覆す条件: usedMethod selection logic changes to allow "client_secret_basic"
  or "client_secret_post" without requiring the corresponding credential
  source — e.g., a future refactor that decouples method selection from
  credential presence.
```

The existing source comment at `clientAuth.mts:323-325` already documents this; no code change needed.

## Test count

oauth: 319 → 327 (+8). All packages green; full suite passes.

## Test plan

- [x] `pnpm exec vitest run` (oauth): 327/327 pass
- [x] `pnpm -r run test`: all green (one flaky redis run, passed on retry — same supertest socket race as the F6 PR1 review cycle)
- [x] `pnpm run lint`: 0 errors, 18 pre-existing warnings (none in new code)
- [x] `pnpm exec tsc --noEmit` (oauth): clean
- [x] `pnpm exec vitest run --coverage`: F6 PR1 surface patch coverage = 99.04% (515/520 statements)
- [ ] Codex + Copilot review via `/multi-agent-review`