### PR TITLE
F8 PR3 — IH-12 GitHub PKCE no-op (v0.5.1, BREAKING)

### DIFF
--- a/packages/federation-github/README.md
+++ b/packages/federation-github/README.md
@@ -27,6 +27,11 @@ const githubConfigBridgeModule = defineModule({
         clientId: slice.clientId as string,
         clientSecret: slice.clientSecret as string,
         callbackURL: slice.callbackURL as string,
+        // IH-12: required. Use "oauth-app" for legacy GitHub Developer Settings
+        // OAuth App registrations (PKCE silently ignored by GitHub) and
+        // "github-app" for newer GitHub Apps (PKCE enforced). The provider
+        // emits PKCE parameters only on the github-app branch.
+        appKind: (slice.appKind as "oauth-app" | "github-app") ?? "oauth-app",
       };
     },
   },

--- a/packages/federation-github/src/__tests__/github-module-boot.test.mts
+++ b/packages/federation-github/src/__tests__/github-module-boot.test.mts
@@ -48,6 +48,8 @@ const stubGithubConfig: GithubProviderConfig = {
 	clientId: "test-client-id",
 	clientSecret: "test-client-secret",
 	callbackURL: "https://example.com/auth/github/callback",
+	// IH-12: boot integration covers the OAuth App registration shape (legacy default).
+	appKind: "oauth-app",
 	sessionDomain: "example.com",
 	authCallbackUrl: "https://example.com/auth/callback",
 	clientUrl: "https://example.com/",

--- a/packages/federation-github/src/__tests__/github-module.test.mts
+++ b/packages/federation-github/src/__tests__/github-module.test.mts
@@ -45,6 +45,7 @@ describe("githubFederationModule const Module", () => {
 				clientId: "abc",
 				clientSecret: "xyz",
 				callbackURL: "https://example.com/cb",
+				appKind: "oauth-app",
 			},
 		} as never);
 		expect(provider.name).toBe("github");

--- a/packages/federation-github/src/__tests__/github.test.mts
+++ b/packages/federation-github/src/__tests__/github.test.mts
@@ -49,6 +49,10 @@ describe("createGithubProvider on openid-client", () => {
 		clientId: "client-id",
 		clientSecret: "client-secret",
 		callbackURL: "https://app.example.com/session/oauth/federation/github/callback",
+		// IH-12: legacy registration default. Existing v0.5.0 tests run as OAuth Apps
+		// (PKCE not enforced by GitHub). Each test that needs the github-app branch
+		// constructs its own config explicitly.
+		appKind: "oauth-app" as const,
 	};
 
 	beforeEach(() => {
@@ -61,11 +65,14 @@ describe("createGithubProvider on openid-client", () => {
 		expect([...p.scope]).toEqual(["read:user", "user:email"]);
 	});
 
-	it("buildAuthorizationUrl forwards redirect_uri/state/code_challenge to openid-client with GitHub authorize URL", () => {
+	it("buildAuthorizationUrl forwards redirect_uri/state/code_challenge to openid-client with GitHub authorize URL (github-app branch)", () => {
+		// IH-12: PKCE is only emitted on the github-app branch. baseConfig is "oauth-app"
+		// (legacy default) so this test explicitly opts into github-app to exercise PKCE
+		// forwarding. Dedicated oauth-app tests below assert that those params are absent.
 		mockBuildAuthorizationUrl.mockReturnValueOnce(
 			new URL("https://github.com/login/oauth/authorize?stub=1"),
 		);
-		const p = createGithubProvider(baseConfig);
+		const p = createGithubProvider({ ...baseConfig, appKind: "github-app" });
 		const verifier = "verifier-0123456789-abcdef-0123456789-abcdef-0123456789abcdef";
 		const url = p.buildAuthorizationUrl({
 			redirectUri: baseConfig.callbackURL,
@@ -100,7 +107,11 @@ describe("createGithubProvider on openid-client", () => {
 				{ email: "alice@personal.com", primary: false, verified: true },
 			],
 		});
-		const p = createGithubProvider(baseConfig);
+		// IH-12: this test exercises PKCE forwarding alongside the rest of the
+		// composition contract, so opt explicitly into the github-app branch (oauth-app
+		// strips pkceCodeVerifier; that branch is covered by the dedicated IH-12 RED
+		// tests below).
+		const p = createGithubProvider({ ...baseConfig, appKind: "github-app" });
 		const profile = await p.exchangeCode({
 			code: "gh-code",
 			codeVerifier: "v",
@@ -271,5 +282,130 @@ describe("createGithubProvider on openid-client", () => {
 		const { url, method } = await p.endSession({});
 		expect(method).toBe("GET");
 		expect(url.href).toContain("https://github.com/logout");
+	});
+
+	// -----------------------------------------------------------------------
+	// IH-12 — appKind discriminator + PKCE branching
+	// -----------------------------------------------------------------------
+
+	describe("IH-12: appKind discriminator + PKCE branching", () => {
+		// IH-12 RED-1 — compile-time guard. `appKind` is a required field on
+		// GithubProviderConfig with no default; omitting it must fail tsc. The
+		// `@ts-expect-error` directive itself errors if the next line type-checks
+		// successfully, so this is the runnable form of the spec's "config without
+		// appKind → TypeScript error" assertion.
+		it("appKind is required at the type level", () => {
+			// @ts-expect-error appKind is required; omitting it must fail TypeScript.
+			createGithubProvider({
+				clientId: "id",
+				clientSecret: "sec",
+				callbackURL: "https://app.example.com/cb",
+			});
+			// Runtime: the omission compiles via the @ts-expect-error escape, and the
+			// provider returns without throwing — the contract is enforced at the type
+			// level, not at runtime, by design (matches the spec's explicit-choice goal).
+		});
+
+		// IH-12 RED-2 — oauth-app branch must NOT emit PKCE params. Pre-fix the route
+		// always sends `code_challenge` + `code_challenge_method`, GitHub silently ignores
+		// them, and consumers reading the auth URL get a misleading security signal that
+		// PKCE is binding the request.
+		it("oauth-app: buildAuthorizationUrl does not include code_challenge or code_challenge_method", () => {
+			mockBuildAuthorizationUrl.mockReturnValueOnce(
+				new URL("https://github.com/login/oauth/authorize?stub=1"),
+			);
+			const p = createGithubProvider({ ...baseConfig, appKind: "oauth-app" });
+			p.buildAuthorizationUrl({
+				redirectUri: baseConfig.callbackURL,
+				state: "s",
+				codeVerifier: "verifier-0123456789-abcdef",
+			});
+			const [, params] = mockBuildAuthorizationUrl.mock.calls[0] as [
+				unknown,
+				Record<string, unknown>,
+			];
+			expect(params.code_challenge).toBeUndefined();
+			expect(params.code_challenge_method).toBeUndefined();
+			// Sibling-fields that are NOT gated by appKind must still be present so the
+			// strip is surgical, not a regression of the rest of the auth URL.
+			expect(params.state).toBe("s");
+			expect(params.redirect_uri).toBe(baseConfig.callbackURL);
+		});
+
+		// IH-12 RED-3 — github-app branch MUST emit PKCE params (positive guard;
+		// complements the migrated existing test by asserting from the perspective of a
+		// reviewer who lands on RED-2 first and needs to confirm the branch isn't
+		// always-off).
+		it("github-app: buildAuthorizationUrl includes code_challenge=<base64url> + code_challenge_method=S256", () => {
+			mockBuildAuthorizationUrl.mockReturnValueOnce(
+				new URL("https://github.com/login/oauth/authorize?stub=1"),
+			);
+			const p = createGithubProvider({ ...baseConfig, appKind: "github-app" });
+			p.buildAuthorizationUrl({
+				redirectUri: baseConfig.callbackURL,
+				state: "s",
+				codeVerifier: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+			});
+			const [, params] = mockBuildAuthorizationUrl.mock.calls[0] as [
+				unknown,
+				Record<string, string>,
+			];
+			expect(params.code_challenge_method).toBe("S256");
+			expect(params.code_challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+		});
+
+		// IH-12 RED-4 — oauth-app branch must NOT pass `pkceCodeVerifier` to the token
+		// exchange. GitHub OAuth Apps ignore it, and including it muddies the upstream
+		// library's idea of which flow is in use.
+		it("oauth-app: exchangeCode omits pkceCodeVerifier from authorizationCodeGrant", async () => {
+			mockAuthorizationCodeGrant.mockResolvedValueOnce({
+				access_token: "gh-at",
+				expires_in: 28800,
+			});
+			mockFetchUserInfo.mockResolvedValueOnce({
+				id: 12345,
+				login: "octocat",
+				email: "octocat@example.com",
+			});
+			const p = createGithubProvider({ ...baseConfig, appKind: "oauth-app" });
+			await p.exchangeCode({
+				code: "auth-code",
+				codeVerifier: "v",
+				redirectUri: baseConfig.callbackURL,
+			});
+			const [, , checks] = mockAuthorizationCodeGrant.mock.calls[0] as [
+				unknown,
+				unknown,
+				Record<string, unknown>,
+			];
+			expect(checks).not.toHaveProperty("pkceCodeVerifier");
+		});
+
+		// IH-12 RED-5 — github-app branch MUST pass `pkceCodeVerifier` so openid-client
+		// posts `code_verifier` to GitHub's token endpoint and the upstream PKCE check
+		// runs.
+		it("github-app: exchangeCode passes pkceCodeVerifier to authorizationCodeGrant", async () => {
+			mockAuthorizationCodeGrant.mockResolvedValueOnce({
+				access_token: "gh-at",
+				expires_in: 28800,
+			});
+			mockFetchUserInfo.mockResolvedValueOnce({
+				id: 12345,
+				login: "octocat",
+				email: "octocat@example.com",
+			});
+			const p = createGithubProvider({ ...baseConfig, appKind: "github-app" });
+			await p.exchangeCode({
+				code: "auth-code",
+				codeVerifier: "my-verifier",
+				redirectUri: baseConfig.callbackURL,
+			});
+			const [, , checks] = mockAuthorizationCodeGrant.mock.calls[0] as [
+				unknown,
+				unknown,
+				{ pkceCodeVerifier?: string },
+			];
+			expect(checks.pkceCodeVerifier).toBe("my-verifier");
+		});
 	});
 });

--- a/packages/federation-github/src/github.mts
+++ b/packages/federation-github/src/github.mts
@@ -45,6 +45,24 @@ export interface GithubProviderConfig {
 	clientId: string;
 	clientSecret: string;
 	callbackURL: string;
+	/**
+	 * IH-12: discriminates between the two GitHub registration types so the
+	 * authorization-code flow only emits PKCE parameters when GitHub actually enforces
+	 * them.
+	 *
+	 * - `"oauth-app"`: GitHub OAuth Apps (Developer Settings → OAuth Apps). PKCE is NOT
+	 *   enforced by GitHub for this registration type — `code_challenge` /
+	 *   `code_verifier` are silently ignored. We omit them to remove the misleading
+	 *   security signal that PKCE is providing protection. Most consumers registered
+	 *   before the GitHub Apps platform are on this kind.
+	 * - `"github-app"`: GitHub Apps (Developer Settings → GitHub Apps). PKCE IS
+	 *   enforced. `code_challenge` + `code_challenge_method=S256` are sent on the
+	 *   authorization URL and `code_verifier` is sent on the token exchange.
+	 *
+	 * Required field — no default. Existing v0.5.0 callers MUST add `appKind:
+	 * "oauth-app"` to migrate (the legacy default is OAuth Apps; see CHANGELOG).
+	 */
+	appKind: "oauth-app" | "github-app";
 	/** Cookie / session domain used to validate redirect URLs (e.g. ".example.com"). Optional. */
 	sessionDomain?: string;
 	/** URL of the auth-callback page (used to build the post-login redirect). Optional. */
@@ -83,12 +101,22 @@ export function createGithubProvider(config: GithubProviderConfig): GithubProvid
 			readonly state: string;
 			readonly codeVerifier: string;
 		}): URL {
+			// IH-12: only emit PKCE on registration types that actually enforce it. GitHub
+			// OAuth Apps silently drop `code_challenge` / `code_challenge_method`, so sending
+			// them is a misleading security signal — strip them in the oauth-app branch.
+			// Inline the conditional spread so the inferred record type stays
+			// `Record<string, string>` (a precomputed `pkceParams` constant produces a
+			// union that openid-client's `Record<string, string>` parameter rejects).
 			return oidc.buildAuthorizationUrl(oidcConfig, {
 				redirect_uri: params.redirectUri,
 				scope: SCOPES.join(" "),
 				state: params.state,
-				code_challenge: codeChallenge(params.codeVerifier),
-				code_challenge_method: "S256",
+				...(config.appKind === "github-app"
+					? {
+							code_challenge: codeChallenge(params.codeVerifier),
+							code_challenge_method: "S256",
+						}
+					: {}),
 			});
 		},
 
@@ -101,8 +129,12 @@ export function createGithubProvider(config: GithubProviderConfig): GithubProvid
 			const callbackUrl = new URL(params.redirectUri);
 			callbackUrl.searchParams.set("code", params.code);
 
+			// IH-12: pair with `buildAuthorizationUrl` — only thread the verifier on the
+			// github-app branch so the upstream library's PKCE flow is exercised symmetrically.
+			// On oauth-app, GitHub's token endpoint ignores `pkceCodeVerifier`; omitting it
+			// keeps the request payload clean and the security contract explicit.
 			const tokens = await oidc.authorizationCodeGrant(oidcConfig, callbackUrl, {
-				pkceCodeVerifier: params.codeVerifier,
+				...(config.appKind === "github-app" ? { pkceCodeVerifier: params.codeVerifier } : {}),
 				expectedState: oidc.skipStateCheck,
 			});
 


### PR DESCRIPTION
## Summary

Final PR in the F8 batch (federation OIDC compliance). Closes IH-12 — GitHub OAuth Apps silently ignore PKCE parameters, so sending them is a misleading security signal. GitHub Apps (the newer registration type) DO enforce PKCE, so the existing code path is correct for them. IH-12 makes the distinction explicit via a new required `appKind` discriminator on `GithubProviderConfig`.

- **New required field** on `GithubProviderConfig`: `appKind: "oauth-app" | "github-app"`. No default — consumers must declare intent (ADR-compliant: no Zod `.default()`).
- `buildAuthorizationUrl` only emits `code_challenge` + `code_challenge_method` on the github-app branch.
- `exchangeCode` only passes `pkceCodeVerifier` on the github-app branch.

## Behavioral changes (visible to callers)

- **BREAKING**: `GithubProviderConfig` requires `appKind`. v0.5.0 configs without it fail TypeScript compilation. Migration: add `appKind: "oauth-app"` (legacy default — most v0.5.0 users registered via Developer Settings → OAuth Apps).
- GitHub OAuth App federation no longer sends PKCE params that GitHub silently drops. Functionally a no-op (GitHub never enforced them) but removes the misleading security signal in the auth URL and request payload.
- GitHub App federation behavior unchanged.

## Test count delta

| package | before | after | delta |
|---|---|---|---|
| federation-github | 20 | 25 | +5 |

All 2166 workspace tests green (was 2161). `pnpm -r run build`, `pnpm -w run lint`, and `pnpm -r exec tsc --noEmit` all pass.

## Test plan

- [x] `appKind` required at type level (`@ts-expect-error` compile-time guard).
- [x] oauth-app branch strips `code_challenge` + `code_challenge_method`.
- [x] github-app branch keeps `code_challenge` + `code_challenge_method=S256`.
- [x] oauth-app branch strips `pkceCodeVerifier` from token exchange.
- [x] github-app branch passes `pkceCodeVerifier` to token exchange.
- [x] Pre-existing PKCE-asserting tests migrated to opt into `appKind: "github-app"`.
- [x] All 3 test fixtures (`baseConfig`, `stubGithubConfig`, inline factory config) migrated.
- [x] README config-bridge example updated with `appKind` thread-through.

## F8 batch status

- ✅ F8 PR1 (PB-4 + PB-5 + TD-9 + TD-6) — PR #133 @ 513f9676
- ✅ F8 PR2 (SF-12 + SF-13) — PR #134 @ 4cc38d69
- ⏳ F8 PR3 (IH-12) — this PR

After this lands, F8 batch is **fully closed**. Next: F9 (API surface corrections — CC-5 readonly + AS naming/export/token shape batches), independent of F8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)