### PR TITLE
F6 PR2 — IH-13 RT family fixed expiry + SF-3/MIN-4 PKCE timing-safe + IH-16 nonce bound + TS-4 supportedMethods (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,63 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security (Phase F — F6 PR2 PKCE + RT family hardening, v0.5.1)
+
+- **PKCE `code_verifier` comparison is now timing-safe** (`@o3co/auth-provider-oauth`,
+  closes SF-3 + MIN-4): both the S256 and `plain` branches in the
+  authorization-code grant now use `constantTimeStringEqual` (re-exported
+  from `@o3co/auth-provider-core`), replacing JavaScript `!==` whose
+  short-circuit on the first mismatched byte leaked progress information
+  about how many bytes of a candidate verifier matched the stored challenge
+  (RFC 7636 §4.1, OAuth 2.1 BCP §4.5). The helper encodes inputs to UTF-8
+  buffers before the byte-length comparison so it is safe for any string
+  including multi-byte Unicode.
+
+- **`/authorize` bounds the OIDC `nonce` query parameter** (`@o3co/auth-provider-oauth`,
+  closes IH-16): nonce values exceeding 256 characters or containing
+  non-printable bytes are rejected via `redirectError invalid_request`.
+  Pre-fix, an unbounded nonce was stored on the code record and echoed
+  verbatim into the `id_token` payload — a malicious RP could exhaust
+  per-request memory or amplify the JWT payload by several orders of
+  magnitude. The ceiling is configurable via `oauth.nonce.maxLength`
+  (env `OAUTH_NONCE_MAX_LENGTH`, default 256). Standard OIDC libraries
+  generate 22–44 char nonces, so legitimate clients are unaffected.
+
+- **Refresh-token family TTL is fixed at creation, no longer slides**
+  (`@o3co/auth-provider-core`, closes IH-13): the rotation wrapper now
+  applies `Math.min(requestedExpiresAtMs, current.expiresAtMs)` inside the
+  CAS updater so subsequent rotations cannot extend the family's absolute
+  ceiling. Before this fix, every rotation re-stamped `expiresAtMs` to
+  `now + refreshToken.expiresIn`, letting an attacker who continuously
+  rotated a stolen RT keep the family alive indefinitely (OAuth 2.1 BCP
+  §4.14.1). The committed ceiling is exposed via the new optional
+  `cappedExpiresAtMs` field on the `"rotated"` outcome — reserved for a
+  Phase F follow-up that re-mints the issued JWT to match. For v0.5.1 the
+  storage-level cap is the security primary; the issued refresh-token
+  JWT's `exp` claim may still reflect `now + expiresIn` and the actual
+  refresh-token lifetime is bounded by the server-side family TTL.
+
+- **`pkceConfig.supportedMethods` element-type validation** (`@o3co/auth-provider-oauth`,
+  closes TS-4): a new `resolvePkceSupportedMethods` helper replaces the
+  duplicated `Array.isArray(...) ? (... as string[])` cast at
+  `authorization.mts:57` and `routes.mts:431`. The cast was compile-time
+  only — operator config such as `pkce.supportedMethods = [123, null, "S256"]`
+  would have been accepted as `string[]` at the type level and the
+  non-string elements silently relied on `.includes()` mismatch to be
+  filtered. The helper performs per-element type narrowing, falls back to
+  `["S256", "plain"]` on empty / non-array / all-non-string input, and
+  emits a structured `pkce_supportedMethods_non_string_filtered` warn log
+  when filtering occurs (logger plumbing at the call sites is deferred to
+  D-4).
+
+#### Migration
+
+No client- or operator-visible behavioural changes for well-formed
+configurations. Operators using `oauth.nonce.maxLength` env override should
+note the field name (`OAUTH_NONCE_MAX_LENGTH`). Custom rotation-wrapper
+implementations that destructure the `"rotated"` outcome remain
+source-compatible because `cappedExpiresAtMs` is optional.
+
 ### BREAKING (Phase F — F6 PR1 D-6 PB-2 client authentication redesign, v0.5.1)
 
 - **`Client` interface gains `tokenEndpointAuthMethod`** (`@o3co/auth-provider-core`)

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -52,6 +52,14 @@ oauth {
   code {
     adapter = ${?OAUTH_CODE_ADAPTER}
   }
+  # IH-16: hard ceiling on the OIDC `nonce` query parameter at /authorize.
+  # Standard OIDC clients generate 22-44 char base64url nonces; 256 leaves
+  # ~2x headroom for non-standard RPs. Operators with stricter requirements
+  # set OAUTH_NONCE_MAX_LENGTH.
+  nonce {
+    maxLength = 256
+    maxLength = ${?OAUTH_NONCE_MAX_LENGTH}
+  }
 }
 
 session {

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -140,6 +140,15 @@ export const CoreConfigSchema = z.object({
 				adapter: z.enum(["memory", "redis"]).optional(),
 			})
 			.optional(),
+		// IH-16 (v0.5.1): bound the OIDC `nonce` query parameter at /authorize
+		// ingress so a malicious RP cannot exhaust per-request memory or amplify
+		// the id_token payload by sending a multi-megabyte nonce. Shape-only —
+		// per the v0.5.1 ADR (defaults live in HOCON, not in zod).
+		nonce: z
+			.object({
+				maxLength: z.coerce.number().int().positive(),
+			})
+			.optional(),
 	}),
 });
 

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -376,3 +376,9 @@ export type {
 	RefreshTokenFamilyStore,
 	RefreshTokenFamilyUpdateResult,
 } from "./refresh-token-family/types.mjs";
+
+// SF-3 + MIN-4 (v0.5.1): timing-safe primitives. Exported from the package
+// root because `packages/core/package.json#exports` does not register a
+// `./security/*` subpath — Codex Delta 1 confirmed the subpath approach
+// would fail at runtime under Node's exports gating.
+export { constantTimeStringEqual } from "./security/timingSafe.mjs";

--- a/packages/core/src/refresh-token-family/__tests__/rotation.test.mts
+++ b/packages/core/src/refresh-token-family/__tests__/rotation.test.mts
@@ -88,4 +88,68 @@ describe("createRefreshTokenFamilyRotation", () => {
 		const unknown = await rotation.rotate("jti-x", "jti-y", "ghost", FUTURE());
 		expect(Object.isFrozen(unknown)).toBe(true);
 	});
+
+	// IH-13 (v0.5.1): RT family expiresAtMs is set ONCE at creation and
+	// never extended on rotation (OAuth 2.1 BCP §4.14.1 absolute expiry).
+	// `Math.min(requestedExpiresAtMs, current.expiresAtMs)` enforces the
+	// ceiling. The committed value is exposed via the optional
+	// `cappedExpiresAtMs` field on the "rotated" outcome.
+	describe("IH-13: absolute expiry cap (no sliding window)", () => {
+		it("does not extend family expiresAtMs on rotation when caller requests later expiry", async () => {
+			const store = createMemoryRefreshTokenFamilyStore();
+			const rotation = createRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
+
+			const ceiling = Date.now() + 1000; // 1s ceiling
+			await rotation.register("jti-1", "fam-1", ceiling);
+
+			// Caller requests rotation with a much-later expiry (sliding-window
+			// behaviour pre-IH-13). After the cap, the stored value MUST NOT
+			// exceed the original ceiling.
+			const later = Date.now() + 86_400_000; // 1 day
+			const out = await rotation.rotate("jti-1", "jti-2", "fam-1", later);
+
+			expect(out.outcome).toBe("rotated");
+			const after = await store.findFamily("fam-1");
+			expect(after?.expiresAtMs).toBeLessThanOrEqual(ceiling);
+		});
+
+		it("rotated outcome carries cappedExpiresAtMs equal to the committed family ceiling", async () => {
+			const store = createMemoryRefreshTokenFamilyStore();
+			const rotation = createRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
+
+			const ceiling = Date.now() + 60_000;
+			await rotation.register("jti-1", "fam-1", ceiling);
+
+			const later = Date.now() + 86_400_000;
+			const out = await rotation.rotate("jti-1", "jti-2", "fam-1", later);
+
+			expect(out.outcome).toBe("rotated");
+			if (out.outcome !== "rotated") return; // type narrowing
+			expect(out.cappedExpiresAtMs).toBeDefined();
+			expect(out.cappedExpiresAtMs).toBeLessThanOrEqual(ceiling);
+
+			// And matches the actually-stored value.
+			const after = await store.findFamily("fam-1");
+			expect(out.cappedExpiresAtMs).toBe(after?.expiresAtMs);
+		});
+
+		it("caller-supplied expiresAtMs is honoured when it is smaller than the ceiling", async () => {
+			// The cap is a one-way clamp: requested > ceiling collapses to
+			// ceiling, but requested < ceiling is honoured (the caller chose
+			// to shrink the TTL — e.g., session-bound RT). This test guards
+			// against an over-eager `Math.max` swap during refactor.
+			const store = createMemoryRefreshTokenFamilyStore();
+			const rotation = createRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
+
+			const ceiling = Date.now() + 86_400_000; // 1 day
+			await rotation.register("jti-1", "fam-1", ceiling);
+
+			const earlier = Date.now() + 1000; // 1s
+			const out = await rotation.rotate("jti-1", "jti-2", "fam-1", earlier);
+
+			expect(out.outcome).toBe("rotated");
+			if (out.outcome !== "rotated") return;
+			expect(out.cappedExpiresAtMs).toBe(earlier);
+		});
+	});
 });

--- a/packages/core/src/refresh-token-family/__tests__/rotation.test.mts
+++ b/packages/core/src/refresh-token-family/__tests__/rotation.test.mts
@@ -94,12 +94,19 @@ describe("createRefreshTokenFamilyRotation", () => {
 	// `Math.min(requestedExpiresAtMs, current.expiresAtMs)` enforces the
 	// ceiling. The committed value is exposed via the optional
 	// `cappedExpiresAtMs` field on the "rotated" outcome.
+	//
+	// Test stability (Copilot review on PR #126): all ceilings here use
+	// `>= 60s` so loaded CI runners cannot lazy-GC the family between
+	// `register` and `rotate`/`findFamily`. The cap logic does not depend
+	// on the absolute ceiling value — only on the relative ordering of
+	// `ceiling` vs the rotation's requested expiry — so a 60s ceiling is
+	// equivalent to a 1s ceiling for what these tests assert.
 	describe("IH-13: absolute expiry cap (no sliding window)", () => {
 		it("does not extend family expiresAtMs on rotation when caller requests later expiry", async () => {
 			const store = createMemoryRefreshTokenFamilyStore();
 			const rotation = createRefreshTokenFamilyRotation({ refreshTokenFamilyStore: store });
 
-			const ceiling = Date.now() + 1000; // 1s ceiling
+			const ceiling = Date.now() + 60_000; // 60s ceiling — CI-safe; see describe block comment
 			await rotation.register("jti-1", "fam-1", ceiling);
 
 			// Caller requests rotation with a much-later expiry (sliding-window
@@ -144,7 +151,9 @@ describe("createRefreshTokenFamilyRotation", () => {
 			const ceiling = Date.now() + 86_400_000; // 1 day
 			await rotation.register("jti-1", "fam-1", ceiling);
 
-			const earlier = Date.now() + 1000; // 1s
+			// 30s — well above the lazy-GC window but still smaller than the
+			// 1-day ceiling, exercising the requested-< -ceiling branch.
+			const earlier = Date.now() + 30_000;
 			const out = await rotation.rotate("jti-1", "jti-2", "fam-1", earlier);
 
 			expect(out.outcome).toBe("rotated");

--- a/packages/core/src/refresh-token-family/__tests__/types.test.mts
+++ b/packages/core/src/refresh-token-family/__tests__/types.test.mts
@@ -70,8 +70,11 @@ test("RefreshTokenFamilyUpdateResult committed variant carries family", () => {
 });
 
 test("RefreshTokenFamilyRotationOutcome is a 4-variant discriminated union", () => {
+	// IH-13 (v0.5.1): "rotated" variant carries optional `cappedExpiresAtMs`.
+	// Optional, not required, so existing stubs returning `{ outcome: "rotated" }`
+	// without the field continue to type-check (Codex Delta 2).
 	expectTypeOf<RefreshTokenFamilyRotationOutcome>().toEqualTypeOf<
-		| { readonly outcome: "rotated" }
+		| { readonly outcome: "rotated"; readonly cappedExpiresAtMs?: number }
 		| { readonly outcome: "replayed" }
 		| { readonly outcome: "revoked" }
 		| { readonly outcome: "unknown_family" }

--- a/packages/core/src/refresh-token-family/rotation.mts
+++ b/packages/core/src/refresh-token-family/rotation.mts
@@ -72,10 +72,17 @@ export function createRefreshTokenFamilyRotation(
 					abortReason = "replayed";
 					return null;
 				}
+				// IH-13: absolute expiry cap. The family TTL is SET ONCE at
+				// creation. Subsequent rotations MUST NOT extend the ceiling
+				// — `Math.min` clamps a sliding-window-style request back to
+				// the original creation value (or honours a smaller caller-
+				// supplied value, e.g. a session-bound RT). Per OAuth 2.1
+				// BCP §4.14.1.
+				const cappedExpiresAtMs = Math.min(expiresAtMs, current.expiresAtMs);
 				return Object.freeze({
 					...current,
 					activeJti: newJti,
-					expiresAtMs,
+					expiresAtMs: cappedExpiresAtMs,
 				});
 			});
 
@@ -87,7 +94,15 @@ export function createRefreshTokenFamilyRotation(
 						outcome: abortReason ?? "replayed",
 					} as const) as RefreshTokenFamilyRotationOutcome;
 				case "committed":
-					return Object.freeze({ outcome: "rotated" } as const);
+					// IH-13: surface the committed ceiling so the grant handler
+					// can detect when the cap reduced the requested expiry and
+					// (Phase F) re-mint the issued JWT to match. For v0.5.1
+					// the storage cap alone is the security primary; JWT exp
+					// alignment is deferred per the spec's open question.
+					return Object.freeze({
+						outcome: "rotated",
+						cappedExpiresAtMs: result.family.expiresAtMs,
+					} as const);
 			}
 		},
 	};

--- a/packages/core/src/refresh-token-family/rotation.mts
+++ b/packages/core/src/refresh-token-family/rotation.mts
@@ -78,6 +78,17 @@ export function createRefreshTokenFamilyRotation(
 				// the original creation value (or honours a smaller caller-
 				// supplied value, e.g. a session-bound RT). Per OAuth 2.1
 				// BCP §4.14.1.
+				//
+				// Naming note: `cappedExpiresAtMs` here is the PRE-commit
+				// computed value used by the updater. The "rotated" outcome
+				// below exposes a same-named field that reads the POST-commit
+				// `result.family.expiresAtMs` — for the Redis adapter this
+				// drifts forward by a few ms vs the closure value (see
+				// `RefreshTokenFamilyRotationOutcome` JSDoc + the Redis
+				// `updateFamily` post-EXEC reconstruction comment). They are
+				// the same value modulo single-digit-ms drift; consumers
+				// must read the field on the outcome, not assume the
+				// updater's pre-commit value.
 				const cappedExpiresAtMs = Math.min(expiresAtMs, current.expiresAtMs);
 				return Object.freeze({
 					...current,

--- a/packages/core/src/refresh-token-family/types.mts
+++ b/packages/core/src/refresh-token-family/types.mts
@@ -159,6 +159,20 @@ export interface RefreshTokenFamilyStore {
  *   so the family TTL is set ONCE at creation and never extended). The
  *   field is optional so existing test stubs that return `{ outcome:
  *   "rotated" }` without it continue to compile.
+ *
+ *   **Drift caveat**: `cappedExpiresAtMs` is read from
+ *   `RefreshTokenFamilyUpdateResult.family.expiresAtMs` after a successful
+ *   commit. The Redis adapter reconstructs that value as
+ *   `Date.now() + newTtlMs` after the EXEC round-trip, so the returned
+ *   epoch-ms drifts forward by single-digit milliseconds vs the value
+ *   the updater computed. This drift is benign for cap-detection
+ *   (`cappedExpiresAtMs < requestedExpiresAtMs` still indicates the cap
+ *   fired), but the value is NOT a millisecond-precise mirror of the
+ *   stored Redis TTL — Phase F consumers planning to align an issued
+ *   JWT `exp` claim should subtract a safety margin or use `findFamily`
+ *   for a fresher read. See `packages/redis/src/refresh-token-family.mts`
+ *   `updateFamily` comment for the underlying mechanism.
+ *
  * - `replayed`: family exists, not revoked, but previousJti did NOT match
  *   the active jti (e.g., previous jti was already rotated out). Caller
  *   MUST reject and treat as a replay-attack audit signal.

--- a/packages/core/src/refresh-token-family/types.mts
+++ b/packages/core/src/refresh-token-family/types.mts
@@ -153,7 +153,12 @@ export interface RefreshTokenFamilyStore {
  * 4-outcome union for the rotation ceremony.
  *
  * - `rotated`: family exists, not revoked, previousJti matched the active
- *   jti, CAS commit succeeded with newJti.
+ *   jti, CAS commit succeeded with newJti. Optional `cappedExpiresAtMs`
+ *   carries the actually-committed family ceiling (per IH-13: the rotation
+ *   wrapper applies `Math.min(requestedExpiresAtMs, current.expiresAtMs)`
+ *   so the family TTL is set ONCE at creation and never extended). The
+ *   field is optional so existing test stubs that return `{ outcome:
+ *   "rotated" }` without it continue to compile.
  * - `replayed`: family exists, not revoked, but previousJti did NOT match
  *   the active jti (e.g., previous jti was already rotated out). Caller
  *   MUST reject and treat as a replay-attack audit signal.
@@ -164,10 +169,10 @@ export interface RefreshTokenFamilyStore {
  *   v0.5.0 default is configurable via `oauth.refreshToken.unknownFamilyPolicy`
  *   (owned by the oauth grant handler module, NOT this wrapper).
  *
- * Per A3 §5.2.
+ * Per A3 §5.2 + IH-13 (v0.5.1).
  */
 export type RefreshTokenFamilyRotationOutcome =
-	| { readonly outcome: "rotated" }
+	| { readonly outcome: "rotated"; readonly cappedExpiresAtMs?: number }
 	| { readonly outcome: "replayed" }
 	| { readonly outcome: "revoked" }
 	| { readonly outcome: "unknown_family" };

--- a/packages/core/src/security/__tests__/timingSafe.test.mts
+++ b/packages/core/src/security/__tests__/timingSafe.test.mts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { constantTimeStringEqual } from "../timingSafe.mjs";
+
+describe("constantTimeStringEqual (SF-3 + MIN-4)", () => {
+	it("returns true for two equal strings", () => {
+		expect(constantTimeStringEqual("abc", "abc")).toBe(true);
+	});
+
+	it("returns false for two different strings of the same length", () => {
+		expect(constantTimeStringEqual("abc", "abd")).toBe(false);
+	});
+
+	it("returns false for strings that differ only in the last byte (near-miss)", () => {
+		// PKCE base64url-encoded SHA-256 outputs are always 43 chars; verify the
+		// helper still returns false when the difference is at the very end —
+		// rules out an early-return bug that would mask near-miss failures
+		// (the whole point of the timing-safe primitive).
+		const a = "a".repeat(42) + "x";
+		const b = "a".repeat(42) + "y";
+		expect(constantTimeStringEqual(a, b)).toBe(false);
+	});
+
+	it("returns false for strings of different length without throwing", () => {
+		// `crypto.timingSafeEqual` throws when buffer lengths differ; the
+		// helper must short-circuit on the byte-length comparison first
+		// (Codex Delta 3: encode-then-length, not length-then-encode).
+		expect(() => constantTimeStringEqual("abc", "ab")).not.toThrow();
+		expect(constantTimeStringEqual("abc", "ab")).toBe(false);
+	});
+
+	it("returns true for two empty strings", () => {
+		expect(constantTimeStringEqual("", "")).toBe(true);
+	});
+
+	it("returns false when one string is empty and the other is not", () => {
+		expect(constantTimeStringEqual("", "x")).toBe(false);
+		expect(constantTimeStringEqual("x", "")).toBe(false);
+	});
+
+	it("uses byte-length (UTF-8) for the length comparison, not JS string length", () => {
+		// Codex Delta 3: a multi-byte character (e.g. emoji) has JS string
+		// length 2 but UTF-8 byte length 4. The helper encodes first and
+		// compares byte-lengths so `timingSafeEqual` (which requires equal
+		// buffer lengths) never throws on Unicode input.
+		const emoji = "😀"; // JS length 2, UTF-8 length 4
+		const ascii = "ab"; // JS length 2, UTF-8 length 2
+		expect(() => constantTimeStringEqual(emoji, ascii)).not.toThrow();
+		expect(constantTimeStringEqual(emoji, ascii)).toBe(false);
+	});
+});

--- a/packages/core/src/security/timingSafe.mts
+++ b/packages/core/src/security/timingSafe.mts
@@ -17,7 +17,8 @@
 import { timingSafeEqual } from "node:crypto";
 
 /**
- * Constant-time string equality.
+ * Constant-time string equality — for inputs whose **byte length is public
+ * information** (e.g. PKCE code_verifier, OAuth `code_challenge`).
  *
  * `===`/`!==` short-circuit on the first mismatched byte, leaking timing
  * information about how many bytes of the candidate matched the secret.
@@ -25,24 +26,45 @@ import { timingSafeEqual } from "node:crypto";
  * §4.5 this is a security defect — a network-positioned attacker can
  * iteratively recover a stored `code_challenge` byte-by-byte.
  *
- * Implementation note (Codex Delta 3 of SF-3 spec): the buffers are
- * encoded BEFORE the length check. `timingSafeEqual` requires equal-length
- * inputs, and JS string length does not equal UTF-8 byte length for
- * multi-byte code points (`"😀".length === 2` but `Buffer.byteLength("😀") === 4`).
- * Comparing byte-lengths after encoding makes the helper safe for
- * arbitrary Unicode strings and avoids a thrown `RangeError` on the rare
- * non-ASCII PKCE input.
+ * ## Contract — read this BEFORE reusing the helper
  *
- * The byte-length difference itself is NOT a usable timing oracle for
- * PKCE: `code_verifier` length is bounded to 43–128 ASCII chars by RFC
- * 7636, so its byte-length is publicly known. For the SHA-256 base64url
- * output it is always 43 chars / 43 bytes.
+ * The early-return on byte-length mismatch (`bufA.length !== bufB.length →
+ * return false`) is structurally NOT constant-time across length-distinct
+ * inputs: an attacker can distinguish "lengths differ" (returns ~immediately)
+ * from "lengths equal but bytes differ" (returns after `timingSafeEqual`'s
+ * fixed-time loop). For the use cases this helper currently serves —
+ * PKCE `code_verifier` (RFC 7636: 43–128 chars) and the SHA-256 base64url
+ * `code_challenge` (always 43 chars) — input lengths are bounded by the
+ * protocol and are not secrets, so the length-mismatch branch is NOT a
+ * usable oracle.
+ *
+ * **DO NOT** reuse this helper for secrets whose byte length is itself
+ * sensitive (variable-length tokens, password hashes of variable cost,
+ * etc.) without first auditing whether a length oracle is acceptable.
+ * For the secret-length-is-secret case, compare fixed-size digests
+ * (e.g. HMAC) instead, or use a dedicated constant-time-irrespective-
+ * of-length primitive. Per Copilot review on PR #126: the helper is
+ * named/documented as suitable for public-length inputs only; widening
+ * its contract is out of scope for v0.5.1.
+ *
+ * ## Implementation note
+ *
+ * Codex Delta 3 of SF-3 spec: the buffers are encoded BEFORE the length
+ * check. `timingSafeEqual` requires equal-length inputs, and JS string
+ * length does not equal UTF-8 byte length for multi-byte code points
+ * (`"😀".length === 2` but `Buffer.byteLength("😀") === 4`). Comparing
+ * byte-lengths after encoding makes the helper safe for arbitrary
+ * Unicode strings and avoids a thrown `RangeError` on the rare non-ASCII
+ * input.
  *
  * Per SF-3 + MIN-4 (v0.5.1).
  */
 export function constantTimeStringEqual(a: string, b: string): boolean {
 	const bufA = Buffer.from(a, "utf8");
 	const bufB = Buffer.from(b, "utf8");
+	// NOTE: this length check is intentional — `timingSafeEqual` throws on
+	// unequal lengths. Constant-time across DIFFERENT lengths is not the
+	// helper's contract; see the JSDoc § "Contract" above.
 	if (bufA.length !== bufB.length) return false;
 	return timingSafeEqual(bufA, bufB);
 }

--- a/packages/core/src/security/timingSafe.mts
+++ b/packages/core/src/security/timingSafe.mts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Constant-time string equality.
+ *
+ * `===`/`!==` short-circuit on the first mismatched byte, leaking timing
+ * information about how many bytes of the candidate matched the secret.
+ * For PKCE `code_verifier` comparison (RFC 7636 §4.1) and OAuth 2.1 BCP
+ * §4.5 this is a security defect — a network-positioned attacker can
+ * iteratively recover a stored `code_challenge` byte-by-byte.
+ *
+ * Implementation note (Codex Delta 3 of SF-3 spec): the buffers are
+ * encoded BEFORE the length check. `timingSafeEqual` requires equal-length
+ * inputs, and JS string length does not equal UTF-8 byte length for
+ * multi-byte code points (`"😀".length === 2` but `Buffer.byteLength("😀") === 4`).
+ * Comparing byte-lengths after encoding makes the helper safe for
+ * arbitrary Unicode strings and avoids a thrown `RangeError` on the rare
+ * non-ASCII PKCE input.
+ *
+ * The byte-length difference itself is NOT a usable timing oracle for
+ * PKCE: `code_verifier` length is bounded to 43–128 ASCII chars by RFC
+ * 7636, so its byte-length is publicly known. For the SHA-256 base64url
+ * output it is always 43 chars / 43 bytes.
+ *
+ * Per SF-3 + MIN-4 (v0.5.1).
+ */
+export function constantTimeStringEqual(a: string, b: string): boolean {
+	const bufA = Buffer.from(a, "utf8");
+	const bufB = Buffer.from(b, "utf8");
+	if (bufA.length !== bufB.length) return false;
+	return timingSafeEqual(bufA, bufB);
+}

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -111,6 +111,13 @@ async function buildAuthorizeApp(opts: {
 	sessionFields: Record<string, unknown>;
 	captureCode: (params: Parameters<CodeRepository["createCode"]>[0]) => void;
 	captureSession?: (session: Record<string, unknown>) => void;
+	/**
+	 * Optional config override merged into the default `authorizeConfig`.
+	 * Used by IH-16 tests that need to set a non-default
+	 * `oauth.nonce.maxLength` so the configurable code path is exercised
+	 * (the no-override path uses the `?? 256` fallback only).
+	 */
+	configOverride?: Partial<AppConfig>;
 }) {
 	const app = express();
 	app.use(express.json());
@@ -143,9 +150,22 @@ async function buildAuthorizeApp(opts: {
 		removeByCode: async () => {},
 	};
 
+	const mergedConfig = (
+		opts.configOverride
+			? {
+					...authorizeConfig,
+					...opts.configOverride,
+					oauth: {
+						...(authorizeConfig as unknown as { oauth: Record<string, unknown> }).oauth,
+						...((opts.configOverride as { oauth?: Record<string, unknown> }).oauth ?? {}),
+					},
+				}
+			: authorizeConfig
+	) as AppConfig;
+
 	const { router } = await createOAuthRouter(express, {
 		registry: new GrantRegistry(),
-		config: authorizeConfig,
+		config: mergedConfig,
 		clientRepository: authorizeClientRepo,
 		codeRepository: codeRepo,
 		keyStore: createSymmetricKeyStore("test-secret-at-least-32-chars!!"),
@@ -691,6 +711,44 @@ describe("IH-16: /authorize nonce length + character-set validation", () => {
 		expect(location.origin + location.pathname).toBe("https://example.test/cb");
 		expect(location.searchParams.get("error")).toBe("invalid_request");
 		expect(location.searchParams.get("error_description")).toMatch(/non-printable|character/i);
+		expect(captureCode).not.toHaveBeenCalled();
+	});
+
+	it("honours an operator-configured `oauth.nonce.maxLength` (not just the default 256)", async () => {
+		// Without this test, the configurable code path was completely
+		// untested — the other IH-16 tests exercise only the `?? 256`
+		// fallback. Drop the limit to 10 and verify both an 11-char nonce
+		// rejects and a 10-char nonce passes; this proves
+		// `config.oauth.nonce.maxLength` actually flows through to the gate.
+		const captureCode = vi.fn();
+		const app = await buildAuthorizeApp({
+			sessionFields: { sid: "sid-1" },
+			captureCode,
+			configOverride: {
+				oauth: {
+					jwt: { issuer: "https://auth.example" },
+					accessToken: { expiresIn: 3600 },
+					refreshToken: { expiresIn: 86400 },
+					nonce: { maxLength: 10 },
+				},
+			} as unknown as Partial<AppConfig>,
+		});
+
+		// Over the operator limit — must redirect-error with the configured value.
+		const res = await request(app)
+			.get("/oauth/authorize")
+			.query({
+				response_type: "code",
+				client_id: "client-1",
+				redirect_uri: "https://example.test/cb",
+				nonce: "a".repeat(11),
+			});
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers.location);
+		expect(location.searchParams.get("error")).toBe("invalid_request");
+		// The error description must echo the OPERATOR's value (not 256) —
+		// proves the override took effect.
+		expect(location.searchParams.get("error_description")).toMatch(/maximum length of 10\b/);
 		expect(captureCode).not.toHaveBeenCalled();
 	});
 });

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -585,6 +585,116 @@ describe("authorize persists OIDC round-trip state on code record (TODO-F-3)", (
 	});
 });
 
+// IH-16 (v0.5.1): /authorize must bound the `nonce` query parameter.
+//
+// Pre-IH-16 the route accepted any-length nonce verbatim and stored it on
+// the code record + echoed it into the id_token. A malicious RP sending
+// nonce=<huge-string> could exhaust per-request memory or amplify the
+// id_token payload. The route now enforces a default 256-char ceiling
+// (configurable via `oauth.nonce.maxLength`) and rejects non-printable
+// ASCII via `redirectError` — the redirect_uri is already client-allowlisted
+// at this point in the route, so RFC 6749 §4.1.2.1 redirect-based errors
+// apply (Codex calibration delta 2).
+describe("IH-16: /authorize nonce length + character-set validation", () => {
+	it("accepts a normal-sized printable nonce (32 chars)", async () => {
+		let captured: Parameters<CodeRepository["createCode"]>[0] | undefined;
+		const app = await buildAuthorizeApp({
+			sessionFields: { sid: "sid-1" },
+			captureCode: (p) => {
+				captured = p;
+			},
+		});
+
+		const nonce = "a".repeat(32);
+		const res = await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "client-1",
+			redirect_uri: "https://example.test/cb",
+			nonce,
+		});
+
+		// Successful /authorize redirects (302) to redirect_uri with `code` —
+		// the absence of an `error` parameter confirms the gate passed.
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers.location);
+		expect(location.searchParams.get("error")).toBeNull();
+		expect(captured?.nonce).toBe(nonce);
+	});
+
+	it("accepts a nonce at the boundary (256 chars exactly)", async () => {
+		let captured: Parameters<CodeRepository["createCode"]>[0] | undefined;
+		const app = await buildAuthorizeApp({
+			sessionFields: { sid: "sid-1" },
+			captureCode: (p) => {
+				captured = p;
+			},
+		});
+
+		const nonce = "a".repeat(256);
+		const res = await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "client-1",
+			redirect_uri: "https://example.test/cb",
+			nonce,
+		});
+
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers.location);
+		expect(location.searchParams.get("error")).toBeNull();
+		expect(captured?.nonce).toBe(nonce);
+	});
+
+	it("rejects an oversized nonce (257 chars) with redirect-based invalid_request", async () => {
+		const captureCode = vi.fn();
+		const app = await buildAuthorizeApp({
+			sessionFields: { sid: "sid-1" },
+			captureCode,
+		});
+
+		const res = await request(app)
+			.get("/oauth/authorize")
+			.query({
+				response_type: "code",
+				client_id: "client-1",
+				redirect_uri: "https://example.test/cb",
+				state: "client-state-xyz",
+				nonce: "a".repeat(257),
+			});
+
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers.location);
+		expect(location.origin + location.pathname).toBe("https://example.test/cb");
+		expect(location.searchParams.get("error")).toBe("invalid_request");
+		expect(location.searchParams.get("error_description")).toMatch(/nonce/i);
+		// `state` MUST round-trip on error redirects per RFC 6749 §4.1.2.1.
+		expect(location.searchParams.get("state")).toBe("client-state-xyz");
+		expect(captureCode).not.toHaveBeenCalled();
+	});
+
+	it("rejects a non-printable nonce with redirect-based invalid_request", async () => {
+		const captureCode = vi.fn();
+		const app = await buildAuthorizeApp({
+			sessionFields: { sid: "sid-1" },
+			captureCode,
+		});
+
+		// `\x00` is below the printable ASCII range (0x20-0x7E).
+		const res = await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "client-1",
+			redirect_uri: "https://example.test/cb",
+			nonce: "a\x00b",
+		});
+
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers.location);
+		expect(location.origin + location.pathname).toBe("https://example.test/cb");
+		expect(location.searchParams.get("error")).toBe("invalid_request");
+		expect(location.searchParams.get("error_description")).toMatch(/non-printable|character/i);
+		expect(captureCode).not.toHaveBeenCalled();
+	});
+});
+
 // D-1 / CR-2: /authorize MUST embed the identity binding in the code record,
 // not in the Express session. Pre-fix, four session writes (req.session.code,
 // req.session.code_client_id, req.session.code_redirect_uri,

--- a/packages/oauth/src/grants/__tests__/pkce.test.mts
+++ b/packages/oauth/src/grants/__tests__/pkce.test.mts
@@ -58,14 +58,39 @@ describe("resolvePkceSupportedMethods (TS-4)", () => {
 		expect(logger.warn).not.toHaveBeenCalled();
 	});
 
-	it("falls back to default when supportedMethods is the empty array literal", () => {
-		const result = resolvePkceSupportedMethods({ supportedMethods: [] });
+	it("falls back to default when supportedMethods is the empty array literal — silently (operator may have intended `[]` as 'use defaults')", () => {
+		const logger = {
+			trace: vi.fn(),
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			fatal: vi.fn(),
+			child: vi.fn(),
+		};
+		const result = resolvePkceSupportedMethods({ supportedMethods: [] }, logger);
 		expect(result).toEqual(["S256", "plain"]);
+		// Literal `[]` is treated as "no opinion → use defaults"; warning here
+		// would flood logs for operators who intentionally cleared the field.
+		expect(logger.warn).not.toHaveBeenCalled();
 	});
 
-	it("falls back to default when all elements are non-string (filtered to empty)", () => {
-		const result = resolvePkceSupportedMethods({ supportedMethods: [123, null] });
+	it("falls back to default AND warns when all elements are non-string (filtered to empty)", () => {
+		// Without the warn, an operator typo like `supportedMethods = [123, null]`
+		// would silently disable their PKCE method allowlist and the helper
+		// would substitute defaults. The warn surfaces this misconfiguration.
+		const logger = {
+			trace: vi.fn(),
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			fatal: vi.fn(),
+			child: vi.fn(),
+		};
+		const result = resolvePkceSupportedMethods({ supportedMethods: [123, null] }, logger);
 		expect(result).toEqual(["S256", "plain"]);
+		expect(logger.warn).toHaveBeenCalledTimes(1);
 	});
 
 	it("falls back to default when supportedMethods is absent", () => {

--- a/packages/oauth/src/grants/__tests__/pkce.test.mts
+++ b/packages/oauth/src/grants/__tests__/pkce.test.mts
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import { resolvePkceSupportedMethods } from "#/grants/pkce.mjs";
+
+describe("resolvePkceSupportedMethods (TS-4)", () => {
+	it("returns the valid string array unchanged", () => {
+		const result = resolvePkceSupportedMethods({ supportedMethods: ["S256", "plain"] });
+		expect(result).toEqual(["S256", "plain"]);
+	});
+
+	it("filters non-string elements and warns via the optional logger", () => {
+		const logger = {
+			trace: vi.fn(),
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			fatal: vi.fn(),
+			child: vi.fn(),
+		};
+		const result = resolvePkceSupportedMethods(
+			{ supportedMethods: ["S256", 123, null, "plain"] },
+			logger,
+		);
+		expect(result).toEqual(["S256", "plain"]);
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT warn when no filtering is needed (all elements are strings)", () => {
+		const logger = {
+			trace: vi.fn(),
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			fatal: vi.fn(),
+			child: vi.fn(),
+		};
+		resolvePkceSupportedMethods({ supportedMethods: ["S256"] }, logger);
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
+
+	it("falls back to default when supportedMethods is the empty array literal", () => {
+		const result = resolvePkceSupportedMethods({ supportedMethods: [] });
+		expect(result).toEqual(["S256", "plain"]);
+	});
+
+	it("falls back to default when all elements are non-string (filtered to empty)", () => {
+		const result = resolvePkceSupportedMethods({ supportedMethods: [123, null] });
+		expect(result).toEqual(["S256", "plain"]);
+	});
+
+	it("falls back to default when supportedMethods is absent", () => {
+		const result = resolvePkceSupportedMethods({});
+		expect(result).toEqual(["S256", "plain"]);
+	});
+
+	it("falls back to default when supportedMethods is not an array (e.g. a string)", () => {
+		const result = resolvePkceSupportedMethods({
+			supportedMethods: "S256",
+		} as unknown as Record<string, unknown>);
+		expect(result).toEqual(["S256", "plain"]);
+	});
+
+	it("falls back to default when pkceConfig itself is undefined", () => {
+		const result = resolvePkceSupportedMethods(undefined);
+		expect(result).toEqual(["S256", "plain"]);
+	});
+});
+
+// SF-3 + MIN-4 (v0.5.1) — PKCE timing-safe comparison regression guard.
+//
+// The fix replaces `!==` with `constantTimeStringEqual`. Pure behavioural
+// tests (a "wrong verifier returns 400") cannot detect a regression to
+// `!==` because both implementations are functionally equivalent on a
+// fixed input. ESM-level `vi.spyOn` is unreliable here: the consumer
+// imports `constantTimeStringEqual` from `@o3co/auth-provider-core` and
+// holds its own immutable binding, so a post-hoc spy on the namespace
+// object would not intercept the call. The most reliable guard is a
+// source-level assertion: the production source must reference the
+// helper and must not contain the original `!==` shape against
+// `codeData.code_challenge`. Codex Delta 2 explicitly accepts this
+// "comment-anchored test" alternative.
+describe("SF-3 + MIN-4: authorization.mts uses constantTimeStringEqual (regression guard)", () => {
+	const authorizationSource = readFileSync(
+		resolve(dirname(fileURLToPath(import.meta.url)), "../authorization.mts"),
+		"utf8",
+	);
+
+	it("imports and uses constantTimeStringEqual", () => {
+		expect(authorizationSource).toMatch(/\bconstantTimeStringEqual\b/);
+	});
+
+	it("does NOT contain the pre-fix S256 `base64url !== codeData.code_challenge` compare", () => {
+		expect(authorizationSource).not.toMatch(/base64url\s*!==\s*codeData\.code_challenge\b/);
+	});
+
+	it("does NOT contain the pre-fix plain `code_verifier !== codeData.code_challenge` compare", () => {
+		expect(authorizationSource).not.toMatch(/code_verifier\s*!==\s*codeData\.code_challenge\b/);
+	});
+});

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -196,15 +196,22 @@ export const createAuthorizationGrant = (
 			// (challenge is stored only when method is resolved — see
 			// `routes.mts:632-661`), so in practice this guard fires only on
 			// a corrupt store record or a custom CodeRepository implementation
-			// that wrote the partial state. Reject as `invalid_request`; a
-			// vacuous-pass would be a silent verifier bypass.
+			// that wrote the partial state.
+			//
+			// RFC 6749 error mapping (Copilot review on PR #126): the request
+			// itself is well-formed; the persisted authorization code is
+			// unredeemable. `invalid_grant` is the standard code for "this
+			// code cannot be used", which matches what is happening here
+			// (and is also what the other unredeemable-code branches in this
+			// handler return). errorDescription says "invalid code" (the
+			// same wording used by the other invalid-code branches above)
+			// so storage implementation details do not leak to the client.
 			if (codeData.code_challenge && !codeData.code_challenge_method) {
 				return {
 					result: {
 						status: 400,
-						error: "invalid_request",
-						errorDescription:
-							"code_challenge present but code_challenge_method missing on code record",
+						error: "invalid_grant",
+						errorDescription: "invalid code",
 					},
 				};
 			}

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -189,6 +189,26 @@ export const createAuthorizationGrant = (
 				};
 			}
 
+			// SF-3 fixup: a code record carrying `code_challenge` without
+			// `code_challenge_method` would silently bypass PKCE validation
+			// because the outer `if (codeData.code_challenge_method)` gate
+			// below is falsy. The /authorize route never persists this shape
+			// (challenge is stored only when method is resolved — see
+			// `routes.mts:632-661`), so in practice this guard fires only on
+			// a corrupt store record or a custom CodeRepository implementation
+			// that wrote the partial state. Reject as `invalid_request`; a
+			// vacuous-pass would be a silent verifier bypass.
+			if (codeData.code_challenge && !codeData.code_challenge_method) {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_request",
+						errorDescription:
+							"code_challenge present but code_challenge_method missing on code record",
+					},
+				};
+			}
+
 			// Validate code_verifier using code data from repository
 			if (codeData.code_challenge_method) {
 				// SF-3 (v0.5.1): a code record with `code_challenge_method` set

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -18,6 +18,7 @@ import crypto from "node:crypto";
 import {
 	type ClientRepository,
 	type CodeRepository,
+	constantTimeStringEqual,
 	type GrantContext,
 	type GrantDependencies,
 	type GrantHandler,
@@ -29,6 +30,7 @@ import {
 	type UserSession,
 } from "@o3co/auth-provider-core";
 import { decodeJwtPayload } from "./_jwtPayload.mjs";
+import { resolvePkceSupportedMethods } from "./pkce.mjs";
 
 export const createAuthorizationGrant = (
 	deps: GrantDependencies & { codeRepository: CodeRepository; clientRepository: ClientRepository },
@@ -53,10 +55,12 @@ export const createAuthorizationGrant = (
 	})();
 
 	// B-7: structured pkce config (supportedMethods, defaultMethod, required)
-	// Fall back to legacy requireS256 for backward compatibility
-	const supportedMethods: string[] = Array.isArray(pkceConfig?.supportedMethods)
-		? (pkceConfig.supportedMethods as string[])
-		: ["S256", "plain"];
+	// Fall back to legacy requireS256 for backward compatibility.
+	// TS-4 (v0.5.1): per-element string validation lives in
+	// `resolvePkceSupportedMethods` — the previous `Array.isArray(...) ? (... as string[])`
+	// pattern silently accepted operator-typed garbage like `[123, null]`
+	// because `Array.isArray` does not constrain element types.
+	const supportedMethods = resolvePkceSupportedMethods(pkceConfig);
 	const pkceRequired: boolean = pkceConfig?.required === true;
 	// Legacy fallback: requireS256=true means only S256 is supported
 	const requireS256Legacy = pkceConfig?.requireS256 === true;
@@ -187,6 +191,23 @@ export const createAuthorizationGrant = (
 
 			// Validate code_verifier using code data from repository
 			if (codeData.code_challenge_method) {
+				// SF-3 (v0.5.1): a code record with `code_challenge_method` set
+				// but no `code_challenge` is structurally invalid — the two are a
+				// pair persisted together at /authorize. Pre-SF-3 this state was
+				// silently accepted because `verifier !== undefined` is always
+				// true (the comparison "passed" for the wrong reason). Now that
+				// `constantTimeStringEqual` requires both arguments to be
+				// strings, the malformed shape is rejected explicitly. Reject as
+				// invalid_request; the code is consumed already so no replay risk.
+				if (typeof codeData.code_challenge !== "string") {
+					return {
+						result: {
+							status: 400,
+							error: "invalid_request",
+							errorDescription: "code_challenge missing on code record",
+						},
+					};
+				}
 				// B-7: check method is in supportedMethods
 				if (!effectiveSupportedMethods.includes(codeData.code_challenge_method)) {
 					return {
@@ -221,7 +242,11 @@ export const createAuthorizationGrant = (
 					case "S256": {
 						const hash = crypto.createHash("sha256").update(code_verifier).digest();
 						const base64url = hash.toString("base64url");
-						if (base64url !== codeData.code_challenge) {
+						// SF-3 + MIN-4 (v0.5.1): timing-safe compare. Replaces a
+						// short-circuit `!==` whose per-byte timing leaked progress
+						// of a candidate verifier against the stored challenge —
+						// see RFC 7636 §4.1 + OAuth 2.1 BCP §4.5.
+						if (!constantTimeStringEqual(base64url, codeData.code_challenge)) {
 							return {
 								result: {
 									status: 400,
@@ -233,7 +258,11 @@ export const createAuthorizationGrant = (
 						break;
 					}
 					case "plain":
-						if (code_verifier !== codeData.code_challenge) {
+						// SF-3 + MIN-4 (v0.5.1): timing-safe compare on the plain
+						// branch as well — the same timing-leak applies regardless
+						// of whether the stored value is a challenge digest (S256)
+						// or the raw verifier (plain).
+						if (!constantTimeStringEqual(code_verifier, codeData.code_challenge)) {
 							return {
 								result: {
 									status: 400,

--- a/packages/oauth/src/grants/pkce.mts
+++ b/packages/oauth/src/grants/pkce.mts
@@ -52,7 +52,27 @@ export function resolvePkceSupportedMethods(
 	const raw = pkceConfig?.supportedMethods;
 	if (!Array.isArray(raw)) return DEFAULT_PKCE_METHODS;
 	const filtered = raw.filter((m): m is string => typeof m === "string");
-	if (filtered.length === 0) return DEFAULT_PKCE_METHODS;
+	if (filtered.length === 0) {
+		// All-non-string fallback (e.g. operator wrote `[123, null]`).
+		// Pre-Claude-review-fixup the helper fell back to defaults silently
+		// here, so a completely garbage allowlist disabled the operator's
+		// intended PKCE policy with zero log signal. Warn now so the
+		// misconfiguration is visible. We deliberately do NOT warn on the
+		// `raw.length === 0` case (operator literal `[]` may be an
+		// intentional "use defaults" signal); only an explicit non-empty
+		// non-string array trips this branch.
+		// Object-first per F5 D-4 Logger convention.
+		if (raw.length > 0) {
+			logger?.warn(
+				{
+					raw,
+					removed: raw.length,
+				},
+				"pkce_supportedMethods_all_non_string_fallback_to_default",
+			);
+		}
+		return DEFAULT_PKCE_METHODS;
+	}
 	if (filtered.length !== raw.length) {
 		// Object-first call shape per F5 D-4 Logger convention: structured
 		// fields first so PII-redaction tooling can inspect keys directly.

--- a/packages/oauth/src/grants/pkce.mts
+++ b/packages/oauth/src/grants/pkce.mts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Logger } from "@o3co/auth-provider-core";
+
+const DEFAULT_PKCE_METHODS: readonly string[] = Object.freeze(["S256", "plain"]);
+
+/**
+ * Resolves the PKCE supported methods from an untyped pkce config block.
+ *
+ * Replaces the duplicated `Array.isArray(...) ? (... as string[])` pattern
+ * at `authorization.mts` and `routes.mts`: `Array.isArray` proves the value
+ * is an array but does NOT constrain element types, so a misconfiguration
+ * such as `supportedMethods = [123, null, "S256"]` would have been accepted
+ * as `string[]` and silently weakened the PKCE method allowlist (the
+ * `.includes(method)` gate in consumers happens to filter the non-string
+ * elements by accident, not by contract).
+ *
+ * Behaviour:
+ * - Non-array / undefined / missing field → fall back to `["S256", "plain"]`.
+ * - Array with mixed string/non-string elements → filter to strings and warn.
+ * - Array filtered to empty (or literal `[]`) → fall back to default
+ *   (defensive: an empty allowlist would disable PKCE entirely).
+ *
+ * The `logger` argument is optional. v0.5.1 consumers (`authorization.mts`,
+ * `routes.mts`) call without a logger because there is no logger slot on
+ * `GrantDependencies` / `createOAuthRouter` deps in this release; the warn
+ * branch is exercised via direct unit tests on the helper. Logger plumbing
+ * to the call sites is deferred to D-4 (ComponentMap.logger wiring).
+ *
+ * Per TS-4 spec (Wave 5j) + Codex calibration delta 1 (no logger at consumer
+ * sites in v0.5.1) + delta 2 (literal-empty + filtered-empty cases tested
+ * separately).
+ */
+export function resolvePkceSupportedMethods(
+	pkceConfig: Record<string, unknown> | undefined,
+	logger?: Logger,
+): readonly string[] {
+	const raw = pkceConfig?.supportedMethods;
+	if (!Array.isArray(raw)) return DEFAULT_PKCE_METHODS;
+	const filtered = raw.filter((m): m is string => typeof m === "string");
+	if (filtered.length === 0) return DEFAULT_PKCE_METHODS;
+	if (filtered.length !== raw.length) {
+		// Object-first call shape per F5 D-4 Logger convention: structured
+		// fields first so PII-redaction tooling can inspect keys directly.
+		logger?.warn(
+			{
+				raw,
+				filtered,
+				removed: raw.length - filtered.length,
+			},
+			"pkce_supportedMethods_non_string_filtered",
+		);
+	}
+	return filtered;
+}

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -564,7 +564,26 @@ export const createOAuthRouter = async (
 				// any earlier than this is unsafe — it must follow `redirect_uri`
 				// validation so errors can use `redirectError`.
 				const nonceMaxLength = config.oauth.nonce?.maxLength ?? 256;
-				if (typeof req.query.nonce === "string") {
+				if (req.query.nonce !== undefined) {
+					// Reject non-string `nonce` (Copilot review on PR #126):
+					// Express + qs parses repeated `?nonce=a&nonce=b` as an
+					// array, which silently failed the previous
+					// `typeof === "string"` gate, causing the request to
+					// proceed with `nonce: undefined` on the issued code. The
+					// client's downstream OIDC nonce check would then fail
+					// long after `/authorize` returned 302 + code, surfacing
+					// as a confusing client-side error. Reject as
+					// `invalid_request` immediately so the failure is at the
+					// request boundary, not asynchronously at id_token
+					// validation time.
+					if (typeof req.query.nonce !== "string") {
+						return redirectError(
+							redirect_uri,
+							"invalid_request",
+							"nonce must be a single string value",
+							toStr(state),
+						);
+					}
 					const nonceValue = req.query.nonce;
 					if (nonceValue.length > nonceMaxLength) {
 						return redirectError(

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -38,6 +38,7 @@ import {
 } from "@o3co/auth-provider-core";
 import type { Request, RequestHandler, Response, Router } from "express";
 import { decodeProtectedHeader, jwtVerify } from "jose";
+import { resolvePkceSupportedMethods } from "./grants/pkce.mjs";
 import { createClientAuthMiddleware } from "./middleware/clientAuth.mjs";
 import * as federationTokenRoute from "./routes/federationToken.mjs";
 import * as logoutRoute from "./routes/logout.mjs";
@@ -499,9 +500,10 @@ export const createOAuthRouter = async (
 				const pkceRequired: boolean = pkceConfig?.required === true;
 				const defaultMethod: string =
 					typeof pkceConfig?.defaultMethod === "string" ? pkceConfig.defaultMethod : "plain";
-				const supportedMethods: string[] = Array.isArray(pkceConfig?.supportedMethods)
-					? (pkceConfig.supportedMethods as string[])
-					: ["S256", "plain"];
+				// TS-4 (v0.5.1): per-element validation via `resolvePkceSupportedMethods`.
+				// See authorization.mts for the rationale — `Array.isArray + as string[]`
+				// silently accepted non-string operator-typed values.
+				const supportedMethods = resolvePkceSupportedMethods(pkceConfig);
 
 				// D-6 (RFC 9700 §2.1.1): PKCE/S256 is mandatory for public clients
 				// regardless of operator `pkce.required` config. Public clients have
@@ -640,6 +642,41 @@ export const createOAuthRouter = async (
 				} else {
 					// No challenge: method is irrelevant (no PKCE)
 					resolvedMethod = undefined;
+				}
+
+				// IH-16 (v0.5.1): bound the OIDC `nonce` query parameter. Pre-fix
+				// the value was stored on the code record + echoed verbatim into
+				// the id_token, letting a malicious RP exhaust per-request memory
+				// or amplify the token payload with a multi-megabyte string. The
+				// 256-char ceiling is operator-tunable via `oauth.nonce.maxLength`
+				// (default in core HOCON, env-var `OAUTH_NONCE_MAX_LENGTH`).
+				// Errors use `redirectError` because `redirect_uri` is already
+				// validated against the client allowlist at this point — RFC 6749
+				// §4.1.2.1 requires error redirects from here on.
+				const oauthConfig = config.oauth as { nonce?: { maxLength?: number } } | undefined;
+				const nonceMaxLength = oauthConfig?.nonce?.maxLength ?? 256;
+				if (typeof req.query.nonce === "string") {
+					const nonceValue = req.query.nonce;
+					if (nonceValue.length > nonceMaxLength) {
+						return redirectError(
+							redirect_uri,
+							"invalid_request",
+							`nonce exceeds maximum length of ${nonceMaxLength}`,
+							toStr(state),
+						);
+					}
+					// Printable ASCII only (0x20-0x7E). Non-printable input could
+					// confuse downstream JWT libraries that don't escape control
+					// chars in JSON payloads. OIDC Core §3.1.2.1 leaves the
+					// alphabet unconstrained; this is a defensive narrowing.
+					if (!/^[\x20-\x7E]*$/.test(nonceValue)) {
+						return redirectError(
+							redirect_uri,
+							"invalid_request",
+							"nonce contains non-printable characters",
+							toStr(state),
+						);
+					}
 				}
 
 				// CP-14: persist `undefined` when no scopes/audiences survived —

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -546,6 +546,48 @@ export const createOAuthRouter = async (
 					);
 				}
 
+				// IH-16 (v0.5.1): bound the OIDC `nonce` query parameter BEFORE the
+				// scope/policy block runs. Pre-fix the value was stored on the code
+				// record + echoed verbatim into the id_token, letting a malicious
+				// RP exhaust per-request memory or amplify the token payload with a
+				// multi-megabyte string. The 256-char ceiling is operator-tunable
+				// via `oauth.nonce.maxLength` (default in core HOCON, env-var
+				// `OAUTH_NONCE_MAX_LENGTH`). Errors use `redirectError` because
+				// `redirect_uri` is already validated against the client allowlist
+				// at this point — RFC 6749 §4.1.2.1 requires error redirects from
+				// here on.
+				//
+				// Placement (Claude review fixup): the gate runs BEFORE
+				// `grantPolicy.evaluate()` so an oversized nonce cannot trigger
+				// external policy I/O (Redis lookup / HTTP call) before the cheap
+				// length+character-set check rejects the request. Moving the gate
+				// any earlier than this is unsafe — it must follow `redirect_uri`
+				// validation so errors can use `redirectError`.
+				const nonceMaxLength = config.oauth.nonce?.maxLength ?? 256;
+				if (typeof req.query.nonce === "string") {
+					const nonceValue = req.query.nonce;
+					if (nonceValue.length > nonceMaxLength) {
+						return redirectError(
+							redirect_uri,
+							"invalid_request",
+							`nonce exceeds maximum length of ${nonceMaxLength}`,
+							toStr(state),
+						);
+					}
+					// Printable ASCII only (0x20-0x7E). Non-printable input could
+					// confuse downstream JWT libraries that don't escape control
+					// chars in JSON payloads. OIDC Core §3.1.2.1 leaves the
+					// alphabet unconstrained; this is a defensive narrowing.
+					if (!/^[\x20-\x7E]*$/.test(nonceValue)) {
+						return redirectError(
+							redirect_uri,
+							"invalid_request",
+							"nonce contains non-printable characters",
+							toStr(state),
+						);
+					}
+				}
+
 				const requestedScopes = toStr(scope)?.split(" ").filter(Boolean) ?? [];
 				const allowedFilteredScopes =
 					requestedScopes.length > 0
@@ -642,41 +684,6 @@ export const createOAuthRouter = async (
 				} else {
 					// No challenge: method is irrelevant (no PKCE)
 					resolvedMethod = undefined;
-				}
-
-				// IH-16 (v0.5.1): bound the OIDC `nonce` query parameter. Pre-fix
-				// the value was stored on the code record + echoed verbatim into
-				// the id_token, letting a malicious RP exhaust per-request memory
-				// or amplify the token payload with a multi-megabyte string. The
-				// 256-char ceiling is operator-tunable via `oauth.nonce.maxLength`
-				// (default in core HOCON, env-var `OAUTH_NONCE_MAX_LENGTH`).
-				// Errors use `redirectError` because `redirect_uri` is already
-				// validated against the client allowlist at this point — RFC 6749
-				// §4.1.2.1 requires error redirects from here on.
-				const oauthConfig = config.oauth as { nonce?: { maxLength?: number } } | undefined;
-				const nonceMaxLength = oauthConfig?.nonce?.maxLength ?? 256;
-				if (typeof req.query.nonce === "string") {
-					const nonceValue = req.query.nonce;
-					if (nonceValue.length > nonceMaxLength) {
-						return redirectError(
-							redirect_uri,
-							"invalid_request",
-							`nonce exceeds maximum length of ${nonceMaxLength}`,
-							toStr(state),
-						);
-					}
-					// Printable ASCII only (0x20-0x7E). Non-printable input could
-					// confuse downstream JWT libraries that don't escape control
-					// chars in JSON payloads. OIDC Core §3.1.2.1 leaves the
-					// alphabet unconstrained; this is a defensive narrowing.
-					if (!/^[\x20-\x7E]*$/.test(nonceValue)) {
-						return redirectError(
-							redirect_uri,
-							"invalid_request",
-							"nonce contains non-printable characters",
-							toStr(state),
-						);
-					}
 				}
 
 				// CP-14: persist `undefined` when no scopes/audiences survived —


### PR DESCRIPTION
## Summary

Phase F F6 PR2 — bundles four v0.5.1 security/safety fixes targeting `authorization.mts` PKCE/code path and the RT family rotation wrapper. Per F6 batch order, four specs are landed together because they share the same diff window (avoid repeated merge conflicts).

- **IH-13** — RT family fixed expiry (no sliding window). `Math.min(requestedExpiresAtMs, current.expiresAtMs)` cap inside the rotation CAS updater. New optional `cappedExpiresAtMs` field on `"rotated"` outcome.
- **SF-3 + MIN-4** — Timing-safe PKCE compare. New `constantTimeStringEqual` helper at `packages/core/src/security/timingSafe.mts`, wired into both S256 and `plain` branches of authorization.mts.
- **IH-16** — `/authorize` nonce length + printable-ASCII bound (default 256, env `OAUTH_NONCE_MAX_LENGTH`).
- **TS-4** — `pkceConfig.supportedMethods` per-element type validation via new `resolvePkceSupportedMethods` helper at `packages/oauth/src/grants/pkce.mts`.

Includes Claude review fixups (IH-16 gate moved before `grantPolicy.evaluate()` for DoS amplification, TS-4 all-non-string warn added with spy test, drift JSDoc on `cappedExpiresAtMs`, defensive challenge-without-method guard).

Backward compatible: `cappedExpiresAtMs` is optional on the outcome (existing stubs unaffected); HOCON default lives in `application.conf` (no schema-side `.default()` per ADR); `oauth.nonce` schema is shape-only and additive.

## Specs (with inline Codex calibration deltas applied)

- `auth/.claude/superpowers/specs/2026-05-05-ih13-rt-family-fixed-expiry.md`
- `auth/.claude/superpowers/specs/2026-05-05-sf3-pkce-timing-safe.md`
- `auth/.claude/superpowers/specs/2026-05-05-ih16-nonce-length-bound.md`
- `auth/.claude/superpowers/specs/2026-05-05-ts4-pkce-supported-methods-element-type.md`

Notable Codex deltas honoured: IH-13 ` family_expired` outcome stays out (lazy-GC unreachable at rotation layer); SF-3 import via package root not subpath, encode-before-length-check for Unicode safety; IH-16 schema shape-only + redirectError; TS-4 consumers do NOT pass logger (deferred D-4).

## Phase F open question (deferred)

The RT JWT `exp` claim may still reflect `now + refreshToken.expiresIn` even after the family TTL was capped. The actual lifetime is bounded by the server-side family TTL, not the JWT exp. Aligning the JWT exp by re-minting requires either pre-rotate `findFamily` or post-rotate JTI re-registration; the spec itself flags this as a Phase F open question. Storage-level cap is the v0.5.1 security primary.

## Test plan

- [x] `pnpm -r run test` — all packages green (core 1123, oauth 343, redis 293, etc.)
- [x] `pnpm exec biome check` — clean (18 pre-existing warnings unchanged)
- [x] Build (`pnpm run -r build`) — clean
- [x] /multi-agent-review (Claude design/logic review — 1 round): findings applied in fixup commit `279ab08e`
- [ ] Codex review (will run on PR push if applicable; sandbox-EPERM noise meant no usable structured output from local pre-push run — see F5 progress note 4)
- [ ] Copilot post-push review

## Files changed

15 files, 802 insertions, 25 deletions:
- New: `packages/core/src/security/{timingSafe.mts,__tests__/timingSafe.test.mts}`
- New: `packages/oauth/src/grants/{pkce.mts,__tests__/pkce.test.mts}`
- Modified: rotation.mts/types.mts (IH-13), authorization.mts/routes.mts (SF-3, IH-16, TS-4 wiring + defensive guards), application.schema.mts/application.conf (IH-16 schema + HOCON default), index.mts (constantTimeStringEqual export), oauthAuthorization.test.mts (IH-16 + explicit-config tests), CHANGELOG.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)