### PR TITLE
test(oauth): F6 PR2 + PR3 patch coverage boost

### DIFF
--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -1764,8 +1764,12 @@ describe("F6 PR2 patch coverage — SF-3 corrupt code records + PKCE branches", 
 		// RFC 7636 §4.1: code_verifier is 43-128 chars from the unreserved set.
 		// "too-short" is 9 chars → must reject. The pre-existing test for this
 		// branch omitted body.redirect_uri and so was returning early at the
-		// redirect_uri-mismatch gate (status 400, but for the wrong reason).
-		// This test pins redirect_uri so the regex check is the actual cause.
+		// redirect_uri *presence* gate (authorization.mts:125, after D-1
+		// hoisted the absence check ahead of consumeByCode). The error string
+		// happened to be `"redirect_uri mismatch"` either way, but it was
+		// firing at presence-check, not at the equality-check at L168, and
+		// never reached the regex at L263. This test pins redirect_uri so
+		// the regex check is the actual cause and errorDescription is asserted.
 		const deps = makeDeps(
 			vi.fn().mockResolvedValue({
 				code: "abc",

--- a/packages/oauth/src/__tests__/authorization.test.mts
+++ b/packages/oauth/src/__tests__/authorization.test.mts
@@ -1693,3 +1693,198 @@ describe("CR-4 — TOCTOU re-check session before returning tokens", () => {
 		expect(sessionFamilyIndex.addFamilyId).not.toHaveBeenCalled();
 	});
 });
+
+// F6 coverage boost — patch lines for PR #126 (IH-13 + SF-3 + IH-16 + TS-4)
+// that are reachable but were not exercised by the original test suite.
+// Each test pins both status code AND errorDescription so a future refactor
+// that shifts an error to a different branch is caught.
+describe("F6 PR2 patch coverage — SF-3 corrupt code records + PKCE branches", () => {
+	it("returns 400 invalid_grant when code record has code_challenge without code_challenge_method (SF-3 corrupt code A)", async () => {
+		const deps = makeDeps(
+			vi.fn().mockResolvedValue({
+				code: "abc",
+				client_id: "client1",
+				redirect_uri: RP_URI,
+				// SF-3 corrupt shape: challenge persisted but method missing.
+				// /authorize never writes this pairing — only a misbehaving
+				// CodeRepository implementation could produce it.
+				code_challenge: "challenge",
+				// code_challenge_method intentionally omitted
+			}),
+		);
+		const handler = createAuthorizationGrant(deps);
+		const ctx: GrantContext = {
+			body: { code: "abc", client_id: "client1", redirect_uri: RP_URI },
+			session: { code: "abc", code_client_id: "client1" },
+			issuer: "localhost",
+			metadata: { ip: "127.0.0.1" },
+			authenticatedClient: DEFAULT_AUTH_CLIENT,
+		};
+
+		const { result } = await handler.handle(ctx);
+
+		expect(result.status).toBe(400);
+		expect("error" in result && result.error).toBe("invalid_grant");
+		expect((result as { errorDescription?: string }).errorDescription).toBe("invalid code");
+	});
+
+	it("returns 400 invalid_request when code_challenge_method is set but code_challenge is non-string (SF-3 corrupt code B)", async () => {
+		const deps = makeDeps(
+			vi.fn().mockResolvedValue({
+				code: "abc",
+				client_id: "client1",
+				redirect_uri: RP_URI,
+				// code_challenge typed as `unknown` from a corrupt store record.
+				// Pre-SF-3 this passed silently because `verifier !== undefined`
+				// is true; constantTimeStringEqual now rejects non-string args.
+				code_challenge: 12345 as unknown as string,
+				code_challenge_method: "S256",
+			}),
+		);
+		const handler = createAuthorizationGrant(deps);
+		const verifier = "a".repeat(43);
+		const ctx: GrantContext = {
+			body: { code: "abc", client_id: "client1", redirect_uri: RP_URI, code_verifier: verifier },
+			session: { code: "abc", code_client_id: "client1" },
+			issuer: "localhost",
+			metadata: { ip: "127.0.0.1" },
+			authenticatedClient: DEFAULT_AUTH_CLIENT,
+		};
+
+		const { result } = await handler.handle(ctx);
+
+		expect(result.status).toBe(400);
+		expect("error" in result && result.error).toBe("invalid_request");
+		expect((result as { errorDescription?: string }).errorDescription).toBe(
+			"code_challenge missing on code record",
+		);
+	});
+
+	it("returns 400 invalid_request when code_verifier fails RFC 7636 format check", async () => {
+		// RFC 7636 §4.1: code_verifier is 43-128 chars from the unreserved set.
+		// "too-short" is 9 chars → must reject. The pre-existing test for this
+		// branch omitted body.redirect_uri and so was returning early at the
+		// redirect_uri-mismatch gate (status 400, but for the wrong reason).
+		// This test pins redirect_uri so the regex check is the actual cause.
+		const deps = makeDeps(
+			vi.fn().mockResolvedValue({
+				code: "abc",
+				client_id: "client1",
+				redirect_uri: RP_URI,
+				code_challenge: "challenge",
+				code_challenge_method: "S256",
+			}),
+		);
+		const handler = createAuthorizationGrant(deps);
+		const ctx: GrantContext = {
+			body: {
+				code: "abc",
+				client_id: "client1",
+				redirect_uri: RP_URI,
+				code_verifier: "too-short",
+			},
+			session: { code: "abc", code_client_id: "client1" },
+			issuer: "localhost",
+			metadata: { ip: "127.0.0.1" },
+			authenticatedClient: DEFAULT_AUTH_CLIENT,
+		};
+
+		const { result } = await handler.handle(ctx);
+
+		expect(result.status).toBe(400);
+		expect("error" in result && result.error).toBe("invalid_request");
+		expect((result as { errorDescription?: string }).errorDescription).toBe(
+			"invalid code_verifier format",
+		);
+	});
+
+	it("returns 400 invalid_grant when plain method code_verifier does not match challenge (SF-3 + MIN-4 timing-safe)", async () => {
+		// Both verifier and challenge are valid 43-char RFC 7636 strings, but
+		// they differ. Pre-SF-3+MIN-4 the comparison was a short-circuit `!==`
+		// whose per-byte timing leaked progress against the stored challenge;
+		// constantTimeStringEqual replaces it on both S256 and plain branches.
+		const verifier = "a".repeat(43);
+		const challenge = "b".repeat(43);
+		const deps = makeDeps(
+			vi.fn().mockResolvedValue({
+				code: "abc",
+				client_id: "client1",
+				redirect_uri: RP_URI,
+				code_challenge: challenge,
+				code_challenge_method: "plain",
+			}),
+		);
+		const handler = createAuthorizationGrant(deps);
+		const ctx: GrantContext = {
+			body: { code: "abc", client_id: "client1", redirect_uri: RP_URI, code_verifier: verifier },
+			session: { code: "abc", code_client_id: "client1" },
+			issuer: "localhost",
+			metadata: { ip: "127.0.0.1" },
+			authenticatedClient: DEFAULT_AUTH_CLIENT,
+		};
+
+		const { result } = await handler.handle(ctx);
+
+		expect(result.status).toBe(400);
+		expect("error" in result && result.error).toBe("invalid_grant");
+		expect((result as { errorDescription?: string }).errorDescription).toBe(
+			"invalid code_verifier",
+		);
+	});
+
+	it("returns 400 invalid_request when code_challenge_method falls through the switch default (defense-in-depth)", async () => {
+		// The supportedMethods includes-check at the top of the PKCE block
+		// rejects unknown methods before the switch, so the `default` arm is
+		// structurally unreachable in production. We exercise it deliberately
+		// here by widening supportedMethods so includes() passes, then setting
+		// a method the switch doesn't case on. This pins the runtime guard
+		// that protects against future supportedMethods/switch divergence.
+		const config = {
+			oauth: {
+				jwt: { secret: "test-secret" },
+				accessToken: { expiresIn: 3600 },
+				refreshToken: { expiresIn: 86400 },
+				grants: {
+					authorization_code: {
+						enabled: true,
+						pkce: { supportedMethods: ["S256", "plain", "BOGUS"] },
+					},
+				},
+			},
+		} as unknown as GrantDependencies["config"];
+		const verifier = "a".repeat(43);
+		const deps = {
+			config,
+			keyStore: createSymmetricKeyStore("test-secret"),
+			codeRepository: {
+				consumeByCode: vi.fn().mockResolvedValue({
+					code: "abc",
+					client_id: "client1",
+					redirect_uri: RP_URI,
+					code_challenge: verifier,
+					code_challenge_method: "BOGUS",
+				}),
+				createCode: vi.fn(),
+				getByCode: vi.fn(),
+				removeByCode: vi.fn(),
+			} as unknown as CodeRepository,
+			clientRepository: mockClientRepository,
+		};
+		const handler = createAuthorizationGrant(deps);
+		const ctx: GrantContext = {
+			body: { code: "abc", client_id: "client1", redirect_uri: RP_URI, code_verifier: verifier },
+			session: { code: "abc", code_client_id: "client1" },
+			issuer: "localhost",
+			metadata: { ip: "127.0.0.1" },
+			authenticatedClient: DEFAULT_AUTH_CLIENT,
+		};
+
+		const { result } = await handler.handle(ctx);
+
+		expect(result.status).toBe(400);
+		expect("error" in result && result.error).toBe("invalid_request");
+		expect((result as { errorDescription?: string }).errorDescription).toBe(
+			"invalid code_challenge_method",
+		);
+	});
+});

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -1376,4 +1376,53 @@ describe("createRefreshTokenGrant", () => {
 			expect(Object.hasOwn(rtPayload, "sid")).toBe(false);
 		});
 	});
+
+	// F6 coverage boost — patch line for PR #127 (PB-1 + CC-2 + SF-6) that is
+	// reachable only via runtime-cast to a future outcome value not yet in the
+	// `RefreshTokenFamilyRotationOutcome` union. The `default` arm exists as a
+	// runtime invariant so a future outcome added without updating the switch
+	// is rejected with a stable error rather than silently falling through to
+	// token issuance. We exercise it deliberately to pin that contract.
+	describe("F6 PR3 patch coverage — exhaustive switch defense-in-depth", () => {
+		it("throws 'unhandled rotation outcome' when rotation returns an unknown outcome variant", async () => {
+			const rotation = {
+				async register() {},
+				async rotate() {
+					// Simulates a future outcome added to the union without
+					// updating the consumer switch — the type cast is the
+					// whole point: TypeScript would otherwise prevent this
+					// and only the runtime guard catches the divergence.
+					return { outcome: "future_outcome_xx" } as unknown as Awaited<
+						ReturnType<RefreshTokenFamilyRotation["rotate"]>
+					>;
+				},
+			} satisfies RefreshTokenFamilyRotation;
+			const depsWithStore: GrantDependencies = {
+				...mockDeps,
+				refreshTokenFamilyRotation: rotation,
+			};
+			// SF-6: token must carry both jti AND family_id so the legacy
+			// gate doesn't fire before rotation runs.
+			const token = await new SignJWT({
+				sub: "u1",
+				scope: "read write",
+				family_id: "fam-future",
+			})
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setAudience(DEFAULT_CLIENT_ID)
+				.setExpirationTime("24h")
+				.setJti("prev-jti-future")
+				.sign(secretKey);
+			const handler = createRefreshTokenGrant(depsWithStore);
+			const ctx: GrantContext = {
+				body: { refresh_token: token },
+				session: {},
+				issuer: "localhost",
+				metadata: {},
+				authenticatedClient: DEFAULT_AUTH_CLIENT,
+			};
+
+			await expect(handler.handle(ctx)).rejects.toThrow(/unhandled rotation outcome/);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

PR #126 (F6 PR2) and PR #127 (F6 PR3) merged with `codecov/patch` failing on develop. The informational gates were missing coverage on a handful of error / defense-in-depth branches added by SF-3/MIN-4/TS-4 (PR #126) and the exhaustive rotation switch (PR #127). This PR adds 6 unit tests to close the gap and follow the F6 PR1 → PR #125 precedent.

PR #128 (F6 PR4) already has codecov/patch SUCCESS, so it is not in scope here.

**Test-only PR. No production code changed. No CHANGELOG entry.**

## Tests added (6)

### `authorization.test.mts` — PR #126 patch coverage (5)

`grants/authorization.mts`:

| # | Branch | Status | errorDescription |
|---|---|---|---|
| 1 | SF-3 corrupt code A: challenge present, method missing | 400 invalid_grant | `invalid code` |
| 2 | SF-3 corrupt code B: method=S256, challenge non-string | 400 invalid_request | `code_challenge missing on code record` |
| 3 | RFC 7636 invalid verifier format (`too-short`) | 400 invalid_request | `invalid code_verifier format` |
| 4 | plain method timing-safe mismatch | 400 invalid_grant | `invalid code_verifier` |
| 5 | PKCE switch default (deliberate `supportedMethods=["S256","plain","BOGUS"]`) | 400 invalid_request | `invalid code_challenge_method` |

The pre-existing test for #3 omitted `body.redirect_uri` and was actually returning 400 from the redirect_uri-mismatch gate, never reaching the regex check. The new test pins `redirect_uri` so the format check is the actual cause and the errorDescription is asserted.

### `refreshToken.test.mts` — PR #127 patch coverage (1)

`grants/refreshToken.mts`:

| # | Branch | Behavior |
|---|---|---|
| 6 | Exhaustive switch never default (rotation returns future outcome variant via cast) | `handler.handle()` rejects with `/unhandled rotation outcome/` |

This pins the runtime guard that protects against future `RefreshTokenFamilyRotationOutcome` additions without consumer-switch updates.

## Dismissed lines

`refreshToken.mts:444-449` — CC-2 `unknown_family` + `familyId === null` defense-in-depth.

```
Dismiss reason: [x] Contract-based
  unknown_family case で `familyId === null` を hit するには:
    - SF-6 gate (L321): `familyId === null` で legacyRtPolicy=reject
      → 400 早期 return
    - legacyRtPolicy=accept-with-warning → rotation else-branch
      (L350) は skip
    - => `familyId === null` がここに到達するパスは存在しない
  既存の SF-6 invariant test (refreshToken.test.mts:859-930) が
  同じ判断を assertions で document 済 (rotateSpy not called +
  audit log fired)。
覆す条件: SF-6 gate の reorder により `familyId === null` token が
  rotation-block else-branch に流入できるようになった場合。
```

Same dismissal pattern as PR #125's `clientAuth.mts:322-331` secret-undefined branch.

## Test count

oauth: 362 → 368 (+6)

- `authorization.test.mts` +5 tests in new describe `F6 PR2 patch coverage — SF-3 corrupt code records + PKCE branches`
- `refreshToken.test.mts` +1 test in new describe `F6 PR3 patch coverage — exhaustive switch defense-in-depth`

## Test plan

- [x] `pnpm exec vitest run` (oauth): 368/368 pass
- [x] `pnpm -r run test`: all green (one redis flake, passed on retry — same supertest socket race as F6 PR1/PR4 review cycles)
- [x] `pnpm run lint`: 0 errors, 18 pre-existing warnings (none in new tests)
- [x] `pnpm exec tsc --noEmit` (oauth): clean
- [x] `pnpm exec vitest run --coverage`: PR #126 patch lines now 100%; PR #127 patch lines 100% modulo L444-449 dismissed branch
- [ ] Codex + Claude review via `/multi-agent-review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)