### PR TITLE
F6 PR3 — RT grant hardening: PB-1 + CC-2 + SF-6 (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,79 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security (Phase F — F6 PR3 refresh-token grant hardening, v0.5.1)
+
+- **Refresh-token reuse now revokes the entire family** (`@o3co/auth-provider-oauth`,
+  closes PB-1): when `refreshTokenFamilyRotation.rotate` reports the
+  `"replayed"` outcome, the grant handler now calls
+  `refreshTokenFamilyRevocation.revokeFamily(familyId)` before returning
+  `400 invalid_grant / replay_detected`. Pre-fix, only the present request
+  was rejected — sibling refresh tokens issued from the same family
+  remained valid, contradicting RFC 6819 §5.2.2 / OAuth 2.1 BCP §4.14.2.
+  Fail-closed semantics: a rotation wired without a revocation dependency,
+  or a `revokeFamily` call that throws, returns
+  `503 temporarily_unavailable` rather than silently rejecting only the
+  current request. Audit log
+  `rt_reuse_detected_family_revoked { familyId, clientId }` is emitted
+  on the success path; `rt_reuse_detected_but_no_revocation_dep` flags
+  the misconfiguration case.
+
+- **Unknown `family_id` is now rejected by default** (`@o3co/auth-provider-core` +
+  `@o3co/auth-provider-oauth`, closes CC-2 / IH-3 / TD-2): a new
+  `oauth.refreshToken.unknownFamilyPolicy` config key (default `"reject"`,
+  defined in `application.conf`) replaces the v0.4.x implicit fall-through
+  to success. An attacker presenting a refresh token whose `family_id`
+  claim does not match any registered family now receives
+  `400 invalid_grant / unknown_family` instead of fresh tokens. Operators
+  migrating from v0.4.x in-memory family stores to Redis can opt into
+  `"accept"` for a bounded migration window — that path emits the audit
+  log `unknown_family_accepted_legacy_mode` so each acceptance is traceable.
+  A defense-in-depth `familyId === null` guard hard-rejects regardless
+  of policy (covered by SF-6's gate but kept for resilience).
+
+- **Refresh tokens missing `jti` or `family_id` claims are rejected**
+  (`@o3co/auth-provider-core` + `@o3co/auth-provider-oauth`, closes
+  SF-6 / TD-7): when `refreshTokenFamilyRotation` is wired, refresh
+  tokens MUST carry both claims to enter the rotation block. Pre-fix,
+  the entire rotation block was skipped when `previousJti === null`,
+  letting v0.4.x-shaped tokens bypass replay detection entirely. New
+  `oauth.refreshToken.legacyRtPolicy` config key (default `"reject"`)
+  hard-rejects such tokens with
+  `400 invalid_grant / missing_jti_or_family_id`; the
+  `"accept-with-warning"` opt-in skips rotation for a migration window
+  and emits `legacy_rt_accepted_no_replay_protection`. Pair with
+  `unknownFamilyPolicy = "accept"` for a one-refresh sliding bridge
+  (the issued RT's fresh `family_id` is not registered in the store, so
+  the next rotation hits `unknown_family`).
+
+- **Rotation outcome handling is now an exhaustive switch**
+  (`@o3co/auth-provider-oauth`): the four-outcome rotation union
+  (`rotated | replayed | revoked | unknown_family`) is now classified by
+  a `switch` with a `never`-typed default. A future addition to
+  `RefreshTokenFamilyRotationOutcome` that forgets to update the handler
+  produces a TypeScript compile error rather than silently falling
+  through to token issuance — the failure mode that v0.4.x's implicit
+  fall-through enabled for `unknown_family`.
+
+#### Migration
+
+**BREAKING** for deployments that previously relied on either of:
+
+- A refresh token with an unknown `family_id` succeeding (rare; see CC-2
+  rationale above) — set
+  `OAUTH_REFRESH_TOKEN_UNKNOWN_FAMILY_POLICY=accept` for a bounded window.
+- v0.4.x-shaped refresh tokens (no `jti` / `family_id`) succeeding while
+  family rotation is wired — set
+  `OAUTH_REFRESH_TOKEN_LEGACY_RT_POLICY=accept-with-warning` until all
+  v0.4.x tokens have expired (≤ `OAUTH_REFRESH_TOKEN_EXPIRES_IN` seconds
+  after deployment), and pair with `OAUTH_REFRESH_TOKEN_UNKNOWN_FAMILY_POLICY=accept`
+  to bridge the next refresh.
+
+Deployments without `refreshTokenFamilyRotation` wired are unaffected
+(the gate only fires when rotation is present). Newly issued tokens
+already carry both `jti` and `family_id` since v0.5.0, so the long-tail
+exposure is bounded by `oauth.refreshToken.expiresIn`.
+
 ### Security (Phase F — F6 PR2 PKCE + RT family hardening, v0.5.1)
 
 - **PKCE `code_verifier` comparison is now timing-safe** (`@o3co/auth-provider-oauth`,

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -32,6 +32,19 @@ oauth {
   refreshToken {
     expiresIn = 86400
     expiresIn = ${?OAUTH_REFRESH_TOKEN_EXPIRES_IN}
+    # CC-2: handling for refresh tokens whose family_id is not in the store.
+    # "reject" is safe-by-default. Use "accept" only during a migration window
+    # (e.g. moving from v0.4.x in-memory family store to Redis while old
+    # tokens are still in circulation).
+    unknownFamilyPolicy = "reject"
+    unknownFamilyPolicy = ${?OAUTH_REFRESH_TOKEN_UNKNOWN_FAMILY_POLICY}
+    # SF-6: handling for refresh tokens lacking jti or family_id claims when
+    # family rotation is wired. "reject" is safe-by-default. Use
+    # "accept-with-warning" only during a migration window where v0.4.x
+    # tokens (no jti) are still in circulation; that mode skips replay
+    # detection for the request and emits an audit log.
+    legacyRtPolicy = "reject"
+    legacyRtPolicy = ${?OAUTH_REFRESH_TOKEN_LEGACY_RT_POLICY}
   }
   grants {
     session { enabled = true, enabled = ${?OAUTH_GRANTS_SESSION_ENABLED} }

--- a/packages/core/src/__tests__/config-composition.test.mts
+++ b/packages/core/src/__tests__/config-composition.test.mts
@@ -34,7 +34,11 @@ const minimalCoreConfig = {
 			},
 		},
 		accessToken: { expiresIn: 3600 },
-		refreshToken: { expiresIn: 86400 },
+		refreshToken: {
+			expiresIn: 86400,
+			unknownFamilyPolicy: "reject",
+			legacyRtPolicy: "reject",
+		},
 		grants: {},
 	},
 };
@@ -214,7 +218,11 @@ describe("AppConfigSchema backward compatibility", () => {
 					},
 				},
 				accessToken: { expiresIn: 3600 },
-				refreshToken: { expiresIn: 86400 },
+				refreshToken: {
+					expiresIn: 86400,
+					unknownFamilyPolicy: "reject",
+					legacyRtPolicy: "reject",
+				},
 				grants: {
 					session: { enabled: true },
 					authorization_code: { enabled: true },

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -121,6 +121,21 @@ export const CoreConfigSchema = z.object({
 		}),
 		refreshToken: z.object({
 			expiresIn: z.coerce.number(),
+			// CC-2 (v0.5.1): policy for refresh tokens whose `family_id` does not
+			// match a known family record. `"reject"` is the safe default; the
+			// pre-fix behavior was implicit `"accept"` (silent fall-through to
+			// success). `"accept"` is intended only for time-bounded migration
+			// windows. Per the v0.5.1 ADR the literal default lives in
+			// `application.conf`, not here.
+			unknownFamilyPolicy: z.enum(["accept", "reject"]),
+			// SF-6 (v0.5.1): policy for refresh tokens lacking `jti` or
+			// `family_id` claims when family rotation is wired. `"reject"` is
+			// the safe default; `"accept-with-warning"` skips replay detection
+			// for the request and emits an audit log — intended only for time-
+			// bounded migration windows where v0.4.x tokens are still in
+			// circulation. Per the v0.5.1 ADR the literal default lives in
+			// `application.conf`, not here.
+			legacyRtPolicy: z.enum(["reject", "accept-with-warning"]),
 		}),
 		grants: z.object({}).passthrough(),
 		// OR-9 (Wave 5d): adapter switch for the OAuth authorization-code

--- a/packages/core/src/grants/types.mts
+++ b/packages/core/src/grants/types.mts
@@ -127,6 +127,14 @@ export interface GrantDependencies {
 	sessionRPRegistry?: SessionRPRegistry;
 	sessionFamilyIndex?: SessionFamilyIndex;
 	sessionFederationIndex?: SessionFederationIndex;
+	/**
+	 * Optional structured logger for security-relevant grant audit events
+	 * (RT replay detection, unknown-family policy decisions, legacy-token
+	 * acceptance). Falls back silently when absent so the grant factory
+	 * remains usable from minimal test harnesses; production wires the
+	 * `logger` slot per `ComponentMap.logger` declaration merge.
+	 */
+	logger?: import("../logging/Logger.mjs").Logger;
 }
 
 /**

--- a/packages/core/src/refresh-token-family/types.mts
+++ b/packages/core/src/refresh-token-family/types.mts
@@ -178,10 +178,16 @@ export interface RefreshTokenFamilyStore {
  *   MUST reject and treat as a replay-attack audit signal.
  * - `revoked`: family exists but its `revoked` flag is set. Caller MUST
  *   reject and treat as a logout-cascade signal.
- * - `unknown_family`: no family record matches. Caller policy decides
- *   whether to accept or reject — the v0.4.x default was accept; the
- *   v0.5.0 default is configurable via `oauth.refreshToken.unknownFamilyPolicy`
- *   (owned by the oauth grant handler module, NOT this wrapper).
+ * - `unknown_family`: no family record matches `family_id`. The grant
+ *   handler consults `oauth.refreshToken.unknownFamilyPolicy`:
+ *   - `"reject"` (default, safe-by-default in v0.5.1+): returns
+ *     `400 invalid_grant / "unknown_family"`.
+ *   - `"accept"` (legacy migration mode only): falls through to issuance
+ *     and emits a warn audit log. Intended for time-bounded migration
+ *     windows when moving from v0.4.x in-memory family stores to Redis.
+ *   The v0.4.x behavior was unconditional accept; v0.5.1+ defaults to
+ *   reject per CC-2. Policy ownership lives in the oauth grant handler
+ *   module, NOT this wrapper.
  *
  * Per A3 §5.2 + IH-13 (v0.5.1).
  */

--- a/packages/core/src/testing/fixtures/valid-config.mts
+++ b/packages/core/src/testing/fixtures/valid-config.mts
@@ -80,7 +80,11 @@ export function makeValidCoreConfig() {
 				},
 			},
 			accessToken: { expiresIn: 3600 },
-			refreshToken: { expiresIn: 86400 },
+			refreshToken: {
+				expiresIn: 86400,
+				unknownFamilyPolicy: "reject",
+				legacyRtPolicy: "reject",
+			},
 			grants: {},
 		},
 	} satisfies CoreConfig;

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -19,12 +19,29 @@ import {
 	type GrantContext,
 	type GrantDependencies,
 	type GrantPolicyHookBase,
+	type Logger,
 	type RefreshTokenFamilyRotation,
 	type UserSessionStore,
 } from "@o3co/auth-provider-core";
 import { SignJWT } from "jose";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createRefreshTokenGrant } from "#/grants/refreshToken.mjs";
+
+// Vitest mock-shaped Logger that satisfies the interface; tests pass a fresh
+// `vi.fn()` for `warn` and inspect its calls. Other levels are vi.fn() so
+// unrelated calls don't crash on undefined.
+function makeStubLogger(warn: ReturnType<typeof vi.fn>): Logger {
+	const stub = {
+		trace: vi.fn(),
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn,
+		error: vi.fn(),
+		fatal: vi.fn(),
+	};
+	// `child()` returns the same stub so child loggers are observable too.
+	return { ...stub, child: () => stub as unknown as Logger } as unknown as Logger;
+}
 
 const SECRET = "test-secret-at-least-32-chars!!";
 const keyStore = createSymmetricKeyStore(SECRET);
@@ -34,7 +51,14 @@ const mockConfig = {
 	oauth: {
 		jwt: { secret: SECRET },
 		accessToken: { expiresIn: 3600 },
-		refreshToken: { expiresIn: 86400 },
+		refreshToken: {
+			expiresIn: 86400,
+			// CC-2 (v0.5.1): default policy for unknown_family is "reject".
+			unknownFamilyPolicy: "reject",
+			// SF-6 (v0.5.1): default policy for tokens lacking jti or family_id
+			// when rotation is wired is "reject".
+			legacyRtPolicy: "reject",
+		},
 		grants: {
 			session: { enabled: true },
 			authorization_code: { enabled: true },
@@ -425,9 +449,23 @@ describe("createRefreshTokenGrant", () => {
 
 		it("returns invalid_grant/replay_detected when the rotation reports 'replayed'", async () => {
 			const stub = createStubRotation("replayed");
-			const depsWithStore: GrantDependencies = { ...mockDeps, refreshTokenFamilyRotation: stub };
-			// Token must include a jti so that previousJti !== null and rotate() is called
-			const token = await new SignJWT({ sub: "u1", scope: "read write" })
+			// PB-1 (v0.5.1): rotation wired without revocation must fail-closed
+			// to 503. Existing tests that only assert the "replayed" path supply
+			// a noop revocation stub so the request reaches the replay branch.
+			const noopRevocation = {
+				async revokeFamily() {},
+				async isFamilyRevoked() {
+					return false;
+				},
+			};
+			const depsWithStore: GrantDependencies = {
+				...mockDeps,
+				refreshTokenFamilyRotation: stub,
+				refreshTokenFamilyRevocation: noopRevocation,
+			};
+			// SF-6 (v0.5.1): when rotation is wired the token MUST carry both
+			// jti AND family_id, otherwise the legacy gate fires before rotation.
+			const token = await new SignJWT({ sub: "u1", scope: "read write", family_id: "fam-1" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
@@ -464,7 +502,8 @@ describe("createRefreshTokenGrant", () => {
 				...mockDeps,
 				refreshTokenFamilyRotation: throwingRotation,
 			};
-			const token = await new SignJWT({ sub: "u1", scope: "read write" })
+			// SF-6 (v0.5.1): token must carry family_id when rotation is wired.
+			const token = await new SignJWT({ sub: "u1", scope: "read write", family_id: "fam-1" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
@@ -488,8 +527,8 @@ describe("createRefreshTokenGrant", () => {
 		it("returns invalid_grant/family_revoked when the rotation reports 'revoked'", async () => {
 			const stub = createStubRotation("revoked");
 			const depsWithStore: GrantDependencies = { ...mockDeps, refreshTokenFamilyRotation: stub };
-			// Token must include a jti so that previousJti !== null and rotate() is called
-			const token = await new SignJWT({ sub: "u1", scope: "read write" })
+			// SF-6 (v0.5.1): token must carry family_id when rotation is wired.
+			const token = await new SignJWT({ sub: "u1", scope: "read write", family_id: "fam-1" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
@@ -513,6 +552,524 @@ describe("createRefreshTokenGrant", () => {
 			} else {
 				expect.fail("Expected error in result");
 			}
+		});
+	});
+
+	describe("F6 PR3 — PB-1 RT reuse → family revoke", () => {
+		console.log("DEBUG: F6 PR3 PB-1 describe being collected");
+		// Stub rotation that always reports "replayed" (jti mismatch).
+		const replayedRotation: RefreshTokenFamilyRotation = {
+			async register() {},
+			async rotate() {
+				return { outcome: "replayed" };
+			},
+		};
+
+		// Helper: a refresh token with both jti and family_id present so SF-6
+		// gate doesn't fire. The replayed outcome is decided by the rotation
+		// stub regardless of the actual jti — the stub is unconditional.
+		async function makeReplayedRt(familyId = "fam-1"): Promise<string> {
+			return new SignJWT({ sub: "u1", scope: "read write", family_id: familyId })
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setAudience(DEFAULT_CLIENT_ID)
+				.setExpirationTime("24h")
+				.setJti("jti-A")
+				.sign(secretKey);
+		}
+
+		const baseCtx: GrantContext = {
+			body: {},
+			session: {},
+			issuer: "localhost",
+			metadata: { ip: "127.0.0.1" },
+			authenticatedClient: DEFAULT_AUTH_CLIENT,
+		};
+
+		it("revokes the RT family with the exact family_id when replay is detected (RED 1)", async () => {
+			const revokeFamily = vi.fn().mockResolvedValue(undefined);
+			const revocation = {
+				revokeFamily,
+				async isFamilyRevoked() {
+					return false;
+				},
+			};
+			const deps: GrantDependencies = {
+				...mockDeps,
+				refreshTokenFamilyRotation: replayedRotation,
+				refreshTokenFamilyRevocation: revocation,
+			};
+			const rt = await makeReplayedRt("fam-1");
+
+			const { result } = await createRefreshTokenGrant(deps).handle({
+				...baseCtx,
+				body: { refresh_token: rt },
+			});
+
+			expect(result.status).toBe(400);
+			if (!("error" in result)) expect.fail("Expected error in result");
+			expect(result.error).toBe("invalid_grant");
+			expect(result.errorDescription).toBe("replay_detected");
+			// PB-1 Codex Delta 3: assert exact family_id, not expect.any(String).
+			expect(revokeFamily).toHaveBeenCalledWith("fam-1");
+			expect(revokeFamily).toHaveBeenCalledTimes(1);
+		});
+
+		it("returns 503 when revocation dep is missing (PB-1 Codex Delta 1, fail-closed)", async () => {
+			// Rotation wired but no revocation dep — fail-closed per Delta 1
+			// (silent skip would violate RFC 6819 §5.2.2 compliance guarantee).
+			const deps: GrantDependencies = {
+				...mockDeps,
+				refreshTokenFamilyRotation: replayedRotation,
+			};
+			const rt = await makeReplayedRt("fam-1");
+
+			const { result } = await createRefreshTokenGrant(deps).handle({
+				...baseCtx,
+				body: { refresh_token: rt },
+			});
+
+			expect(result.status).toBe(503);
+			if (!("error" in result)) expect.fail("Expected error in result");
+			expect(result.error).toBe("temporarily_unavailable");
+		});
+
+		it("returns 503 when revokeFamily throws during replay handling (RED 5)", async () => {
+			const revocation = {
+				async revokeFamily() {
+					throw new Error("Redis down");
+				},
+				async isFamilyRevoked() {
+					return false;
+				},
+			};
+			const deps: GrantDependencies = {
+				...mockDeps,
+				refreshTokenFamilyRotation: replayedRotation,
+				refreshTokenFamilyRevocation: revocation,
+			};
+			const rt = await makeReplayedRt("fam-1");
+
+			const { result } = await createRefreshTokenGrant(deps).handle({
+				...baseCtx,
+				body: { refresh_token: rt },
+			});
+
+			expect(result.status).toBe(503);
+			if (!("error" in result)) expect.fail("Expected error in result");
+			expect(result.error).toBe("temporarily_unavailable");
+		});
+
+		it("emits rt_reuse_detected_family_revoked audit log on replay (RED 3)", async () => {
+			const warn = vi.fn();
+			const logger = makeStubLogger(warn);
+			const revocation = {
+				async revokeFamily() {},
+				async isFamilyRevoked() {
+					return false;
+				},
+			};
+			const deps: GrantDependencies = {
+				...mockDeps,
+				refreshTokenFamilyRotation: replayedRotation,
+				refreshTokenFamilyRevocation: revocation,
+				logger,
+			};
+			const rt = await makeReplayedRt("fam-1");
+
+			await createRefreshTokenGrant(deps).handle({
+				...baseCtx,
+				body: { refresh_token: rt },
+			});
+
+			expect(warn).toHaveBeenCalledWith(
+				expect.objectContaining({ familyId: "fam-1", clientId: DEFAULT_CLIENT_ID }),
+				"rt_reuse_detected_family_revoked",
+			);
+		});
+
+		it("concurrent replay calls revoke twice idempotently (PB-1 Codex Delta 2)", async () => {
+			const revokeFamily = vi.fn().mockResolvedValue(undefined);
+			const revocation = {
+				revokeFamily,
+				async isFamilyRevoked() {
+					return false;
+				},
+			};
+			const deps: GrantDependencies = {
+				...mockDeps,
+				refreshTokenFamilyRotation: replayedRotation,
+				refreshTokenFamilyRevocation: revocation,
+			};
+			const rt = await makeReplayedRt("fam-race");
+			const handler = createRefreshTokenGrant(deps);
+
+			const [r1, r2] = await Promise.all([
+				handler.handle({ ...baseCtx, body: { refresh_token: rt } }),
+				handler.handle({ ...baseCtx, body: { refresh_token: rt } }),
+			]);
+
+			expect(r1.result.status).toBe(400);
+			expect(r2.result.status).toBe(400);
+			expect(revokeFamily).toHaveBeenCalledTimes(2);
+			expect(revokeFamily).toHaveBeenCalledWith("fam-race");
+		});
+
+		it("a fresh family after revocation is independent (RED 4 — orthogonality smoke)", async () => {
+			// "rotated" outcome on a different family — issuance succeeds, no
+			// revocation invoked. Demonstrates the replay branch is targeted
+			// only at the matching family_id.
+			const rotated: RefreshTokenFamilyRotation = {
+				async register() {},
+				async rotate() {
+					return { outcome: "rotated" };
+				},
+			};
+			const revokeFamily = vi.fn().mockResolvedValue(undefined);
+			const revocation = {
+				revokeFamily,
+				async isFamilyRevoked() {
+					return false;
+				},
+			};
+			const deps: GrantDependencies = {
+				...mockDeps,
+				refreshTokenFamilyRotation: rotated,
+				refreshTokenFamilyRevocation: revocation,
+			};
+			const rt = await new SignJWT({ sub: "u1", scope: "read", family_id: "fam-2" })
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setAudience(DEFAULT_CLIENT_ID)
+				.setExpirationTime("24h")
+				.setJti("jti-fresh")
+				.sign(secretKey);
+
+			const { result } = await createRefreshTokenGrant(deps).handle({
+				...baseCtx,
+				body: { refresh_token: rt },
+			});
+
+			expect(result.status).toBe(200);
+			expect(revokeFamily).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("F6 PR3 — CC-2 unknown_family policy", () => {
+		const unknownFamilyRotation: RefreshTokenFamilyRotation = {
+			async register() {},
+			async rotate() {
+				return { outcome: "unknown_family" };
+			},
+		};
+
+		const baseCtx: GrantContext = {
+			body: {},
+			session: {},
+			issuer: "localhost",
+			metadata: { ip: "127.0.0.1" },
+			authenticatedClient: DEFAULT_AUTH_CLIENT,
+		};
+
+		async function makeRtWithFamily(familyId = "fam-unknown"): Promise<string> {
+			return new SignJWT({ sub: "u1", scope: "read write", family_id: familyId })
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setAudience(DEFAULT_CLIENT_ID)
+				.setExpirationTime("24h")
+				.setJti("jti-X")
+				.sign(secretKey);
+		}
+
+		function configWithUnknownPolicy(policy: "accept" | "reject"): GrantDependencies["config"] {
+			return {
+				...mockConfig,
+				oauth: {
+					...mockConfig.oauth,
+					refreshToken: {
+						...mockConfig.oauth.refreshToken,
+						unknownFamilyPolicy: policy,
+					},
+				},
+			} as unknown as GrantDependencies["config"];
+		}
+
+		it("returns 400 invalid_grant for unknown_family with default policy (RED 1)", async () => {
+			const deps: GrantDependencies = {
+				...mockDeps,
+				refreshTokenFamilyRotation: unknownFamilyRotation,
+			};
+			const rt = await makeRtWithFamily();
+
+			const { result } = await createRefreshTokenGrant(deps).handle({
+				...baseCtx,
+				body: { refresh_token: rt },
+			});
+
+			expect(result.status).toBe(400);
+			if (!("error" in result)) expect.fail("Expected error in result");
+			expect(result.error).toBe("invalid_grant");
+			expect(result.errorDescription).toBe("unknown_family");
+		});
+
+		it("issues tokens with unknownFamilyPolicy=accept (RED 2 — legacy mode)", async () => {
+			const warn = vi.fn();
+			const logger = makeStubLogger(warn);
+			const deps: GrantDependencies = {
+				config: configWithUnknownPolicy("accept"),
+				keyStore: mockDeps.keyStore,
+				refreshTokenFamilyRotation: unknownFamilyRotation,
+				logger,
+			};
+			const rt = await makeRtWithFamily("fam-legacy");
+
+			const { result } = await createRefreshTokenGrant(deps).handle({
+				...baseCtx,
+				body: { refresh_token: rt },
+			});
+
+			expect(result.status).toBe(200);
+			expect(warn).toHaveBeenCalledWith(
+				expect.objectContaining({ familyId: "fam-legacy" }),
+				"unknown_family_accepted_legacy_mode",
+			);
+		});
+
+		it("returns 400 with explicit unknownFamilyPolicy=reject (RED 3)", async () => {
+			const warn = vi.fn();
+			const logger = makeStubLogger(warn);
+			const deps: GrantDependencies = {
+				config: configWithUnknownPolicy("reject"),
+				keyStore: mockDeps.keyStore,
+				refreshTokenFamilyRotation: unknownFamilyRotation,
+				logger,
+			};
+			const rt = await makeRtWithFamily("fam-unknown");
+
+			const { result } = await createRefreshTokenGrant(deps).handle({
+				...baseCtx,
+				body: { refresh_token: rt },
+			});
+
+			expect(result.status).toBe(400);
+			if (!("error" in result)) expect.fail("Expected error in result");
+			expect(result.errorDescription).toBe("unknown_family");
+			expect(warn).toHaveBeenCalledWith(
+				expect.objectContaining({ familyId: "fam-unknown" }),
+				"unknown_family_rejected",
+			);
+		});
+
+		it("force-rejects unknown_family when familyId is null even with accept policy (CC-2 Codex Delta 3)", async () => {
+			// SF-6 normally blocks tokens lacking family_id — but to exercise
+			// CC-2's defense-in-depth guard we set legacyRtPolicy=accept-with-warning
+			// so the SF-6 gate falls through. Then the rotation block is reached
+			// with familyId === null, and the unknown_family branch must hard-reject.
+			const config = {
+				...mockConfig,
+				oauth: {
+					...mockConfig.oauth,
+					refreshToken: {
+						...mockConfig.oauth.refreshToken,
+						unknownFamilyPolicy: "accept",
+						legacyRtPolicy: "accept-with-warning",
+					},
+				},
+			} as unknown as GrantDependencies["config"];
+			const deps: GrantDependencies = {
+				config,
+				keyStore: mockDeps.keyStore,
+				refreshTokenFamilyRotation: unknownFamilyRotation,
+			};
+			// RT with no family_id claim — familyId resolves to null
+			const rt = await new SignJWT({ sub: "u1" })
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setAudience(DEFAULT_CLIENT_ID)
+				.setExpirationTime("24h")
+				.setJti("jti-no-fam")
+				.sign(secretKey);
+
+			const { result } = await createRefreshTokenGrant(deps).handle({
+				...baseCtx,
+				body: { refresh_token: rt },
+			});
+
+			// SF-6 accept-with-warning skips the rotation block entirely, so
+			// CC-2's familyId===null guard is reached only via a code path that
+			// SF-6 today already blocks. The expected behavior is that
+			// accept-with-warning skips rotation → tokens issued (200). We
+			// document this: the CC-2 null guard is defense-in-depth, currently
+			// unreachable when SF-6 holds. If a future change moves the rotation
+			// block ahead of the SF-6 gate, this test catches it.
+			expect(result.status).toBe(200);
+		});
+
+		it("still handles replayed outcome correctly (RED 4 — orthogonality)", async () => {
+			const replayedRotation: RefreshTokenFamilyRotation = {
+				async register() {},
+				async rotate() {
+					return { outcome: "replayed" };
+				},
+			};
+			const revocation = {
+				async revokeFamily() {},
+				async isFamilyRevoked() {
+					return false;
+				},
+			};
+			const deps: GrantDependencies = {
+				...mockDeps,
+				refreshTokenFamilyRotation: replayedRotation,
+				refreshTokenFamilyRevocation: revocation,
+			};
+			const rt = await makeRtWithFamily("fam-replay");
+
+			const { result } = await createRefreshTokenGrant(deps).handle({
+				...baseCtx,
+				body: { refresh_token: rt },
+			});
+
+			expect(result.status).toBe(400);
+			if (!("error" in result)) expect.fail("Expected error in result");
+			// MUST be "replay_detected", NOT "unknown_family"
+			expect(result.errorDescription).toBe("replay_detected");
+		});
+	});
+
+	describe("F6 PR3 — SF-6 RT without jti/family_id rejection", () => {
+		const rotatedRotation: RefreshTokenFamilyRotation = {
+			async register() {},
+			async rotate() {
+				return { outcome: "rotated" };
+			},
+		};
+
+		const baseCtx: GrantContext = {
+			body: {},
+			session: {},
+			issuer: "localhost",
+			metadata: { ip: "127.0.0.1" },
+			authenticatedClient: DEFAULT_AUTH_CLIENT,
+		};
+
+		it("returns 400 invalid_grant for RT without jti when rotation is wired (RED 1)", async () => {
+			const deps: GrantDependencies = {
+				...mockDeps,
+				refreshTokenFamilyRotation: rotatedRotation,
+			};
+			// Token has family_id but no jti — legacy gate must fire
+			const rt = await new SignJWT({ sub: "u1", scope: "read", family_id: "fam-1" })
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setAudience(DEFAULT_CLIENT_ID)
+				.setExpirationTime("24h")
+				.sign(secretKey);
+
+			const { result } = await createRefreshTokenGrant(deps).handle({
+				...baseCtx,
+				body: { refresh_token: rt },
+			});
+
+			expect(result.status).toBe(400);
+			if (!("error" in result)) expect.fail("Expected error in result");
+			expect(result.error).toBe("invalid_grant");
+			expect(result.errorDescription).toBe("missing_jti_or_family_id");
+		});
+
+		it("returns 400 invalid_grant for RT without family_id when rotation is wired (RED 2)", async () => {
+			const deps: GrantDependencies = {
+				...mockDeps,
+				refreshTokenFamilyRotation: rotatedRotation,
+			};
+			// Token has jti but no family_id
+			const rt = await new SignJWT({ sub: "u1", scope: "read" })
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setAudience(DEFAULT_CLIENT_ID)
+				.setExpirationTime("24h")
+				.setJti("jti-only")
+				.sign(secretKey);
+
+			const { result } = await createRefreshTokenGrant(deps).handle({
+				...baseCtx,
+				body: { refresh_token: rt },
+			});
+
+			expect(result.status).toBe(400);
+			if (!("error" in result)) expect.fail("Expected error in result");
+			expect(result.errorDescription).toBe("missing_jti_or_family_id");
+		});
+
+		it("accepts legacy RT in accept-with-warning mode and skips rotation (RED 3)", async () => {
+			const warn = vi.fn();
+			const logger = makeStubLogger(warn);
+			const rotateSpy = vi.fn().mockResolvedValue({ outcome: "rotated" });
+			const rotation: RefreshTokenFamilyRotation = {
+				async register() {},
+				rotate: rotateSpy,
+			};
+			const config = {
+				...mockConfig,
+				oauth: {
+					...mockConfig.oauth,
+					refreshToken: {
+						...mockConfig.oauth.refreshToken,
+						legacyRtPolicy: "accept-with-warning",
+					},
+				},
+			} as unknown as GrantDependencies["config"];
+			const deps: GrantDependencies = {
+				config,
+				keyStore: mockDeps.keyStore,
+				refreshTokenFamilyRotation: rotation,
+				logger,
+			};
+			// Legacy token with no jti
+			const rt = await new SignJWT({ sub: "u1", scope: "read", family_id: "fam-1" })
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setAudience(DEFAULT_CLIENT_ID)
+				.setExpirationTime("24h")
+				.sign(secretKey);
+
+			const { result } = await createRefreshTokenGrant(deps).handle({
+				...baseCtx,
+				body: { refresh_token: rt },
+			});
+
+			expect(result.status).toBe(200);
+			expect(warn).toHaveBeenCalledWith(
+				expect.objectContaining({ hasJti: false, hasFamilyId: true }),
+				"legacy_rt_accepted_no_replay_protection",
+			);
+			// SF-6 Codex Delta 3: rotation MUST be skipped in accept-with-warning
+			expect(rotateSpy).not.toHaveBeenCalled();
+		});
+
+		it("proceeds with normal rotation when RT has both jti and family_id (RED 4)", async () => {
+			const rotateSpy = vi.fn().mockResolvedValue({ outcome: "rotated" });
+			const rotation: RefreshTokenFamilyRotation = {
+				async register() {},
+				rotate: rotateSpy,
+			};
+			const deps: GrantDependencies = {
+				...mockDeps,
+				refreshTokenFamilyRotation: rotation,
+			};
+			const rt = await new SignJWT({ sub: "u1", scope: "read", family_id: "fam-1" })
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setAudience(DEFAULT_CLIENT_ID)
+				.setExpirationTime("24h")
+				.setJti("jti-1")
+				.sign(secretKey);
+
+			const { result } = await createRefreshTokenGrant(deps).handle({
+				...baseCtx,
+				body: { refresh_token: rt },
+			});
+
+			expect(result.status).toBe(200);
+			// SF-6 Codex Delta 3: rotation called with original family_id
+			expect(rotateSpy).toHaveBeenCalledWith(
+				"jti-1",
+				expect.any(String),
+				"fam-1",
+				expect.any(Number),
+			);
 		});
 	});
 

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -556,7 +556,6 @@ describe("createRefreshTokenGrant", () => {
 	});
 
 	describe("F6 PR3 — PB-1 RT reuse → family revoke", () => {
-		console.log("DEBUG: F6 PR3 PB-1 describe being collected");
 		// Stub rotation that always reports "replayed" (jti mismatch).
 		const replayedRotation: RefreshTokenFamilyRotation = {
 			async register() {},
@@ -857,11 +856,40 @@ describe("createRefreshTokenGrant", () => {
 			);
 		});
 
-		it("force-rejects unknown_family when familyId is null even with accept policy (CC-2 Codex Delta 3)", async () => {
-			// SF-6 normally blocks tokens lacking family_id — but to exercise
-			// CC-2's defense-in-depth guard we set legacyRtPolicy=accept-with-warning
-			// so the SF-6 gate falls through. Then the rotation block is reached
-			// with familyId === null, and the unknown_family branch must hard-reject.
+		it("SF-6 short-circuits null-familyId tokens before CC-2's null guard (defense-in-depth invariant)", async () => {
+			// CC-2 Codex Delta 3 originally asked for a RED test exercising the
+			// `familyId === null` hard-reject guard inside the unknown_family
+			// branch when `unknownFamilyPolicy = "accept"`. With SF-6's gate
+			// in place, that guard is structurally unreachable: when familyId
+			// is null the SF-6 gate fires FIRST and either rejects (default)
+			// or short-circuits to issuance with `accept-with-warning` —
+			// rotation never runs, so the unknown_family branch is never
+			// entered with null familyId.
+			//
+			// This test pins the invariant by:
+			//   1. Setting BOTH `unknownFamilyPolicy = "accept"` (so the
+			//      CC-2 branch would issue tokens if reached) AND
+			//      `legacyRtPolicy = "accept-with-warning"` (so SF-6 doesn't
+			//      hard-reject upstream).
+			//   2. Asserting the SF-6 audit log fires (proves the gate
+			//      caught the null familyId before rotation).
+			//   3. Asserting the rotation stub is NOT called (proves the
+			//      else-branch with the unknown_family case never runs).
+			//   4. Asserting tokens are issued (the surface behaviour, also
+			//      asserted indirectly by the audit log).
+			//
+			// If a future change reorders gates so rotation runs with
+			// familyId === null, the rotation stub `unknownFamilyRotation`
+			// would be invoked (assertion 3 would fail), at which point
+			// the CC-2 null guard inside the unknown_family case would
+			// kick in. Either failure mode catches a regression.
+			const warn = vi.fn();
+			const logger = makeStubLogger(warn);
+			const rotateSpy = vi.fn().mockResolvedValue({ outcome: "unknown_family" });
+			const rotation: RefreshTokenFamilyRotation = {
+				async register() {},
+				rotate: rotateSpy,
+			};
 			const config = {
 				...mockConfig,
 				oauth: {
@@ -876,7 +904,8 @@ describe("createRefreshTokenGrant", () => {
 			const deps: GrantDependencies = {
 				config,
 				keyStore: mockDeps.keyStore,
-				refreshTokenFamilyRotation: unknownFamilyRotation,
+				refreshTokenFamilyRotation: rotation,
+				logger,
 			};
 			// RT with no family_id claim — familyId resolves to null
 			const rt = await new SignJWT({ sub: "u1" })
@@ -891,14 +920,13 @@ describe("createRefreshTokenGrant", () => {
 				body: { refresh_token: rt },
 			});
 
-			// SF-6 accept-with-warning skips the rotation block entirely, so
-			// CC-2's familyId===null guard is reached only via a code path that
-			// SF-6 today already blocks. The expected behavior is that
-			// accept-with-warning skips rotation → tokens issued (200). We
-			// document this: the CC-2 null guard is defense-in-depth, currently
-			// unreachable when SF-6 holds. If a future change moves the rotation
-			// block ahead of the SF-6 gate, this test catches it.
 			expect(result.status).toBe(200);
+			// Pin the invariant: SF-6 fired and rotation was skipped.
+			expect(warn).toHaveBeenCalledWith(
+				expect.objectContaining({ hasFamilyId: false }),
+				"legacy_rt_accepted_no_replay_protection",
+			);
+			expect(rotateSpy).not.toHaveBeenCalled();
 		});
 
 		it("still handles replayed outcome correctly (RED 4 — orthogonality)", async () => {

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -27,7 +27,7 @@ import { decodeProtectedHeader, type JWTPayload, jwtVerify } from "jose";
 import { decodeJwtPayload } from "./_jwtPayload.mjs";
 
 export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler => {
-	const { config, keyStore } = deps;
+	const { config, keyStore, logger } = deps;
 
 	return {
 		async handle(ctx: GrantContext): Promise<GrantHandlerResult> {
@@ -310,50 +310,191 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				},
 			);
 
-			if (deps.refreshTokenFamilyRotation && previousJti !== null) {
-				const newRefreshPayload = decodeJwtPayload(newRefreshToken.token);
-				const newJti = newRefreshPayload.jti as string | undefined;
-				const newExp = newRefreshPayload.exp as number | undefined;
-				if (typeof newJti === "string" && typeof newExp === "number") {
-					// CP-17: fail-closed when the store is unavailable. Same
-					// rationale as CP-16 — we cannot atomically consume the old
-					// jti and register the new one, so replay detection cannot
-					// be guaranteed. Return 503 so the client retries rather
-					// than bubbling an unhandled 500 HTML from express.
-					let rotateResult: Awaited<ReturnType<typeof deps.refreshTokenFamilyRotation.rotate>>;
-					try {
-						rotateResult = await deps.refreshTokenFamilyRotation.rotate(
-							previousJti,
-							newJti,
-							newFamilyId,
-							newExp * 1000,
+			if (deps.refreshTokenFamilyRotation) {
+				// SF-6: when rotation is wired, refresh tokens MUST carry both
+				// jti AND family_id. Tokens lacking either bypass replay
+				// detection because the rotation block cannot match a previous
+				// jti or address a family record. The legacy gate either
+				// rejects (default, safe) or accepts with an audit log
+				// (migration window only) — never silently skips replay
+				// detection without operator awareness.
+				if (previousJti === null || familyId === null) {
+					const policy = config.oauth.refreshToken.legacyRtPolicy ?? "reject";
+					if (policy === "reject") {
+						logger?.warn(
+							{
+								clientId: authenticatedClientId,
+								hasJti: previousJti !== null,
+								hasFamilyId: familyId !== null,
+							},
+							"legacy_rt_rejected",
 						);
-					} catch {
-						return {
-							result: {
-								status: 503,
-								error: "temporarily_unavailable",
-								errorDescription: "refresh token store unavailable",
-							},
-						};
-					}
-					if (rotateResult.outcome === "replayed") {
 						return {
 							result: {
 								status: 400,
 								error: "invalid_grant",
-								errorDescription: "replay_detected",
+								errorDescription: "missing_jti_or_family_id",
 							},
 						};
 					}
-					if (rotateResult.outcome === "revoked") {
-						return {
-							result: {
-								status: 400,
-								error: "invalid_grant",
-								errorDescription: "family_revoked",
-							},
-						};
+					// "accept-with-warning": skip rotation entirely (legacy path)
+					// + emit audit log so operators can monitor migration progress.
+					logger?.warn(
+						{
+							clientId: authenticatedClientId,
+							hasJti: previousJti !== null,
+							hasFamilyId: familyId !== null,
+						},
+						"legacy_rt_accepted_no_replay_protection",
+					);
+				} else {
+					const newRefreshPayload = decodeJwtPayload(newRefreshToken.token);
+					const newJti = newRefreshPayload.jti as string | undefined;
+					const newExp = newRefreshPayload.exp as number | undefined;
+					if (typeof newJti === "string" && typeof newExp === "number") {
+						// CP-17: fail-closed when the store is unavailable. Same
+						// rationale as CP-16 — we cannot atomically consume the old
+						// jti and register the new one, so replay detection cannot
+						// be guaranteed. Return 503 so the client retries rather
+						// than bubbling an unhandled 500 HTML from express.
+						let rotateResult: Awaited<ReturnType<typeof deps.refreshTokenFamilyRotation.rotate>>;
+						try {
+							rotateResult = await deps.refreshTokenFamilyRotation.rotate(
+								previousJti,
+								newJti,
+								newFamilyId,
+								newExp * 1000,
+							);
+						} catch {
+							return {
+								result: {
+									status: 503,
+									error: "temporarily_unavailable",
+									errorDescription: "refresh token store unavailable",
+								},
+							};
+						}
+						// Exhaustive switch over the 4-outcome rotation union.
+						// Each case explicitly handles the security-relevant
+						// outcome; falling through to issuance (the v0.4.x
+						// behavior for unknown_family) is now an explicit
+						// policy decision under operator control (CC-2).
+						switch (rotateResult.outcome) {
+							case "rotated":
+								// Successful rotation — fall through to the
+								// success path below (token issuance).
+								break;
+							case "replayed": {
+								// PB-1: RFC 6819 §5.2.2 / OAuth 2.1 BCP §4.14.2
+								// require revoking the entire family on replay
+								// so siblings cannot continue to redeem. Fail
+								// closed when the revocation dep is missing or
+								// throws — silently rejecting only the present
+								// request would leave sibling RTs valid.
+								if (!deps.refreshTokenFamilyRevocation) {
+									logger?.error(
+										{ clientId: authenticatedClientId },
+										"rt_reuse_detected_but_no_revocation_dep",
+									);
+									return {
+										result: {
+											status: 503,
+											error: "temporarily_unavailable",
+											errorDescription: "refresh token family revocation not configured",
+										},
+									};
+								}
+								try {
+									await deps.refreshTokenFamilyRevocation.revokeFamily(newFamilyId);
+								} catch {
+									return {
+										result: {
+											status: 503,
+											error: "temporarily_unavailable",
+											errorDescription: "refresh token store unavailable",
+										},
+									};
+								}
+								logger?.warn(
+									{ familyId: newFamilyId, clientId: authenticatedClientId },
+									"rt_reuse_detected_family_revoked",
+								);
+								return {
+									result: {
+										status: 400,
+										error: "invalid_grant",
+										errorDescription: "replay_detected",
+									},
+								};
+							}
+							case "revoked":
+								return {
+									result: {
+										status: 400,
+										error: "invalid_grant",
+										errorDescription: "family_revoked",
+									},
+								};
+							case "unknown_family": {
+								// CC-2: defense-in-depth — SF-6 already rejects
+								// tokens with familyId === null when rotation is
+								// wired, but if a future change reorders gates,
+								// fall through to a hard reject regardless of
+								// policy when there was never a family to consult.
+								if (familyId === null) {
+									logger?.warn(
+										{ clientId: authenticatedClientId },
+										"unknown_family_rejected_no_family_id_claim",
+									);
+									return {
+										result: {
+											status: 400,
+											error: "invalid_grant",
+											errorDescription: "unknown_family",
+										},
+									};
+								}
+								const policy = config.oauth.refreshToken.unknownFamilyPolicy ?? "reject";
+								if (policy === "reject") {
+									logger?.warn(
+										{
+											familyId: newFamilyId,
+											jti: previousJti,
+											clientId: authenticatedClientId,
+										},
+										"unknown_family_rejected",
+									);
+									return {
+										result: {
+											status: 400,
+											error: "invalid_grant",
+											errorDescription: "unknown_family",
+										},
+									};
+								}
+								// "accept" — legacy migration mode only; emit
+								// audit log and fall through to issuance.
+								logger?.warn(
+									{
+										familyId: newFamilyId,
+										jti: previousJti,
+										clientId: authenticatedClientId,
+									},
+									"unknown_family_accepted_legacy_mode",
+								);
+								break;
+							}
+							default: {
+								// Exhaustiveness guard: every outcome above
+								// either returns or breaks. A future addition
+								// to RefreshTokenFamilyRotationOutcome that
+								// forgets to update this switch will produce a
+								// compile error here rather than silently
+								// falling through to token issuance.
+								const _exhaustive: never = rotateResult;
+								throw new Error(`unhandled rotation outcome: ${JSON.stringify(_exhaustive)}`);
+							}
+						}
 					}
 				}
 			}

--- a/packages/oauth/src/oauthAuthorization.mts
+++ b/packages/oauth/src/oauthAuthorization.mts
@@ -72,11 +72,19 @@ export const oauthAuthorizationModule = (params: { config: AppConfig }): Module 
 			// policy enforcement. Boot planner only injects keys listed here, so
 			// omitting them silently drops both features at the grant boundary.
 			"refreshTokenFamilyRotation", // A3 §5.2 — replaces legacy refreshTokenStore (#101)
+			// PB-1 (v0.5.1): the refresh grant must call `revokeFamily` on
+			// rotation `replayed` outcome (RFC 6819 §5.2.2). Listed optional so
+			// deployments without rotation wired (no replay path reachable)
+			// remain valid; when rotation IS wired, omitting revocation is
+			// caught at runtime by the fail-closed 503 path in
+			// `refreshToken.mts` rather than silently no-op-ing.
+			"refreshTokenFamilyRevocation",
 			"grantPolicy",
 			"userSessionStore",
 			"sessionRPRegistry", // Amendment 4 (§1.1.4)
 			"sessionFamilyIndex", // Amendment 4 (§1.1.4)
 			"sessionFederationIndex", // Amendment 4 (§1.1.4)
+			"logger", // D-4 — structured logger; security audit logs (PB-1/CC-2/SF-6)
 		],
 		contributes: { grants },
 	});

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -32,6 +32,21 @@ oauth {
   refreshToken {
     expiresIn = 86400
     expiresIn = ${?OAUTH_REFRESH_TOKEN_EXPIRES_IN}
+    # CC-2 (v0.5.1): handling for refresh tokens whose family_id is not
+    # found in the rotation store. "reject" (default, inherited from core
+    # application.conf) is safe-by-default. Use "accept" only during a
+    # bounded migration window — e.g. moving from v0.4.x in-memory family
+    # store to Redis with old tokens still in circulation. Operators set
+    # OAUTH_REFRESH_TOKEN_UNKNOWN_FAMILY_POLICY for env-var override.
+    # unknownFamilyPolicy = "reject"
+    # SF-6 (v0.5.1): handling for refresh tokens lacking jti or family_id
+    # claims when rotation is wired. "reject" (default) is safe. Use
+    # "accept-with-warning" only during a migration window where v0.4.x
+    # tokens (issued before claim standardization) are still in circulation;
+    # that mode skips replay detection for the request and emits an audit
+    # log. Pair with `unknownFamilyPolicy = "accept"` to avoid immediate
+    # rejection on the next refresh — see Phase F migration guide.
+    # legacyRtPolicy = "reject"
   }
   grants {
     session { enabled = true, enabled = ${?OAUTH_GRANTS_SESSION_ENABLED} }

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -45,7 +45,11 @@ const config: AppConfig = {
 			},
 		},
 		accessToken: { expiresIn: 3600 },
-		refreshToken: { expiresIn: 86400 },
+		refreshToken: {
+			expiresIn: 86400,
+			unknownFamilyPolicy: "reject" as const,
+			legacyRtPolicy: "reject" as const,
+		},
 		grants: {},
 		// OR-9: explicit memory adapter for the smoke test. The legacy
 		// `repositories.code.type` fallback would also pick memory here,


### PR DESCRIPTION
## Summary

F6 PR3 of the v0.5.1 hotfix series — bundles three security specs that all touch `packages/oauth/src/grants/refreshToken.mts` so the rotation outcome handling is reshaped exactly once. Builds on top of F6 PR2's IH-13 outcome-union reshape (`d494728e`).

- **PB-1** — RT reuse → revoke entire family (RFC 6819 §5.2.2 / OAuth 2.1 BCP §4.14.2). Pre-fix only the present request was rejected; siblings continued to redeem.
- **CC-2** (closes IH-3 + TD-2) — `oauth.refreshToken.unknownFamilyPolicy` config key (default `"reject"`); attacker presenting unknown family_id is rejected instead of silently issued fresh tokens. 5 RED tests close TD-2.
- **SF-6** (closes TD-7) — `oauth.refreshToken.legacyRtPolicy` config key (default `"reject"`); refresh tokens lacking `jti` or `family_id` claims are rejected when rotation is wired (instead of bypassing replay detection entirely). 4 RED tests close TD-7.

The four-outcome rotation union (`rotated | replayed | revoked | unknown_family`) is now classified by an exhaustive `switch` with a `never`-typed default, so a future addition to `RefreshTokenFamilyRotationOutcome` that forgets to update the handler fails at compile time rather than silently issuing tokens.

`refreshTokenFamilyRevocation` and `logger` are added to `oauthAuthorizationModule`'s optional slots so the boot planner injects them into the grant factory deps.

## Test plan

- [x] `pnpm -r run build` — clean across all packages
- [x] `packages/oauth` tests: 343 → 358 (+15: PB-1×6 + CC-2×5 + SF-6×4)
- [x] `packages/core` tests: 1123 unchanged
- [x] `templates/standalone` tests: 24 unchanged
- [x] `pnpm exec biome check packages templates` — 18 pre-existing warnings, 0 new errors
- [x] Multi-agent review (Codex + Claude code-reviewer) — Issues Found, 1 Important + 2 Minor, all addressed in the second commit (`21c3ba78`)

### BREAKING for migration

- Refresh tokens with unknown `family_id` now hard-reject by default. Operators migrating from v0.4.x in-memory family stores can opt into `OAUTH_REFRESH_TOKEN_UNKNOWN_FAMILY_POLICY=accept` for a bounded window.
- Refresh tokens lacking `jti` or `family_id` claims are now rejected when rotation is wired. Operators with v0.4.x tokens still in circulation can opt into `OAUTH_REFRESH_TOKEN_LEGACY_RT_POLICY=accept-with-warning` until those tokens have expired (≤ `OAUTH_REFRESH_TOKEN_EXPIRES_IN` seconds after deployment).

Both BREAKING changes only affect deployments with `refreshTokenFamilyRotation` wired; deployments without rotation are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)