### PR TITLE
F7 PR3 — SF-8 /introspect token_type + OR-8 insertion counter monotonic (v0.5.1)

### DIFF
--- a/packages/oauth/src/__tests__/introspectCascade.test.mts
+++ b/packages/oauth/src/__tests__/introspectCascade.test.mts
@@ -278,11 +278,12 @@ describe("/introspect — SF-8: token_type + access-only enforcement", () => {
 			.sign(secretKey);
 	}
 
-	it("RED-1: returns active=true with token_type=Bearer for a valid access token (NOT 'at+jwt')", async () => {
+	it("RED-1: returns active=true with token_type=Bearer + jti for a valid access token (NOT 'at+jwt')", async () => {
 		// RFC 6750 §6.1.1 — `Bearer` is the OAuth Token Type. The pre-SF-8
 		// response leaked the JOSE `typ` ("at+jwt"), wrong namespace per
-		// RFC 7662 §2.2.
-		const token = await makeAccessToken({ client_id: "client1" });
+		// RFC 7662 §2.2. RFC 7662 §2.2 also lists `jti` as a registered
+		// response field (Codex calibration m3) — confirm presence.
+		const token = await makeAccessToken({ client_id: "client1", jti: "jti-sf8-red1" });
 		const app = await buildApp();
 		const res = await introspect(app, token);
 
@@ -290,6 +291,7 @@ describe("/introspect — SF-8: token_type + access-only enforcement", () => {
 		expect(res.body.active).toBe(true);
 		expect(res.body.token_type).toBe("Bearer");
 		expect(res.body.token_type).not.toBe("at+jwt");
+		expect(res.body.jti).toBe("jti-sf8-red1");
 	});
 
 	it("RED-2: returns active=false for a refresh token (no leak of RT validity)", async () => {

--- a/packages/oauth/src/__tests__/introspectCascade.test.mts
+++ b/packages/oauth/src/__tests__/introspectCascade.test.mts
@@ -251,6 +251,91 @@ describe("/introspect — family revoke cascade (TODO-F-3 task 5)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// SF-8: /introspect token_type + access-only enforcement (RFC 7662 §2.2)
+//
+// Pre-SF-8, /introspect echoed the JOSE `typ` header value (e.g. "at+jwt") in
+// `token_type` — wrong namespace per RFC 7662 (which references the OAuth
+// Token Type registry, not JOSE). It also accepted RT / id_token JWTs as
+// `active: true` since the verifier was signature-only. SF-8 hardcodes
+// `token_type: "Bearer"` for active access tokens and relies on SF-1's typ
+// pin to filter non-access tokens to `{ active: false }`.
+// ---------------------------------------------------------------------------
+
+describe("/introspect — SF-8: token_type + access-only enforcement", () => {
+	async function makeRefreshToken(overrides: Record<string, unknown> = {}): Promise<string> {
+		return new SignJWT({ sub: "u1", scope: "read", ...overrides })
+			.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+			.setIssuer("https://auth.example")
+			.setExpirationTime("1h")
+			.sign(secretKey);
+	}
+
+	async function makeIdToken(overrides: Record<string, unknown> = {}): Promise<string> {
+		return new SignJWT({ sub: "u1", aud: "client1", ...overrides })
+			.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "id+jwt" })
+			.setIssuer("https://auth.example")
+			.setExpirationTime("1h")
+			.sign(secretKey);
+	}
+
+	it("RED-1: returns active=true with token_type=Bearer for a valid access token (NOT 'at+jwt')", async () => {
+		// RFC 6750 §6.1.1 — `Bearer` is the OAuth Token Type. The pre-SF-8
+		// response leaked the JOSE `typ` ("at+jwt"), wrong namespace per
+		// RFC 7662 §2.2.
+		const token = await makeAccessToken({ client_id: "client1" });
+		const app = await buildApp();
+		const res = await introspect(app, token);
+
+		expect(res.status).toBe(200);
+		expect(res.body.active).toBe(true);
+		expect(res.body.token_type).toBe("Bearer");
+		expect(res.body.token_type).not.toBe("at+jwt");
+	});
+
+	it("RED-2: returns active=false for a refresh token (no leak of RT validity)", async () => {
+		// RFC 7662 §2.1 + OAuth Security Topics §5.1: introspection is for
+		// access tokens only. A valid RT MUST return active:false to prevent
+		// a resource server from probing RT validity via the introspect
+		// endpoint.
+		const token = await makeRefreshToken();
+		const app = await buildApp();
+		const res = await introspect(app, token);
+
+		expect(res.status).toBe(200);
+		expect(res.body.active).toBe(false);
+		expect(res.body.token_type).toBeUndefined();
+	});
+
+	it("RED-3: returns active=false for an id_token", async () => {
+		// Same RFC 7662 §2.1 reasoning as RT: id_tokens are not introspectable
+		// access tokens; treating them as active leaks information.
+		const token = await makeIdToken();
+		const app = await buildApp();
+		const res = await introspect(app, token);
+
+		expect(res.status).toBe(200);
+		expect(res.body.active).toBe(false);
+	});
+
+	it("RED-4: response carries client_id (RFC 7662 §2.2 RECOMMENDED) — sourced from client_id when present, falls back to azp for v0.5.1 compat", async () => {
+		// Codex calibration m2: current issuance emits `azp` (RFC 9068 §2.2),
+		// not `client_id`. RFC 7662 §2.2 lists `client_id` as RECOMMENDED in
+		// the response. SF-8 returns `client_id: payload.client_id ?? azp`
+		// so resource servers see the authorized-party identifier under the
+		// standard field name regardless of which side of the v0.5/v0.6
+		// upgrade window the issuance is on. v0.6+ flips issuance to emit
+		// `client_id` directly; this fallback becomes a no-op then.
+		const token = await makeAccessToken({ azp: "client1" });
+		const app = await buildApp();
+		const res = await introspect(app, token);
+
+		expect(res.status).toBe(200);
+		expect(res.body.active).toBe(true);
+		expect(res.body.client_id).toBe("client1");
+	});
+});
+
+// ---------------------------------------------------------------------------
 // oauthModule — refreshTokenFamilyRevocation composition (C1) via createTestApp
 //
 // Migrated to createTestApp pattern: oauthModule is booted via the Phase 4

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -26,6 +26,7 @@ import {
 	formatObject,
 	type GrantPolicyHookBase,
 	type GrantRegistry,
+	JwtVerificationError,
 	type KeyStore,
 	type Logger,
 	type PublicClient,
@@ -334,7 +335,17 @@ export const createOAuthRouter = async (
 							logger,
 						});
 						return next();
-					} catch {
+					} catch (cause) {
+						// SF-8: distinguish non-access-token typ rejections so SIEM
+						// can spot a refresh / id token presented as a Bearer
+						// credential. RFC 7662 §2.2 forbids leaking the typ to the
+						// caller — the audit log carries the signal instead.
+						if (cause instanceof JwtVerificationError && cause.reason === "typ") {
+							logger.warn(
+								{ reason: "non_access_token", site: "introspect_bearer" },
+								"introspect_non_access_token",
+							);
+						}
 						return res.status(200).json({ active: false });
 					}
 				}
@@ -357,7 +368,7 @@ export const createOAuthRouter = async (
 						legacyTypAccept: legacyTypAcceptOpt ?? true,
 						logger,
 					});
-					const { payload, header } = verified;
+					const { payload } = verified;
 
 					// TODO-F-3: cascading revoke (RFC 7009 §2.1 SHOULD). When a refresh_token
 					// family has been revoked, all access_tokens minted under the same
@@ -401,10 +412,18 @@ export const createOAuthRouter = async (
 						}
 					}
 
-					const { exp, iat, iss, aud, sub } = payload;
+					const { exp, iat, iss, aud, sub, jti } = payload;
 					const claims = payload as Record<string, unknown>;
 					const azp = typeof claims.azp === "string" ? claims.azp : undefined;
+					const rawClientId = claims.client_id;
+					const clientId = typeof rawClientId === "string" ? rawClientId : azp;
 					const scope = typeof claims.scope === "string" ? claims.scope : undefined;
+					// SF-8 (RFC 7662 §2.2): `token_type` is the OAuth 2.0 token-type
+					// identifier registry value (`Bearer` per RFC 6750 §6.1.1), NOT
+					// the JOSE `typ` header value (`at+jwt`). Hardcode the literal —
+					// the SF-1 verifier with `type: "access_token"` already enforces
+					// `typ: "at+jwt"` upstream, so any token reaching this point
+					// has been confirmed as a Bearer access token.
 					return res.status(200).json(
 						formatObject({
 							active: true,
@@ -414,11 +433,22 @@ export const createOAuthRouter = async (
 							aud,
 							sub,
 							azp,
+							client_id: clientId,
 							scope,
-							token_type: header.typ,
+							token_type: "Bearer",
+							jti: typeof jti === "string" ? jti : undefined,
 						}),
 					);
-				} catch {
+				} catch (cause) {
+					// SF-8: same non-access-token signal as the bearer path above.
+					// `active: false` is required by RFC 7662 §2.2 regardless of
+					// rejection reason; audit log carries the typ-mismatch signal.
+					if (cause instanceof JwtVerificationError && cause.reason === "typ") {
+						logger.warn(
+							{ reason: "non_access_token", site: "introspect_body" },
+							"introspect_non_access_token",
+						);
+					}
 					return res.status(200).json({ active: false });
 				}
 			},

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -340,6 +340,11 @@ export const createOAuthRouter = async (
 						// can spot a refresh / id token presented as a Bearer
 						// credential. RFC 7662 §2.2 forbids leaking the typ to the
 						// caller — the audit log carries the signal instead.
+						// Other JwtVerificationError reasons (alg / iss / aud /
+						// signature / expired / kid_*) already emit
+						// `jwt_verify_rejected` from the central verifier — SIEM
+						// rule authors should NOT double-count by also matching
+						// `introspect_non_access_token` for those reasons.
 						if (cause instanceof JwtVerificationError && cause.reason === "typ") {
 							logger.warn(
 								{ reason: "non_access_token", site: "introspect_bearer" },
@@ -443,6 +448,10 @@ export const createOAuthRouter = async (
 					// SF-8: same non-access-token signal as the bearer path above.
 					// `active: false` is required by RFC 7662 §2.2 regardless of
 					// rejection reason; audit log carries the typ-mismatch signal.
+					// Symmetric with the bearer-self-intro catch: only `reason
+					// === "typ"` triggers `introspect_non_access_token`. All other
+					// rejection reasons emit `jwt_verify_rejected` from the
+					// central verifier; SIEM rules should NOT double-count.
 					if (cause instanceof JwtVerificationError && cause.reason === "typ") {
 						logger.warn(
 							{ reason: "non_access_token", site: "introspect_body" },

--- a/packages/redis/__tests__/internalSidSortedSet.test.mts
+++ b/packages/redis/__tests__/internalSidSortedSet.test.mts
@@ -149,6 +149,83 @@ describe("createRedisSidSortedSet", () => {
 		);
 		expect(await z.list("sid-conc-same")).toEqual(["m-shared"]);
 	});
+
+	// OR-8 RED tests — `_insertionCounter` monotonic across restart.
+	describe("OR-8: _insertionCounter restart-monotonicity", () => {
+		it("RED-1: two add() calls with same expiresAt — second member sorts after first in list()", async () => {
+			const z = createRedisSidSortedSet({ client, keyPrefix: prefix("or8-same-exp") });
+			const sharedExp = FUTURE();
+			await z.add("sid-or8-1", "first", sharedExp);
+			await z.add("sid-or8-1", "second", sharedExp);
+			// Insertion order preserved even when expiresAt is identical (the
+			// pre-fix score formula depended on the counter alone, so this case
+			// tests the same-millisecond invariant).
+			expect(await z.list("sid-or8-1")).toEqual(["first", "second"]);
+		});
+
+		it("RED-2: post-restart simulation — pre-crash entries injected with low scores via raw ZADD sort BEFORE post-restart entries added via the module", async () => {
+			// Pre-crash members: injected via raw redis.zadd() with low scores
+			// (1, 2, 3) — bypasses the module counter entirely, simulating a
+			// session that survives a process restart.
+			//
+			// Post-restart new members: added via createRedisSidSortedSet.add()
+			// using DIFFERENT member names (NX flag preserves existing-member
+			// scores, so re-adding the same name would not exercise the bug).
+			//
+			// Post-fix expectation: post-restart scores start at Date.now()
+			// (~1.75×10^12 in 2026) and exceed all pre-crash scores; new
+			// members sort AFTER pre-crash ones in the ascending zRange.
+			const sid = "sid-or8-restart";
+			const key = `${prefix("or8-restart")}${sid}`;
+			await raw.zadd(key, "NX", 1, "pre-crash-A");
+			await raw.zadd(key, "NX", 2, "pre-crash-B");
+			await raw.zadd(key, "NX", 3, "pre-crash-C");
+
+			const z = createRedisSidSortedSet({ client, keyPrefix: prefix("or8-restart") });
+			await z.add(sid, "post-restart-A", FUTURE());
+			await z.add(sid, "post-restart-B", FUTURE());
+
+			expect(await z.list(sid)).toEqual([
+				"pre-crash-A",
+				"pre-crash-B",
+				"pre-crash-C",
+				"post-restart-A",
+				"post-restart-B",
+			]);
+		});
+
+		it("RED-3: module counter is shared across multiple createRedisSidSortedSet instances — interleaved adds get strictly increasing scores globally", async () => {
+			const za = createRedisSidSortedSet({ client, keyPrefix: prefix("or8-shared-A") });
+			const zb = createRedisSidSortedSet({ client, keyPrefix: prefix("or8-shared-B") });
+			await za.add("sid-X", "a-1", FUTURE());
+			await zb.add("sid-X", "b-1", FUTURE());
+			await za.add("sid-X", "a-2", FUTURE());
+			await zb.add("sid-X", "b-2", FUTURE());
+
+			const scoreA1 = await raw.zscore(`${prefix("or8-shared-A")}sid-X`, "a-1");
+			const scoreB1 = await raw.zscore(`${prefix("or8-shared-B")}sid-X`, "b-1");
+			const scoreA2 = await raw.zscore(`${prefix("or8-shared-A")}sid-X`, "a-2");
+			const scoreB2 = await raw.zscore(`${prefix("or8-shared-B")}sid-X`, "b-2");
+
+			expect(scoreA1).not.toBeNull();
+			expect(scoreB1).not.toBeNull();
+			expect(scoreA2).not.toBeNull();
+			expect(scoreB2).not.toBeNull();
+			// Strict global monotonicity: a-1 < b-1 < a-2 < b-2.
+			expect(Number(scoreA1)).toBeLessThan(Number(scoreB1));
+			expect(Number(scoreB1)).toBeLessThan(Number(scoreA2));
+			expect(Number(scoreA2)).toBeLessThan(Number(scoreB2));
+		});
+
+		it("RED-4: counter baseline starts above realistic pre-crash counter values (Date.now() > 10^12 in 2026)", () => {
+			// Unit test (no Redis): documents the assumption that the post-fix
+			// epoch baseline is astronomically above any counter that started
+			// at 0 and incremented per add() under realistic operational
+			// throughput. See OR-8 spec Codex Delta 3 — sufficient under
+			// realistic throughput, NOT mathematically absolute.
+			expect(Date.now()).toBeGreaterThan(1_000_000_000_000);
+		});
+	});
 });
 
 function makeWrapper(io: Redis): SessionSidSortedSetClient {

--- a/packages/redis/__tests__/internalSidSortedSet.test.mts
+++ b/packages/redis/__tests__/internalSidSortedSet.test.mts
@@ -16,7 +16,7 @@
 
 import Redis from "ioredis";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { SessionSidSortedSetClient, SessionSidSortedSetMultiClient } from "../src/clients.mjs";
 import { createRedisSidSortedSet } from "../src/internal/redisSidSortedSet.mjs";
 
@@ -163,35 +163,44 @@ describe("createRedisSidSortedSet", () => {
 			expect(await z.list("sid-or8-1")).toEqual(["first", "second"]);
 		});
 
-		it("RED-2: post-restart simulation — pre-crash entries injected with low scores via raw ZADD sort BEFORE post-restart entries added via the module", async () => {
-			// Pre-crash members: injected via raw redis.zadd() with low scores
-			// (1, 2, 3) — bypasses the module counter entirely, simulating a
-			// session that survives a process restart.
+		it("RED-2: post-restart simulation via fresh module load — first score from a freshly-imported module exceeds an injected high pre-crash baseline", async () => {
+			// Codex review: the original RED-2 was not a meaningful TDD guard
+			// because earlier tests in this file already advanced the module-
+			// scoped `_insertionCounter` past low injected scores, so pre-fix
+			// the counter would already be high enough to win the order
+			// assertion. Force a true module reset via `vi.resetModules()` +
+			// dynamic re-import so the counter re-initialises (post-fix:
+			// `Date.now()`; pre-fix: `0`). Then inject a pre-crash score that
+			// is HIGH enough to require the Date.now() baseline to beat —
+			// `100_000` is well above any plausible counter value pre-fix
+			// (this whole test file performs ~10 adds total) and well below
+			// `Date.now()` (~1.75×10^12 in 2026). Assert via raw `zscore`
+			// that the new module's first add produces a score greater than
+			// the injected baseline.
 			//
-			// Post-restart new members: added via createRedisSidSortedSet.add()
-			// using DIFFERENT member names (NX flag preserves existing-member
-			// scores, so re-adding the same name would not exercise the bug).
-			//
-			// Post-fix expectation: post-restart scores start at Date.now()
-			// (~1.75×10^12 in 2026) and exceed all pre-crash scores; new
-			// members sort AFTER pre-crash ones in the ascending zRange.
-			const sid = "sid-or8-restart";
-			const key = `${prefix("or8-restart")}${sid}`;
-			await raw.zadd(key, "NX", 1, "pre-crash-A");
-			await raw.zadd(key, "NX", 2, "pre-crash-B");
-			await raw.zadd(key, "NX", 3, "pre-crash-C");
+			// NX semantics: pre-crash members must use DIFFERENT names from
+			// the post-restart member; ZADD NX would otherwise preserve the
+			// pre-existing low score and the bug would silently mask
+			// (Codex Delta 1).
+			const sid = "sid-or8-restart-v2";
+			const key = `${prefix("or8-restart-v2")}${sid}`;
+			const PRE_CRASH_HIGH = 100_000;
+			await raw.zadd(key, "NX", PRE_CRASH_HIGH, "pre-crash-high");
 
-			const z = createRedisSidSortedSet({ client, keyPrefix: prefix("or8-restart") });
-			await z.add(sid, "post-restart-A", FUTURE());
-			await z.add(sid, "post-restart-B", FUTURE());
+			vi.resetModules();
+			const fresh = (await import(
+				"../src/internal/redisSidSortedSet.mjs?freshOR8RED2"
+			)) as typeof import("../src/internal/redisSidSortedSet.mjs");
+			const z = fresh.createRedisSidSortedSet({ client, keyPrefix: prefix("or8-restart-v2") });
+			await z.add(sid, "post-restart-fresh", FUTURE());
 
-			expect(await z.list(sid)).toEqual([
-				"pre-crash-A",
-				"pre-crash-B",
-				"pre-crash-C",
-				"post-restart-A",
-				"post-restart-B",
-			]);
+			const score = await raw.zscore(key, "post-restart-fresh");
+			expect(score).not.toBeNull();
+			expect(Number(score)).toBeGreaterThan(PRE_CRASH_HIGH);
+			// Order assertion: the high-but-pre-fix-unreachable injected
+			// score is itself > 0 yet < Date.now(), so post-fix the new
+			// member sorts AFTER the pre-crash member.
+			expect(await z.list(sid)).toEqual(["pre-crash-high", "post-restart-fresh"]);
 		});
 
 		it("RED-3: module counter is shared across multiple createRedisSidSortedSet instances — interleaved adds get strictly increasing scores globally", async () => {
@@ -217,13 +226,32 @@ describe("createRedisSidSortedSet", () => {
 			expect(Number(scoreA2)).toBeLessThan(Number(scoreB2));
 		});
 
-		it("RED-4: counter baseline starts above realistic pre-crash counter values (Date.now() > 10^12 in 2026)", () => {
-			// Unit test (no Redis): documents the assumption that the post-fix
-			// epoch baseline is astronomically above any counter that started
-			// at 0 and incremented per add() under realistic operational
-			// throughput. See OR-8 spec Codex Delta 3 — sufficient under
-			// realistic throughput, NOT mathematically absolute.
-			expect(Date.now()).toBeGreaterThan(1_000_000_000_000);
+		it("RED-4: a freshly-loaded module emits a first score that exceeds 10^12 (structural assertion of the Date.now() baseline, not a tautology)", async () => {
+			// Codex review: the previous RED-4 (`expect(Date.now() > 1e12)`)
+			// was tautological — passes through year ~33658 regardless of
+			// production state. Replaced with a structural test that exercises
+			// the module's actual init: `vi.resetModules()` re-evaluates the
+			// `let _insertionCounter = ...` line, then a single add() through
+			// the fresh instance must produce a score above 10^12. Pre-fix
+			// (counter starts at 0) the first score is `1` and this fails;
+			// post-fix (`Date.now()`) the first score is `~1.75×10^12` and
+			// this passes.
+			const sid = "sid-or8-fresh-baseline";
+			const key = `${prefix("or8-fresh-baseline")}${sid}`;
+
+			vi.resetModules();
+			const fresh = (await import(
+				"../src/internal/redisSidSortedSet.mjs?freshOR8RED4"
+			)) as typeof import("../src/internal/redisSidSortedSet.mjs");
+			const z = fresh.createRedisSidSortedSet({
+				client,
+				keyPrefix: prefix("or8-fresh-baseline"),
+			});
+			await z.add(sid, "first-after-reload", FUTURE());
+
+			const score = await raw.zscore(key, "first-after-reload");
+			expect(score).not.toBeNull();
+			expect(Number(score)).toBeGreaterThan(1_000_000_000_000);
 		});
 	});
 });

--- a/packages/redis/src/internal/redisSidSortedSet.mts
+++ b/packages/redis/src/internal/redisSidSortedSet.mts
@@ -43,17 +43,31 @@ export interface RedisSidSortedSet {
  *     member are no-ops (score preserved), satisfying the NX contract.
  *   - ZRANGE ascending score == call-site insertion order unconditionally.
  *
- * Process-restart behaviour: the counter resets to 0. If the same Redis key
- * survives a restart (i.e. it has not yet TTL-expired), new members added
- * after restart may receive a lower score than pre-restart members and
- * therefore sort ahead of them. In practice this case cannot occur because
- * PEXPIREAT synchronises key lifetime to session.expiresAt; a restarted
- * process issues a new session (new key prefix) before any add.
+ * Process-restart behaviour (OR-8): the counter is initialised from
+ * `Date.now()` at module load. Epoch-ms in 2026 (~1.75×10^12) exceeds any
+ * pre-crash counter that started at 0 and incremented once per `add()`,
+ * provided the process did not run continuously at ~100k adds/sec for ~200
+ * days — sufficient under realistic operational throughput, not
+ * mathematically absolute. Post-restart members therefore receive scores
+ * strictly greater than pre-crash members in the same Redis key, preserving
+ * insertion order across restart boundaries for long-lived sessions (e.g.
+ * 24 h TTL). Verified live path: `SessionFamilyIndex.addFamilyId` is called
+ * after restart on a surviving session during the auth-code grant
+ * (`packages/oauth/src/grants/authorization.mts`).
  *
- * JavaScript `number` range: 2^53 - 1 ≈ 9 × 10^15. At 1 million adds/second
- * the counter overflows after ~285 years — treated as unbounded in practice.
+ * Edge case: a backward system-clock step (NTP correction, VM migration)
+ * can invert the guarantee. Phase F may switch to `process.hrtime.bigint()`.
+ *
+ * Non-goal: cluster-wide total ordering. Two replicas starting in the same
+ * millisecond can independently emit identical scores against the same
+ * Redis key — only single-process restart baseline inversion is fixed.
+ * Cross-replica monotonic scores remain Phase F (e.g. Redis `INCR`).
+ *
+ * JavaScript `number` range: 2^53 - 1 ≈ 9 × 10^15. At 1M adds/second from
+ * the Date.now() baseline (~1.75×10^12), headroom is ~7.25×10^15 — still
+ * ~285 years before overflow. Treated as unbounded in practice.
  */
-let _insertionCounter = 0;
+let _insertionCounter = Date.now();
 
 /**
  * Private redis helper used by `SessionFamilyIndex` + `SessionFederationIndex`.


### PR DESCRIPTION
## Summary

- **SF-8** — RFC 7662 §2.2 compliance for `/introspect`: hardcodes `token_type: "Bearer"` (RFC 6750 §6.1.1), filters non-access tokens (RT/id_token JWTs return `active: false` instead of leaking validity), adds RFC 7662 RECOMMENDED `client_id` field with `azp` fallback (Codex m2 — bridges v0.5/v0.6 issuance window), adds `jti` (Codex m3), distinguishes `JwtVerificationError(reason: "typ")` for the `introspect_non_access_token` audit signal at both bearer-self-intro and body-handler catch blocks.
- **OR-8** — `_insertionCounter` initialized from `Date.now()` instead of `0`. Long-lived Redis sorted-set keys (24 h sessions) surviving a process restart no longer invert post-restart members ahead of pre-crash members. Verified live path: `SessionFamilyIndex.addFamilyId` post-restart on surviving session during auth-code grant.
- F7 PR3 closes the F7 batch (IH-9 + SF-1 + SF-8 + OR-8 all landed).

## Test plan

- [x] Build all packages green (`pnpm -r run build`)
- [x] Full test suite green (`pnpm -r run test` — oauth 368 → 372 +4 SF-8; redis 293 → 297 +4 OR-8)
- [x] Lint clean (`pnpm -w run lint` — 0 errors; pre-existing warnings unchanged)
- [x] Strict typecheck clean (`pnpm -r exec tsc --noEmit`)

## Codex calibration deltas applied

**SF-8:**
- m1 ✓ id_token typ default = `id+jwt` (already enforced via SF-1 verifier)
- m2 ✓ `requireClientId` deferred to v0.6 (current issuance emits `azp` only); SF-8 v0.5.1 adds the RFC 7662 `client_id` response field with `azp` fallback so resource servers see the standard field name regardless of issuance window
- m3 ✓ `jti` included in response

**OR-8:**
- Delta 1 ✓ NX-aware test design — RED-2 uses different member names for post-restart entries
- Delta 2 ✓ score formula confirmed (pure `++_insertionCounter`, no `expiresAtMs` term)
- Delta 3 ✓ wording corrected: "sufficient under realistic operational throughput" (NOT "mathematically absolute")
- Delta 4 ✓ explicit non-goal note: cross-replica ordering remains Phase F
- Delta 5 ✓ verified live counterexample documented (`SessionFamilyIndex.addFamilyId` after restart during auth-code grant)

## Breaking changes (CHANGELOG)

- `/introspect` `token_type` was previously the JOSE `typ` value (`at+jwt`); now `Bearer` per RFC 6750 §6.1.1.
- `/introspect` previously returned `active: true` for valid RT / id_token JWTs; now `active: false` (resource servers MUST only introspect access tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)