### PR TITLE
F6 PR4 — CR-4 authorization-grant TOCTOU re-check (last F6 PR, v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `sessionFamilyIndex.removeBySid(sid)` runs AFTER
   `userSessionStore.delete(sid)` to clear any orphan family-index entry
   written into the index by an authorization grant racing through the
-  remaining window described above. Idempotent (ZSET removal of a missing
-  member is a no-op) and best-effort: a failure here does not change the
-  cascade outcome (orphan entries are bounded by the family ZSET TTL even
+  remaining window described above. Idempotent per the
+  `SessionFamilyIndex.removeBySid` contract (no-op when the sid has no
+  entries) and best-effort: a failure here does not change the cascade
+  outcome (orphan entries are bounded by the family-index TTL even
   without the second pass).
 
 #### Migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security (Phase F — F6 PR4 authorization-grant TOCTOU re-check, v0.5.1)
+
+- **Authorization-code grant re-validates session liveness before linking the
+  token family** (`@o3co/auth-provider-oauth`, closes CR-4): a second
+  `userSessionStore.get(sid)` runs immediately before
+  `sessionFamilyIndex.addFamilyId`, after the `clientRepository.findById`
+  await that previously left a TOCTOU window open. If the session was
+  invalidated by `cascadeLogout` during that window, the grant now returns
+  `400 invalid_grant / session_invalidated` and emits the audit log
+  `authorization_grant_rejected_session_invalidated_during_token_issuance`.
+  Per Codex calibration, this **reduces** rather than eliminates the window
+  — a logout interleaved between the second `get` and `addFamilyId` (sub-
+  millisecond) is still possible. The fully-atomic
+  `addFamilyIdIfSessionActive` Lua EVAL is deferred to a Phase F follow-up
+  to avoid an interface change to `SessionFamilyIndex` for an already-narrow
+  remaining window.
+
+- **`cascadeLogout` defense-in-depth: post-step-4 `removeBySid` cleanup**
+  (`@o3co/auth-provider-oauth`): a second
+  `sessionFamilyIndex.removeBySid(sid)` runs AFTER
+  `userSessionStore.delete(sid)` to clear any orphan family-index entry
+  written into the index by an authorization grant racing through the
+  remaining window described above. Idempotent (ZSET removal of a missing
+  member is a no-op) and best-effort: a failure here does not change the
+  cascade outcome (orphan entries are bounded by the family ZSET TTL even
+  without the second pass).
+
+#### Migration
+
+No public-API change. The new `session_invalidated` error from the
+authorization code grant is a new behavior that surfaces only on the narrow
+race path (logout completing between `findById` and `addFamilyId`); clients
+that previously succeeded in this race window will now receive
+`400 invalid_grant`. This is the correct behavior per RFC 6749 §5.2.
+
 ### Security (Phase F — F6 PR3 refresh-token grant hardening, v0.5.1)
 
 - **Refresh-token reuse now revokes the entire family** (`@o3co/auth-provider-oauth`,

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -27,6 +27,7 @@ import {
 import { decodeJwt } from "jose";
 import { describe, expect, it, vi } from "vitest";
 import { createAuthorizationGrant } from "#/grants/authorization.mjs";
+import { createMockLogger } from "./_helpers/mockLogger.mjs";
 
 // D-1 / v0.5.1: codeData must carry client_id and redirect_uri (required fields).
 // `body.redirect_uri` must match codeData.redirect_uri or /token rejects.
@@ -1541,5 +1542,145 @@ describe("createAuthorizationGrant", () => {
 				expect(result.error).toBe("temporarily_unavailable");
 			});
 		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// CR-4 — TOCTOU: re-validate session before returning tokens
+//
+// Background: between the first `userSessionStore.get(sid)` and the call to
+// `sessionFamilyIndex.addFamilyId`, the handler awaits `clientRepository.findById`.
+// If `cascadeLogout` runs during that await window, the session is gone and
+// the just-issued tokens become orphaned from logout orchestration. CR-4 closes
+// the common case (logout fully completes before the second check) by adding a
+// second `userSessionStore.get(sid)` immediately before `addFamilyId`. Per
+// Codex Delta 1, this REDUCES the window — it does not eliminate it. Phase F
+// follow-up is the atomic Lua EVAL `addFamilyIdIfSessionActive`.
+// ---------------------------------------------------------------------------
+
+describe("CR-4 — TOCTOU re-check session before returning tokens", () => {
+	it("returns 400 invalid_grant / session_invalidated when session is deleted between findById and addFamilyId", async () => {
+		// Mock: first get returns session (initial check at line ~439), second get
+		// returns null (the new CR-4 re-check immediately before addFamilyId).
+		let getCallCount = 0;
+		const userSessionStore = {
+			kind: "spy",
+			async create() {},
+			async get() {
+				getCallCount++;
+				if (getCallCount === 1) {
+					return {
+						sid: "sid-toctou",
+						sub: "u1",
+						authTime: new Date(),
+						createdAt: new Date(),
+						expiresAt: new Date(Date.now() + 3600_000),
+						claims: {},
+					};
+				}
+				return null;
+			},
+			async delete() {},
+		};
+		const sessionFamilyIndex = makeSessionFamilyIndex();
+		const sessionRPRegistry = makeSessionRPRegistry();
+		const logger = createMockLogger();
+
+		const deps = {
+			...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "sid-toctou", ...validCode })),
+			userSessionStore,
+			sessionFamilyIndex,
+			sessionRPRegistry,
+			logger,
+		};
+
+		const handler = createAuthorizationGrant(deps);
+		const { result } = await handler.handle({
+			body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
+			session: {
+				code: "abc",
+				code_client_id: "client1",
+				granted_scopes: ["read"],
+				user: { id: "u1" },
+			},
+			issuer: "localhost",
+			metadata: { ip: "127.0.0.1" },
+			authenticatedClient: DEFAULT_AUTH_CLIENT,
+		});
+
+		// Behavioral: 400 invalid_grant / session_invalidated (distinct from the
+		// existing first-check rejection which returns "session_invalid").
+		expect(result.status).toBe(400);
+		if (!("error" in result)) throw new Error("expected error");
+		expect(result.error).toBe("invalid_grant");
+		expect((result as { errorDescription?: string }).errorDescription).toBe("session_invalidated");
+
+		// Proof of re-check: get was called twice (first + CR-4 second).
+		expect(getCallCount).toBe(2);
+
+		// Negative invariants: token-linking ops MUST NOT run when second check fails.
+		expect(sessionFamilyIndex.addFamilyId).not.toHaveBeenCalled();
+		expect(sessionRPRegistry.registerRP).not.toHaveBeenCalled();
+
+		// Codex Delta 3: audit log MUST fire on session_invalidated rejection.
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		const [warnPayload, warnMsg] = logger.warn.mock.calls[0] as [Record<string, unknown>, string];
+		expect(warnPayload).toMatchObject({
+			sid: "sid-toctou",
+			clientId: "client1",
+		});
+		expect(warnMsg).toBe("authorization_grant_rejected_session_invalidated_during_token_issuance");
+	});
+
+	it("returns 503 temporarily_unavailable when the second userSessionStore.get throws", async () => {
+		// First get succeeds; second get throws (e.g. Redis blip mid-grant).
+		// The throw is inside the existing try/catch that wraps findById/addFamilyId/
+		// registerRP, so it must surface as a controlled 503.
+		let getCallCount = 0;
+		const userSessionStore = {
+			kind: "spy",
+			async create() {},
+			async get() {
+				getCallCount++;
+				if (getCallCount === 1) {
+					return {
+						sid: "sid-blip",
+						sub: "u1",
+						authTime: new Date(),
+						createdAt: new Date(),
+						expiresAt: new Date(Date.now() + 3600_000),
+						claims: {},
+					};
+				}
+				throw new Error("store down on second check");
+			},
+			async delete() {},
+		};
+		const sessionFamilyIndex = makeSessionFamilyIndex();
+		const deps = {
+			...makeDeps(vi.fn().mockResolvedValue({ code: "abc", sid: "sid-blip", ...validCode })),
+			userSessionStore,
+			sessionFamilyIndex,
+			sessionRPRegistry: makeSessionRPRegistry(),
+		};
+		const handler = createAuthorizationGrant(deps);
+		const { result } = await handler.handle({
+			body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
+			session: {
+				code: "abc",
+				code_client_id: "client1",
+				granted_scopes: ["read"],
+				user: { id: "u1" },
+			},
+			issuer: "localhost",
+			metadata: { ip: "127.0.0.1" },
+			authenticatedClient: DEFAULT_AUTH_CLIENT,
+		});
+
+		expect(result.status).toBe(503);
+		if (!("error" in result)) throw new Error("expected error");
+		expect(result.error).toBe("temporarily_unavailable");
+		expect(getCallCount).toBe(2);
+		expect(sessionFamilyIndex.addFamilyId).not.toHaveBeenCalled();
 	});
 });

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -1680,6 +1680,12 @@ describe("CR-4 — TOCTOU re-check session before returning tokens", () => {
 		expect(result.status).toBe(503);
 		if (!("error" in result)) throw new Error("expected error");
 		expect(result.error).toBe("temporarily_unavailable");
+		// errorDescription matches the first-get's wording — the second `get` has its
+		// own try/catch (not the outer findById/addFamilyId catch) so operators see a
+		// store-availability error description, not a misleading "session linking" one.
+		expect((result as { errorDescription?: string }).errorDescription).toBe(
+			"session store unavailable",
+		);
 		expect(getCallCount).toBe(2);
 		expect(sessionFamilyIndex.addFamilyId).not.toHaveBeenCalled();
 	});

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -1634,8 +1634,11 @@ describe("CR-4 — TOCTOU re-check session before returning tokens", () => {
 
 	it("returns 503 temporarily_unavailable when the second userSessionStore.get throws", async () => {
 		// First get succeeds; second get throws (e.g. Redis blip mid-grant).
-		// The throw is inside the existing try/catch that wraps findById/addFamilyId/
-		// registerRP, so it must surface as a controlled 503.
+		// The CR-4 second `get` has its own dedicated try/catch — store-availability
+		// failures here surface as `503 / "session store unavailable"`, matching the
+		// first-get path and not the broader outer catch that wraps findById /
+		// addFamilyId / registerRP (which surfaces as `503 / "session linking
+		// unavailable"`).
 		let getCallCount = 0;
 		const userSessionStore = {
 			kind: "spy",

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -474,11 +474,30 @@ export const createAuthorizationGrant = (
 					// (logout fully completes before the second check). It does NOT close
 					// the sub-millisecond window between this check and `addFamilyId`;
 					// Phase F's atomic `addFamilyIdIfSessionActive` Lua EVAL closes that.
-					// A throw here is caught by the outer catch and surfaces as 503.
-					const revalidatedSession = await deps.userSessionStore.get(sid);
+					//
+					// The store-availability path is handled by its OWN try/catch (mirrors
+					// the first-get pattern at line ~437) so a Redis blip emits the same
+					// `"session store unavailable"` errorDescription as the first-get path,
+					// rather than being misattributed to the outer "session linking
+					// unavailable" catch (which spans findById + addFamilyId + registerRP).
+					let revalidatedSession: Awaited<ReturnType<typeof deps.userSessionStore.get>>;
+					try {
+						revalidatedSession = await deps.userSessionStore.get(sid);
+					} catch {
+						return {
+							result: {
+								status: 503,
+								error: "temporarily_unavailable",
+								errorDescription: "session store unavailable",
+							},
+						};
+					}
 					if (!revalidatedSession) {
 						// Codex Delta 3: log security-relevant rejection so SIEMs can
-						// correlate against cascadeLogout audit events.
+						// correlate against cascadeLogout audit events. The audit payload
+						// intentionally omits a code identifier — the `Code` / `CodeData`
+						// type does not carry a stable jti, and logging the raw `code`
+						// string would leak secret material.
 						logger?.warn(
 							{ sid, clientId: authenticatedClientId },
 							"authorization_grant_rejected_session_invalidated_during_token_issuance",

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -59,8 +59,12 @@ export const createAuthorizationGrant = (
 	// TS-4 (v0.5.1): per-element string validation lives in
 	// `resolvePkceSupportedMethods` — the previous `Array.isArray(...) ? (... as string[])`
 	// pattern silently accepted operator-typed garbage like `[123, null]`
-	// because `Array.isArray` does not constrain element types.
-	const supportedMethods = resolvePkceSupportedMethods(pkceConfig);
+	// because `Array.isArray` does not constrain element types. Pass `logger`
+	// so the helper's misconfig warnings (non-string elements, filtered-empty
+	// fallback) reach the operator's structured logger; F6 PR3 added the
+	// `logger` slot to GrantDependencies so the TS-4-deferred plumbing is now
+	// available at this call site.
+	const supportedMethods = resolvePkceSupportedMethods(pkceConfig, logger);
 	const pkceRequired: boolean = pkceConfig?.required === true;
 	// Legacy fallback: requireS256=true means only S256 is supported
 	const requireS256Legacy = pkceConfig?.requireS256 === true;

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -35,7 +35,7 @@ import { resolvePkceSupportedMethods } from "./pkce.mjs";
 export const createAuthorizationGrant = (
 	deps: GrantDependencies & { codeRepository: CodeRepository; clientRepository: ClientRepository },
 ): GrantHandler => {
-	const { config, codeRepository, clientRepository, keyStore } = deps;
+	const { config, codeRepository, clientRepository, keyStore, logger } = deps;
 
 	const grantsConfig = config.oauth.grants as Record<string, Record<string, unknown>> | undefined;
 	const authorizationConfig = grantsConfig?.authorization_code as
@@ -465,6 +465,36 @@ export const createAuthorizationGrant = (
 					// the binding gate above, but reading from the authenticated
 					// slot keeps Codex M2's "no raw body for identity" invariant.
 					const clientRecord = await clientRepository.findById(authenticatedClientId);
+
+					// CR-4: re-validate session liveness immediately before mutating the
+					// family index. Between the first `get` (line above) and `addFamilyId`,
+					// `findById` is awaited — a `cascadeLogout` interleaving in that window
+					// would leave the just-issued tokens orphaned from logout orchestration.
+					// Per Codex Delta 1, this REDUCES the window for the common case
+					// (logout fully completes before the second check). It does NOT close
+					// the sub-millisecond window between this check and `addFamilyId`;
+					// Phase F's atomic `addFamilyIdIfSessionActive` Lua EVAL closes that.
+					// A throw here is caught by the outer catch and surfaces as 503.
+					const revalidatedSession = await deps.userSessionStore.get(sid);
+					if (!revalidatedSession) {
+						// Codex Delta 3: log security-relevant rejection so SIEMs can
+						// correlate against cascadeLogout audit events.
+						logger?.warn(
+							{ sid, clientId: authenticatedClientId },
+							"authorization_grant_rejected_session_invalidated_during_token_issuance",
+						);
+						return {
+							result: {
+								status: 400,
+								error: "invalid_grant",
+								errorDescription: "session_invalidated",
+							},
+						};
+					}
+					// Use the revalidated session for downstream TTL bookkeeping. Subsequent
+					// id_token generation reads `userSession`, so refresh the outer binding.
+					userSession = revalidatedSession;
+
 					// Composition-root invariant (A4 §3.4/§8): the bundled session-stores
 					// module wires all 4 sibling stores together. When deps.userSessionStore is
 					// present (outer guard), sessionFamilyIndex and sessionRPRegistry are also

--- a/packages/oauth/src/grants/pkce.mts
+++ b/packages/oauth/src/grants/pkce.mts
@@ -35,15 +35,14 @@ const DEFAULT_PKCE_METHODS: readonly string[] = Object.freeze(["S256", "plain"])
  * - Array filtered to empty (or literal `[]`) → fall back to default
  *   (defensive: an empty allowlist would disable PKCE entirely).
  *
- * The `logger` argument is optional. v0.5.1 consumers (`authorization.mts`,
- * `routes.mts`) call without a logger because there is no logger slot on
- * `GrantDependencies` / `createOAuthRouter` deps in this release; the warn
- * branch is exercised via direct unit tests on the helper. Logger plumbing
- * to the call sites is deferred to D-4 (ComponentMap.logger wiring).
+ * The `logger` argument is optional. As of F6 PR4 (v0.5.1) both production
+ * call sites (`authorization.mts` via `GrantDependencies.logger`, and
+ * `routes.mts` via `createOAuthRouter` options) DO supply a logger so the
+ * misconfig warnings reach operators' structured logging stack. Tests
+ * continue to call without a logger to exercise the optional-logger path.
  *
- * Per TS-4 spec (Wave 5j) + Codex calibration delta 1 (no logger at consumer
- * sites in v0.5.1) + delta 2 (literal-empty + filtered-empty cases tested
- * separately).
+ * Per TS-4 spec (Wave 5j) + Codex calibration delta 2 (literal-empty +
+ * filtered-empty cases tested separately).
  */
 export function resolvePkceSupportedMethods(
 	pkceConfig: Record<string, unknown> | undefined,

--- a/packages/oauth/src/logout/__tests__/cascadeLogout.test.mts
+++ b/packages/oauth/src/logout/__tests__/cascadeLogout.test.mts
@@ -425,4 +425,81 @@ describe("cascadeLogout (A4 §6.2)", () => {
 			expect(result.errors[0]).toBeInstanceOf(Error);
 		}
 	});
+
+	// -------------------------------------------------------------------------
+	// CR-4 — post-step-4 sessionFamilyIndex cleanup
+	//
+	// Defense-in-depth: any addFamilyId call that raced into the family index
+	// between Step 3 and Step 4 (the TOCTOU window the authorization grant's
+	// second-check fix narrows but does not fully close) leaves an orphan entry.
+	// A second removeBySid AFTER the session delete clears that orphan. The
+	// invocation order MUST be: Step 3 removeBySid → Step 4 delete → post-step-4
+	// removeBySid. Codex Delta 5: pin the order to catch accidental reshuffling.
+	// -------------------------------------------------------------------------
+
+	it("CR-4: runs sessionFamilyIndex.removeBySid AFTER userSessionStore.delete (post-step-4 cleanup)", async () => {
+		const sessionFamilyIndex = makeSessionFamilyIndex({
+			listFamilyIds: vi.fn(async () => []),
+		});
+		const uss = makeUserSessionStore();
+
+		const result = await cascadeLogout({
+			sid: "sid-cr4",
+			refreshTokenFamilyRevocation: makeFamilyRevocation(),
+			federationTokenStore: makeFedStore(),
+			userSessionStore: uss,
+			sessionRPRegistry: makeSessionRPRegistry(),
+			sessionFamilyIndex,
+			sessionFederationIndex: makeSessionFederationIndex(),
+		});
+
+		expect(result.outcome).toBe("done");
+
+		// Step 3 removeBySid + post-step-4 removeBySid → twice total.
+		expect(sessionFamilyIndex.removeBySid).toHaveBeenCalledTimes(2);
+		expect(sessionFamilyIndex.removeBySid).toHaveBeenNthCalledWith(1, "sid-cr4");
+		expect(sessionFamilyIndex.removeBySid).toHaveBeenNthCalledWith(2, "sid-cr4");
+
+		// Codex Delta 5: pin invocation order.
+		// removeBySid call 1 (Step 3) MUST precede userSessionStore.delete (Step 4).
+		// userSessionStore.delete (Step 4) MUST precede removeBySid call 2 (post-step-4).
+		const removeOrders = (sessionFamilyIndex.removeBySid as ReturnType<typeof vi.fn>).mock
+			.invocationCallOrder;
+		const deleteOrder = (uss.delete as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
+		expect(removeOrders).toHaveLength(2);
+		expect(removeOrders[0]).toBeLessThan(deleteOrder);
+		expect(deleteOrder).toBeLessThan(removeOrders[1]);
+	});
+
+	it("CR-4: post-step-4 removeBySid failure does NOT change cascade outcome (best-effort)", async () => {
+		// First removeBySid (Step 3) succeeds, second (post-step-4) throws — must be
+		// swallowed and logged so the cascade still reports done.
+		let calls = 0;
+		const sessionFamilyIndex = makeSessionFamilyIndex({
+			listFamilyIds: vi.fn(async () => []),
+			removeBySid: vi.fn(async () => {
+				calls++;
+				if (calls === 2) {
+					throw new Error("post-delete cleanup failed");
+				}
+			}),
+		});
+		const logger = createMockLogger();
+
+		const result = await cascadeLogout({
+			sid: "sid-besteffort",
+			refreshTokenFamilyRevocation: makeFamilyRevocation(),
+			federationTokenStore: makeFedStore(),
+			userSessionStore: makeUserSessionStore(),
+			sessionRPRegistry: makeSessionRPRegistry(),
+			sessionFamilyIndex,
+			sessionFederationIndex: makeSessionFederationIndex(),
+			logger,
+		});
+
+		expect(result.outcome).toBe("done");
+		expect(calls).toBe(2);
+		// Failure surfaces via the structured logger.
+		expect(logger.warn).toHaveBeenCalled();
+	});
 });

--- a/packages/oauth/src/logout/__tests__/cascadeLogout.test.mts
+++ b/packages/oauth/src/logout/__tests__/cascadeLogout.test.mts
@@ -84,7 +84,7 @@ function makeSessionFederationIndex(
 // ---------------------------------------------------------------------------
 
 describe("cascadeLogout (A4 §6.2)", () => {
-	it("executes in §6.2 order: listFamilyIds → revokeFamily (each) → deleteBySession → removeBySid (×3) → delete", async () => {
+	it("executes in §6.2 order: listFamilyIds → revokeFamily (each) → deleteBySession → removeBySid (×3) → delete → post-step-4 sessionFamilyIndex.removeBySid (CR-4)", async () => {
 		const sessionFamilyIndex = makeSessionFamilyIndex({
 			listFamilyIds: vi.fn(async () => ["fam-1", "fam-2"]),
 		});
@@ -113,11 +113,14 @@ describe("cascadeLogout (A4 §6.2)", () => {
 		expect(rts.revokeFamily).toHaveBeenNthCalledWith(2, "fam-2");
 		// Step 2: federation tokens deleted
 		expect(fts.deleteBySession).toHaveBeenCalledWith("sid-1");
-		// Step 3: all three reverse-index removeBySid called
+		// Step 3: all three reverse-index removeBySid called.
 		expect(sessionRPRegistry.removeBySid).toHaveBeenCalledWith("sid-1");
-		expect(sessionFamilyIndex.removeBySid).toHaveBeenCalledWith("sid-1");
 		expect(sessionFederationIndex.removeBySid).toHaveBeenCalledWith("sid-1");
-		// Step 4: session deleted last
+		// CR-4: sessionFamilyIndex.removeBySid is now called twice — once at Step 3
+		// and again as defense-in-depth after Step 4 (see CR-4 invocation-order test
+		// below). Both calls receive the same sid argument.
+		expect(sessionFamilyIndex.removeBySid).toHaveBeenCalledWith("sid-1");
+		// Step 4: primary invalidation must succeed.
 		expect(uss.delete).toHaveBeenCalledWith("sid-1");
 	});
 

--- a/packages/oauth/src/logout/cascadeLogout.mts
+++ b/packages/oauth/src/logout/cascadeLogout.mts
@@ -149,5 +149,20 @@ export async function cascadeLogout(opts: CascadeLogoutOptions): Promise<Cascade
 		return { outcome: "failed", step: 4, errors: [error] };
 	}
 
+	// CR-4 defense-in-depth: re-run sessionFamilyIndex cleanup AFTER the session
+	// delete. The authorization grant's second-check (re-validate session before
+	// addFamilyId) reduces but does not fully close the TOCTOU window — an
+	// addFamilyId call interleaved between this Step 3 removeBySid and Step 4
+	// delete leaves an orphan entry. This second pass clears it. Idempotent
+	// (ZSET removal of a non-existent member is a no-op) and best-effort:
+	// a failure here does not change the cascade outcome (orphan entries are
+	// bounded by the family ZSET's TTL anyway).
+	await opts.sessionFamilyIndex.removeBySid(opts.sid).catch((error) => {
+		logger.warn(
+			`cascadeLogout: post-delete sessionFamilyIndex.removeBySid(${opts.sid}) failed:`,
+			error,
+		);
+	});
+
 	return { outcome: "done" };
 }

--- a/packages/oauth/src/logout/cascadeLogout.mts
+++ b/packages/oauth/src/logout/cascadeLogout.mts
@@ -154,9 +154,11 @@ export async function cascadeLogout(opts: CascadeLogoutOptions): Promise<Cascade
 	// addFamilyId) reduces but does not fully close the TOCTOU window — an
 	// addFamilyId call interleaved between this Step 3 removeBySid and Step 4
 	// delete leaves an orphan entry. This second pass clears it. Idempotent
-	// (ZSET removal of a non-existent member is a no-op) and best-effort:
-	// a failure here does not change the cascade outcome (orphan entries are
-	// bounded by the family ZSET's TTL anyway).
+	// (the SessionFamilyIndex contract treats removeBySid on a missing sid as a
+	// no-op — Redis impl `DEL`s the sid's family-index key, in-memory impl
+	// `Map.delete`s the entry, both no-ops on a non-existent target) and
+	// best-effort: a failure here does not change the cascade outcome (orphan
+	// entries are bounded by the family index's TTL anyway).
 	await opts.sessionFamilyIndex.removeBySid(opts.sid).catch((error) => {
 		logger.warn(
 			`cascadeLogout: post-delete sessionFamilyIndex.removeBySid(${opts.sid}) failed:`,

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -502,8 +502,10 @@ export const createOAuthRouter = async (
 					typeof pkceConfig?.defaultMethod === "string" ? pkceConfig.defaultMethod : "plain";
 				// TS-4 (v0.5.1): per-element validation via `resolvePkceSupportedMethods`.
 				// See authorization.mts for the rationale — `Array.isArray + as string[]`
-				// silently accepted non-string operator-typed values.
-				const supportedMethods = resolvePkceSupportedMethods(pkceConfig);
+				// silently accepted non-string operator-typed values. The router
+				// already has `logger` in scope (createOAuthRouter options); forward
+				// it so the helper's misconfig warnings reach the operator.
+				const supportedMethods = resolvePkceSupportedMethods(pkceConfig, logger);
 
 				// D-6 (RFC 9700 §2.1.1): PKCE/S256 is mandatory for public clients
 				// regardless of operator `pkce.required` config. Public clients have


### PR DESCRIPTION
## Summary

- Authorization-code grant now performs a second `userSessionStore.get(sid)` between `clientRepository.findById` and `sessionFamilyIndex.addFamilyId`. If the session was invalidated by `cascadeLogout` during the `findById` await window, the grant returns `400 invalid_grant / session_invalidated` and emits the audit log `authorization_grant_rejected_session_invalidated_during_token_issuance`.
- `cascadeLogout` adds a defense-in-depth post-step-4 `sessionFamilyIndex.removeBySid` call (after `userSessionStore.delete`). Idempotent (per `SessionFamilyIndex.removeBySid` contract), best-effort (cascade outcome unchanged on failure).
- Closes **CR-4** (Phase F batch F6 PR4 — last F6 PR).

Per Codex calibration deltas in `auth/.claude/superpowers/specs/2026-05-05-cr4-authorization-toctou.md`, this **reduces** rather than eliminates the TOCTOU window — a sub-millisecond race between the second check and `addFamilyId` remains. Phase F follow-up: atomic `addFamilyIdIfSessionActive` Lua EVAL.

After this PR, F6 closes. Next: a coverage-boost PR for F6 PR2 + PR3 codecov/patch failures (single PR, F6 PR1 → PR #125 precedent).

## Test plan

- [x] 2 new tests in `packages/oauth/src/__tests__/authorization.test.mts`:
  - TOCTOU rejection: `getCallCount`-based mock → 400 / `session_invalidated` + invariants (`addFamilyId` and `registerRP` not called) + audit log fired with structured payload + log key
  - 503 path: second `get` throws → 503 / `session store unavailable` (errorDescription matches the first-get path after Claude review M2 fixup)
- [x] 2 new tests in `packages/oauth/src/logout/__tests__/cascadeLogout.test.mts`:
  - Post-step-4 ordering pinned via `mock.invocationCallOrder` (Step 3 → Step 4 → post-step-4)
  - Best-effort: post-step-4 throw does NOT change `outcome: "done"`; `logger.warn` fires
- [x] oauth tests: 358 → 362 (+4) all green in isolation
- [x] tsc --noEmit clean across all packages
- [x] biome check clean on touched files
- [x] Multi-agent review (Codex + Claude code-reviewer in parallel): both **Approved**, 4 Minor (no convergence), all 4 fixed in the second commit

## Reviewer findings addressed (review fixups commit `f49f53ce`)

- **Codex M1**: stale describe wording in cascadeLogout test → updated to mention the new post-step-4 cleanup
- **Codex M2**: "ZSET removal" wording was Redis-inaccurate → generalized to the `SessionFamilyIndex.removeBySid` contract
- **Claude M1**: documented why the audit log payload omits a code identifier (`Code` has no `jti`; raw `code` would leak secret material)
- **Claude M2**: extracted the second `get` into its own try/catch so a Redis blip emits `"session store unavailable"` (matching the first-get path) instead of the misleading outer "session linking unavailable" — Test 2 strengthened to pin the new errorDescription

🤖 Generated with [Claude Code](https://claude.com/claude-code)