### PR TITLE
F9 PR1 — CC-5 readonly Theme D (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Custom code mutating `Client.allowedRedirectUris.push(…)` or assigning
   `Client.allowedScopes = […]` directly fails to compile — use the
   repository's create/upsert API to issue a new `Client` instead.
+- Direct field assignments on `User`, `CodeData`, or `Code` instances
+  (e.g. `user.id = "…"`, `codeData.client_id = "…"`, `code.code = "…"`)
+  fail to compile. Replace with repository create / upsert calls so the
+  store always issues a fresh record.
 - No runtime behavior change: `readonly` is compile-time only; no
   `Object.freeze()` is applied. Existing valid call sites continue to work
   unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Breaking (Phase F — F9 PR1 CC-5 readonly Theme D, v0.5.1)
+
+- **Public DTOs are now fully `readonly`** (`@o3co/auth-provider-core`,
+  `@o3co/auth-provider-oauth-token-exchange`, closes CC-5 / AS-5 / AS-6 /
+  AS-M2): `ValidatedToken`, `ExchangeTokenValidationContext`,
+  `GrantContext`, `Client`, `User`, `CodeData`, and `Code` field declarations
+  now carry `readonly` modifiers. Array-typed fields on `Client`
+  (`allowedRedirectUris`, `allowedScopes`, `allowedAudiences`,
+  `postLogoutRedirectUris`) are `readonly string[]` so element-level mutation
+  (`.push`, index assignment) is rejected at compile time. `GrantContext.session`
+  is `readonly` (wholesale `ctx.session = {…}` rejected); `SessionData`
+  field-level writes (`ctx.session.isAuthenticated = true`) continue to
+  compile so handlers writing through Express's `req.session` keep working.
+  `selfIssuedAccessToken.mts` was refactored from sequential mutable-builder
+  assignment to object-spread construction so it survives the new
+  `readonly ValidatedToken` contract.
+
+#### Migration
+
+- Validator implementations using sequential `result.scope = …` builders
+  must switch to object-spread (`{ sub, claims, ...(condition ? { x } : {}) }`).
+- Custom code mutating `Client.allowedRedirectUris.push(…)` or assigning
+  `Client.allowedScopes = […]` directly fails to compile — use the
+  repository's create/upsert API to issue a new `Client` instead.
+- No runtime behavior change: `readonly` is compile-time only; no
+  `Object.freeze()` is applied. Existing valid call sites continue to work
+  unchanged.
+
 ### Security (Phase F — F6 PR4 authorization-grant TOCTOU re-check, v0.5.1)
 
 - **Authorization-code grant re-validates session liveness before linking the

--- a/packages/core/src/__tests__/grant-context-readonly.test.mts
+++ b/packages/core/src/__tests__/grant-context-readonly.test.mts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { GrantContext } from "../grants/types.mjs";
+
+// CC-5 readonly compile-time assertions for GrantContext. See
+// readonly-types.test.mts in oauth-token-exchange for the rationale.
+
+describe("CC-5: GrantContext readonly (compile-time)", () => {
+	it("GrantContext top-level fields are readonly", () => {
+		if (false as boolean) {
+			const ctx = {
+				body: {},
+				session: {},
+				issuer: "https://example.com",
+				metadata: {},
+				ip: "127.0.0.1",
+				userAgent: "test",
+				authenticatedClient: null,
+			} as GrantContext;
+			// @ts-expect-error — readonly violation
+			ctx.body = {};
+			// @ts-expect-error — readonly violation
+			ctx.issuer = "other";
+			// @ts-expect-error — readonly violation
+			ctx.metadata = {};
+			// @ts-expect-error — readonly violation
+			ctx.ip = "other";
+			// @ts-expect-error — readonly violation
+			ctx.userAgent = "other";
+			// @ts-expect-error — readonly violation (wholesale session replacement)
+			ctx.session = {};
+			void ctx;
+		}
+		expect(true).toBe(true);
+	});
+
+	it("GrantContext.session field-level mutation still compiles (SessionData fields are mutable)", () => {
+		if (false as boolean) {
+			const ctx = {
+				body: {},
+				session: {},
+				issuer: "https://example.com",
+				metadata: {},
+				ip: "127.0.0.1",
+				userAgent: "test",
+				authenticatedClient: null,
+			} as GrantContext;
+			// SessionData fields are intentionally mutable — handlers write via req.session
+			ctx.session.isAuthenticated = true;
+			ctx.session.user = { id: "u" };
+			void ctx;
+		}
+		expect(true).toBe(true);
+	});
+});

--- a/packages/core/src/__tests__/repository-types-readonly.test.mts
+++ b/packages/core/src/__tests__/repository-types-readonly.test.mts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Client, Code, CodeData, User } from "../repositories/types.mjs";
+
+// CC-5 readonly compile-time assertions for repository DTOs. See
+// readonly-types.test.mts in oauth-token-exchange for the rationale.
+
+describe("CC-5: repository DTOs readonly (compile-time)", () => {
+	it("User fields are readonly", () => {
+		if (false as boolean) {
+			const u = { id: "x", username: "y" } as User;
+			// @ts-expect-error — readonly violation
+			u.id = "z";
+			// @ts-expect-error — readonly violation
+			u.username = "z";
+			void u;
+		}
+		expect(true).toBe(true);
+	});
+
+	it("Client array fields are readonly arrays (push/element-mutation rejected)", () => {
+		if (false as boolean) {
+			const c = {} as Client;
+			// @ts-expect-error — element mutation on readonly array
+			c.allowedRedirectUris.push("extra");
+			// @ts-expect-error — element mutation on readonly array
+			c.allowedScopes.push("extra");
+			// @ts-expect-error — wholesale array replacement on readonly property
+			c.allowedRedirectUris = [];
+			// @ts-expect-error — wholesale array replacement on readonly property
+			c.allowedScopes = [];
+			void c;
+		}
+		expect(true).toBe(true);
+	});
+
+	it("CodeData fields are readonly", () => {
+		if (false as boolean) {
+			const cd = { client_id: "c", redirect_uri: "u" } as CodeData;
+			// @ts-expect-error — readonly violation
+			cd.client_id = "x";
+			// @ts-expect-error — readonly violation
+			cd.redirect_uri = "x";
+			// @ts-expect-error — readonly violation
+			cd.code_challenge = "x";
+			// @ts-expect-error — readonly violation
+			cd.code_challenge_method = "x";
+			// @ts-expect-error — readonly violation
+			cd.nonce = "x";
+			// @ts-expect-error — readonly violation
+			cd.sid = "x";
+			void cd;
+		}
+		expect(true).toBe(true);
+	});
+
+	it("Code fields are readonly (incl. inherited CodeData fields)", () => {
+		if (false as boolean) {
+			const code = { code: "k", client_id: "c", redirect_uri: "u" } as Code;
+			// @ts-expect-error — readonly violation
+			code.code = "y";
+			// @ts-expect-error — readonly violation
+			code.expiresIn = 1;
+			// @ts-expect-error — readonly violation
+			code.grantedScope = [];
+			// @ts-expect-error — readonly violation
+			code.grantedAudience = [];
+			void code;
+		}
+		expect(true).toBe(true);
+	});
+});

--- a/packages/core/src/__tests__/repository-types-readonly.test.mts
+++ b/packages/core/src/__tests__/repository-types-readonly.test.mts
@@ -33,17 +33,32 @@ describe("CC-5: repository DTOs readonly (compile-time)", () => {
 		expect(true).toBe(true);
 	});
 
-	it("Client array fields are readonly arrays (push/element-mutation rejected)", () => {
+	it("Client array fields are readonly arrays (push/index/wholesale all rejected, all 4 array fields)", () => {
 		if (false as boolean) {
 			const c = {} as Client;
+			// push() rejected on readonly arrays
 			// @ts-expect-error — element mutation on readonly array
 			c.allowedRedirectUris.push("extra");
 			// @ts-expect-error — element mutation on readonly array
 			c.allowedScopes.push("extra");
+			// @ts-expect-error — element mutation on readonly array
+			c.allowedAudiences?.push("extra");
+			// @ts-expect-error — element mutation on readonly array
+			c.postLogoutRedirectUris?.push("extra");
+			// Index assignment rejected on readonly arrays
+			// @ts-expect-error — index assignment on readonly array
+			c.allowedRedirectUris[0] = "x";
+			// @ts-expect-error — index assignment on readonly array
+			c.allowedScopes[0] = "x";
+			// Wholesale array replacement rejected on readonly property
 			// @ts-expect-error — wholesale array replacement on readonly property
 			c.allowedRedirectUris = [];
 			// @ts-expect-error — wholesale array replacement on readonly property
 			c.allowedScopes = [];
+			// @ts-expect-error — wholesale array replacement on readonly property
+			c.allowedAudiences = [];
+			// @ts-expect-error — wholesale array replacement on readonly property
+			c.postLogoutRedirectUris = [];
 			void c;
 		}
 		expect(true).toBe(true);

--- a/packages/core/src/grants/types.mts
+++ b/packages/core/src/grants/types.mts
@@ -68,12 +68,18 @@ export interface SessionData {
 }
 
 export interface GrantContext {
-	body: Record<string, unknown>;
-	session: SessionData;
-	issuer?: string;
-	metadata: Record<string, unknown>;
-	ip?: string;
-	userAgent?: string;
+	readonly body: Readonly<Record<string, unknown>>;
+	/**
+	 * Readonly property — wholesale `ctx.session = {…}` replacement is rejected
+	 * at compile time. Field-level mutation (`ctx.session.isAuthenticated = …`)
+	 * is intentionally still allowed because handlers write through Express's
+	 * `req.session` object; `SessionData` mirrors that mutable surface.
+	 */
+	readonly session: SessionData;
+	readonly issuer?: string;
+	readonly metadata: Readonly<Record<string, unknown>>;
+	readonly ip?: string;
+	readonly userAgent?: string;
 	/**
 	 * The authenticated client established by `clientAuthMw` before grant
 	 * dispatch on `/token`. Grant handlers that bind tokens to client identity

--- a/packages/core/src/repositories/types.mts
+++ b/packages/core/src/repositories/types.mts
@@ -41,16 +41,16 @@ export interface Client {
 	 * `"none"`. The `ClientEntrySchema` superRefine enforces both directions.
 	 */
 	readonly clientSecret?: string;
-	readonly allowedRedirectUris: string[];
-	readonly allowedScopes: string[];
+	readonly allowedRedirectUris: readonly string[];
+	readonly allowedScopes: readonly string[];
 	/**
 	 * Audience URIs that this client may request in Token Exchange (RFC 8693)
 	 * `audience` parameter. Empty or undefined means only the client's own
 	 * clientId is allowed as audience. Not used outside Token Exchange.
 	 */
-	readonly allowedAudiences?: string[];
+	readonly allowedAudiences?: readonly string[];
 	// NEW (TODO-F-5): Logout metadata.
-	readonly postLogoutRedirectUris?: string[];
+	readonly postLogoutRedirectUris?: readonly string[];
 	readonly backchannelLogoutUri?: string;
 	// default: true (includes sid in logout_token) — intentional deviation from OIDC Back-Channel
 	// Logout 1.0 §2.2 spec default of false, to default to the safer behavior. See ClientEntrySchema.
@@ -74,9 +74,9 @@ export interface Client {
 }
 
 export interface User {
-	id: string;
-	username: string;
-	[key: string]: unknown;
+	readonly id: string;
+	readonly username: string;
+	readonly [key: string]: unknown;
 }
 
 /**
@@ -93,19 +93,19 @@ export interface User {
  * misses either field fail typecheck at the destructure site.
  */
 export interface CodeData {
-	client_id: string; // required — replaces the session.code_client_id gate
-	redirect_uri: string; // required — closes IH-4 vacuous-pass (RFC 6749 §4.1.3)
-	code_challenge?: string;
-	code_challenge_method?: string;
+	readonly client_id: string; // required — replaces the session.code_client_id gate
+	readonly redirect_uri: string; // required — closes IH-4 vacuous-pass (RFC 6749 §4.1.3)
+	readonly code_challenge?: string;
+	readonly code_challenge_method?: string;
 	// NEW (TODO-F-3): OIDC authorize → token round-trip state.
 	// These fields are persisted at /authorize and read at /token.
-	nonce?: string;
-	sid?: string;
+	readonly nonce?: string;
+	readonly sid?: string;
 }
 
 export interface Code extends CodeData {
-	code: string;
-	expiresIn?: number;
-	grantedScope?: readonly string[];
-	grantedAudience?: readonly string[];
+	readonly code: string;
+	readonly expiresIn?: number;
+	readonly grantedScope?: readonly string[];
+	readonly grantedAudience?: readonly string[];
 }

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -9,12 +9,14 @@
 		"src/refresh-token-family/**/*.mts",
 		"src/user-sessions/**/*.mts",
 		"src/adapters/**/*.mts",
-		"src/repositories/__tests__/InMemoryCodeRepository.test.mts"
+		"src/repositories/__tests__/InMemoryCodeRepository.test.mts",
 		// D-1 FOLLOW-UP: this entry is a single file, not a `repositories/__tests__/**` glob,
 		// because `InMemoryClientRepository.test.mts` has 16 pre-existing TS errors
 		// (Map<...> shape mismatches) unrelated to D-1. Widen this to the glob
 		// once that file is cleaned up — track in the next core/repositories
 		// hygiene PR.
+		"src/__tests__/grant-context-readonly.test.mts",
+		"src/__tests__/repository-types-readonly.test.mts"
 	],
 	"exclude": ["node_modules", "dist"]
 }

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -17,6 +17,10 @@ export default defineConfig({
 				// is cleaned up — track in the next core/repositories
 				// hygiene PR.
 				"src/repositories/__tests__/InMemoryCodeRepository.test.mts",
+				// CC-5 readonly compile-time contract tests. The @ts-expect-error
+				// directives in these files only fire under typecheck mode.
+				"src/__tests__/grant-context-readonly.test.mts",
+				"src/__tests__/repository-types-readonly.test.mts",
 			],
 			tsconfig: "./tsconfig.test.json",
 		},

--- a/packages/oauth-token-exchange/src/__tests__/readonly-types.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/readonly-types.test.mts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ExchangeTokenValidationContext, ValidatedToken } from "#/validator/types.mjs";
+
+// CC-5 readonly compile-time assertions.
+//
+// These tests verify at compile time that public DTOs are `readonly`. The
+// `@ts-expect-error` directives below cause `tsc --noEmit` to fail (with
+// "Unused '@ts-expect-error' directive") whenever a field that should be
+// readonly becomes mutable. The runtime body is a no-op — the type system
+// is the assertion. Wrapped in `if (false)` so no runtime mutation runs.
+
+describe("CC-5: validator types readonly (compile-time)", () => {
+	it("ExchangeTokenValidationContext.role is readonly", () => {
+		if (false as boolean) {
+			const ctx = { role: "subject" } as ExchangeTokenValidationContext;
+			// @ts-expect-error — readonly violation
+			ctx.role = "actor";
+			void ctx;
+		}
+		expect(true).toBe(true);
+	});
+
+	it("ValidatedToken all fields readonly (exhaustive)", () => {
+		if (false as boolean) {
+			const t = { sub: "u1", claims: {} } as ValidatedToken;
+			// @ts-expect-error
+			t.sub = "u2";
+			// @ts-expect-error
+			t.scope = "read";
+			// @ts-expect-error
+			t.aud = ["a"];
+			// @ts-expect-error
+			t.familyId = "f";
+			// @ts-expect-error
+			t.act = {};
+			// @ts-expect-error
+			t.claims = {};
+			void t;
+		}
+		expect(true).toBe(true);
+	});
+});

--- a/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
+++ b/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
@@ -114,19 +114,18 @@ export function createSelfIssuedAccessTokenValidator(
 				if (revoked) return null;
 			}
 
-			const result: ValidatedToken = {
+			return {
 				sub: payload.sub,
 				claims: payload,
+				...(typeof payload.scope === "string" ? { scope: payload.scope } : {}),
+				...(typeof payload.aud === "string" || Array.isArray(payload.aud)
+					? { aud: payload.aud as string | string[] }
+					: {}),
+				...(familyId ? { familyId } : {}),
+				...(payload.act && typeof payload.act === "object" && !Array.isArray(payload.act)
+					? { act: payload.act as Record<string, unknown> }
+					: {}),
 			};
-			if (typeof payload.scope === "string") result.scope = payload.scope;
-			if (typeof payload.aud === "string" || Array.isArray(payload.aud)) {
-				result.aud = payload.aud as string | string[];
-			}
-			if (familyId) result.familyId = familyId;
-			if (payload.act && typeof payload.act === "object" && !Array.isArray(payload.act)) {
-				result.act = payload.act as Record<string, unknown>;
-			}
-			return result;
 		},
 	};
 }

--- a/packages/oauth-token-exchange/src/validator/types.mts
+++ b/packages/oauth-token-exchange/src/validator/types.mts
@@ -20,7 +20,7 @@
  * - "actor":   the token of the party performing the exchange (`actor_token`)
  */
 export interface ExchangeTokenValidationContext {
-	role: "subject" | "actor";
+	readonly role: "subject" | "actor";
 }
 
 export interface ExchangeTokenValidator {
@@ -70,10 +70,10 @@ export interface ExchangeTokenValidator {
  *     preserves this when applicable (RFC 8693 §4.1).
  */
 export interface ValidatedToken {
-	sub: string;
-	scope?: string;
-	aud?: string | string[];
-	familyId?: string;
-	act?: Record<string, unknown>;
-	claims: Record<string, unknown>;
+	readonly sub: string;
+	readonly scope?: string;
+	readonly aud?: string | readonly string[];
+	readonly familyId?: string;
+	readonly act?: Readonly<Record<string, unknown>>;
+	readonly claims: Readonly<Record<string, unknown>>;
 }

--- a/packages/oauth-token-exchange/tsconfig.test.json
+++ b/packages/oauth-token-exchange/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": [
+		"src/validator/**/*.mts",
+		"src/__tests__/readonly-types.test.mts"
+	],
+	"exclude": ["node_modules", "dist"]
+}

--- a/packages/oauth-token-exchange/tsconfig.test.json
+++ b/packages/oauth-token-exchange/tsconfig.test.json
@@ -3,9 +3,6 @@
 	"compilerOptions": {
 		"noEmit": true
 	},
-	"include": [
-		"src/validator/**/*.mts",
-		"src/__tests__/readonly-types.test.mts"
-	],
+	"include": ["src/validator/**/*.mts", "src/__tests__/readonly-types.test.mts"],
 	"exclude": ["node_modules", "dist"]
 }

--- a/packages/oauth-token-exchange/vitest.config.mts
+++ b/packages/oauth-token-exchange/vitest.config.mts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/__tests__/**/*.test.mts"],
+		typecheck: {
+			enabled: true,
+			include: [
+				// CC-5 readonly compile-time contract tests. The @ts-expect-error
+				// directives in this file only fire under typecheck mode.
+				"src/__tests__/readonly-types.test.mts",
+			],
+			tsconfig: "./tsconfig.test.json",
+		},
+	},
+});


### PR DESCRIPTION
## Summary

- Make exported DTOs (`ValidatedToken`, `ExchangeTokenValidationContext`, `GrantContext`, `Client`, `User`, `CodeData`, `Code`) fully `readonly` so the public API surface stops promising a mutation contract callers should not rely on.
- Refactor `selfIssuedAccessToken.mts` from sequential mutable-builder to object-spread construction so the validator survives the new readonly contract.
- Wire compile-time `@ts-expect-error` contract tests into vitest typecheck so future regressions surface in CI.
- Closes CC-5 / AS-5 / AS-6 / AS-M2 (D-3 ADR JSDoc directive already satisfied in earlier F-series PR).

## Scope

- `packages/oauth-token-exchange/src/validator/types.mts`: `ValidatedToken` 6 fields readonly; `aud` is `readonly string[]`; `act` / `claims` are `Readonly<Record<string, unknown>>`. `ExchangeTokenValidationContext.role` readonly.
- `packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts`: lines 117-129 mutable-builder → object-spread.
- `packages/core/src/grants/types.mts`: `GrantContext` fields readonly. `session` is a readonly property (wholesale replacement rejected) but `SessionData` field-level writes still compile so Express `req.session` handlers keep working.
- `packages/core/src/repositories/types.mts`: `Client` array fields become `readonly string[]` (`.push` / element assignment rejected); `User` / `CodeData` / `Code` fields readonly. Picks up D-1 CC-1 + D-6 PB-2 additions with readonly applied.
- New compile-time contract tests under `__tests__/` for both packages, plus `tsconfig.test.json` + `vitest.config.mts` glue so the `@ts-expect-error` directives are enforced under typecheck mode.

## Migration

- Validator implementations using sequential `result.scope = …` builders must switch to object-spread.
- Code mutating `Client.allowedRedirectUris.push(…)` or assigning a new array directly fails to compile — use the repository create/upsert API to issue a fresh `Client`.
- No runtime behavior change. `readonly` is compile-time only; no `Object.freeze()` applied.

## Test plan

- [x] `pnpm -r run build` green
- [x] `pnpm -r run test` green (core 145 files / 1166 tests, oauth-token-exchange 7 / 94, all packages green; vitest reports `Type Errors: no errors`)
- [x] `pnpm -r exec tsc --noEmit` exit 0
- [x] `pnpm -w run lint` matches develop baseline (1 error / 18 warnings / 2 infos pre-existing on develop, none in CC-5 surface)
- [x] RED → GREEN verified: prior to readonly modifiers, `vitest --typecheck` flagged 20 `Unused '@ts-expect-error' directive` errors in the new contract tests; after applying readonly the same tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)