### PR TITLE
fix(create-app): npx scaffold ENOENT when install path contains 'node_modules' (v0.5.1)

### DIFF
--- a/create-app/scripts/copy-templates.mjs
+++ b/create-app/scripts/copy-templates.mjs
@@ -8,13 +8,22 @@ const dest = resolve(__dirname, "../templates/standalone");
 
 const EXCLUDED_DIRS = new Set(["node_modules", "dist"]);
 
+// Mirrors `shouldCopyTemplateEntry` in src/index.mts: only segments INSIDE
+// `src` are checked against EXCLUDED_DIRS, not the absolute install-prefix
+// path above it. Without this, running the prebuild script with the workspace
+// itself living under a `node_modules` directory would copy zero files.
+const shouldCopy = (source) => {
+	if (source === src) return true;
+	const prefix = src.endsWith(sep) ? src : `${src}${sep}`;
+	if (!source.startsWith(prefix)) return true;
+	const rel = source.slice(prefix.length);
+	return !rel.split(sep).some((segment) => EXCLUDED_DIRS.has(segment));
+};
+
 rmSync(dest, { recursive: true, force: true });
 cpSync(src, dest, {
 	recursive: true,
-	filter: (source) => {
-		const segments = source.split(sep);
-		return !segments.some((segment) => EXCLUDED_DIRS.has(segment));
-	},
+	filter: shouldCopy,
 });
 
 // Embed package versions so they're available at runtime without

--- a/create-app/scripts/copy-templates.mjs
+++ b/create-app/scripts/copy-templates.mjs
@@ -8,10 +8,12 @@ const dest = resolve(__dirname, "../templates/standalone");
 
 const EXCLUDED_DIRS = new Set(["node_modules", "dist"]);
 
-// Mirrors `shouldCopyTemplateEntry` in src/index.mts: only segments INSIDE
-// `src` are checked against EXCLUDED_DIRS, not the absolute install-prefix
-// path above it. Without this, running the prebuild script with the workspace
-// itself living under a `node_modules` directory would copy zero files.
+// Mirrors `shouldCopyTemplateEntry` in src/internal/template-filter.mts: only
+// segments INSIDE `src` are checked against EXCLUDED_DIRS, not the absolute
+// install-prefix path above it. Without this, running the prebuild script with
+// the workspace itself living under a `node_modules` directory would copy zero
+// files. (This script runs at build time before tsc, so it cannot import the
+// compiled module — the logic is duplicated by necessity.)
 const shouldCopy = (source) => {
 	if (source === src) return true;
 	const prefix = src.endsWith(sep) ? src : `${src}${sep}`;

--- a/create-app/src/__tests__/index.test.mts
+++ b/create-app/src/__tests__/index.test.mts
@@ -1,41 +1,75 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, posix, win32 } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isValidDirName, isValidProjectName, main, scaffold } from "../index.mjs";
 import { shouldCopyTemplateEntry } from "../internal/template-filter.mjs";
 
-describe("shouldCopyTemplateEntry", () => {
-	const root =
-		"/Users/x/.npm/_npx/abc/node_modules/@o3co/create-auth-provider/templates/standalone";
+// Both POSIX and Windows separators are exercised explicitly so the suite
+// validates the separator-relative segment logic regardless of the host
+// platform. (`path.sep` is the production default; tests pass it explicitly.)
+const platforms = [
+	{
+		name: "POSIX-style paths",
+		sep: posix.sep,
+		installRoot:
+			"/Users/x/.npm/_npx/abc/node_modules/@o3co/create-auth-provider/templates/standalone",
+		localRoot: "/repo/templates/standalone",
+	},
+	{
+		name: "Windows-style paths",
+		sep: win32.sep,
+		installRoot:
+			"C:\\Users\\x\\AppData\\Roaming\\npm-cache\\_npx\\abc\\node_modules\\@o3co\\create-auth-provider\\templates\\standalone",
+		localRoot: "C:\\repo\\templates\\standalone",
+	},
+] as const;
+
+describe.each(platforms)("shouldCopyTemplateEntry on $name", ({ sep, installRoot, localRoot }) => {
+	const joinSegments = (base: string, ...rest: readonly string[]): string =>
+		[base, ...rest].join(sep);
 
 	it("includes the template root itself", () => {
-		expect(shouldCopyTemplateEntry(root, root)).toBe(true);
+		expect(shouldCopyTemplateEntry(installRoot, installRoot, sep)).toBe(true);
 	});
 
 	it("includes a file directly under the template root even when ancestor path contains 'node_modules'", () => {
 		// Regression for v0.5.0 npx install bug: when the package is installed
-		// at ~/.npm/_npx/<hash>/node_modules/..., the previous filter checked
-		// every segment of the absolute source path and excluded everything,
-		// so cpSync copied no files and the target directory was never created.
-		expect(shouldCopyTemplateEntry(`${root}/package.json`, root)).toBe(true);
+		// at .../node_modules/@o3co/create-auth-provider/..., the previous filter
+		// checked every segment of the absolute source path and excluded
+		// everything, so cpSync copied no files.
+		expect(
+			shouldCopyTemplateEntry(joinSegments(installRoot, "package.json"), installRoot, sep),
+		).toBe(true);
 	});
 
 	it("includes nested template files even when ancestor path contains 'node_modules' or 'dist'", () => {
-		expect(shouldCopyTemplateEntry(`${root}/src/app.mts`, root)).toBe(true);
-		expect(shouldCopyTemplateEntry(`${root}/config/application.conf`, root)).toBe(true);
+		expect(
+			shouldCopyTemplateEntry(joinSegments(installRoot, "src", "app.mts"), installRoot, sep),
+		).toBe(true);
+		expect(
+			shouldCopyTemplateEntry(
+				joinSegments(installRoot, "config", "application.conf"),
+				installRoot,
+				sep,
+			),
+		).toBe(true);
 	});
 
 	it("excludes node_modules subdirectories that live INSIDE the template root", () => {
-		const localRoot = "/repo/templates/standalone";
-		expect(shouldCopyTemplateEntry(`${localRoot}/node_modules/foo/index.js`, localRoot)).toBe(
-			false,
-		);
+		expect(
+			shouldCopyTemplateEntry(
+				joinSegments(localRoot, "node_modules", "foo", "index.js"),
+				localRoot,
+				sep,
+			),
+		).toBe(false);
 	});
 
 	it("excludes dist subdirectories that live INSIDE the template root", () => {
-		const localRoot = "/repo/templates/standalone";
-		expect(shouldCopyTemplateEntry(`${localRoot}/dist/index.mjs`, localRoot)).toBe(false);
+		expect(
+			shouldCopyTemplateEntry(joinSegments(localRoot, "dist", "index.mjs"), localRoot, sep),
+		).toBe(false);
 	});
 });
 

--- a/create-app/src/__tests__/index.test.mts
+++ b/create-app/src/__tests__/index.test.mts
@@ -3,6 +3,41 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isValidDirName, isValidProjectName, main, scaffold } from "../index.mjs";
+import { shouldCopyTemplateEntry } from "../internal/template-filter.mjs";
+
+describe("shouldCopyTemplateEntry", () => {
+	const root =
+		"/Users/x/.npm/_npx/abc/node_modules/@o3co/create-auth-provider/templates/standalone";
+
+	it("includes the template root itself", () => {
+		expect(shouldCopyTemplateEntry(root, root)).toBe(true);
+	});
+
+	it("includes a file directly under the template root even when ancestor path contains 'node_modules'", () => {
+		// Regression for v0.5.0 npx install bug: when the package is installed
+		// at ~/.npm/_npx/<hash>/node_modules/..., the previous filter checked
+		// every segment of the absolute source path and excluded everything,
+		// so cpSync copied no files and the target directory was never created.
+		expect(shouldCopyTemplateEntry(`${root}/package.json`, root)).toBe(true);
+	});
+
+	it("includes nested template files even when ancestor path contains 'node_modules' or 'dist'", () => {
+		expect(shouldCopyTemplateEntry(`${root}/src/app.mts`, root)).toBe(true);
+		expect(shouldCopyTemplateEntry(`${root}/config/application.conf`, root)).toBe(true);
+	});
+
+	it("excludes node_modules subdirectories that live INSIDE the template root", () => {
+		const localRoot = "/repo/templates/standalone";
+		expect(shouldCopyTemplateEntry(`${localRoot}/node_modules/foo/index.js`, localRoot)).toBe(
+			false,
+		);
+	});
+
+	it("excludes dist subdirectories that live INSIDE the template root", () => {
+		const localRoot = "/repo/templates/standalone";
+		expect(shouldCopyTemplateEntry(`${localRoot}/dist/index.mjs`, localRoot)).toBe(false);
+	});
+});
 
 describe("scaffold", () => {
 	let tempDir: string;

--- a/create-app/src/__tests__/published-package.test.mts
+++ b/create-app/src/__tests__/published-package.test.mts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CREATE_APP_DIR = resolve(__dirname, "../..");
+
+interface NpmPackResult {
+	readonly filename: string;
+}
+
+describe("published-package install context (e2e)", () => {
+	let workspace: string;
+	let tarballPath: string;
+
+	beforeAll(() => {
+		workspace = mkdtempSync(join(tmpdir(), "create-auth-provider-e2e-"));
+		// Isolate npm's cache to a per-run directory so a polluted developer
+		// `~/.npm/_cacache/` (e.g. root-owned files left by a sudo install) cannot
+		// fail the test with EPERM. The prepack hook only needs to read the
+		// workspace, but `npm pack` itself touches the cache regardless.
+		const npmCache = join(workspace, "npm-cache");
+		// `npm pack` runs the `prepack` script (rimraf dist + copy-templates + tsc),
+		// so this exercises the same artifact npm publishes to the registry.
+		const stdout = execFileSync("npm", ["pack", "--pack-destination", workspace, "--json"], {
+			cwd: CREATE_APP_DIR,
+			encoding: "utf-8",
+			env: { ...process.env, npm_config_cache: npmCache },
+		});
+		const [packed] = JSON.parse(stdout) as readonly NpmPackResult[];
+		tarballPath = join(workspace, packed.filename);
+	}, 120_000);
+
+	afterAll(() => {
+		if (workspace) rmSync(workspace, { recursive: true, force: true });
+	});
+
+	it("scaffolds successfully when installed under a path containing 'node_modules'", () => {
+		// Regression for v0.5.0 npx bug: simulate the actual install layout
+		// (~/.npm/_npx/<hash>/node_modules/@o3co/create-auth-provider/) so the
+		// cpSync filter sees an absolute source path whose ancestors include
+		// 'node_modules'. Before the fix, the filter excluded every file and
+		// `cpSync` left the target directory empty.
+		const installRoot = join(workspace, "node_modules", "@o3co", "create-auth-provider");
+		mkdirSync(installRoot, { recursive: true });
+		execFileSync("tar", ["-xzf", tarballPath, "--strip-components=1", "-C", installRoot]);
+
+		const projectCwd = join(workspace, "scaffold-cwd");
+		mkdirSync(projectCwd);
+		execFileSync("node", [join(installRoot, "dist", "cli.mjs"), "my-test-project"], {
+			cwd: projectCwd,
+			encoding: "utf-8",
+		});
+
+		const targetDir = join(projectCwd, "my-test-project");
+		expect(existsSync(targetDir)).toBe(true);
+		expect(existsSync(join(targetDir, "package.json"))).toBe(true);
+		expect(existsSync(join(targetDir, "src", "app.mts"))).toBe(true);
+		expect(existsSync(join(targetDir, "config", "application.conf"))).toBe(true);
+
+		const pkg = JSON.parse(readFileSync(join(targetDir, "package.json"), "utf-8"));
+		expect(pkg.name).toBe("my-test-project");
+		for (const section of ["dependencies", "devDependencies", "peerDependencies"] as const) {
+			const deps = pkg[section] as Record<string, string> | undefined;
+			if (!deps) continue;
+			for (const [, version] of Object.entries(deps)) {
+				expect(version).not.toBe("workspace:*");
+			}
+		}
+	}, 30_000);
+});

--- a/create-app/src/index.mts
+++ b/create-app/src/index.mts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 import { cpSync, existsSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, resolve, sep } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { shouldCopyTemplateEntry } from "./internal/template-filter.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = resolve(__dirname, "../templates/standalone");
@@ -52,13 +53,9 @@ export const scaffold = (targetDir: string, projectName: string): void => {
 	}
 
 	// Copy template to target
-	const EXCLUDED_DIRS = new Set(["node_modules", "dist"]);
 	cpSync(TEMPLATES_DIR, targetDir, {
 		recursive: true,
-		filter: (source) => {
-			const segments = source.split(sep);
-			return !segments.some((s) => EXCLUDED_DIRS.has(s));
-		},
+		filter: (source) => shouldCopyTemplateEntry(source, TEMPLATES_DIR),
 	});
 
 	// Rewrite package.json

--- a/create-app/src/internal/template-filter.mts
+++ b/create-app/src/internal/template-filter.mts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//
+// INTERNAL — not exposed via the package's `exports` map. Reachable only from
+// other files in this package (and its tests). See package.json `exports`.
+//
+import { sep } from "node:path";
+
+const EXCLUDED_DIRS = new Set(["node_modules", "dist"]);
+
+/**
+ * Decide whether `cpSync` should copy a given source path.
+ *
+ * Only segments INSIDE `templateRoot` are checked against EXCLUDED_DIRS — the
+ * install-prefix path above the root (e.g. `~/.npm/_npx/<hash>/node_modules/...`
+ * when the package is run via `npx`) is ignored. Otherwise the filter would
+ * reject every file whenever the package itself happens to live under a
+ * `node_modules` directory (which is the v0.5.0 npx regression this fixes).
+ *
+ * NOTE: `sep` is the load-bearing platform abstraction here — DO NOT replace it
+ * with a hardcoded `"/"`. On Windows `sep === "\\"` and `cpSync` passes
+ * back-slash-delimited absolute paths, so segment splitting must follow the
+ * platform separator.
+ */
+export const shouldCopyTemplateEntry = (source: string, templateRoot: string): boolean => {
+	if (source === templateRoot) return true;
+	const prefix = templateRoot.endsWith(sep) ? templateRoot : `${templateRoot}${sep}`;
+	if (!source.startsWith(prefix)) return true;
+	const rel = source.slice(prefix.length);
+	return !rel.split(sep).some((s) => EXCLUDED_DIRS.has(s));
+};

--- a/create-app/src/internal/template-filter.mts
+++ b/create-app/src/internal/template-filter.mts
@@ -30,15 +30,20 @@ const EXCLUDED_DIRS = new Set(["node_modules", "dist"]);
  * reject every file whenever the package itself happens to live under a
  * `node_modules` directory (which is the v0.5.0 npx regression this fixes).
  *
- * NOTE: `sep` is the load-bearing platform abstraction here — DO NOT replace it
- * with a hardcoded `"/"`. On Windows `sep === "\\"` and `cpSync` passes
- * back-slash-delimited absolute paths, so segment splitting must follow the
- * platform separator.
+ * The `pathSep` parameter exists so unit tests can exercise both POSIX and
+ * Windows separators regardless of the host platform; production callers omit
+ * it and pick up `path.sep` of the running platform. DO NOT change this to a
+ * hardcoded `"/"` — `cpSync` passes back-slash-delimited absolute paths on
+ * Windows, so segment splitting must follow the platform separator.
  */
-export const shouldCopyTemplateEntry = (source: string, templateRoot: string): boolean => {
+export const shouldCopyTemplateEntry = (
+	source: string,
+	templateRoot: string,
+	pathSep: string = sep,
+): boolean => {
 	if (source === templateRoot) return true;
-	const prefix = templateRoot.endsWith(sep) ? templateRoot : `${templateRoot}${sep}`;
+	const prefix = templateRoot.endsWith(pathSep) ? templateRoot : `${templateRoot}${pathSep}`;
 	if (!source.startsWith(prefix)) return true;
 	const rel = source.slice(prefix.length);
-	return !rel.split(sep).some((s) => EXCLUDED_DIRS.has(s));
+	return !rel.split(pathSep).some((s) => EXCLUDED_DIRS.has(s));
 };


### PR DESCRIPTION
## Summary

Fixes a critical bug in **v0.5.0** of `@o3co/create-auth-provider` where every `npx @o3co/create-auth-provider <name>` invocation failed with `ENOENT: ... <project>/package.json` and never created the project.

### Root cause

[create-app/src/index.mts:55-62 (v0.5.0)](https://github.com/o3co/auth.provider/blob/develop/create-app/src/index.mts#L55-L62) — the `cpSync` filter rejected a path when **any segment of the absolute source path** was in `EXCLUDED_DIRS = {"node_modules", "dist"}`. When installed via npm/npx the package always lives under a path containing `node_modules` (e.g. `~/.npm/_npx/<hash>/node_modules/@o3co/create-auth-provider/...`), so the filter excluded every template file → `cpSync` copied nothing → `readFileSync(<targetDir>/package.json)` failed with ENOENT.

### Why CI did not catch this

The existing test suite imports `scaffold()` directly from source and `TEMPLATES_DIR` resolves to the workspace path, which contains no `node_modules` segment, so the filter passed in test context. The bug only manifests on the installed artifact.

### Fix

- New internal module `src/internal/template-filter.mts` exporting `shouldCopyTemplateEntry(source, templateRoot)` that checks segments **only relative to `templateRoot`**, ignoring the install-prefix path above it.
- `scripts/copy-templates.mjs` mirrors the same logic locally (build-time script can't import compiled output before tsc runs).
- **Public exports list change: none.** The new function is gated behind the package's `exports` map (`.` only) and unreachable as a deep import — it is genuinely internal to the package.

## Test plan

- [x] `pnpm --filter @o3co/create-auth-provider test` — 72/72 (66 baseline + 5 new unit + 1 new e2e)
- [x] **RED phase verified**: 4 of the 6 new tests failed before the fix for the right reason (filter excluded files because of `node_modules` ancestor segment); the EXCLUDED_DIRS-inside-template-root guards passed under both old and new logic
- [x] `pnpm exec biome check create-app/src create-app/scripts` — clean
- [x] `pnpm --filter @o3co/create-auth-provider build` — tsc clean, `dist/index.d.mts` confirmed to NOT export `shouldCopyTemplateEntry` (public surface unchanged)
- [x] e2e test runs `npm pack` → extracts under `<workspace>/node_modules/@o3co/create-auth-provider/` → runs CLI from a separate cwd → asserts project + package.json + nested template files; uses per-run `npm_config_cache` so a polluted developer cache does not fail the test

### New tests

- `create-app/src/__tests__/index.test.mts` — `describe("shouldCopyTemplateEntry")` block (5 cases): root passthrough, regression for the v0.5.0 npx layout, nested template files, EXCLUDED_DIRS-inside-template-root guard for `node_modules` and `dist`.
- `create-app/src/__tests__/published-package.test.mts` — full e2e through `npm pack` + tarball extraction + CLI invocation. Adds ~1s to the suite.

## Multi-agent review

- 🔵 Claude review: 1 Important addressed (`shouldCopyTemplateEntry` was initially exported and would have entered the public type surface — moved to `src/internal/`).
- 🟠 Codex review: no findings on the code change. Codex's run also surfaced an environmental fragility (`npm pack` requires a writable `~/.npm/_cacache/`) — addressed by passing `npm_config_cache: <tempdir>` to the e2e test's `execFileSync` call.

## Follow-ups (out of scope)

- `auth.policy-verifier/create-app` has the **same filter bug** in its source; tracked separately because it ships as a different npm package with its own release cycle.
- The e2e test invokes `tar` via PATH; on Windows runners, consider `it.skipIf(process.platform === "win32")` if matrix CI is added.