### PR TITLE
F7 PR2 — SF-1 central JWT verifier alg/iss/aud/typ pinning across 8 sites (v0.5.1)

### DIFF
--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -8,6 +8,14 @@ http {
 oauth {
   jwt {
     issuer = ${?OAUTH_JWT_ISSUER}
+    # SF-1 (v0.5.1): the central JWT verifier accepts tokens whose `typ`
+    # header is absent, emitting a `jwt_verify_legacy_typ` warning. This
+    # exists so v0.4.x tokens (issued before the at+jwt/rt+jwt/id+jwt
+    # convention) keep verifying through the v0.5.x transition window.
+    # Operators MUST flip this to false in v0.6+ so typ-less tokens are
+    # rejected as a hard signal of misconfiguration or downgrade attack.
+    legacyTypAccept = true
+    legacyTypAccept = ${?OAUTH_JWT_LEGACY_TYP_ACCEPT}
     signingKey {
       provider = "local"
       provider = ${?OAUTH_JWT_SIGNING_KEY_PROVIDER}

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -112,6 +112,11 @@ const LEGACY_JWT_FIELDS = [
 const jwtSchemaBase = z.object({
 	issuer: z.string().optional(),
 	signingKey: signingKeySchema,
+	// SF-1 (v0.5.1): when true (default in HOCON), the central JWT verifier
+	// accepts tokens whose `typ` header is absent and emits a deprecation
+	// warning. v0.6+ should set this to false and reject typ-less tokens.
+	// Per the v0.5.1 ADR the literal default lives in `application.conf`.
+	legacyTypAccept: z.boolean().optional(),
 });
 
 /**

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -134,6 +134,14 @@ export type {
 	SessionData,
 	SessionMutation,
 } from "./grants/types.mjs";
+// JWT verifier (SF-1) — central verifyJwt with alg/iss/aud/typ pinning
+export type {
+	JwtType,
+	JwtVerificationReason,
+	JwtVerifyOptions,
+	VerifiedJwt,
+} from "./jwt/verify.mjs";
+export { JwtVerificationError, verifyJwt } from "./jwt/verify.mjs";
 export type { KeyStoreFactory } from "./keys/factory.mjs";
 export { createKeyStoreFactory, registerBuiltinKeyStores } from "./keys/factory.mjs";
 // Keys

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -157,6 +157,8 @@ export type {
 export {
 	createAsymmetricKeyStore,
 	createSymmetricKeyStore,
+	ExpiredKidError,
+	UnknownKidError,
 } from "./keys/KeyStore.mjs";
 export { consoleLogger, createConsoleLogger } from "./logging/consoleLogger.mjs";
 // Logging

--- a/packages/core/src/jwt/__tests__/verify.test.mts
+++ b/packages/core/src/jwt/__tests__/verify.test.mts
@@ -211,6 +211,35 @@ describe("verifyJwt", () => {
 		});
 	});
 
+	it("Test 7b — rejects typ-less token with contradicting legacy payload.type even when legacyTypAccept=true (reason=typ)", async () => {
+		// Multi-agent review (Copilot Important): legacyTypAccept=true was
+		// silently accepting cross-type tokens whose v0.3-era `payload.type`
+		// disagreed with the expected JwtType. Example: a typ-less RT
+		// (payload.type=refresh) accepted as an access token at /userinfo.
+		const keyStore = makeKeyStore();
+		const secretKey = createSecretKey(Buffer.from(TEST_SECRET));
+		const jwt = await new SignJWT({
+			iss: TEST_ISSUER,
+			aud: TEST_AUDIENCE,
+			sub: "user-1",
+			type: "refresh",
+		})
+			.setProtectedHeader({ alg: "HS256", kid: TEST_KID })
+			.setIssuedAt()
+			.setExpirationTime("5m")
+			.sign(secretKey);
+		await expect(
+			verifyJwt(jwt, keyStore, {
+				...baseOptions,
+				type: "access_token",
+				legacyTypAccept: true,
+			}),
+		).rejects.toMatchObject({
+			name: "JwtVerificationError",
+			reason: "typ",
+		});
+	});
+
 	it("Test 8b — distinguishes expired kid from unknown kid (reason=kid_expired)", async () => {
 		// Multi-agent review (Claude Important): expired and unknown kids
 		// represent different operator-vs-attacker signals. The verifier must

--- a/packages/core/src/jwt/__tests__/verify.test.mts
+++ b/packages/core/src/jwt/__tests__/verify.test.mts
@@ -211,6 +211,35 @@ describe("verifyJwt", () => {
 		});
 	});
 
+	it("Test 8b — distinguishes expired kid from unknown kid (reason=kid_expired)", async () => {
+		// Multi-agent review (Claude Important): expired and unknown kids
+		// represent different operator-vs-attacker signals. The verifier must
+		// surface them as separate reasons so SIEM rules can page differently.
+		const SECRET = "test-secret-32-bytes-long-string12";
+		const expiredKid = "v0";
+		const expiredAt = new Date(Date.now() - 1000); // expired 1s ago
+		// Build a keystore where v0 is "current" but a previousSecret with the
+		// same secret rotates in as `vRot` already-expired. We then sign with
+		// `vRot` so verification fails with kid_expired.
+		const rotatingKeyStore = createSymmetricKeyStore(SECRET, "vCurrent", [
+			{ kid: expiredKid, secret: SECRET, expiresAt: expiredAt },
+		]);
+		const secretKey = createSecretKey(Buffer.from(SECRET));
+		const jwt = await new SignJWT({
+			iss: TEST_ISSUER,
+			aud: TEST_AUDIENCE,
+			sub: "user-1",
+		})
+			.setProtectedHeader({ alg: "HS256", kid: expiredKid, typ: "at+jwt" })
+			.setIssuedAt()
+			.setExpirationTime("5m")
+			.sign(secretKey);
+		await expect(verifyJwt(jwt, rotatingKeyStore, baseOptions)).rejects.toMatchObject({
+			name: "JwtVerificationError",
+			reason: "kid_expired",
+		});
+	});
+
 	it("Test 9 — rejects JWT with iat in future beyond clock skew with reason=not_yet_valid", async () => {
 		const keyStore = makeKeyStore();
 		const futureIat = Math.floor(Date.now() / 1000) + 400; // > 300s skew

--- a/packages/core/src/jwt/__tests__/verify.test.mts
+++ b/packages/core/src/jwt/__tests__/verify.test.mts
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createSecretKey } from "node:crypto";
+import { exportPKCS8, exportSPKI, generateKeyPair, SignJWT } from "jose";
+import { describe, expect, it, vi } from "vitest";
+import { type JwtVerifyOptions, verifyJwt } from "#/jwt/verify.mjs";
+import {
+	createAsymmetricKeyStore,
+	createSymmetricKeyStore,
+	type KeyStore,
+} from "#/keys/KeyStore.mjs";
+import type { Logger } from "#/logging/Logger.mjs";
+
+const TEST_SECRET = "test-secret-32-bytes-long-string12";
+const TEST_KID = "v0";
+const TEST_ISSUER = "https://example.com";
+const TEST_AUDIENCE = "client1";
+
+function makeMockLogger(): Logger {
+	return {
+		trace: vi.fn(),
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		fatal: vi.fn(),
+		child: vi.fn(() => makeMockLogger()),
+	};
+}
+
+function makeKeyStore(): KeyStore {
+	return createSymmetricKeyStore(TEST_SECRET, TEST_KID);
+}
+
+async function signValidAccessToken(
+	overrides: Partial<{
+		iss: string;
+		aud: string | string[];
+		sub: string;
+		typ: string | undefined;
+		iat: number;
+		exp: number;
+		azp: string;
+		nonce: string;
+	}> = {},
+	keyStore: KeyStore = makeKeyStore(),
+): Promise<string> {
+	const claims: Record<string, unknown> = {
+		iss: overrides.iss ?? TEST_ISSUER,
+		aud: overrides.aud ?? TEST_AUDIENCE,
+		sub: overrides.sub ?? "user-1",
+	};
+	if (overrides.azp !== undefined) claims.azp = overrides.azp;
+	if (overrides.nonce !== undefined) claims.nonce = overrides.nonce;
+	const explicitTyp = "typ" in overrides ? overrides.typ : "at+jwt";
+	const headerTyp = explicitTyp;
+	// Use keyStore.sign so the header has correct alg + kid; we then need to
+	// inject explicit iat/exp/typ overrides via jose's SignJWT directly when
+	// the helper is asked for non-default values, since keyStore.sign always
+	// sets iat to now and doesn't honor numeric overrides.
+	if (overrides.iat !== undefined || overrides.exp !== undefined) {
+		const secretKey = createSecretKey(Buffer.from(TEST_SECRET));
+		const signer = new SignJWT(claims).setProtectedHeader({
+			alg: "HS256",
+			kid: TEST_KID,
+			...(headerTyp !== undefined ? { typ: headerTyp } : {}),
+		});
+		if (overrides.iat !== undefined) signer.setIssuedAt(overrides.iat);
+		if (overrides.exp !== undefined) signer.setExpirationTime(overrides.exp);
+		return signer.sign(secretKey);
+	}
+	return await keyStore.sign({
+		claims: { ...claims, exp: Math.floor(Date.now() / 1000) + 300 },
+		header: headerTyp !== undefined ? { typ: headerTyp } : undefined,
+	});
+}
+
+const baseOptions: JwtVerifyOptions = {
+	type: "access_token",
+	expectedIssuer: TEST_ISSUER,
+	expectedAudience: TEST_AUDIENCE,
+};
+
+describe("verifyJwt", () => {
+	it("Test 1 — rejects alg=none JWT with reason=alg", async () => {
+		const keyStore = makeKeyStore();
+		const headerB64 = Buffer.from(
+			JSON.stringify({ alg: "none", typ: "at+jwt", kid: TEST_KID }),
+		).toString("base64url");
+		const payloadB64 = Buffer.from(
+			JSON.stringify({
+				iss: TEST_ISSUER,
+				aud: TEST_AUDIENCE,
+				sub: "user-1",
+				exp: Math.floor(Date.now() / 1000) + 300,
+				iat: Math.floor(Date.now() / 1000),
+			}),
+		).toString("base64url");
+		const noneAlgJwt = `${headerB64}.${payloadB64}.`;
+		await expect(verifyJwt(noneAlgJwt, keyStore, baseOptions)).rejects.toMatchObject({
+			name: "JwtVerificationError",
+			reason: "alg",
+		});
+	});
+
+	it("Test 2 — rejects JWT signed with unexpected alg with reason=alg", async () => {
+		// Asymmetric keystore expects RS256; sign with HS256 token to test
+		// algorithm-confusion rejection.
+		const { privateKey, publicKey } = await generateKeyPair("RS256", {
+			extractable: true,
+		});
+		const rsKeyStore = await createAsymmetricKeyStore({
+			algorithm: "RS256",
+			kid: TEST_KID,
+			privateKeyPem: await exportPKCS8(privateKey),
+			publicKeyPem: await exportSPKI(publicKey),
+		});
+		const hsToken = await signValidAccessToken({}, makeKeyStore());
+		await expect(verifyJwt(hsToken, rsKeyStore, baseOptions)).rejects.toMatchObject({
+			name: "JwtVerificationError",
+			reason: "alg",
+		});
+	});
+
+	it("Test 3 — rejects JWT with wrong iss with reason=iss", async () => {
+		const keyStore = makeKeyStore();
+		const jwt = await signValidAccessToken({ iss: "https://wrong-issuer.example.com" }, keyStore);
+		await expect(verifyJwt(jwt, keyStore, baseOptions)).rejects.toMatchObject({
+			name: "JwtVerificationError",
+			reason: "iss",
+		});
+	});
+
+	it("Test 4 — rejects JWT with aud not containing expected with reason=aud", async () => {
+		const keyStore = makeKeyStore();
+		const jwt = await signValidAccessToken({ aud: "other-client" }, keyStore);
+		await expect(verifyJwt(jwt, keyStore, baseOptions)).rejects.toMatchObject({
+			name: "JwtVerificationError",
+			reason: "aud",
+		});
+	});
+
+	it("Test 5 — rejects JWT with wrong typ when legacyTypAccept=false with reason=typ", async () => {
+		const keyStore = makeKeyStore();
+		// Token typ=rt+jwt verified as access_token (expected at+jwt) — strict mode
+		const jwt = await signValidAccessToken({ typ: "rt+jwt" }, keyStore);
+		await expect(
+			verifyJwt(jwt, keyStore, { ...baseOptions, legacyTypAccept: false }),
+		).rejects.toMatchObject({
+			name: "JwtVerificationError",
+			reason: "typ",
+		});
+	});
+
+	it("Test 6 — accepts JWT with undefined typ when legacyTypAccept=true and emits jwt_verify_legacy_typ warning", async () => {
+		const keyStore = makeKeyStore();
+		const logger = makeMockLogger();
+		const jwt = await signValidAccessToken({ typ: undefined }, keyStore);
+		const result = await verifyJwt(jwt, keyStore, {
+			...baseOptions,
+			legacyTypAccept: true,
+			logger,
+		});
+		expect(result.type).toBe("access_token");
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({ reason: "typ" }),
+			"jwt_verify_legacy_typ",
+		);
+	});
+
+	it("Test 7 — rejects JWT with undefined typ when legacyTypAccept=false with reason=typ", async () => {
+		const keyStore = makeKeyStore();
+		const jwt = await signValidAccessToken({ typ: undefined }, keyStore);
+		await expect(
+			verifyJwt(jwt, keyStore, { ...baseOptions, legacyTypAccept: false }),
+		).rejects.toMatchObject({
+			name: "JwtVerificationError",
+			reason: "typ",
+		});
+	});
+
+	it("Test 8 — rejects JWT with valid signature but unknown kid with reason=kid_unknown", async () => {
+		const keyStore = makeKeyStore();
+		// Sign with the same secret but advertise an unknown kid in the header
+		const secretKey = createSecretKey(Buffer.from(TEST_SECRET));
+		const jwt = await new SignJWT({
+			iss: TEST_ISSUER,
+			aud: TEST_AUDIENCE,
+			sub: "user-1",
+		})
+			.setProtectedHeader({ alg: "HS256", kid: "unknown-kid", typ: "at+jwt" })
+			.setIssuedAt()
+			.setExpirationTime("5m")
+			.sign(secretKey);
+		await expect(verifyJwt(jwt, keyStore, baseOptions)).rejects.toMatchObject({
+			name: "JwtVerificationError",
+			reason: "kid_unknown",
+		});
+	});
+
+	it("Test 9 — rejects JWT with iat in future beyond clock skew with reason=not_yet_valid", async () => {
+		const keyStore = makeKeyStore();
+		const futureIat = Math.floor(Date.now() / 1000) + 400; // > 300s skew
+		const futureExp = futureIat + 300;
+		const jwt = await signValidAccessToken({ iat: futureIat, exp: futureExp }, keyStore);
+		await expect(verifyJwt(jwt, keyStore, baseOptions)).rejects.toMatchObject({
+			name: "JwtVerificationError",
+			reason: "not_yet_valid",
+		});
+	});
+
+	it("Test 10 — rejects expired JWT with reason=expired", async () => {
+		const keyStore = makeKeyStore();
+		const pastIat = Math.floor(Date.now() / 1000) - 700;
+		const pastExp = Math.floor(Date.now() / 1000) - 400;
+		const jwt = await signValidAccessToken({ iat: pastIat, exp: pastExp }, keyStore);
+		await expect(verifyJwt(jwt, keyStore, baseOptions)).rejects.toMatchObject({
+			name: "JwtVerificationError",
+			reason: "expired",
+		});
+	});
+
+	it("Test 11 — returns VerifiedJwt with payload, header, and type for valid JWT", async () => {
+		const keyStore = makeKeyStore();
+		const jwt = await signValidAccessToken({}, keyStore);
+		const result = await verifyJwt(jwt, keyStore, baseOptions);
+		expect(result.type).toBe("access_token");
+		expect(result.payload.iss).toBe(TEST_ISSUER);
+		expect(result.payload.aud).toBe(TEST_AUDIENCE);
+		expect(result.payload.sub).toBe("user-1");
+		expect(result.header.alg).toBe("HS256");
+		expect(result.header.typ).toBe("at+jwt");
+		expect(result.header.kid).toBe(TEST_KID);
+	});
+
+	it("Test 12b — when expectedIssuer is empty, accepts token regardless of iss and emits jwt_verify_iss_skipped warning", async () => {
+		// Test fixtures + partial-config dev roots produce tokens without a
+		// matching iss claim. Empty-string expectedIssuer is the explicit
+		// opt-out. The verifier MUST log this and proceed.
+		const keyStore = makeKeyStore();
+		const logger = makeMockLogger();
+		const jwt = await signValidAccessToken({ iss: "anything-goes" }, keyStore);
+		const result = await verifyJwt(jwt, keyStore, {
+			type: "access_token",
+			expectedIssuer: "",
+			expectedAudience: TEST_AUDIENCE,
+			logger,
+		});
+		expect(result.type).toBe("access_token");
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({ reason: "iss" }),
+			"jwt_verify_iss_skipped",
+		);
+	});
+
+	it("Test 12a — when expectedAudience is undefined, accepts token regardless of aud and emits jwt_verify_aud_skipped warning", async () => {
+		// Bearer-as-credential routes (introspect Bearer / userinfo /
+		// id_token_hint logout) cannot determine the calling client identity
+		// before verification, so they explicitly omit `expectedAudience`.
+		// The verifier MUST log this gap (audit-visible) and proceed.
+		const keyStore = makeKeyStore();
+		const logger = makeMockLogger();
+		const jwt = await signValidAccessToken({ aud: "any-other-audience" }, keyStore);
+		const { type } = await verifyJwt(jwt, keyStore, {
+			type: "access_token",
+			expectedIssuer: TEST_ISSUER,
+			logger,
+		});
+		expect(type).toBe("access_token");
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({ reason: "aud" }),
+			"jwt_verify_aud_skipped",
+		);
+	});
+
+	it("Test 12 — rejects azp mismatch with reason=azp", async () => {
+		const keyStore = makeKeyStore();
+		// Refresh-token verification path: typ=rt+jwt + azp claim binds RT to client
+		const jwt = await signValidAccessToken({ typ: "rt+jwt", azp: "other-client" }, keyStore);
+		await expect(
+			verifyJwt(jwt, keyStore, {
+				type: "refresh_token",
+				expectedIssuer: TEST_ISSUER,
+				expectedAudience: TEST_AUDIENCE,
+				expectedAzp: TEST_AUDIENCE,
+			}),
+		).rejects.toMatchObject({
+			name: "JwtVerificationError",
+			reason: "azp",
+		});
+	});
+});

--- a/packages/core/src/jwt/verify.mts
+++ b/packages/core/src/jwt/verify.mts
@@ -44,7 +44,12 @@ export type JwtVerificationReason =
 	| "signature"
 	| "expired"
 	| "not_yet_valid"
-	| "kid_unknown";
+	| "kid_unknown"
+	// `kid_expired` is distinct from `kid_unknown`: an expired kid is an
+	// operator-rotation signal (the previous key's expiresAt has passed), an
+	// unknown kid is an attacker-fabricated header signal. SIEM filters can
+	// page differently on each.
+	| "kid_expired";
 
 /**
  * Thrown by {@link verifyJwt} on any verification failure. The `reason` field
@@ -189,9 +194,15 @@ export async function verifyJwt(
 		throw err;
 	}
 
-	// typ check — header-only, runs before signature so a wrong-type token
-	// never even attempts crypto verification (also avoids leaking timing
-	// signal that would distinguish "wrong typ" from "wrong key").
+	// typ check — header-only, runs before signature as a cheap token-type-
+	// confusion screen. typ is in the public protected header (not part of
+	// the signed claims set), so checking it pre-signature is a no-op for an
+	// attacker who controls the header but not the key; it does NOT add a
+	// timing oracle since rejecting on typ short-circuits before the HMAC /
+	// RSA op the attacker would otherwise time. Pre-signature placement also
+	// short-circuits id_token / logout_token tokens reaching an at+jwt-only
+	// route (they would still fail signature against the same KeyStore, but
+	// failing here keeps the audit log honest about *why*).
 	const effectiveExpectedTyp = expectedTyp === undefined ? DEFAULT_TYP_BY_TYPE[type] : expectedTyp;
 	if (effectiveExpectedTyp !== null) {
 		const headerTyp = header.typ;
@@ -229,8 +240,16 @@ export async function verifyJwt(
 	let verificationKey: Awaited<ReturnType<KeyStore["getVerificationKey"]>>;
 	try {
 		verificationKey = await keyStore.getVerificationKey(requestedKid);
-	} catch {
-		const err = new JwtVerificationError("kid_unknown", `Unknown or expired kid: ${requestedKid}`);
+	} catch (cause) {
+		// IH-9 KeyStore distinguishes the two failure modes by message
+		// prefix (`Expired kid:` vs `Unknown kid:`). Surface them as separate
+		// reasons so SIEM pipelines can tell operator-rotation expiry apart
+		// from attacker-fabricated header values.
+		const causeMessage = cause instanceof Error ? cause.message : String(cause);
+		const reason: JwtVerificationReason = causeMessage.startsWith("Expired kid:")
+			? "kid_expired"
+			: "kid_unknown";
+		const err = new JwtVerificationError(reason, causeMessage);
 		emitRejection(logger, err, undefined, header);
 		throw err;
 	}

--- a/packages/core/src/jwt/verify.mts
+++ b/packages/core/src/jwt/verify.mts
@@ -20,7 +20,7 @@ import {
 	jwtVerify,
 	type ProtectedHeaderParameters,
 } from "jose";
-import type { KeyStore } from "../keys/KeyStore.mjs";
+import { ExpiredKidError, type KeyStore } from "../keys/KeyStore.mjs";
 import type { Logger } from "../logging/Logger.mjs";
 
 /**
@@ -144,6 +144,19 @@ const DEFAULT_TYP_BY_TYPE: Record<JwtType, string> = {
 	id_token: "id+jwt",
 };
 
+/**
+ * Maps the v0.3-era `payload.type` legacy claim back to a {@link JwtType}.
+ * v0.3 tokens predated the `typ` header convention; refresh tokens emitted
+ * `payload.type = "refresh"` instead. Unknown values map to `undefined`
+ * (the verifier accepts them under `legacyTypAccept` rather than rejecting,
+ * matching the philosophy that an unrecognized legacy hint is not evidence
+ * of cross-type confusion).
+ */
+const LEGACY_PAYLOAD_TYPE_MAP: Record<string, JwtType> = {
+	refresh: "refresh_token",
+	access: "access_token",
+};
+
 const DEFAULT_CLOCK_SKEW_MS = 300_000;
 
 /**
@@ -241,15 +254,14 @@ export async function verifyJwt(
 	try {
 		verificationKey = await keyStore.getVerificationKey(requestedKid);
 	} catch (cause) {
-		// IH-9 KeyStore distinguishes the two failure modes by message
-		// prefix (`Expired kid:` vs `Unknown kid:`). Surface them as separate
-		// reasons so SIEM pipelines can tell operator-rotation expiry apart
-		// from attacker-fabricated header values.
-		const causeMessage = cause instanceof Error ? cause.message : String(cause);
-		const reason: JwtVerificationReason = causeMessage.startsWith("Expired kid:")
-			? "kid_expired"
-			: "kid_unknown";
-		const err = new JwtVerificationError(reason, causeMessage);
+		// KeyStore distinguishes the two failure modes via typed errors
+		// (ExpiredKidError / UnknownKidError) so SIEM pipelines can tell
+		// operator-rotation expiry apart from attacker-fabricated header
+		// values without coupling to message text.
+		const reason: JwtVerificationReason =
+			cause instanceof ExpiredKidError ? "kid_expired" : "kid_unknown";
+		const message = cause instanceof Error ? cause.message : String(cause);
+		const err = new JwtVerificationError(reason, message);
 		emitRejection(logger, err, undefined, header);
 		throw err;
 	}
@@ -270,7 +282,11 @@ export async function verifyJwt(
 				? expectedAudience
 				: [...expectedAudience];
 	if (expectedAudience === undefined) {
-		logger?.warn({ reason: "aud", iss: expectedIssuer, type }, "jwt_verify_aud_skipped");
+		// Once-per-(logger, reason, type) so /userinfo and other hot bearer-as-
+		// credential routes don't flood ingestion with a warn record per request.
+		// Operators see the gap on first occurrence; volume signal is preserved
+		// in route-level request counters, not the audit log.
+		warnAuditGapOnce(logger, "aud", type, { iss: expectedIssuer }, "jwt_verify_aud_skipped");
 	}
 	// Issuer pinning is normally required, but operators who haven't
 	// configured `oauth.jwt.issuer` (e.g. partial-config test fixtures, dev
@@ -279,7 +295,7 @@ export async function verifyJwt(
 	// expected issuer so it's auditable.
 	const skipIssuer = expectedIssuer === "";
 	if (skipIssuer) {
-		logger?.warn({ reason: "iss", type }, "jwt_verify_iss_skipped");
+		warnAuditGapOnce(logger, "iss", type, {}, "jwt_verify_iss_skipped");
 	}
 
 	let payload: JoseJWTPayload;
@@ -299,6 +315,24 @@ export async function verifyJwt(
 		);
 		emitRejection(logger, err, undefined, header);
 		throw err;
+	}
+
+	// Legacy cross-type acceptance guard (Copilot review): when the header
+	// `typ` was absent and `legacyTypAccept` waved through the typ check,
+	// a v0.3-era token whose `payload.type` claim contradicts the expected
+	// {@link JwtType} would otherwise pass — e.g. a typ-less RT carrying
+	// `payload.type: "refresh"` accepted as an access token at /userinfo.
+	// Map the legacy claim back to the type universe and reject contradictions.
+	if (header.typ === undefined && typeof payload.type === "string") {
+		const mappedType = LEGACY_PAYLOAD_TYPE_MAP[payload.type];
+		if (mappedType !== undefined && mappedType !== type) {
+			const err = new JwtVerificationError(
+				"typ",
+				`JWT legacy payload.type ${payload.type} maps to ${mappedType}, expected ${type}`,
+			);
+			emitRejection(logger, err, payload, header);
+			throw err;
+		}
 	}
 
 	// iat in future beyond skew — jose does not enforce this; RFC 8725 §3.10
@@ -384,4 +418,37 @@ function emitRejection(
 		},
 		"jwt_verify_rejected",
 	);
+}
+
+/**
+ * Per-logger once-per-(reason, type) memoization for audit-gap warnings
+ * (`jwt_verify_aud_skipped`, `jwt_verify_iss_skipped`). Hot bearer-as-
+ * credential routes (e.g. /userinfo) would otherwise emit one warn record
+ * per request — operationally noisy and a real ingestion-cost issue.
+ *
+ * The map is keyed by Logger identity so each unique logger instance gets
+ * its own dedupe set: production deployments with a singleton logger emit
+ * each gap exactly once; tests that construct fresh mock loggers per case
+ * see a fresh emission per test (so assertions on warn calls remain
+ * deterministic). WeakMap auto-clears on logger GC.
+ */
+const auditGapEmitted = new WeakMap<Logger, Set<string>>();
+
+function warnAuditGapOnce(
+	logger: Logger | undefined,
+	reason: "aud" | "iss",
+	type: JwtType,
+	bindings: Record<string, unknown>,
+	msg: string,
+): void {
+	if (!logger) return;
+	let seen = auditGapEmitted.get(logger);
+	if (!seen) {
+		seen = new Set<string>();
+		auditGapEmitted.set(logger, seen);
+	}
+	const key = `${reason}:${type}`;
+	if (seen.has(key)) return;
+	seen.add(key);
+	logger.warn({ reason, type, ...bindings }, msg);
 }

--- a/packages/core/src/jwt/verify.mts
+++ b/packages/core/src/jwt/verify.mts
@@ -1,0 +1,368 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+	decodeProtectedHeader,
+	type JWTPayload as JoseJWTPayload,
+	errors as joseErrors,
+	jwtVerify,
+	type ProtectedHeaderParameters,
+} from "jose";
+import type { KeyStore } from "../keys/KeyStore.mjs";
+import type { Logger } from "../logging/Logger.mjs";
+
+/**
+ * Token type — drives default `typ` expectation and selects appropriate
+ * post-signature claim checks (e.g. `azp` on refresh tokens).
+ */
+export type JwtType = "access_token" | "refresh_token" | "id_token";
+
+/**
+ * Discriminator for {@link JwtVerificationError}. One reason per failure mode
+ * keeps caller `catch` blocks structurally exhaustive when the exhaustive
+ * switch over this union is type-checked.
+ */
+export type JwtVerificationReason =
+	| "alg"
+	| "iss"
+	| "aud"
+	| "typ"
+	| "azp"
+	| "nonce"
+	| "signature"
+	| "expired"
+	| "not_yet_valid"
+	| "kid_unknown";
+
+/**
+ * Thrown by {@link verifyJwt} on any verification failure. The `reason` field
+ * is the audit-stable discriminator; `message` is a human-readable summary
+ * suitable for `logger.warn` but NOT for client-facing error responses
+ * (callers must map to RFC-compliant error envelopes themselves).
+ */
+export class JwtVerificationError extends Error {
+	override readonly name = "JwtVerificationError";
+	constructor(
+		readonly reason: JwtVerificationReason,
+		message: string,
+	) {
+		super(message);
+	}
+}
+
+export interface JwtVerifyOptions {
+	/** Token type — selects default `typ` expectation. */
+	readonly type: JwtType;
+	/**
+	 * Required `iss` claim — exact match. Pass an empty string to skip iss
+	 * pinning when the operator has not configured `oauth.jwt.issuer` and
+	 * the call site has no other source of expected issuer; the verifier
+	 * emits a `jwt_verify_iss_skipped` warning so the gap is audit-visible.
+	 */
+	readonly expectedIssuer: string;
+	/**
+	 * Required `aud` claim — must be present (string) or contain (array).
+	 *
+	 * Optional only because bearer-as-credential routes (introspect Bearer
+	 * self-intro, /userinfo, /logout id_token_hint) cannot establish the
+	 * calling-client identity *before* JWT verification, so the audience to
+	 * pin against is unknown at the verify call. At those sites the caller
+	 * passes `undefined`; the verifier emits a `jwt_verify_aud_skipped`
+	 * warning so the gap is audit-visible. All sites that DO know the
+	 * calling client (token / refresh / federation / token-exchange) MUST
+	 * supply this.
+	 */
+	readonly expectedAudience?: string | readonly string[];
+	/**
+	 * Optional `azp` claim binding. When provided, `payload.azp` must equal
+	 * this value or verification fails with `reason: "azp"`. Used by refresh
+	 * token verification to bind the RT to the authorized party (D-6 PB-2).
+	 */
+	readonly expectedAzp?: string;
+	/**
+	 * Optional `nonce` claim binding. Used by id_token verification to bind
+	 * the token to the original authorization request (PB-4+5).
+	 */
+	readonly expectedNonce?: string;
+	/**
+	 * Clock skew tolerance in milliseconds applied to `exp`/`nbf`/`iat`
+	 * checks. Default: 300_000 (5 min) per RFC 8725 §3.10 guidance.
+	 */
+	readonly clockSkewMs?: number;
+	/**
+	 * Override default `typ` for this {@link JwtType}. Pass `null` to skip
+	 * `typ` checking entirely (legacy migration paths only).
+	 */
+	readonly expectedTyp?: string | null;
+	/**
+	 * Override expected algorithms passed to jose. Default: `[keyStore.algorithm]`.
+	 * Setting an explicit list is required when verifying tokens issued by an
+	 * upstream provider whose alg differs from the local KeyStore.
+	 */
+	readonly expectedAlgs?: readonly string[];
+	/**
+	 * Audit logger. All rejection paths emit a structured warn record with
+	 * `{reason, jti, sub, iss, typ}` bindings so SIEM filters can index by
+	 * reason without scraping message text. Optional — when absent the
+	 * rejection is silent (caller handles it via the thrown error).
+	 */
+	readonly logger?: Logger;
+	/**
+	 * v0.5.1 transition: when `true` (default), tokens whose `typ` header is
+	 * absent are accepted with a `jwt_verify_legacy_typ` warning. Set to
+	 * `false` in v0.6+ to enforce typ presence on all tokens.
+	 */
+	readonly legacyTypAccept?: boolean;
+}
+
+export interface VerifiedJwt {
+	readonly payload: JoseJWTPayload;
+	readonly header: ProtectedHeaderParameters;
+	readonly type: JwtType;
+}
+
+const DEFAULT_TYP_BY_TYPE: Record<JwtType, string> = {
+	access_token: "at+jwt",
+	refresh_token: "rt+jwt",
+	id_token: "id+jwt",
+};
+
+const DEFAULT_CLOCK_SKEW_MS = 300_000;
+
+/**
+ * Centralized JWT verification with alg / iss / aud / typ pinning.
+ *
+ * The verifier:
+ *  1. decodes the protected header (without signature check) to read `kid`
+ *     and `typ`,
+ *  2. validates `typ` against the expected value (legacy compat is opt-in
+ *     via {@link JwtVerifyOptions.legacyTypAccept}),
+ *  3. resolves the verification key by `kid` via
+ *     {@link KeyStore.getVerificationKey} (falls back to the current signing
+ *     kid when the JWT has no `kid` header),
+ *  4. delegates to jose `jwtVerify` with explicit `algorithms`, `issuer`, and
+ *     `audience` options — pinning all three at the security-critical layer,
+ *  5. enforces `iat <= now + clockSkewMs` post-signature (jose does not
+ *     validate `iat`-in-future by default), and
+ *  6. enforces optional `azp` / `nonce` claim bindings post-signature.
+ *
+ * On any failure the verifier throws {@link JwtVerificationError} with a
+ * stable {@link JwtVerificationReason}. Callers map that to their own error
+ * envelope (e.g. RFC 6749 `error: "invalid_token"`).
+ */
+export async function verifyJwt(
+	jwt: string,
+	keyStore: KeyStore,
+	options: JwtVerifyOptions,
+): Promise<VerifiedJwt> {
+	const {
+		type,
+		expectedIssuer,
+		expectedAudience,
+		expectedAzp,
+		expectedNonce,
+		clockSkewMs = DEFAULT_CLOCK_SKEW_MS,
+		expectedTyp,
+		expectedAlgs,
+		logger,
+		legacyTypAccept = true,
+	} = options;
+
+	let header: ProtectedHeaderParameters;
+	try {
+		header = decodeProtectedHeader(jwt);
+	} catch {
+		const err = new JwtVerificationError("signature", "JWT header decode failed");
+		emitRejection(logger, err, undefined, undefined);
+		throw err;
+	}
+
+	// typ check — header-only, runs before signature so a wrong-type token
+	// never even attempts crypto verification (also avoids leaking timing
+	// signal that would distinguish "wrong typ" from "wrong key").
+	const effectiveExpectedTyp = expectedTyp === undefined ? DEFAULT_TYP_BY_TYPE[type] : expectedTyp;
+	if (effectiveExpectedTyp !== null) {
+		const headerTyp = header.typ;
+		if (headerTyp === undefined) {
+			if (legacyTypAccept) {
+				logger?.warn(
+					{
+						reason: "typ",
+						typ: undefined,
+						expectedTyp: effectiveExpectedTyp,
+					},
+					"jwt_verify_legacy_typ",
+				);
+			} else {
+				const err = new JwtVerificationError(
+					"typ",
+					`JWT typ header is required (expected ${effectiveExpectedTyp})`,
+				);
+				emitRejection(logger, err, undefined, header);
+				throw err;
+			}
+		} else if (headerTyp !== effectiveExpectedTyp) {
+			const err = new JwtVerificationError(
+				"typ",
+				`JWT typ ${headerTyp} does not match expected ${effectiveExpectedTyp}`,
+			);
+			emitRejection(logger, err, undefined, header);
+			throw err;
+		}
+	}
+
+	// kid resolution — fall back to current signing kid when the JWT has no
+	// kid header (back-compat with tokens signed before kid was emitted).
+	const requestedKid = header.kid ?? keyStore.getSigningKidFallback();
+	let verificationKey: Awaited<ReturnType<KeyStore["getVerificationKey"]>>;
+	try {
+		verificationKey = await keyStore.getVerificationKey(requestedKid);
+	} catch {
+		const err = new JwtVerificationError("kid_unknown", `Unknown or expired kid: ${requestedKid}`);
+		emitRejection(logger, err, undefined, header);
+		throw err;
+	}
+
+	const algorithms = expectedAlgs ?? [keyStore.algorithm];
+	const clockSkewSeconds = Math.floor(clockSkewMs / 1000);
+
+	// Audience pinning is OPT-IN. When the caller cannot establish the
+	// expected audience before verification (introspect Bearer self-intro,
+	// /userinfo, /logout id_token_hint — bearer-as-credential routes), the
+	// jose `audience` option is omitted and the gap is logged so the audit
+	// trail records that the aud check was deliberately skipped at this
+	// site rather than silently bypassed.
+	const audienceForJose: string | string[] | undefined =
+		expectedAudience === undefined
+			? undefined
+			: typeof expectedAudience === "string"
+				? expectedAudience
+				: [...expectedAudience];
+	if (expectedAudience === undefined) {
+		logger?.warn({ reason: "aud", iss: expectedIssuer, type }, "jwt_verify_aud_skipped");
+	}
+	// Issuer pinning is normally required, but operators who haven't
+	// configured `oauth.jwt.issuer` (e.g. partial-config test fixtures, dev
+	// composition roots) still need verification to function. Empty-string
+	// expectedIssuer is the explicit skip — different from passing a real
+	// expected issuer so it's auditable.
+	const skipIssuer = expectedIssuer === "";
+	if (skipIssuer) {
+		logger?.warn({ reason: "iss", type }, "jwt_verify_iss_skipped");
+	}
+
+	let payload: JoseJWTPayload;
+	try {
+		const result = await jwtVerify(jwt, verificationKey, {
+			algorithms: [...algorithms],
+			...(skipIssuer ? {} : { issuer: expectedIssuer }),
+			...(audienceForJose !== undefined ? { audience: audienceForJose } : {}),
+			clockTolerance: clockSkewSeconds,
+		});
+		payload = result.payload;
+	} catch (cause) {
+		const reason = classifyJoseError(cause);
+		const err = new JwtVerificationError(
+			reason,
+			cause instanceof Error ? cause.message : String(cause),
+		);
+		emitRejection(logger, err, undefined, header);
+		throw err;
+	}
+
+	// iat in future beyond skew — jose does not enforce this; RFC 8725 §3.10
+	// recommends rejecting because a future iat indicates clock tampering or
+	// token replay from a forged time source.
+	if (typeof payload.iat === "number") {
+		const nowSeconds = Math.floor(Date.now() / 1000);
+		if (payload.iat > nowSeconds + clockSkewSeconds) {
+			const err = new JwtVerificationError(
+				"not_yet_valid",
+				`JWT iat ${payload.iat} is in the future beyond clock skew`,
+			);
+			emitRejection(logger, err, payload, header);
+			throw err;
+		}
+	}
+
+	if (expectedAzp !== undefined && payload.azp !== expectedAzp) {
+		const err = new JwtVerificationError(
+			"azp",
+			`JWT azp ${String(payload.azp)} does not match expected ${expectedAzp}`,
+		);
+		emitRejection(logger, err, payload, header);
+		throw err;
+	}
+
+	if (expectedNonce !== undefined && payload.nonce !== expectedNonce) {
+		const err = new JwtVerificationError("nonce", `JWT nonce mismatch (expected ${expectedNonce})`);
+		emitRejection(logger, err, payload, header);
+		throw err;
+	}
+
+	return { payload, header, type };
+}
+
+function classifyJoseError(cause: unknown): JwtVerificationReason {
+	if (cause instanceof joseErrors.JWTExpired) {
+		return "expired";
+	}
+	if (cause instanceof joseErrors.JOSEAlgNotAllowed) {
+		return "alg";
+	}
+	if (cause instanceof joseErrors.JWTClaimValidationFailed) {
+		switch (cause.claim) {
+			case "iss":
+				return "iss";
+			case "aud":
+				return "aud";
+			case "nbf":
+			case "iat":
+				return "not_yet_valid";
+			case "exp":
+				return "expired";
+			default:
+				// Unrecognized claim validation — fall through to generic
+				// signature reason rather than invent a new bucket.
+				return "signature";
+		}
+	}
+	if (cause instanceof joseErrors.JWSSignatureVerificationFailed) {
+		return "signature";
+	}
+	if (cause instanceof joseErrors.JWSInvalid || cause instanceof joseErrors.JWTInvalid) {
+		return "signature";
+	}
+	return "signature";
+}
+
+function emitRejection(
+	logger: Logger | undefined,
+	err: JwtVerificationError,
+	payload: JoseJWTPayload | undefined,
+	header: ProtectedHeaderParameters | undefined,
+): void {
+	if (!logger) return;
+	logger.warn(
+		{
+			reason: err.reason,
+			jti: payload?.jti,
+			sub: payload?.sub,
+			iss: payload?.iss,
+			typ: header?.typ,
+		},
+		"jwt_verify_rejected",
+	);
+}

--- a/packages/core/src/keys/KeyStore.mts
+++ b/packages/core/src/keys/KeyStore.mts
@@ -53,6 +53,35 @@ export interface ManagedKey {
 
 export type Algorithm = "HS256" | "RS256" | "ES256" | "EdDSA";
 
+/**
+ * Thrown by {@link KeyStore.getVerificationKey} when the requested `kid` is
+ * not registered in the keystore. Callers (notably the SF-1 central JWT
+ * verifier) `instanceof`-check this so SIEM pipelines can distinguish
+ * attacker-fabricated kids from operator-rotation expiry.
+ */
+export class UnknownKidError extends Error {
+	override readonly name = "UnknownKidError";
+	constructor(readonly kid: string) {
+		super(`Unknown kid: ${kid}`);
+	}
+}
+
+/**
+ * Thrown by {@link KeyStore.getVerificationKey} when the requested `kid` is
+ * registered but its `expiresAt` has passed. Distinct from
+ * {@link UnknownKidError} so audit pipelines can page differently on
+ * rotation-window expiry vs. attacker-fabricated header values.
+ */
+export class ExpiredKidError extends Error {
+	override readonly name = "ExpiredKidError";
+	constructor(
+		readonly kid: string,
+		readonly expiredAt: Date,
+	) {
+		super(`Expired kid: ${kid}`);
+	}
+}
+
 export interface KeyStore {
 	readonly algorithm: Algorithm;
 	/**
@@ -143,10 +172,10 @@ export async function createAsymmetricKeyStore(
 			}
 			const prev = resolvedPrevious.find((k) => k.kid === requestedKid);
 			if (!prev) {
-				throw new Error(`Unknown kid: ${requestedKid}`);
+				throw new UnknownKidError(requestedKid);
 			}
 			if (prev.expiresAt <= new Date()) {
-				throw new Error(`Expired kid: ${requestedKid}`);
+				throw new ExpiredKidError(requestedKid, prev.expiresAt);
 			}
 			return prev.publicKey;
 		},
@@ -220,10 +249,10 @@ export function createSymmetricKeyStore(
 			}
 			const prev = resolvedPrevious.find((p) => p.kid === requestedKid);
 			if (!prev) {
-				throw new Error(`Unknown kid: ${requestedKid}`);
+				throw new UnknownKidError(requestedKid);
 			}
 			if (prev.expiresAt <= new Date()) {
-				throw new Error(`Expired kid: ${requestedKid}`);
+				throw new ExpiredKidError(requestedKid, prev.expiresAt);
 			}
 			return prev.secretKey;
 		},

--- a/packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts
@@ -52,7 +52,10 @@ describe("createSelfIssuedAccessTokenValidator", () => {
 	});
 
 	it("returns null for an expired token", async () => {
-		const token = await signSelfIssuedAccessToken({}, { expiresIn: "-1s" });
+		// SF-1: the central verifier defaults clockSkewMs to 300_000 (5 min)
+		// per RFC 8725 §3.10, so a "-1s" past exp falls inside skew. Use a
+		// past exp well beyond the default skew so the rejection is robust.
+		const token = await signSelfIssuedAccessToken({}, { expiresIn: "-10m" });
 		const result = await validator().validate(token, { role: "subject" });
 		expect(result).toBeNull();
 	});

--- a/packages/oauth-token-exchange/src/module.mts
+++ b/packages/oauth-token-exchange/src/module.mts
@@ -92,6 +92,10 @@ export const tokenExchangeModule: Module = defineModule({
 		// it here, token-exchange would silently sit outside CP-18 enforcement
 		// while sibling grants are gated.
 		"grantPolicy",
+		// SF-1: forwarded to the central JWT verifier so verifier rejection /
+		// aud-skip warnings emit through the operator's structured logger
+		// rather than being silently dropped.
+		"logger",
 	],
 	contributes: {
 		grants: {
@@ -105,6 +109,13 @@ export const tokenExchangeModule: Module = defineModule({
 					keyStore: deps.keyStore,
 					issuer: deps.config.oauth.jwt.issuer,
 					refreshTokenFamilyRevocation: deps.refreshTokenFamilyRevocation,
+					// SF-1: thread legacyTypAccept through so the operator's
+					// HOCON / env-var override governs the validator. Without
+					// this, the validator's `?? true` fallback masked any
+					// explicit `legacyTypAccept = false` configuration — the
+					// strict mode would not actually engage at this site.
+					legacyTypAccept: deps.config.oauth.jwt.legacyTypAccept,
+					logger: deps.logger,
 				}),
 		},
 	},

--- a/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
+++ b/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
-import type { KeyStore, RefreshTokenFamilyRevocation } from "@o3co/auth-provider-core";
-import { decodeProtectedHeader, jwtVerify } from "jose";
+import {
+	type KeyStore,
+	type Logger,
+	type RefreshTokenFamilyRevocation,
+	verifyJwt,
+} from "@o3co/auth-provider-core";
 import type {
 	ExchangeTokenValidationContext,
 	ExchangeTokenValidator,
@@ -28,6 +32,12 @@ export interface CreateSelfIssuedAccessTokenValidatorOptions {
 	keyStore: KeyStore;
 	refreshTokenFamilyRevocation?: RefreshTokenFamilyRevocation;
 	issuer: string;
+	/**
+	 * SF-1 (v0.5.1): when true (default), the central JWT verifier accepts
+	 * tokens whose `typ` header is absent and emits a deprecation warning.
+	 */
+	legacyTypAccept?: boolean;
+	logger?: Logger;
 }
 
 /**
@@ -59,7 +69,7 @@ export interface CreateSelfIssuedAccessTokenValidatorOptions {
 export function createSelfIssuedAccessTokenValidator(
 	options: CreateSelfIssuedAccessTokenValidatorOptions,
 ): ExchangeTokenValidator {
-	const { keyStore, refreshTokenFamilyRevocation, issuer } = options;
+	const { keyStore, refreshTokenFamilyRevocation, issuer, legacyTypAccept, logger } = options;
 	if (typeof issuer !== "string" || issuer.length === 0) {
 		throw new Error(
 			"createSelfIssuedAccessTokenValidator: issuer is required (a non-empty string). Without an issuer to compare against, an at+jwt signed by the same KeyStore but with a different `iss` claim could be accepted.",
@@ -71,29 +81,24 @@ export function createSelfIssuedAccessTokenValidator(
 			token: string,
 			_context: ExchangeTokenValidationContext,
 		): Promise<ValidatedToken | null> {
+			// SF-1: alg / iss / typ (=at+jwt) + signature pinned by the central
+			// verifier. Token-type-confusion (id_tokens / logout_tokens minted by
+			// the same KeyStore) is closed by the typ pin. Audience is NOT
+			// pinned here: ExchangeTokenValidationContext intentionally does not
+			// carry the calling-client identity (the grant handler authenticated
+			// it upstream and applies may_act / policy gates downstream), so the
+			// expected aud is unknown at this layer. The verifier records the
+			// gap via `jwt_verify_aud_skipped`.
 			let payload: Record<string, unknown>;
-			let header: Awaited<ReturnType<typeof decodeProtectedHeader>>;
 			try {
-				header = decodeProtectedHeader(token);
-				const key = await keyStore.getVerificationKey(
-					header.kid ?? keyStore.getSigningKidFallback(),
-				);
-				const verified = await jwtVerify(token, key);
+				const verified = await verifyJwt(token, keyStore, {
+					type: "access_token",
+					expectedIssuer: issuer,
+					legacyTypAccept: legacyTypAccept ?? true,
+					logger,
+				});
 				payload = verified.payload as Record<string, unknown>;
 			} catch {
-				return null;
-			}
-
-			// Token-type-confusion defense: the RFC 8693 `access_token` subject_token_type
-			// means "a token that was issued as an access_token". Reject any JWT whose
-			// `typ` header is anything other than `at+jwt` — in particular id_tokens
-			// (typ=JWT or typ=id+jwt) and logout_tokens (typ=logout+jwt) minted by the
-			// same KeyStore must never be accepted as a Token Exchange subject.
-			if (header.typ !== "at+jwt") {
-				return null;
-			}
-
-			if (payload.iss !== issuer) {
 				return null;
 			}
 

--- a/packages/oauth/src/__tests__/introspectCascade.test.mts
+++ b/packages/oauth/src/__tests__/introspectCascade.test.mts
@@ -69,6 +69,7 @@ const mockCodeRepository: CodeRepository = {
 async function makeAccessToken(overrides: Record<string, unknown> = {}): Promise<string> {
 	return new SignJWT({ sub: "u1", scope: "read", ...overrides })
 		.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "at+jwt" })
+		.setIssuer("https://auth.example")
 		.setExpirationTime("1h")
 		.sign(secretKey);
 }

--- a/packages/oauth/src/__tests__/logout.test.mts
+++ b/packages/oauth/src/__tests__/logout.test.mts
@@ -48,7 +48,7 @@ async function mintIdToken(extra: Record<string, unknown> = {}): Promise<string>
 		sid: "sid-1",
 		...extra,
 	})
-		.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "JWT" })
+		.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "id+jwt" })
 		.setExpirationTime("1h")
 		.setIssuedAt()
 		.setIssuer("https://auth.example.com")
@@ -264,7 +264,8 @@ describe("POST /oauth/logout", () => {
 			const app = buildApp();
 			// Mint a token without sid
 			const token = await new SignJWT({ sub: "u-1", aud: "client-1" })
-				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "JWT" })
+				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "id+jwt" })
+				.setIssuer("https://auth.example.com")
 				.setExpirationTime("1h")
 				.setIssuedAt()
 				.sign(secretKey);

--- a/packages/oauth/src/__tests__/module.test.mts
+++ b/packages/oauth/src/__tests__/module.test.mts
@@ -374,6 +374,7 @@ describe("oauthModule — federation logout via typed deps", () => {
 
 		const accessToken = await new SignJWT({ sub: "u-1", sid: "sid-1", family_id: "fam-1" })
 			.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "at+jwt" })
+			.setIssuer("https://auth.example.com")
 			.setExpirationTime("1h")
 			.setIssuedAt()
 			.sign(secretKey);

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -83,6 +83,7 @@ const DEFAULT_CLIENT_ID = "client1";
 async function makeRefreshToken(overrides: Record<string, unknown> = {}): Promise<string> {
 	return new SignJWT({ sub: "u1", scope: "read write", ...overrides })
 		.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+		.setIssuer("localhost")
 		.setAudience(DEFAULT_CLIENT_ID)
 		.setExpirationTime("24h")
 		.sign(secretKey);
@@ -151,6 +152,7 @@ describe("createRefreshTokenGrant", () => {
 			// would let any authenticated client redeem any RT, defeating PB-2.
 			const token = await new SignJWT({ sub: "u1" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience("client1")
 				.setExpirationTime("24h")
 				.sign(secretKey);
@@ -199,6 +201,7 @@ describe("createRefreshTokenGrant", () => {
 			// no longer rely on the `aud` fallback.
 			const legacyToken = await new SignJWT({ sub: "u1", scope: "read" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience("client1")
 				// note: no .azp claim (legacy)
 				.setExpirationTime("24h")
@@ -246,6 +249,7 @@ describe("createRefreshTokenGrant", () => {
 		it("returns 200 when client_id matches token audience", async () => {
 			const token = await new SignJWT({ sub: "u1" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience("client1")
 				.setExpirationTime("24h")
 				.sign(secretKey);
@@ -347,6 +351,7 @@ describe("createRefreshTokenGrant", () => {
 			// instead of typ: "rt+jwt" in the protected header.
 			const legacyToken = await new SignJWT({ type: "refresh", sub: "u1" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0" })
+				.setIssuer("localhost")
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.sign(secretKey);
@@ -368,6 +373,7 @@ describe("createRefreshTokenGrant", () => {
 		it("accepts legacy tokens without kid header", async () => {
 			const legacyToken = await new SignJWT({ sub: "u1" })
 				.setProtectedHeader({ alg: "HS256", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.sign(secretKey);
@@ -467,6 +473,7 @@ describe("createRefreshTokenGrant", () => {
 			// jti AND family_id, otherwise the legacy gate fires before rotation.
 			const token = await new SignJWT({ sub: "u1", scope: "read write", family_id: "fam-1" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.setJti("prev-jti-replay")
@@ -505,6 +512,7 @@ describe("createRefreshTokenGrant", () => {
 			// SF-6 (v0.5.1): token must carry family_id when rotation is wired.
 			const token = await new SignJWT({ sub: "u1", scope: "read write", family_id: "fam-1" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.setJti("prev-jti-503")
@@ -530,6 +538,7 @@ describe("createRefreshTokenGrant", () => {
 			// SF-6 (v0.5.1): token must carry family_id when rotation is wired.
 			const token = await new SignJWT({ sub: "u1", scope: "read write", family_id: "fam-1" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.setJti("prev-jti-revoked")
@@ -570,6 +579,7 @@ describe("createRefreshTokenGrant", () => {
 		async function makeReplayedRt(familyId = "fam-1"): Promise<string> {
 			return new SignJWT({ sub: "u1", scope: "read write", family_id: familyId })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.setJti("jti-A")
@@ -737,6 +747,7 @@ describe("createRefreshTokenGrant", () => {
 			};
 			const rt = await new SignJWT({ sub: "u1", scope: "read", family_id: "fam-2" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.setJti("jti-fresh")
@@ -771,6 +782,7 @@ describe("createRefreshTokenGrant", () => {
 		async function makeRtWithFamily(familyId = "fam-unknown"): Promise<string> {
 			return new SignJWT({ sub: "u1", scope: "read write", family_id: familyId })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.setJti("jti-X")
@@ -910,6 +922,7 @@ describe("createRefreshTokenGrant", () => {
 			// RT with no family_id claim — familyId resolves to null
 			const rt = await new SignJWT({ sub: "u1" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.setJti("jti-no-fam")
@@ -985,6 +998,7 @@ describe("createRefreshTokenGrant", () => {
 			// Token has family_id but no jti — legacy gate must fire
 			const rt = await new SignJWT({ sub: "u1", scope: "read", family_id: "fam-1" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.sign(secretKey);
@@ -1008,6 +1022,7 @@ describe("createRefreshTokenGrant", () => {
 			// Token has jti but no family_id
 			const rt = await new SignJWT({ sub: "u1", scope: "read" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.setJti("jti-only")
@@ -1050,6 +1065,7 @@ describe("createRefreshTokenGrant", () => {
 			// Legacy token with no jti
 			const rt = await new SignJWT({ sub: "u1", scope: "read", family_id: "fam-1" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.sign(secretKey);
@@ -1080,6 +1096,7 @@ describe("createRefreshTokenGrant", () => {
 			};
 			const rt = await new SignJWT({ sub: "u1", scope: "read", family_id: "fam-1" })
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.setJti("jti-1")
@@ -1409,6 +1426,7 @@ describe("createRefreshTokenGrant", () => {
 				family_id: "fam-future",
 			})
 				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+				.setIssuer("localhost")
 				.setAudience(DEFAULT_CLIENT_ID)
 				.setExpirationTime("24h")
 				.setJti("prev-jti-future")

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -22,8 +22,9 @@ import {
 	type GrantHandlerResult,
 	generateToken,
 	generateTokenResponse,
+	verifyJwt,
 } from "@o3co/auth-provider-core";
-import { decodeProtectedHeader, type JWTPayload, jwtVerify } from "jose";
+import type { JWTPayload } from "jose";
 import { decodeJwtPayload } from "./_jwtPayload.mjs";
 
 export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler => {
@@ -68,13 +69,22 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			let tokenPayload: JWTPayload;
 			let typ: string | undefined;
 			try {
-				const header = decodeProtectedHeader(refreshTokenValue);
-				typ = header.typ;
-				const key = await keyStore.getVerificationKey(
-					header.kid ?? keyStore.getSigningKidFallback(),
-				);
-				const { payload } = await jwtVerify(refreshTokenValue, key);
-				tokenPayload = payload;
+				// SF-1: pin alg / iss / typ + signature in one place.
+				// aud + azp are NOT pinned at the verifier — the manual azp /
+				// aud-fallback check below produces a more specific error
+				// ("refresh_token was not issued to this client", which is the
+				// PB-2 binding-violation signal) and accommodates pre-D-6 RTs
+				// that emit aud only (no azp). v0.6+ can pass
+				// `expectedAzp: authenticatedClientId` once the legacy upgrade
+				// window closes and remove the manual check.
+				const verified = await verifyJwt(refreshTokenValue, keyStore, {
+					type: "refresh_token",
+					expectedIssuer: issuer ?? "",
+					legacyTypAccept: config.oauth.jwt.legacyTypAccept ?? true,
+					logger,
+				});
+				tokenPayload = verified.payload;
+				typ = verified.header.typ;
 			} catch {
 				return {
 					result: {
@@ -85,7 +95,12 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				};
 			}
 
-			// Accept both new typ header ("rt+jwt") and legacy type payload ("refresh")
+			// SF-1 retains this gate so a typ-less but signature-valid v0.4 token
+			// (legacyTypAccept=true at the verifier) is still required to declare
+			// "refresh" via the legacy `type` payload field. Without this guard
+			// the central verifier's typ-skip would silently accept any AT lacking
+			// typ as a refresh token. v0.6+ flips legacyTypAccept=false at the
+			// verifier and removes this block.
 			const legacyType = (tokenPayload as Record<string, unknown>).type;
 			if (typ !== "rt+jwt" && legacyType !== "refresh") {
 				return {

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -35,9 +35,9 @@ import {
 	type SessionFederationIndex,
 	type SessionRPRegistry,
 	type UserSessionStore,
+	verifyJwt,
 } from "@o3co/auth-provider-core";
 import type { Request, RequestHandler, Response, Router } from "express";
-import { decodeProtectedHeader, jwtVerify } from "jose";
 import { resolvePkceSupportedMethods } from "./grants/pkce.mjs";
 import { createClientAuthMiddleware } from "./middleware/clientAuth.mjs";
 import * as federationTokenRoute from "./routes/federationToken.mjs";
@@ -117,6 +117,11 @@ export const createOAuthRouter = async (
 	// canonical issuer (or this router is constructed in a partial-config test
 	// fixture), the middleware falls back to the literal "oauth".
 	const issuerForRealm = (config as { oauth?: { jwt?: { issuer?: string } } }).oauth?.jwt?.issuer;
+	// SF-1: legacyTypAccept default is `true` for v0.5.x. Use the same
+	// defensive cast as `issuerForRealm` so partial-config test fixtures
+	// (no `oauth.jwt` block at all) don't throw at router construction.
+	const legacyTypAcceptOpt = (config as { oauth?: { jwt?: { legacyTypAccept?: boolean } } }).oauth
+		?.jwt?.legacyTypAccept;
 	// `/oauth/token` MUST accept public clients (`tokenEndpointAuthMethod: "none"`)
 	// because PKCE/S256 at `/oauth/authorize` is their authenticity gate.
 	const tokenClientAuthMw = createClientAuthMiddleware(clientRepository, {
@@ -318,9 +323,16 @@ export const createOAuthRouter = async (
 						return res.status(200).json({ active: false });
 					}
 					try {
-						const { kid } = decodeProtectedHeader(bearerToken);
-						const key = await keyStore.getVerificationKey(kid ?? keyStore.getSigningKidFallback());
-						await jwtVerify(bearerToken, key);
+						// SF-1: bearer self-intro — calling-client identity is not yet
+						// established (introspectClientAuthMw is skipped on this fall-
+						// through path), so audience pinning is deferred. alg / iss /
+						// typ + signature are still pinned by the central verifier.
+						await verifyJwt(bearerToken, keyStore, {
+							type: "access_token",
+							expectedIssuer: issuerForRealm ?? "",
+							legacyTypAccept: legacyTypAcceptOpt ?? true,
+							logger,
+						});
 						return next();
 					} catch {
 						return res.status(200).json({ active: false });
@@ -334,11 +346,18 @@ export const createOAuthRouter = async (
 					return res.status(200).json({ active: false });
 				}
 				try {
-					const header = decodeProtectedHeader(token);
-					const key = await keyStore.getVerificationKey(
-						header.kid ?? keyStore.getSigningKidFallback(),
-					);
-					const { payload } = await jwtVerify(token, key);
+					// SF-1: bind aud to the calling client when introspectClientAuthMw
+					// has identified them; for the bearer-self-intro fall-through path
+					// the identity is unknown and the verifier records the gap via
+					// `jwt_verify_aud_skipped`.
+					const verified = await verifyJwt(token, keyStore, {
+						type: "access_token",
+						expectedIssuer: issuerForRealm ?? "",
+						...(req.oauthClient ? { expectedAudience: req.oauthClient.clientId } : {}),
+						legacyTypAccept: legacyTypAcceptOpt ?? true,
+						logger,
+					});
+					const { payload, header } = verified;
 
 					// TODO-F-3: cascading revoke (RFC 7009 §2.1 SHOULD). When a refresh_token
 					// family has been revoked, all access_tokens minted under the same
@@ -774,6 +793,9 @@ export const createOAuthRouter = async (
 			keyStore,
 			userSessionStore,
 			refreshTokenFamilyRevocation,
+			issuer: issuerForRealm,
+			legacyTypAccept: legacyTypAcceptOpt,
+			logger,
 		}),
 	);
 
@@ -828,6 +850,7 @@ export const createOAuthRouter = async (
 				getFederationProviders,
 				auditSink,
 				logger,
+				legacyTypAccept: legacyTypAcceptOpt,
 			}),
 		);
 	}
@@ -848,6 +871,8 @@ export const createOAuthRouter = async (
 				getFederationProviders,
 				auditSink,
 				logger,
+				issuer: issuerForRealm,
+				legacyTypAccept: legacyTypAcceptOpt,
 			}),
 		);
 	}

--- a/packages/oauth/src/routes/federationToken.mts
+++ b/packages/oauth/src/routes/federationToken.mts
@@ -25,9 +25,8 @@ import type {
 	SessionFederationIndex,
 	UserSessionStore,
 } from "@o3co/auth-provider-core";
-import { emitAuditEvent, supportsLock } from "@o3co/auth-provider-core";
+import { emitAuditEvent, supportsLock, verifyJwt } from "@o3co/auth-provider-core";
 import type { Request, RequestHandler, Response, Router } from "express";
-import { decodeProtectedHeader, jwtVerify } from "jose";
 
 type ExpressLike = {
 	Router: () => Router;
@@ -89,6 +88,13 @@ export interface FederationTokenRouterOptions {
 	 * Default: 30_000 (30 seconds).
 	 */
 	refreshBufferMs?: number;
+	/** Configured issuer — pinned by the SF-1 central verifier. */
+	issuer?: string;
+	/**
+	 * SF-1 (v0.5.1): when true (default), accept tokens whose `typ` header is
+	 * absent and emit a deprecation warning. v0.6+ should set this to false.
+	 */
+	legacyTypAccept?: boolean;
 }
 
 /**
@@ -125,17 +131,18 @@ export function createRouter(express: ExpressLike, opts: FederationTokenRouterOp
 		}
 		const token = auth.slice(auth.indexOf(" ") + 1);
 
-		// Step 2 + 3: Verify JWT signature + check typ === "at+jwt".
+		// Step 2 + 3: SF-1 — alg / iss / typ (=at+jwt) + signature pinned by
+		// the central verifier. Audience is deferred — bearer-as-credential
+		// route, calling-client identity is not separately authenticated; the
+		// verifier records the gap via `jwt_verify_aud_skipped`.
 		let payload: Record<string, unknown>;
 		try {
-			const header = decodeProtectedHeader(token);
-			if (header.typ !== "at+jwt") {
-				throw new Error("invalid token type");
-			}
-			const key = await opts.keyStore.getVerificationKey(
-				header.kid ?? opts.keyStore.getSigningKidFallback(),
-			);
-			const verified = await jwtVerify(token, key);
+			const verified = await verifyJwt(token, opts.keyStore, {
+				type: "access_token",
+				expectedIssuer: opts.issuer ?? "",
+				legacyTypAccept: opts.legacyTypAccept ?? true,
+				logger: opts.logger,
+			});
 			payload = verified.payload as Record<string, unknown>;
 		} catch (error) {
 			logger.warn(

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -27,10 +27,9 @@ import type {
 	SessionRPRegistry,
 	UserSessionStore,
 } from "@o3co/auth-provider-core";
-import { emitAuditEvent } from "@o3co/auth-provider-core";
+import { emitAuditEvent, verifyJwt } from "@o3co/auth-provider-core";
 import accepts from "accepts";
 import type { Request, RequestHandler, Response, Router } from "express";
-import { decodeProtectedHeader, jwtVerify } from "jose";
 import { broadcastBackchannelLogout } from "../logout/broadcastBackchannel.mjs";
 import { cascadeLogout } from "../logout/cascadeLogout.mjs";
 import { renderFrontchannelLogoutHtml } from "../logout/renderFrontchannel.mjs";
@@ -92,6 +91,12 @@ export interface LogoutRouterOptions {
 	logger?: Logger;
 	/** Audit sink for operator observability events. No-op when undefined. */
 	auditSink?: AuditSinkBase;
+	/**
+	 * SF-1 (v0.5.1): when true (default), the central JWT verifier accepts
+	 * tokens whose `typ` header is absent and emits a deprecation warning.
+	 * Forwarded to `verifyJwt` for the bearer AT and id_token_hint paths.
+	 */
+	legacyTypAccept?: boolean;
 }
 
 /**
@@ -148,18 +153,20 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			}
 			const token = auth.slice(auth.indexOf(" ") + 1);
 
-			// Step 2: Verify JWT signature + check typ === "at+jwt".
-			// Reject refresh (rt+jwt), id (id+jwt), and logout (logout+jwt) tokens.
+			// Step 2: SF-1 — alg / iss / typ + signature pinned by the central
+			// verifier. typ must be at+jwt (refresh and id_tokens are signed by
+			// the same KeyStore so a typ check is the only defense against
+			// cross-type acceptance). Audience is deferred — bearer-as-credential
+			// route, calling-client identity is not separately authenticated
+			// here; the verifier records the gap via `jwt_verify_aud_skipped`.
 			let payload: Record<string, unknown>;
 			try {
-				const header = decodeProtectedHeader(token);
-				if (header.typ !== "at+jwt") {
-					throw new Error("invalid token type");
-				}
-				const key = await opts.keyStore.getVerificationKey(
-					header.kid ?? opts.keyStore.getSigningKidFallback(),
-				);
-				const verified = await jwtVerify(token, key);
+				const verified = await verifyJwt(token, opts.keyStore, {
+					type: "access_token",
+					expectedIssuer: opts.issuer,
+					legacyTypAccept: opts.legacyTypAccept ?? true,
+					logger: opts.logger,
+				});
 				payload = verified.payload as Record<string, unknown>;
 			} catch (error) {
 				// Log the reason at warn level — keep minimal (don't log the token itself,
@@ -394,11 +401,16 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 
 			let payload: Record<string, unknown>;
 			try {
-				const header = decodeProtectedHeader(idTokenHint);
-				const key = await opts.keyStore.getVerificationKey(
-					header.kid ?? opts.keyStore.getSigningKidFallback(),
-				);
-				const verified = await jwtVerify(idTokenHint, key);
+				// SF-1: pin alg / iss / typ (=id+jwt) + signature. Audience is
+				// derived from the id_token's aud claim post-verification (the
+				// id_token was issued for a specific client); we can't pin aud
+				// before knowing the client, so the verifier records the gap.
+				const verified = await verifyJwt(idTokenHint, opts.keyStore, {
+					type: "id_token",
+					expectedIssuer: opts.issuer,
+					legacyTypAccept: opts.legacyTypAccept ?? true,
+					logger: opts.logger,
+				});
 				payload = verified.payload as Record<string, unknown>;
 			} catch {
 				return res.status(400).json({

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -163,7 +163,7 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			try {
 				const verified = await verifyJwt(token, opts.keyStore, {
 					type: "access_token",
-					expectedIssuer: opts.issuer,
+					expectedIssuer: opts.issuer ?? "",
 					legacyTypAccept: opts.legacyTypAccept ?? true,
 					logger: opts.logger,
 				});
@@ -407,7 +407,7 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 				// before knowing the client, so the verifier records the gap.
 				const verified = await verifyJwt(idTokenHint, opts.keyStore, {
 					type: "id_token",
-					expectedIssuer: opts.issuer,
+					expectedIssuer: opts.issuer ?? "",
 					legacyTypAccept: opts.legacyTypAccept ?? true,
 					logger: opts.logger,
 				});

--- a/packages/oauth/src/routes/userinfo.mts
+++ b/packages/oauth/src/routes/userinfo.mts
@@ -17,11 +17,12 @@
 import {
 	filterClaimsByScope,
 	type KeyStore,
+	type Logger,
 	type RefreshTokenFamilyRevocation,
 	type UserSessionStore,
+	verifyJwt,
 } from "@o3co/auth-provider-core";
 import type { Request, RequestHandler, Response, Router } from "express";
-import { decodeProtectedHeader, jwtVerify } from "jose";
 
 type ExpressLike = {
 	Router: () => Router;
@@ -33,6 +34,14 @@ export interface UserinfoRouterOptions {
 	keyStore: KeyStore;
 	userSessionStore?: UserSessionStore;
 	refreshTokenFamilyRevocation?: RefreshTokenFamilyRevocation;
+	/** Configured issuer — pinned by the SF-1 central verifier. */
+	issuer?: string;
+	/**
+	 * SF-1 (v0.5.1): when true, accept tokens whose `typ` header is absent
+	 * (a deprecation warning is emitted). Defaults to true through v0.5.x.
+	 */
+	legacyTypAccept?: boolean;
+	logger?: Logger;
 }
 
 /**
@@ -65,23 +74,20 @@ export function createRouter(express: ExpressLike, opts: UserinfoRouterOptions):
 		}
 		const token = auth.slice(7);
 
-		// Verify JWT signature + reject non-access tokens. Refresh tokens
-		// (typ: rt+jwt) and id_tokens (typ: id+jwt) are signed by the same
-		// KeyStore and carry sub/sid/scope claims, so without a typ check
-		// they would also pass signature verification here. RFC 9068
-		// establishes `typ: "at+jwt"` as the indicator that a JWT is
-		// specifically an OAuth 2.0 access token; userinfo is an access-token
-		// resource (OIDC Core §5.3.1), so we require that typ exactly.
+		// SF-1: alg / iss / typ + signature pinned by the central verifier
+		// (typ: at+jwt is required per RFC 9068 since userinfo is an
+		// access-token resource — OIDC Core §5.3.1). Audience pinning is
+		// deferred: userinfo is bearer-as-credential and the calling-client
+		// identity is not separately authenticated here, so the verifier
+		// records the gap via `jwt_verify_aud_skipped`.
 		let payload: Record<string, unknown>;
 		try {
-			const header = decodeProtectedHeader(token);
-			if (header.typ !== "at+jwt") {
-				throw new Error("invalid token type");
-			}
-			const key = await opts.keyStore.getVerificationKey(
-				header.kid ?? opts.keyStore.getSigningKidFallback(),
-			);
-			const verified = await jwtVerify(token, key);
+			const verified = await verifyJwt(token, opts.keyStore, {
+				type: "access_token",
+				expectedIssuer: opts.issuer ?? "",
+				legacyTypAccept: opts.legacyTypAccept ?? true,
+				logger: opts.logger,
+			});
 			payload = verified.payload as Record<string, unknown>;
 		} catch {
 			res.setHeader("WWW-Authenticate", 'Bearer realm="userinfo", error="invalid_token"');

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -12,10 +12,12 @@ oauth {
     # When true (default), tokens whose `typ` header is absent are
     # accepted with a `jwt_verify_legacy_typ` warning so v0.4.x tokens
     # keep verifying through the v0.5.x transition window. Flip to false
-    # in v0.6+ to reject typ-less tokens. Inherited from core
-    # application.conf — operators set OAUTH_JWT_LEGACY_TYP_ACCEPT to
-    # override (set "false" to enforce strict mode early).
-    # legacyTypAccept = true
+    # in v0.6+ to reject typ-less tokens. Active default per the v0.5.1
+    # ADR: literal default lives in HOCON (zod has no `.default()`).
+    # Operators set OAUTH_JWT_LEGACY_TYP_ACCEPT to override (set "false"
+    # to enforce strict mode early).
+    legacyTypAccept = true
+    legacyTypAccept = ${?OAUTH_JWT_LEGACY_TYP_ACCEPT}
     signingKey {
       provider = "local"
       provider = ${?OAUTH_JWT_SIGNING_KEY_PROVIDER}

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -8,6 +8,14 @@ http {
 oauth {
   jwt {
     issuer = ${?OAUTH_JWT_ISSUER}
+    # SF-1 (v0.5.1): legacy typ acceptance for the central JWT verifier.
+    # When true (default), tokens whose `typ` header is absent are
+    # accepted with a `jwt_verify_legacy_typ` warning so v0.4.x tokens
+    # keep verifying through the v0.5.x transition window. Flip to false
+    # in v0.6+ to reject typ-less tokens. Inherited from core
+    # application.conf — operators set OAUTH_JWT_LEGACY_TYP_ACCEPT to
+    # override (set "false" to enforce strict mode early).
+    # legacyTypAccept = true
     signingKey {
       provider = "local"
       provider = ${?OAUTH_JWT_SIGNING_KEY_PROVIDER}


### PR DESCRIPTION
## Summary

- Replaces 8 ad-hoc `jwtVerify()` call sites with a central `verifyJwt()` helper that pins alg / iss / aud / typ + signature in one place. Closes the class of vulnerabilities where verification accepted any-algorithm-by-default-jose-behavior or did not enforce typ/iss/aud in production paths.
- Adds `oauth.jwt.legacyTypAccept` config (zod `.optional()`, HOCON default `true`) so v0.4.x tokens whose `typ` header is absent keep verifying through the v0.5.x window with a `jwt_verify_legacy_typ` deprecation warning. v0.6+ flips to false.
- All Codex calibration deltas applied: `m1` id_token typ default = `id+jwt` (not `JWT`); `m3` kid resolution uses IH-9's `getVerificationKey(kid)` (interim shim not needed — IH-9 already landed at `1e4833bc`); `m4` azp-mismatch RED test included.

## Sites migrated

| File:line | Token type | Audience pinned | Pre-checks removed |
|---|---|---|---|
| `routes.mts:323` (introspect Bearer self-intro) | access | deferred¹ | none |
| `routes.mts:341` (introspect body) | access | `req.oauthClient.clientId` when set | none |
| `grants/refreshToken.mts:76` | refresh | manual aud / azp-fallback retained² | manual typ pre-check |
| `routes/userinfo.mts:84` | access | deferred¹ | manual `header.typ !== "at+jwt"` |
| `routes/logout.mts:162` (federation/:name/logout) | access | deferred¹ | manual typ pre-check |
| `routes/logout.mts:401` (id_token_hint) | id | deferred³ | none (signature-only → full pin) |
| `routes/federationToken.mts:138` | access | deferred¹ | manual typ pre-check |
| `selfIssuedAccessToken.mts:81` (token-exchange validator) | access | deferred⁴ | manual `header.typ`, post-verify `iss` |

¹ Bearer-as-credential — calling-client identity not established before verification. Verifier emits `jwt_verify_aud_skipped` so the gap is audit-visible.
² Manual aud / aud-as-azp fallback retained at the grant handler so the "refresh_token was not issued to this client" specific error survives (D-6 PB-2 binding signal); accommodates pre-D-6 RTs that emit aud only.
³ id_token_hint flow has no separate clientAuth — aud is extracted from the verified payload after the fact.
⁴ `ExchangeTokenValidationContext` does not carry calling-client identity by design (grant handler upstream + may_act / policy gates downstream); v0.6 closes this gap by extending the validator context.

## Test plan

- [x] Build all packages green (`pnpm -r run build`)
- [x] Full test suite green (`pnpm -r run test` — 2188 pass / 1 skipped / 1 todo)
- [x] Lint clean (`pnpm -w run lint` — 0 errors; pre-existing warnings unchanged)
- [x] Strict typecheck clean (`pnpm -r exec tsc --noEmit`)
- [x] 13 new RED → GREEN tests in `packages/core/src/jwt/__tests__/verify.test.mts` covering: alg=none / wrong alg / wrong iss / wrong aud / wrong typ strict / undefined typ legacyAccept warn / undefined typ strict reject / unknown kid / iat-future / expired / valid token shape / **azp mismatch (Codex m4)** / **aud-skip + warning** / **iss-skip + warning**
- [x] Test fixtures updated for the new iss pinning: tokens emitted by tests now declare `setIssuer("...")` matching the test-context issuer; selfIssuedAccessToken's `expiresIn: "-1s"` flipped to `-10m` because the SF-1 default 300s skew (RFC 8725 §3.10) accepts -1s as within tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)