### PR TITLE
F9 PR2 — AS-1 + AS-2 error envelope unification (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Breaking (Phase F — F9 PR2 AS-1 + AS-2 error envelope unification, v0.5.1)
+
+- **All session and rate-limit error responses now use the RFC 6749 §5.2
+  `{error, error_description}` envelope** (`@o3co/auth-provider-core`,
+  `@o3co/auth-provider-session`, `@o3co/auth-provider-oauth`, closes AS-1
+  + AS-2): six historically divergent error responses migrate to a single
+  shape so consumer code can parse error bodies without per-route
+  branching. New `errorEnvelope(error, description?, uri?)` helper
+  exported from `@o3co/auth-provider-core` produces the canonical shape
+  and omits absent optional fields.
+
+| Site | Before | After |
+|---|---|---|
+| `Session.mts` CSRF origin mismatch (403) | `{message:"forbidden"}` | `{error:"access_denied", error_description}` |
+| `Session.mts` regenerate failure (500) | `{message:"Error regenerating session"}` | `{error:"server_error", error_description}` |
+| `Session.mts` logout failure (500) | `{message:"Error logging out"}` | `{error:"server_error", error_description}` |
+| `Federation.mts` unknown provider on start (404) | `{message:"NotFound"}` | `{error:"not_found", error_description}` |
+| `Federation.mts` unknown provider on callback (404) | `{message:"NotFound"}` | `{error:"not_found", error_description}` |
+| `oauth/routes.mts` rate-limit (429) | `{error:"rate_limited", reason}` | `{error:"rate_limited", error_description}` |
+
+#### Migration
+
+- Replace `body.message` checks with `body.error_description` for the five
+  session-router error responses, and replace `body.reason` with
+  `body.error_description` for `429 rate_limited`.
+- Replace `body.message === "forbidden"` with `body.error === "access_denied"`
+  on CSRF-origin failures, `body.message === "NotFound"` with
+  `body.error === "not_found"` on federation 404s, and the two 500-level
+  `{message:"Error …"}` shapes with `body.error === "server_error"`.
+- Consumer code building custom routes can import the helper as
+  `import { errorEnvelope } from "@o3co/auth-provider-core"` to keep the
+  shape consistent.
+- Success 200 responses on `/session/login` and `/session/logout`
+  (`{message:"Logged in successfully"}` / `{message:"Logged out successfully"}`)
+  are intentionally left unchanged — RFC 6749 §5.2 governs error response
+  shapes only.
+
 ### Breaking (Phase F — F9 PR1 CC-5 readonly Theme D, v0.5.1)
 
 - **Public DTOs are now fully `readonly`** (`@o3co/auth-provider-core`,

--- a/packages/core/src/__tests__/errors-envelope.test.mts
+++ b/packages/core/src/__tests__/errors-envelope.test.mts
@@ -47,4 +47,11 @@ describe("AS-1/AS-2 errorEnvelope helper (RFC 6749 §5.2)", () => {
 		const e = errorEnvelope("rate_limited", undefined);
 		expect(Object.keys(e).sort()).toEqual(["error"]);
 	});
+
+	it("treats empty-string description and uri as omissions", () => {
+		const e = errorEnvelope("rate_limited", "", "");
+		expect(e).toEqual({ error: "rate_limited" });
+		expect(e).not.toHaveProperty("error_description");
+		expect(e).not.toHaveProperty("error_uri");
+	});
 });

--- a/packages/core/src/__tests__/errors-envelope.test.mts
+++ b/packages/core/src/__tests__/errors-envelope.test.mts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { errorEnvelope } from "../errors/envelope.mjs";
+
+describe("AS-1/AS-2 errorEnvelope helper (RFC 6749 §5.2)", () => {
+	it("includes error_description and error_uri when provided", () => {
+		const e = errorEnvelope("invalid_grant", "Token expired", "https://docs.example.com");
+		expect(e).toEqual({
+			error: "invalid_grant",
+			error_description: "Token expired",
+			error_uri: "https://docs.example.com",
+		});
+	});
+
+	it("omits optional fields when undefined", () => {
+		const e = errorEnvelope("not_found");
+		expect(e).toEqual({ error: "not_found" });
+		expect(e).not.toHaveProperty("error_description");
+		expect(e).not.toHaveProperty("error_uri");
+	});
+
+	it("includes error_description without error_uri", () => {
+		const e = errorEnvelope("server_error", "Session regeneration failed");
+		expect(e).toEqual({
+			error: "server_error",
+			error_description: "Session regeneration failed",
+		});
+		expect(e).not.toHaveProperty("error_uri");
+	});
+
+	it("treats undefined description as omission, not as a present empty value", () => {
+		const e = errorEnvelope("rate_limited", undefined);
+		expect(Object.keys(e).sort()).toEqual(["error"]);
+	});
+});

--- a/packages/core/src/errors/envelope.mts
+++ b/packages/core/src/errors/envelope.mts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * RFC 6749 §5.2 error response envelope. Used across `/oauth/*` and the
+ * session router so consumer code can parse error responses with a single
+ * shape regardless of which surface produced them.
+ */
+export interface ErrorEnvelope {
+	readonly error: string;
+	readonly error_description?: string;
+	readonly error_uri?: string;
+}
+
+/**
+ * Construct an RFC 6749 §5.2 error envelope. Optional fields are omitted
+ * (rather than serialized as `undefined`) so JSON consumers see a clean
+ * shape — `JSON.stringify({ x: undefined })` does drop the key, but having
+ * the helper pre-omit keeps the in-memory object consistent for tests
+ * that snapshot the structure with `toEqual`.
+ *
+ * @param error       Machine-readable error code (snake_case, e.g. `invalid_grant`).
+ * @param description Optional human-readable detail.
+ * @param uri         Optional reference URL.
+ */
+export function errorEnvelope(error: string, description?: string, uri?: string): ErrorEnvelope {
+	return {
+		error,
+		...(description !== undefined ? { error_description: description } : {}),
+		...(uri !== undefined ? { error_uri: uri } : {}),
+	};
+}

--- a/packages/core/src/errors/envelope.mts
+++ b/packages/core/src/errors/envelope.mts
@@ -32,14 +32,25 @@ export interface ErrorEnvelope {
  * the helper pre-omit keeps the in-memory object consistent for tests
  * that snapshot the structure with `toEqual`.
  *
+ * Empty-string `description` / `uri` are treated as omissions: RFC 6749
+ * §5.2 specifies these as optional human-readable / URI fields, and an
+ * empty string conveys no information while still serializing as a
+ * present-but-empty value. Callers that need an explicit empty string
+ * should construct the envelope literal directly.
+ *
+ * Contract scope: the three RFC 6749 §5.2 stock fields only (`error`,
+ * `error_description`, `error_uri`). Extension fields (e.g. namespaced
+ * sub-codes, rate-limit details) are not added here — pass through a
+ * separate helper or a literal envelope object.
+ *
  * @param error       Machine-readable error code (snake_case, e.g. `invalid_grant`).
- * @param description Optional human-readable detail.
- * @param uri         Optional reference URL.
+ * @param description Optional human-readable detail. Empty string is dropped.
+ * @param uri         Optional reference URL. Empty string is dropped.
  */
 export function errorEnvelope(error: string, description?: string, uri?: string): ErrorEnvelope {
 	return {
 		error,
-		...(description !== undefined ? { error_description: description } : {}),
-		...(uri !== undefined ? { error_uri: uri } : {}),
+		...(description !== undefined && description !== "" ? { error_description: description } : {}),
+		...(uri !== undefined && uri !== "" ? { error_uri: uri } : {}),
 	};
 }

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -81,6 +81,10 @@ export {
 	composeConfigSchema,
 	fullSectionsSchema,
 } from "./config/application.schema.mjs";
+// AS-1/AS-2 RFC 6749 §5.2 shared error envelope. Consumer code that builds
+// custom routes outside the bundled session/oauth surfaces benefits from
+// the same helper so the entire auth product surface emits a single shape.
+export { type ErrorEnvelope, errorEnvelope } from "./errors/envelope.mjs";
 export {
 	createFederationTokenStoreFactory,
 	registerBuiltinFederationTokenStores,

--- a/packages/oauth/src/__tests__/hooks.test.mts
+++ b/packages/oauth/src/__tests__/hooks.test.mts
@@ -198,6 +198,10 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 
 			expect(res.status).toBe(429);
 			expect(res.body.error).toBe("rate_limited");
+			// AS-2: same envelope on this 429 path. Lock in the contract on the
+			// introspect surface too, otherwise drift on this branch goes silent.
+			expect(res.body.error_description).toBe("limit:introspect");
+			expect(res.body).not.toHaveProperty("reason");
 		});
 
 		it("fails open when rateLimiter.check throws and emits rate_limit.unavailable audit (CP-6)", async () => {

--- a/packages/oauth/src/__tests__/hooks.test.mts
+++ b/packages/oauth/src/__tests__/hooks.test.mts
@@ -159,7 +159,9 @@ describe("oauth routes — TODO-C hooks (Phase 1)", () => {
 
 			expect(res.status).toBe(429);
 			expect(res.body.error).toBe("rate_limited");
-			expect(res.body.reason).toBe("limit:token");
+			// AS-2: 429 body migrated from `{reason}` to RFC 6749 §5.2 `{error_description}`.
+			expect(res.body.error_description).toBe("limit:token");
+			expect(res.body).not.toHaveProperty("reason");
 			const retryAfter = Number(res.headers["retry-after"]);
 			expect(retryAfter).toBeGreaterThanOrEqual(29);
 		});

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -21,6 +21,7 @@ import {
 	type CodeRepository,
 	consoleLogger,
 	emitAuditEvent,
+	errorEnvelope,
 	type FederationProviderHandle,
 	type FederationTokenStoreBase,
 	formatObject,
@@ -192,7 +193,10 @@ export const createOAuthRouter = async (
 				const secs = Math.max(0, Math.ceil((decision.resetAt.getTime() - Date.now()) / 1000));
 				res.setHeader("Retry-After", String(secs));
 			}
-			res.status(429).json({ error: "rate_limited", reason: decision.reason });
+			// AS-2: rate-limit body migrated from `{error, reason}` to RFC 6749 §5.2
+			// `{error, error_description}` so all auth-product error responses share
+			// a single shape. `decision.reason` is the operator-visible cause string.
+			res.status(429).json(errorEnvelope("rate_limited", decision.reason ?? "Rate limit exceeded"));
 			return false;
 		}
 		return true;

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -196,7 +196,10 @@ export const createOAuthRouter = async (
 			// AS-2: rate-limit body migrated from `{error, reason}` to RFC 6749 §5.2
 			// `{error, error_description}` so all auth-product error responses share
 			// a single shape. `decision.reason` is the operator-visible cause string.
-			res.status(429).json(errorEnvelope("rate_limited", decision.reason ?? "Rate limit exceeded"));
+			// `||` (not `??`) so that `decision.reason: ""` from a custom rate
+			// limiter also falls back — the envelope helper would otherwise drop
+			// the empty string and produce a 429 response with no `error_description`.
+			res.status(429).json(errorEnvelope("rate_limited", decision.reason || "Rate limit exceeded"));
 			return false;
 		}
 		return true;

--- a/packages/session/src/routes/Federation.mts
+++ b/packages/session/src/routes/Federation.mts
@@ -17,6 +17,7 @@ import { randomBytes, randomUUID } from "node:crypto";
 import {
 	type AppConfig,
 	consoleLogger,
+	errorEnvelope,
 	type FederationTokenStoreBase,
 	type Logger,
 	type SessionFederationIndex,
@@ -100,7 +101,14 @@ export const createRouter = (
 		.get("/oauth/federation/:name", async (req: Request, res: Response) => {
 			const provider = federationProviders.get(String(req.params.name));
 			if (!provider) {
-				return res.status(404).json({ message: "NotFound" });
+				return res
+					.status(404)
+					.json(
+						errorEnvelope(
+							"not_found",
+							`Federation provider not registered: ${String(req.params.name)}`,
+						),
+					);
 			}
 
 			const { redirect_to } = req.query;
@@ -192,7 +200,14 @@ export const createRouter = (
 		.get("/oauth/federation/:name/callback", async (req: Request, res: Response) => {
 			const provider = federationProviders.get(String(req.params.name));
 			if (!provider) {
-				return res.status(404).json({ message: "NotFound" });
+				return res
+					.status(404)
+					.json(
+						errorEnvelope(
+							"not_found",
+							`Federation provider not registered: ${String(req.params.name)}`,
+						),
+					);
 			}
 
 			// Per-handler logger child carrying the provider binding. After

--- a/packages/session/src/routes/Session.mts
+++ b/packages/session/src/routes/Session.mts
@@ -18,6 +18,7 @@ import { randomUUID } from "node:crypto";
 import {
 	type AppConfig,
 	consoleLogger,
+	errorEnvelope,
 	type Logger,
 	type User,
 	type UserRepository,
@@ -71,7 +72,7 @@ export const createRouter = (
 		}
 		const serverOrigin = `${req.protocol}://${req.get("host")}`;
 		if (origin !== serverOrigin && !allowedOrigins.includes(origin)) {
-			res.status(403).json({ message: "forbidden" });
+			res.status(403).json(errorEnvelope("access_denied", "CSRF origin check failed"));
 			return;
 		}
 		next();
@@ -200,7 +201,9 @@ export const createRouter = (
 								/* best-effort cleanup */
 							});
 						}
-						return res.status(500).json({ message: "Error regenerating session" });
+						return res
+							.status(500)
+							.json(errorEnvelope("server_error", "Session regeneration failed"));
 					}
 					req.session.isAuthenticated = true;
 					req.session.user = user as Record<string, unknown> | undefined;
@@ -218,7 +221,7 @@ export const createRouter = (
 		.post("/logout", verifyCsrfOrigin, (req: Request, res: Response) => {
 			req.session.destroy((err: Error | null) => {
 				if (err) {
-					return res.status(500).json({ message: "Error logging out" });
+					return res.status(500).json(errorEnvelope("server_error", "Session destroy failed"));
 				}
 				return res.status(200).json({ message: "Logged out successfully" });
 			});

--- a/packages/session/src/routes/__tests__/Federation.test.mts
+++ b/packages/session/src/routes/__tests__/Federation.test.mts
@@ -445,6 +445,19 @@ describe("Federation routes", () => {
 			expect(res.status).toBe(404);
 		});
 
+		// AS-1 RFC 6749 §5.2 envelope: 404 body shape migrates from {message:"NotFound"}
+		// to {error:"not_found", error_description}.
+		it("AS-1: 404 unknown provider returns RFC 6749 envelope (no `message`)", async () => {
+			const app = buildStatelessApp({ providers: new Map([["test", makeFakeProvider()]]) });
+			const res = await request(app).get("/oauth/federation/unknown");
+			expect(res.status).toBe(404);
+			expect(res.body).toMatchObject({
+				error: "not_found",
+				error_description: expect.any(String),
+			});
+			expect(res.body).not.toHaveProperty("message");
+		});
+
 		// Test 2
 		it("redirects with state + code_challenge + code_challenge_method=S256 in Location", async () => {
 			const provider = makeFakeProvider();
@@ -862,6 +875,18 @@ describe("Federation routes", () => {
 			const app = buildStatelessApp({ providers: new Map([["test", makeFakeProvider()]]) });
 			const res = await request(app).get("/oauth/federation/unknown/callback?state=x&code=y");
 			expect(res.status).toBe(404);
+		});
+
+		// AS-1 RFC 6749 §5.2 envelope: callback 404 body shape migrates same as start.
+		it("AS-1: 404 unknown provider on callback returns RFC 6749 envelope (no `message`)", async () => {
+			const app = buildStatelessApp({ providers: new Map([["test", makeFakeProvider()]]) });
+			const res = await request(app).get("/oauth/federation/unknown/callback?state=x&code=y");
+			expect(res.status).toBe(404);
+			expect(res.body).toMatchObject({
+				error: "not_found",
+				error_description: expect.any(String),
+			});
+			expect(res.body).not.toHaveProperty("message");
 		});
 
 		// Fix 1 — session fixation: regenerate is called; new session has correct sid/isAuthenticated/user

--- a/packages/session/src/routes/__tests__/Session.test.mts
+++ b/packages/session/src/routes/__tests__/Session.test.mts
@@ -61,6 +61,9 @@ function buildApp(
 		userRepository?: UserRepository;
 		userSessionStore?: UserSessionStore;
 		sessionTtlMs?: number;
+		regenerateError?: Error;
+		destroyError?: Error;
+		config?: AppConfig;
 	} = {},
 ) {
 	const {
@@ -74,25 +77,42 @@ function buildApp(
 		} as unknown as UserRepository,
 		userSessionStore,
 		sessionTtlMs,
+		regenerateError,
+		destroyError,
+		config = stubConfig,
 	} = opts;
 
 	const app = express();
 
-	// Minimal express-session stub so req.session.regenerate / req.session.sid work
+	// Minimal express-session stub so req.session.regenerate / destroy / save work.
+	// regenerateError/destroyError opt-ins simulate session-store failures so tests
+	// can drive the AS-1 500 server_error envelope paths.
 	app.use((req, _res, next) => {
 		const sessionData: Record<string, unknown> = {};
 		(req as unknown as { session: Record<string, unknown> }).session = {
 			...sessionData,
-			regenerate(cb: (err: null) => void) {
+			regenerate(cb: (err: Error | null) => void) {
+				if (regenerateError) {
+					cb(regenerateError);
+					return;
+				}
 				// After regenerate, session data is reset — mirror real express-session behaviour.
 				const fresh: Record<string, unknown> = {
 					regenerate: this.regenerate,
 					save: this.save,
+					destroy: this.destroy,
 				};
 				Object.assign(req as unknown as { session: Record<string, unknown> }, { session: fresh });
 				cb(null);
 			},
 			save(cb: (err: null) => void) {
+				cb(null);
+			},
+			destroy(cb: (err: Error | null) => void) {
+				if (destroyError) {
+					cb(destroyError);
+					return;
+				}
 				cb(null);
 			},
 		};
@@ -101,7 +121,7 @@ function buildApp(
 
 	const router = createRouter(express, {
 		userRepository,
-		config: stubConfig,
+		config,
 		...(userSessionStore !== undefined ? { userSessionStore } : {}),
 		...(sessionTtlMs !== undefined ? { sessionTtlMs } : {}),
 	});
@@ -345,6 +365,67 @@ describe("Session routes — POST /session/login", () => {
 
 			expect(res.status).toBe(400);
 			expect(res.body).toMatchObject({ error: "invalid_redirect" });
+		});
+	});
+
+	// AS-1 RFC 6749 §5.2 envelope unification — the 3 historically `{message: …}`
+	// error responses on this router migrate to `{error, error_description}`.
+	describe("AS-1: RFC 6749 §5.2 error envelope", () => {
+		it("CSRF origin mismatch returns 403 access_denied with error_description (no `message`)", async () => {
+			const { app } = buildApp({
+				config: {
+					...stubConfig,
+					cors: { allowedOrigins: ["https://app.example.com"] },
+				} as AppConfig,
+			});
+
+			const res = await request(app)
+				.post("/session/login")
+				.set("Origin", "https://evil.example.com")
+				.set("Content-Type", "application/x-www-form-urlencoded")
+				.send("username=alice&password=secret");
+
+			expect(res.status).toBe(403);
+			expect(res.body).toMatchObject({
+				error: "access_denied",
+				error_description: expect.any(String),
+			});
+			expect(res.body).not.toHaveProperty("message");
+		});
+
+		it("session regeneration failure returns 500 server_error envelope (no `message`)", async () => {
+			const { app } = buildApp({
+				userSessionStore: makeUserSessionStore(),
+				sessionTtlMs: 3600_000,
+				regenerateError: new Error("regenerate failed"),
+			});
+
+			const res = await request(app)
+				.post("/session/login")
+				.send("username=alice&password=secret")
+				.set("Content-Type", "application/x-www-form-urlencoded");
+
+			expect(res.status).toBe(500);
+			expect(res.body).toMatchObject({
+				error: "server_error",
+				error_description: expect.any(String),
+			});
+			expect(res.body).not.toHaveProperty("message");
+		});
+
+		it("logout session destroy failure returns 500 server_error envelope (no `message`)", async () => {
+			const { app } = buildApp({
+				destroyError: new Error("destroy failed"),
+			});
+
+			const res = await request(app).post("/session/logout");
+
+			expect(res.status).toBe(500);
+			expect(res.body).toMatchObject({
+				error: "server_error",
+				error_description: expect.any(String),
+			});
+			expect(res.body).not.toHaveProperty("message");
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Migrate 6 historically divergent error responses (3 Session, 2 Federation, 1 rate-limit) to the RFC 6749 §5.2 envelope `{error, error_description, error_uri?}` so consumer error parsing has a single shape across the auth-product surface.
- Add `errorEnvelope(error, description?, uri?)` helper in `@o3co/auth-provider-core` (`packages/core/src/errors/envelope.mts`) that omits absent optional fields.
- Closes AS-1 (SF) + AS-2 (SF).

## Migrations (BREAKING)

| Site | Before | After |
|---|---|---|
| `Session.mts` CSRF origin (403) | `{message:"forbidden"}` | `{error:"access_denied", error_description}` |
| `Session.mts` regenerate (500) | `{message:"Error regenerating session"}` | `{error:"server_error", error_description}` |
| `Session.mts` destroy (500) | `{message:"Error logging out"}` | `{error:"server_error", error_description}` |
| `Federation.mts` unknown provider start (404) | `{message:"NotFound"}` | `{error:"not_found", error_description}` |
| `Federation.mts` unknown provider callback (404) | `{message:"NotFound"}` | `{error:"not_found", error_description}` |
| `oauth/routes.mts` rate-limit (429) | `{error:"rate_limited", reason}` | `{error:"rate_limited", error_description}` |

Success 200 responses on `/session/login` / `/session/logout` are unchanged — RFC 6749 §5.2 governs error responses only.

## Test plan

- [x] `pnpm -r run build` green
- [x] `pnpm -r run test` green (core 146 / 1170, session 20 / 160, oauth 19 / 384, all packages green; vitest reports `Type Errors: no errors`)
- [x] `pnpm -r exec tsc --noEmit` exit 0
- [x] `pnpm exec biome check --max-diagnostics=200 ...` clean for the diff (warnings/infos pre-existing on develop, none introduced by the PR)
- [x] RED → GREEN verified: prior to the helper + site migrations, the 9 new/migrated assertions failed (5 session AS-1 site assertions + 1 oauth `error_description` migration + helper module-not-found); after the GREEN diff all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)