### PR TITLE
F9 PR6 — AS-M1 contributes-map concrete-type substitution (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Improved (Phase F — F9 PR6 AS-M1 contributes-map concrete-type substitution, v0.5.1)
+
+- **The four same-package contributes-map placeholders are now concrete
+  types instead of `unknown`** (`@o3co/auth-provider-core/modules/manifest`,
+  closes AS-M1):
+
+  | Manifest type | Pre-v0.5.1 | v0.5.1 (substituted) |
+  |---|---|---|
+  | `GrantHandler` | `unknown` | `GrantHandler` from `grants/types.mts` |
+  | `AuditHook` | `unknown` | `AuditSink` (canonical alias of `AuditSinkBase`) |
+  | `MfaFactor` | `unknown` | `MfaProvider` (canonical alias of `MfaProviderBase`) |
+  | `GrantPolicyHookContribution` | `unknown` | `GrantPolicyHook` (canonical alias of `GrantPolicyHookBase`) |
+
+  Module authors now get real type-checking on contribution factory
+  return values — a typo or shape mismatch in
+  `contributes.grants["x"] = (deps) => myHandler` is caught at compile
+  time instead of at runtime when the boot pipeline invokes the factory.
+
+#### Cross-package types still deferred
+
+- `FederationProvider` and `ExchangeTokenValidator` remain `unknown`
+  pending Phase F resolution of a circular package import (`session`
+  and `oauth-token-exchange` are downstream of `core`, so importing
+  their concrete types from the manifest would create a package-level
+  cycle). A new typecheck assertion in
+  `packages/core/src/__tests__/contributes-map-substitution.test.mts`
+  pins both as `unknown` so any premature substitution is caught.
+
+#### Compatibility scope
+
+- **Public direction (additive)**: consumers passing concrete factory
+  return values into the manifest get tighter type checking. No code
+  change required for code that was already returning concrete types.
+- **Test scaffolding (breaking-internal)**: the boot-pipeline tests in
+  `packages/core/src/boot/__tests__/{apply-contributions, plan-boot,
+  integration}.test.mts` were written against the `unknown` placeholder
+  and used inline literals or `as unknown` casts that no longer satisfy
+  the narrowed types. v0.5.1 migrates these fixtures to typed `fakeGrantHandler` /
+  `fakeAuditSink` factories; downstream consumers who copied this
+  pattern will need similar updates.
+
+#### Internal: collector factory generic-ification
+
+- `mergeWithBuiltins` in `packages/core/src/boot/create-app.mts` now
+  parameterises its three built-in collector factories
+  (`makeGrantCollector`, `makeMapNameKeyedCollector<T>`,
+  `makeIdentityDedupListCollector<T>`) so they produce typed collectors
+  matching the narrowed contributes-map slots. Internal-only; no public
+  API change.
+
 ### Added (Phase F — F9 PR5 AS-9 Redis session sub-adapter builders, v0.5.1)
 
 - **Four new `*Builder` exports complete the tripartite

--- a/packages/core/src/__tests__/contributes-map-substitution.test.mts
+++ b/packages/core/src/__tests__/contributes-map-substitution.test.mts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { AuditSink } from "../audit/types.mjs";
+import type { GrantHandler as ConcreteGrantHandler } from "../grants/types.mjs";
+import type { MfaProvider } from "../mfa/types.mjs";
+import type {
+	AuditHook,
+	ExchangeTokenValidator,
+	FederationProvider,
+	GrantHandler,
+	GrantPolicyHookContribution,
+	MfaFactor,
+} from "../modules/manifest/contributes-map.mjs";
+import type { GrantPolicyHook } from "../policy/types.mjs";
+
+// AS-M1 (Phase F F9 PR6 / Phase 9 substitution): the four `unknown`
+// placeholder types in `modules/manifest/contributes-map.mts` whose concrete
+// implementations live in the same `core` package have been substituted
+// with their concrete types. Cross-package types (`FederationProvider` from
+// `session`, `ExchangeTokenValidator` from `oauth-token-exchange`) remain
+// `unknown` pending Phase F resolution of the circular-import concern —
+// this is intentional and pinned by the second describe block below so
+// that any premature substitution of those two is caught.
+
+describe("AS-M1: same-package concrete substitutions in contributes-map", () => {
+	it("GrantHandler is the concrete grants/types GrantHandler", () => {
+		expectTypeOf<GrantHandler>().toEqualTypeOf<ConcreteGrantHandler>();
+		expect(true).toBe(true);
+	});
+
+	it("AuditHook is the canonical AuditSink (alias of AuditSinkBase)", () => {
+		expectTypeOf<AuditHook>().toEqualTypeOf<AuditSink>();
+		expect(true).toBe(true);
+	});
+
+	it("MfaFactor is the canonical MfaProvider (alias of MfaProviderBase)", () => {
+		expectTypeOf<MfaFactor>().toEqualTypeOf<MfaProvider>();
+		expect(true).toBe(true);
+	});
+
+	it("GrantPolicyHookContribution is the canonical GrantPolicyHook (alias of GrantPolicyHookBase)", () => {
+		// Replaces the `= unknown` pin asserted in `naming-aliases.test.mts`
+		// during AS-7 (PR3); that test's deliberate intent was that this
+		// assertion would fail when Phase 9 substitution lands and would be
+		// updated alongside the substitution work. PR6 IS that substitution.
+		expectTypeOf<GrantPolicyHookContribution>().toEqualTypeOf<GrantPolicyHook>();
+		expect(true).toBe(true);
+	});
+});
+
+describe("AS-M1: cross-package types still deferred to Phase F", () => {
+	// Per spec (`auth/.claude/superpowers/specs/2026-05-05-as-export-pattern-batch.md`
+	// lines 197-199): substituting `FederationProvider` (session package)
+	// and `ExchangeTokenValidator` (oauth-token-exchange package) requires
+	// resolving a circular package-import concern. The pragmatic v0.5.1
+	// resolution leaves these two as `unknown`. These pins fail-closed if
+	// a future PR substitutes them without the documented cross-package
+	// mechanism.
+
+	it("FederationProvider is still `unknown` (Phase F deferral)", () => {
+		expectTypeOf<FederationProvider>().toEqualTypeOf<unknown>();
+		expect(true).toBe(true);
+	});
+
+	it("ExchangeTokenValidator is still `unknown` (Phase F deferral)", () => {
+		expectTypeOf<ExchangeTokenValidator>().toEqualTypeOf<unknown>();
+		expect(true).toBe(true);
+	});
+});

--- a/packages/core/src/__tests__/naming-aliases.test.mts
+++ b/packages/core/src/__tests__/naming-aliases.test.mts
@@ -21,7 +21,6 @@ import type {
 	FederationTokenStoreBase,
 } from "../federation-tokens/types.mjs";
 import type { MfaProvider, MfaProviderBase } from "../mfa/types.mjs";
-import type { GrantPolicyHookContribution } from "../modules/manifest/contributes-map.mjs";
 import type { GrantPolicyHook, GrantPolicyHookBase } from "../policy/types.mjs";
 import type { RateLimiter, RateLimiterBase } from "../ratelimit/types.mjs";
 
@@ -56,23 +55,7 @@ describe("AS-7: deprecation aliases for *Base interfaces", () => {
 	});
 });
 
-// AS-7 collision resolution: the manifest's contributes-map placeholder
-// previously named `GrantPolicyHook` is renamed to
-// `GrantPolicyHookContribution`. The new `GrantPolicyHook` (from policy)
-// must NOT be assignable to / from `unknown` trivially — i.e. the
-// `unknown` placeholder semantics belong to `GrantPolicyHookContribution`.
-
-describe("AS-7 collision: GrantPolicyHook (policy) vs GrantPolicyHookContribution (manifest)", () => {
-	it("GrantPolicyHookContribution is the renamed manifest placeholder (still `unknown`)", () => {
-		// Type-only assertion: if the manifest-side rename ever regresses
-		// (someone reverts the placeholder back to `GrantPolicyHook`), the
-		// type-import above fails resolution and this test breaks at
-		// typecheck. The `expectTypeOf<X>().toEqualTypeOf<unknown>()` pins
-		// the placeholder semantics — Phase 9 substitution will replace
-		// `unknown` with the concrete contribution type at which point this
-		// assertion intentionally fails and must be updated alongside the
-		// substitution work.
-		expectTypeOf<GrantPolicyHookContribution>().toEqualTypeOf<unknown>();
-		expect(true).toBe(true);
-	});
-});
+// Note: the AS-7 collision resolution from PR3 introduced
+// `GrantPolicyHookContribution` (the renamed manifest placeholder). Its
+// type-equivalence assertion lives in `contributes-map-substitution.test.mts`
+// alongside the AS-M1 substitution checks (PR6 / Phase 9 substitution work).

--- a/packages/core/src/boot/__tests__/apply-contributions.test.mts
+++ b/packages/core/src/boot/__tests__/apply-contributions.test.mts
@@ -41,17 +41,22 @@ import { validateManifests } from "../validate-manifests.mjs";
 // the slot contracts. The boot-pipeline tests verify routing behaviour
 // (registration order, collector dedup, factory error wrapping), not
 // contract semantics, so these stubs are intentionally no-op. Tests that
-// assert value identity construct typed instances directly (e.g.
-// `const sharedHook: AuditSink = { ... }`) rather than going through these
-// helpers.
+// need value-identity (`expect(...).toBe(stub)`) capture the helper output
+// once into a typed `const sharedHook: AuditSink = fakeAuditSink(...)` and
+// reuse the reference inside factory closures (`() => sharedHook`).
 // ---------------------------------------------------------------------------
 
+// `tag` is propagated into `GrantSuccess.tokens.access_token` so spy
+// collectors that record values can distinguish stub instances. The shape
+// matches `GrantSuccess` (the success arm of `GrantResult`) — `status: 200`
+// + a minimal `TokenResponse`. Pipeline tests don't exercise the result
+// downstream, so the rest of `TokenResponse` is filled with `as never`.
 const fakeGrantHandler = (tag = "stub"): GrantHandler => ({
 	handle: async () => ({
-		// `as never` justified: stubs are never invoked; the boot-pipeline
-		// tests only check registration/dedup. The concrete `GrantResult` /
-		// `SessionMutation` shapes are exercised by the grants-package tests.
-		result: { kind: "success", access_token: tag } as never,
+		result: {
+			status: 200,
+			tokens: { access_token: tag } as never,
+		},
 	}),
 });
 

--- a/packages/core/src/boot/__tests__/apply-contributions.test.mts
+++ b/packages/core/src/boot/__tests__/apply-contributions.test.mts
@@ -15,6 +15,8 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
+import type { AuditSink } from "../../audit/types.mjs";
+import type { GrantHandler } from "../../grants/types.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
 import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { applyContributions } from "../apply-contributions.mjs";
@@ -25,9 +27,38 @@ import type {
 	CollectedRouteContribution,
 	ComponentWorld,
 	ContributionCollectorMap,
+	ListCollector,
+	NameKeyedCollector,
 } from "../types.mjs";
 import { BootError } from "../types.mjs";
 import { validateManifests } from "../validate-manifests.mjs";
+
+// ---------------------------------------------------------------------------
+// AS-M1 (Phase F F9 PR6): minimal typed fixtures. The contributes-map
+// placeholders for `GrantHandler`, `AuditHook`, `MfaFactor`, and
+// `GrantPolicyHookContribution` were narrowed from `unknown` to concrete
+// same-package types in v0.5.1, so inline-literal stubs no longer satisfy
+// the slot contracts. The boot-pipeline tests verify routing behaviour
+// (registration order, collector dedup, factory error wrapping), not
+// contract semantics, so these stubs are intentionally no-op. Tests that
+// assert value identity construct typed instances directly (e.g.
+// `const sharedHook: AuditSink = { ... }`) rather than going through these
+// helpers.
+// ---------------------------------------------------------------------------
+
+const fakeGrantHandler = (tag = "stub"): GrantHandler => ({
+	handle: async () => ({
+		// `as never` justified: stubs are never invoked; the boot-pipeline
+		// tests only check registration/dedup. The concrete `GrantResult` /
+		// `SessionMutation` shapes are exercised by the grants-package tests.
+		result: { kind: "success", access_token: tag } as never,
+	}),
+});
+
+const fakeAuditSink = (tag = "stub"): AuditSink => ({
+	kind: tag,
+	record: async () => {},
+});
 
 // ---------------------------------------------------------------------------
 // Test-only ComponentMap slot augmentation
@@ -117,7 +148,7 @@ function stubHandler(): never {
 
 describe("applyContributions — step 0: synthetic projections", () => {
 	it("grants provided → grantHandlerResolver is defined in component map; lazy read-through works after step 2", async () => {
-		const grantCollector = makeStubNameCollector<unknown>();
+		const grantCollector = makeStubNameCollector<GrantHandler>();
 		const contributionKinds: ContributionCollectorMap = {
 			grants: grantCollector,
 		};
@@ -126,7 +157,7 @@ describe("applyContributions — step 0: synthetic projections", () => {
 			name: "ModA",
 			contributes: {
 				grants: {
-					authorization_code: () => ({ type: "grant" }),
+					authorization_code: () => fakeGrantHandler("authcode"),
 				},
 			},
 		});
@@ -162,14 +193,14 @@ describe("applyContributions — step 2: register order = initOrder", () => {
 	it("2 modules contributing different grants: register call order matches initOrder", async () => {
 		const registerOrder: string[] = [];
 
-		const spyCollector = {
+		const spyCollector: NameKeyedCollector<GrantHandler> = {
 			kind: "name-keyed" as const,
-			register: (n: string, _v: unknown) => {
+			register: (n: string, _v: GrantHandler) => {
 				registerOrder.push(n);
 			},
-			replace: (_n: string, _v: unknown) => {},
+			replace: (_n: string, _v: GrantHandler) => {},
 			get: (_n: string) => undefined,
-			entries: () => new Map<string, unknown>().entries(),
+			entries: () => new Map<string, GrantHandler>().entries(),
 		};
 
 		const contributionKinds: ContributionCollectorMap = {
@@ -184,7 +215,7 @@ describe("applyContributions — step 2: register order = initOrder", () => {
 				slotAC: () => 1,
 			},
 			contributes: {
-				grants: { grant_a: () => "handlerA" as unknown },
+				grants: { grant_a: () => fakeGrantHandler("a") },
 			},
 		});
 
@@ -192,7 +223,7 @@ describe("applyContributions — step 2: register order = initOrder", () => {
 			name: "ModB",
 			requires: ["slotAC"] as const,
 			contributes: {
-				grants: { grant_b: () => "handlerB" as unknown },
+				grants: { grant_b: () => fakeGrantHandler("b") },
 			},
 		});
 
@@ -213,13 +244,16 @@ describe("applyContributions — step 3: append order = input-array order", () =
 	it("append order for auditHooks matches input array order, not initOrder", async () => {
 		const appendOrder: string[] = [];
 
-		// Spy collector that records which hook's tag was appended
-		const auditCollector = {
+		// Spy collector that records which hook's `kind` was appended.
+		// Pre-AS-M1 the synthetic stubs used a `tag` field; after the
+		// AuditHook narrowing the stubs are real `AuditSink`s so we read
+		// from `kind` (the discriminant on `AuditSinkBase`).
+		const auditCollector: ListCollector<AuditSink> = {
 			kind: "list" as const,
-			append: (v: unknown) => {
-				appendOrder.push((v as { tag: string }).tag);
+			append: (v: AuditSink) => {
+				appendOrder.push(v.kind);
 			},
-			values: () => ([] as unknown[]).values(),
+			values: () => ([] as AuditSink[]).values(),
 		};
 
 		const contributionKinds: ContributionCollectorMap = {
@@ -232,7 +266,7 @@ describe("applyContributions — step 3: append order = input-array order", () =
 			name: "ModA",
 			requires: ["slotAC"] as const,
 			contributes: {
-				auditHooks: [() => ({ tag: "hook_a" }) as unknown],
+				auditHooks: [() => fakeAuditSink("hook_a")],
 			},
 		});
 
@@ -242,7 +276,7 @@ describe("applyContributions — step 3: append order = input-array order", () =
 				slotAC: () => 42,
 			},
 			contributes: {
-				auditHooks: [() => ({ tag: "hook_b" }) as unknown],
+				auditHooks: [() => fakeAuditSink("hook_b")],
 			},
 		});
 
@@ -302,7 +336,7 @@ describe("applyContributions — step 3: bare RouteContribution value entries", 
 
 describe("applyContributions — step 2: factory throw wraps as BootError", () => {
 	it("cause === thrown (reference equality), details.module/kind/name/originalError correct", async () => {
-		const grantCollector = makeStubNameCollector<unknown>();
+		const grantCollector = makeStubNameCollector<GrantHandler>();
 		const contributionKinds: ContributionCollectorMap = { grants: grantCollector };
 
 		const thrown = new Error("factory exploded");
@@ -345,18 +379,23 @@ describe("applyContributions — step 2: factory throw wraps as BootError", () =
 
 describe("applyContributions — step 2: pre-scan prevents factory side-effect leak", () => {
 	it("if the second grant name of a module is already registered, no factory runs", async () => {
-		const spy1 = vi.fn(() => "handler1");
-		const spy2 = vi.fn(() => "handler2");
+		const spy1 = vi.fn((): GrantHandler => fakeGrantHandler("handler1"));
+		const spy2 = vi.fn((): GrantHandler => fakeGrantHandler("handler2"));
 
-		// Pre-populate the collector with "grant_conflict" so it already exists
-		const m = new Map<string, unknown>([["grant_conflict", "existing"]]);
-		const spyCollector = {
+		// Pre-populate the collector with "grant_conflict" so it already exists.
+		// `as unknown as GrantHandler` on the existing entry: the pre-scan
+		// path checks NAME presence (collector.entries()), not value shape;
+		// the placeholder string is never invoked.
+		const m = new Map<string, GrantHandler>([
+			["grant_conflict", "existing" as unknown as GrantHandler],
+		]);
+		const spyCollector: NameKeyedCollector<GrantHandler> = {
 			kind: "name-keyed" as const,
-			register: (n: string, v: unknown) => {
+			register: (n: string, v: GrantHandler) => {
 				if (m.has(n)) throw new Error(`already ${n}`);
 				m.set(n, v);
 			},
-			replace: (_n: string, _v: unknown) => {},
+			replace: (_n: string, _v: GrantHandler) => {},
 			get: (n: string) => m.get(n),
 			entries: () => m.entries(),
 		};
@@ -394,19 +433,19 @@ describe("applyContributions — step 2: pre-scan prevents factory side-effect l
 
 describe("applyContributions — step 2: overrides routed via collector.replace", () => {
 	it("override factory result is passed to collector.replace, not register", async () => {
-		const registerCalls: Array<[string, unknown]> = [];
-		const replaceCalls: Array<[string, unknown]> = [];
+		const registerCalls: Array<[string, GrantHandler]> = [];
+		const replaceCalls: Array<[string, GrantHandler]> = [];
 
 		// Collector whose internal map is mutated by both register and replace.
-		const m = new Map<string, unknown>();
-		const spyCollector = {
+		const m = new Map<string, GrantHandler>();
+		const spyCollector: NameKeyedCollector<GrantHandler> = {
 			kind: "name-keyed" as const,
-			register: (n: string, v: unknown) => {
+			register: (n: string, v: GrantHandler) => {
 				if (m.has(n)) throw new Error(`already registered: ${n}`);
 				m.set(n, v);
 				registerCalls.push([n, v]);
 			},
-			replace: (n: string, v: unknown) => {
+			replace: (n: string, v: GrantHandler) => {
 				if (!m.has(n)) throw new Error(`unknown: ${n}`);
 				m.set(n, v);
 				replaceCalls.push([n, v]);
@@ -417,20 +456,23 @@ describe("applyContributions — step 2: overrides routed via collector.replace"
 
 		const contributionKinds: ContributionCollectorMap = { grants: spyCollector };
 
-		const overrideValue = { type: "override_handler" };
+		// Typed instance for the identity-equality assertion at line 481.
+		// Pre-AS-M1 this was `{ type: "override_handler" }` (cast `as unknown`);
+		// post-narrow we construct a real `GrantHandler`.
+		const overrideValue: GrantHandler = fakeGrantHandler("override");
 
 		// ModA contributes base_grant via register; ModB overrides it via replace.
 		const modA = defineModule({
 			name: "ModA",
 			contributes: {
-				grants: { base_grant: () => "base_handler" as unknown },
+				grants: { base_grant: () => fakeGrantHandler("base") },
 			},
 		});
 
 		const modB = defineModule({
 			name: "ModB",
 			overrides: {
-				grants: { base_grant: () => overrideValue as unknown },
+				grants: { base_grant: () => overrideValue },
 			},
 		});
 
@@ -454,24 +496,25 @@ describe("applyContributions — step 2: overrides routed via collector.replace"
 
 describe("applyContributions — step 3: auditHooks same-instance dedup", () => {
 	it("two modules contributing the same hook reference: append called twice but collector dedupes", async () => {
-		const auditCollector = makeStubListCollector<unknown>();
+		const auditCollector = makeStubListCollector<AuditSink>();
 		const appendSpy = vi.spyOn(auditCollector, "append");
 
 		const contributionKinds: ContributionCollectorMap = { auditHooks: auditCollector };
 
-		const sharedHook = { type: "shared_hook" };
+		// Typed instance for the identity-equality assertion at line 521.
+		const sharedHook: AuditSink = fakeAuditSink("shared_hook");
 
 		const modA = defineModule({
 			name: "ModA",
 			contributes: {
-				auditHooks: [() => sharedHook as unknown],
+				auditHooks: [() => sharedHook],
 			},
 		});
 
 		const modB = defineModule({
 			name: "ModB",
 			contributes: {
-				auditHooks: [() => sharedHook as unknown],
+				auditHooks: [() => sharedHook],
 			},
 		});
 
@@ -507,7 +550,7 @@ describe("applyContributions — defence-in-depth: missing required dep", () => 
 			requires: ["slotAC"] as never,
 			contributes: {
 				grants: {
-					my_grant: () => ({ type: "grant" }),
+					my_grant: () => fakeGrantHandler("my_grant"),
 				},
 			},
 		});

--- a/packages/core/src/boot/__tests__/integration.test.mts
+++ b/packages/core/src/boot/__tests__/integration.test.mts
@@ -37,11 +37,20 @@ import type { BootstrapMap } from "../types.mjs";
 import { BootError } from "../types.mjs";
 
 // AS-M1 (Phase F F9 PR6): typed GrantHandler stub for the grants
-// contributions. Pre-AS-M1 inline literal `{ grantType: ... }` worked
-// because the contributes-map placeholder was `unknown`; post-narrow
-// it must satisfy `GrantHandler` (handle / cleanup interface).
+// contributions. Pre-AS-M1 the inline literal `{ grantType: ... }` worked
+// because the contributes-map placeholder was `unknown`; post-narrow it
+// must satisfy `GrantHandler` (handle / cleanup interface). The result
+// shape mirrors `GrantSuccess` — `status: 200` + a minimal `TokenResponse`
+// with `tag` in `access_token` so pipeline assertions can distinguish
+// stubs. The handler is never invoked; the rest of `TokenResponse` is
+// filled with `as never`.
 const fakeGrantHandler = (tag = "stub"): GrantHandler => ({
-	handle: async () => ({ result: { kind: "success", access_token: tag } as never }),
+	handle: async () => ({
+		result: {
+			status: 200,
+			tokens: { access_token: tag } as never,
+		},
+	}),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/boot/__tests__/integration.test.mts
+++ b/packages/core/src/boot/__tests__/integration.test.mts
@@ -29,11 +29,20 @@
 
 import { Router } from "express";
 import { describe, expect, it } from "vitest";
+import type { GrantHandler } from "../../grants/types.mjs";
 import { createApp } from "../../index.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
 import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import type { BootstrapMap } from "../types.mjs";
 import { BootError } from "../types.mjs";
+
+// AS-M1 (Phase F F9 PR6): typed GrantHandler stub for the grants
+// contributions. Pre-AS-M1 inline literal `{ grantType: ... }` worked
+// because the contributes-map placeholder was `unknown`; post-narrow
+// it must satisfy `GrantHandler` (handle / cleanup interface).
+const fakeGrantHandler = (tag = "stub"): GrantHandler => ({
+	handle: async () => ({ result: { kind: "success", access_token: tag } as never }),
+});
 
 // ---------------------------------------------------------------------------
 // Test-only ComponentMap augmentation
@@ -135,7 +144,7 @@ describe("integration — Scenario 1: happy boot of a multi-module manifest", ()
 			requires: ["keyStore", "clientRepository", "codeRepository", "userRepository"],
 			contributes: {
 				grants: {
-					"urn:test:authorization_code": (_deps) => ({ grantType: "authorization_code" }),
+					"urn:test:authorization_code": (_deps) => fakeGrantHandler("authorization_code"),
 				},
 				routes: [
 					{
@@ -273,7 +282,7 @@ describe("integration — Scenario 2: spec §12 worked-example failure diagnosti
 			requires: ["keyStore", "clientRepository", "codeRepository", "intMissingSlot"],
 			contributes: {
 				grants: {
-					"urn:test:authorization_code": (_deps) => ({}),
+					"urn:test:authorization_code": (_deps) => fakeGrantHandler("authorization_code"),
 				},
 			},
 		});

--- a/packages/core/src/boot/__tests__/plan-boot.test.mts
+++ b/packages/core/src/boot/__tests__/plan-boot.test.mts
@@ -14,12 +14,21 @@
  * limitations under the License.
  */
 import { describe, expect, it } from "vitest";
+import type { AuditSink } from "../../audit/types.mjs";
 import { defineModule } from "../../modules/manifest/index.mjs";
 import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import { planBoot } from "../plan-boot.mjs";
 import type { BootstrapMap as BM, BootstrapMap } from "../types.mjs";
 import { BootError } from "../types.mjs";
 import { validateManifests } from "../validate-manifests.mjs";
+
+// AS-M1 (Phase F F9 PR6): typed AuditSink stub for the auditHooks
+// contributions. Pre-AS-M1 the inline literal `{ name, run }` worked because
+// `AuditHook` was `unknown`; post-narrow it must satisfy `AuditSink`.
+const fakeAuditSink = (kind = "stub"): AuditSink => ({
+	kind,
+	record: async () => {},
+});
 
 // ---------------------------------------------------------------------------
 // Test-only ComponentMap slot augmentation
@@ -38,31 +47,31 @@ declare module "@o3co/auth-provider-core" {
 // collector implementations.
 // ---------------------------------------------------------------------------
 
-function makeStubNameCollector() {
-	const m = new Map<string, unknown>();
+function makeStubNameCollector<V = unknown>() {
+	const m = new Map<string, V>();
 	return {
 		kind: "name-keyed" as const,
-		register: (n: string, v: unknown) => {
+		register: (n: string, v: V) => {
 			if (m.has(n)) throw new Error(`already registered: ${n}`);
 			m.set(n, v);
 		},
-		replace: (n: string, v: unknown) => {
+		replace: (n: string, v: V) => {
 			if (!m.has(n)) throw new Error(`unknown key: ${n}`);
 			m.set(n, v);
 		},
 		get: (n: string) => m.get(n),
-		entries: () => m.entries() as IterableIterator<readonly [string, unknown]>,
+		entries: () => m.entries() as IterableIterator<readonly [string, V]>,
 	};
 }
 
-function makeStubListCollector() {
-	const arr: unknown[] = [];
+function makeStubListCollector<V = unknown>() {
+	const arr: V[] = [];
 	return {
 		kind: "list" as const,
-		append: (v: unknown) => {
+		append: (v: V) => {
 			arr.push(v);
 		},
-		values: () => arr.values() as IterableIterator<unknown>,
+		values: () => arr.values() as IterableIterator<V>,
 	};
 }
 
@@ -272,12 +281,12 @@ describe("planBoot — step 4: closure root via contributes", () => {
 			name: "C",
 			requires: ["slotC"] as const,
 			contributes: {
-				auditHooks: [() => ({ name: "hook", run: async () => {} })],
+				auditHooks: [() => fakeAuditSink("hook")],
 			},
 		});
 
 		const vm = validated([modP, modC], minBootstrap, {
-			auditHooks: makeStubListCollector(),
+			auditHooks: makeStubListCollector<AuditSink>(),
 		});
 		const plan = planBoot(vm, minBootstrap, undefined);
 
@@ -397,12 +406,12 @@ describe("planBoot — eager flag semantics", () => {
 			name: "C",
 			requires: ["slotC"] as const,
 			contributes: {
-				auditHooks: [() => ({ name: "hook", run: async () => {} })],
+				auditHooks: [() => fakeAuditSink("hook")],
 			},
 		});
 
 		const vm = validated([modP, modC], minBootstrap, {
-			auditHooks: makeStubListCollector(),
+			auditHooks: makeStubListCollector<AuditSink>(),
 		});
 		const plan = planBoot(vm, minBootstrap, undefined);
 
@@ -426,12 +435,12 @@ describe("planBoot — depsBlueprint", () => {
 			name: "C",
 			requires: ["slotC"] as const,
 			contributes: {
-				auditHooks: [() => ({ name: "hook", run: async () => {} })],
+				auditHooks: [() => fakeAuditSink("hook")],
 			},
 		});
 
 		const vm = validated([modP, modC], minBootstrap, {
-			auditHooks: makeStubListCollector(),
+			auditHooks: makeStubListCollector<AuditSink>(),
 		});
 		const plan = planBoot(vm, minBootstrap, undefined);
 
@@ -446,12 +455,12 @@ describe("planBoot — depsBlueprint", () => {
 			name: "C",
 			requires: ["slotC"] as const,
 			contributes: {
-				auditHooks: [() => ({ name: "hook", run: async () => {} })],
+				auditHooks: [() => fakeAuditSink("hook")],
 			},
 		});
 
 		const vm = validated([modP, modC], minBootstrap, {
-			auditHooks: makeStubListCollector(),
+			auditHooks: makeStubListCollector<AuditSink>(),
 		});
 		const plan = planBoot(vm, minBootstrap, undefined);
 

--- a/packages/core/src/boot/create-app.mts
+++ b/packages/core/src/boot/create-app.mts
@@ -251,7 +251,10 @@ function makeGrantCollector(): NameKeyedCollector<GrantHandler> {
 }
 
 /**
- * Build a plain `Map`-backed `NameKeyedCollector<unknown>`.
+ * Build a plain `Map`-backed `NameKeyedCollector<T>`. Generic-parametric
+ * since AS-M1 (PR6): callers pass the concrete contributes-map slot type
+ * (e.g. `<MfaFactor>`, `<FederationProvider>`) so the produced collector
+ * matches the narrowed `ContributionCollectorMap` slot.
  *
  * Used for `tokenExchangeValidators`, `federations`, and `mfaFactors`.
  * `tokenExchangeValidators` uses this form because `ExchangeTokenValidatorRegistry`
@@ -302,7 +305,11 @@ function makeMapNameKeyedCollector<T>(): NameKeyedCollector<T> {
 }
 
 /**
- * Build a `ListCollector<unknown>` with same-instance deduplication.
+ * Build a `ListCollector<T>` with same-instance deduplication.
+ * Generic-parametric since AS-M1 (PR6): callers pass the concrete
+ * contributes-map slot type (e.g. `<AuditHook>`, `<GrantPolicyHookContribution>`)
+ * so the produced collector matches the narrowed `ContributionCollectorMap`
+ * slot.
  *
  * Used for `auditHooks` and `grantPolicyHooks`. The `Set`-based identity
  * check silently skips re-registration of the same reference per A2-α §4.5.

--- a/packages/core/src/boot/create-app.mts
+++ b/packages/core/src/boot/create-app.mts
@@ -32,6 +32,14 @@
 import type { Router } from "express";
 import { createLifecycleRegistrar } from "../adapters/AdapterFactory.mjs";
 import { GrantRegistry } from "../grants/registry.mjs";
+import type {
+	AuditHook,
+	ExchangeTokenValidator,
+	FederationProvider,
+	GrantHandler,
+	GrantPolicyHookContribution,
+	MfaFactor,
+} from "../modules/manifest/contributes-map.mjs";
 import { applyContributions } from "./apply-contributions.mjs";
 import { assembleApp } from "./assemble-app.mjs";
 import { freezeWorld } from "./freeze-world.mjs";
@@ -178,15 +186,19 @@ export async function createApp<B extends BootstrapMap = DefaultBootstrapMap>(
  * @internal
  */
 function mergeWithBuiltins(consumer: ContributionKindMap | undefined): ContributionCollectorMap {
+	// AS-M1 (PR6): explicit type arguments are required for the four kinds
+	// whose contributes-map placeholders were narrowed from `unknown` to
+	// concrete same-package types in v0.5.1. The factories themselves are
+	// type-parametric so the slot-side concrete type flows through.
 	const builtin: ContributionCollectorMap = {
 		grants: makeGrantCollector(),
-		tokenExchangeValidators: makeMapNameKeyedCollector(),
-		federations: makeMapNameKeyedCollector(),
-		federationRedirectPolicies: makeMapNameKeyedCollector(),
-		mfaFactors: makeMapNameKeyedCollector(),
-		auditHooks: makeIdentityDedupListCollector(),
+		tokenExchangeValidators: makeMapNameKeyedCollector<ExchangeTokenValidator>(),
+		federations: makeMapNameKeyedCollector<FederationProvider>(),
+		federationRedirectPolicies: makeMapNameKeyedCollector<unknown>(),
+		mfaFactors: makeMapNameKeyedCollector<MfaFactor>(),
+		auditHooks: makeIdentityDedupListCollector<AuditHook>(),
 		routes: makeRouteCollector(),
-		grantPolicyHooks: makeIdentityDedupListCollector(),
+		grantPolicyHooks: makeIdentityDedupListCollector<GrantPolicyHookContribution>(),
 	};
 	// Consumer keys override built-ins; unknown consumer kinds pass through.
 	return { ...builtin, ...(consumer ?? {}) } as ContributionCollectorMap;
@@ -207,33 +219,33 @@ function mergeWithBuiltins(consumer: ContributionKindMap | undefined): Contribut
  *
  * @internal
  */
-function makeGrantCollector(): NameKeyedCollector<unknown> {
+function makeGrantCollector(): NameKeyedCollector<GrantHandler> {
 	const registry = new GrantRegistry();
 	// Shadow Map: mirrors every register/replace for entries() support.
-	const shadow = new Map<string, unknown>();
+	const shadow = new Map<string, GrantHandler>();
 
 	return {
 		kind: "name-keyed" as const,
-		register(name: string, value: unknown): void {
+		register(name: string, value: GrantHandler): void {
 			// Delegate to GrantRegistry for throw-on-duplicate semantics.
-			registry.register(name, value as Parameters<GrantRegistry["register"]>[1]);
+			registry.register(name, value);
 			// Mirror into shadow (only if registry didn't throw).
 			shadow.set(name, value);
 		},
-		replace(name: string, value: unknown): void {
+		replace(name: string, value: GrantHandler): void {
 			// Delegate to GrantRegistry for throw-on-unknown semantics.
-			registry.replace(name, value as Parameters<GrantRegistry["replace"]>[1]);
+			registry.replace(name, value);
 			// Mirror into shadow.
 			shadow.set(name, value);
 		},
 		freeze(): void {
 			registry.freeze();
 		},
-		get(name: string): unknown {
+		get(name: string): GrantHandler | undefined {
 			return registry.get(name);
 		},
-		entries(): IterableIterator<readonly [string, unknown]> {
-			return shadow.entries() as IterableIterator<readonly [string, unknown]>;
+		entries(): IterableIterator<readonly [string, GrantHandler]> {
+			return shadow.entries() as IterableIterator<readonly [string, GrantHandler]>;
 		},
 	};
 }
@@ -249,13 +261,13 @@ function makeGrantCollector(): NameKeyedCollector<unknown> {
  *
  * @internal
  */
-function makeMapNameKeyedCollector(): NameKeyedCollector<unknown> {
-	const m = new Map<string, unknown>();
+function makeMapNameKeyedCollector<T>(): NameKeyedCollector<T> {
+	const m = new Map<string, T>();
 	let frozen = false;
 
 	return {
 		kind: "name-keyed" as const,
-		register(name: string, value: unknown): void {
+		register(name: string, value: T): void {
 			if (frozen) {
 				throw new Error(`NameKeyedCollector: frozen; cannot register "${name}"`);
 			}
@@ -266,7 +278,7 @@ function makeMapNameKeyedCollector(): NameKeyedCollector<unknown> {
 			}
 			m.set(name, value);
 		},
-		replace(name: string, value: unknown): void {
+		replace(name: string, value: T): void {
 			if (frozen) {
 				throw new Error(`NameKeyedCollector: frozen; cannot replace "${name}"`);
 			}
@@ -280,11 +292,11 @@ function makeMapNameKeyedCollector(): NameKeyedCollector<unknown> {
 		freeze(): void {
 			frozen = true;
 		},
-		get(name: string): unknown {
+		get(name: string): T | undefined {
 			return m.get(name);
 		},
-		entries(): IterableIterator<readonly [string, unknown]> {
-			return m.entries() as IterableIterator<readonly [string, unknown]>;
+		entries(): IterableIterator<readonly [string, T]> {
+			return m.entries() as IterableIterator<readonly [string, T]>;
 		},
 	};
 }
@@ -297,14 +309,14 @@ function makeMapNameKeyedCollector(): NameKeyedCollector<unknown> {
  *
  * @internal
  */
-function makeIdentityDedupListCollector(): ListCollector<unknown> {
-	const arr: unknown[] = [];
-	const seen = new Set<unknown>();
+function makeIdentityDedupListCollector<T>(): ListCollector<T> {
+	const arr: T[] = [];
+	const seen = new Set<T>();
 	let frozen = false;
 
 	return {
 		kind: "list" as const,
-		append(value: unknown): void {
+		append(value: T): void {
 			if (frozen) {
 				throw new Error("ListCollector: frozen; cannot append");
 			}
@@ -317,7 +329,7 @@ function makeIdentityDedupListCollector(): ListCollector<unknown> {
 		freeze(): void {
 			frozen = true;
 		},
-		values(): IterableIterator<unknown> {
+		values(): IterableIterator<T> {
 			return arr.values();
 		},
 	};

--- a/packages/core/src/modules/manifest/contributes-map.mts
+++ b/packages/core/src/modules/manifest/contributes-map.mts
@@ -14,72 +14,86 @@
  * limitations under the License.
  */
 
+import type { AuditSink } from "../../audit/types.mjs";
+import type { GrantHandler as ConcreteGrantHandler } from "../../grants/types.mjs";
+import type { MfaProvider } from "../../mfa/types.mjs";
+import type { GrantPolicyHook } from "../../policy/types.mjs";
 import type { ProviderDeps } from "./provider.mjs";
 import type { RouteContributionEntry } from "./route-contribution.mjs";
 
-// Domain-type placeholders.
+// Domain-type substitution status (AS-M1 / Phase F F9 PR6).
 //
 // Per A2-α §4.1: each per-kind factory type produces a value owned by
-// the package that declares the kind. Phase 9 substitutes the concrete
-// types when the federation, oauth, and oauth-token-exchange packages
-// migrate to manifest shape. For now, structural placeholders avoid
-// circular package imports.
+// the package that declares the kind. The four kinds owned by `core`
+// itself have been substituted from `unknown` placeholders to their
+// concrete same-package types. The two cross-package kinds remain as
+// `unknown` pending Phase F resolution of a circular-import concern
+// (`session` and `oauth-token-exchange` are downstream of `core`, so
+// importing their types from this file would create a package-level
+// cycle).
 //
-// Inventory of concrete types (paths verified 2026-04-28):
-//   GrantHandler       — packages/core/src/grants/types.mts:67
-//   FederationProvider — packages/session/src/federations/types.mts:69
-//   ExchangeTokenValidator — packages/oauth-token-exchange/src/validator/types.mts:26
-//   MfaFactor          — no dedicated interface found; mfa uses MfaProviderBase
-//                        (packages/core/src/mfa/types.mts). Phase 9 clarifies.
-//   AuditHook          — AuditSinkBase at packages/core/src/audit/types.mts:38
-//   GrantPolicyHookContribution — placeholder; concrete type substitution
-//                        TBD by Phase 9. The canonical `GrantPolicyHook`
-//                        (alias of `GrantPolicyHookBase` at
-//                        packages/core/src/policy/types.mts:50) is the
-//                        public-API name and is exported from the package
-//                        root; this manifest placeholder describes only
-//                        the value type produced by a contribution factory.
+//   GrantHandler                — packages/core/src/grants/types.mts:120 (concrete, AS-M1)
+//   AuditHook                   — AuditSink at packages/core/src/audit/types.mts (AS-M1, canonical alias of AuditSinkBase)
+//   MfaFactor                   — MfaProvider at packages/core/src/mfa/types.mts (AS-M1, canonical alias of MfaProviderBase)
+//   GrantPolicyHookContribution — GrantPolicyHook at packages/core/src/policy/types.mts (AS-M1, canonical alias of GrantPolicyHookBase)
+//   FederationProvider          — packages/session/src/federations/types.mts (Phase F deferred — circular import)
+//   ExchangeTokenValidator      — packages/oauth-token-exchange/src/validator/types.mts (Phase F deferred — circular import)
+//
+// Canonical names are used for the substitution RHS; the deprecated
+// `*Base` aliases are kept by `audit/types.mts`, `mfa/types.mts`, and
+// `policy/types.mts` for v0.5.1-era consumer back-compat (PR3 / AS-7) but
+// new code should reference the un-suffixed canonical names.
 
 /**
- * Structural placeholder for GrantHandler. Phase 9 substitutes the concrete
- * type from packages/core/src/grants/types.mts.
+ * Type produced by a `GrantFactory<Deps>` contribution. Substituted in
+ * v0.5.1 (AS-M1) from the `unknown` placeholder to the concrete
+ * `GrantHandler` interface from `packages/core/src/grants/types.mts`.
  */
-export type GrantHandler = unknown;
+export type GrantHandler = ConcreteGrantHandler;
 
 /**
- * Structural placeholder for FederationProvider. Phase 9 substitutes the
- * concrete type from packages/session/src/federations/types.mts.
+ * Type produced by a `FederationFactory<Deps>` contribution. Still
+ * `unknown` pending Phase F: substituting with `FederationProvider` from
+ * `packages/session/src/federations/types.mts` requires resolving the
+ * core ↔ session circular package import.
  */
 export type FederationProvider = unknown;
 
 /**
- * Structural placeholder for ExchangeTokenValidator. Phase 9 substitutes the
- * concrete type from packages/oauth-token-exchange/src/validator/types.mts.
+ * Type produced by an `ExchangeTokenValidatorFactory<Deps>` contribution.
+ * Still `unknown` pending Phase F: substituting with `ExchangeTokenValidator`
+ * from `packages/oauth-token-exchange/src/validator/types.mts` requires
+ * resolving the core ↔ oauth-token-exchange circular package import.
  */
 export type ExchangeTokenValidator = unknown;
 
 /**
- * Structural placeholder for MfaFactor. Phase 9 substitutes the concrete
- * type; the mfa package uses MfaProviderBase as the extension interface.
+ * Type produced by an `MfaFactorFactory<Deps>` contribution. Substituted
+ * in v0.5.1 (AS-M1) from the `unknown` placeholder to the canonical
+ * `MfaProvider` (alias of `MfaProviderBase`) from
+ * `packages/core/src/mfa/types.mts`.
  */
-export type MfaFactor = unknown;
+export type MfaFactor = MfaProvider;
 
 /**
- * Structural placeholder for AuditHook. Phase 9 substitutes the concrete
- * type from packages/core/src/audit/types.mts (AuditSinkBase).
+ * Type produced by an `AuditHookFactory<Deps>` contribution. Substituted
+ * in v0.5.1 (AS-M1) from the `unknown` placeholder to the canonical
+ * `AuditSink` (alias of `AuditSinkBase`) from
+ * `packages/core/src/audit/types.mts`.
  */
-export type AuditHook = unknown;
+export type AuditHook = AuditSink;
 
 /**
- * Structural placeholder for the value type produced by a
- * `GrantPolicyHookFactory<Deps>` contribution on a module manifest.
+ * Type produced by a `GrantPolicyHookFactory<Deps>` contribution.
  *
- * Renamed from `GrantPolicyHook` in v0.5.1 (AS-7 collision resolution): the
- * canonical `GrantPolicyHook` now refers to the policy-package interface
- * (an alias of `GrantPolicyHookBase`). Phase 9 substitutes this placeholder
- * with the concrete type produced by a factory contribution.
+ * Renamed from `GrantPolicyHook` in v0.5.1 (AS-7 collision resolution):
+ * the canonical `GrantPolicyHook` now refers to the policy-package
+ * interface (an alias of `GrantPolicyHookBase`). Substituted in v0.5.1
+ * (AS-M1) from the `unknown` placeholder to that canonical
+ * `GrantPolicyHook` interface — a contribution factory now produces a
+ * concrete grant-policy-hook adapter rather than an opaque value.
  */
-export type GrantPolicyHookContribution = unknown;
+export type GrantPolicyHookContribution = GrantPolicyHook;
 
 // Per-kind factory types — each follows `(deps: Deps) => Value` per A2-α §4.1.
 

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -17,7 +17,8 @@
 		// hygiene PR.
 		"src/__tests__/grant-context-readonly.test.mts",
 		"src/__tests__/repository-types-readonly.test.mts",
-		"src/__tests__/naming-aliases.test.mts"
+		"src/__tests__/naming-aliases.test.mts",
+		"src/__tests__/contributes-map-substitution.test.mts"
 	],
 	"exclude": ["node_modules", "dist"]
 }

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -23,6 +23,8 @@ export default defineConfig({
 				"src/__tests__/repository-types-readonly.test.mts",
 				// AS-7 deprecation alias type-equivalence assertions.
 				"src/__tests__/naming-aliases.test.mts",
+				// AS-M1 contributes-map concrete-type substitution assertions.
+				"src/__tests__/contributes-map-substitution.test.mts",
 			],
 			tsconfig: "./tsconfig.test.json",
 		},


### PR DESCRIPTION
## Summary

Phase F F9 batch — sixth PR. Closes **AS-M1** (substitute `unknown` placeholders in the manifest contributes-map with concrete same-package types). Phase F9 PR3's `GrantPolicyHook` collision resolution was a prerequisite (now satisfied by `6a6fd46a`).

### What this PR does

The four same-package contributes-map placeholders are now concrete types instead of `unknown`:

| Manifest type | Pre-v0.5.1 | v0.5.1 (substituted) |
|---|---|---|
| `GrantHandler` | `unknown` | `GrantHandler` from `grants/types.mts` |
| `AuditHook` | `unknown` | `AuditSink` (canonical alias of `AuditSinkBase`) |
| `MfaFactor` | `unknown` | `MfaProvider` (canonical alias of `MfaProviderBase`) |
| `GrantPolicyHookContribution` | `unknown` | `GrantPolicyHook` (canonical alias of `GrantPolicyHookBase`) |

Module authors now get real type-checking on factory return values — typos or shape mismatches surface at compile time instead of when the boot pipeline invokes the factory at runtime.

### Cross-package types still deferred

`FederationProvider` and `ExchangeTokenValidator` remain `unknown` pending Phase F resolution of a circular package import. New typecheck assertion at `packages/core/src/__tests__/contributes-map-substitution.test.mts` pins both as `unknown` so any premature substitution is caught.

### Internal: collector factory generic-ification

`mergeWithBuiltins` in `boot/create-app.mts` parameterises its three built-in collector factories so they produce typed collectors matching the narrowed contributes-map slots. Pre-PR6 they returned `<unknown>`, which was structurally assignable to the placeholder slots; post-narrow they need real type parameters. Internal-only refactor; no public API change.

### Test scaffolding migration (breaking-internal)

The boot-pipeline tests in `packages/core/src/boot/__tests__/{apply-contributions, plan-boot, integration}.test.mts` were written against the `unknown` placeholder and used inline literals or `as unknown` casts that no longer satisfy the narrowed types. Migrated to typed `fakeGrantHandler` / `fakeAuditSink` fixture factories per Codex's pre-implementation review:

- Pipeline tests (registration order, dedup, factory-error wrapping) use the typed fixture factories
- Identity-equality tests (`sharedHook`, `overrideValue`) get explicit `: AuditSink` / `: GrantHandler` annotations rather than `as never` casts (per Codex: "avoid `as never` as default — louder than necessary, can hide real incompatibilities")

`naming-aliases.test.mts` lost the `GrantPolicyHookContribution = unknown` pin (PR3 added it with the explicit comment that the assertion would intentionally break when Phase 9 substitution lands). Replacement assertion `GrantPolicyHookContribution = GrantPolicyHook` now lives in `contributes-map-substitution.test.mts`.

### Test count delta

- core: 1183 → 1193 (+10: 6 new substitution assertions + 4 from typecheck-mode re-baselining)
- redis / oauth / session / oauth-token-exchange / federation-* / templates: unchanged

### F9 batch progress

| PR | Specs | Status |
|---|---|---|
| F9 PR1 | CC-5 readonly Theme D | ✅ Merged at `0330f7df` |
| F9 PR2 | AS-1 + AS-2 error envelope | ✅ Merged at `edb68f0a` |
| F9 PR3 | AS-7 + AS-10 + GrantPolicyHook collision | ✅ Merged at `6a6fd46a` |
| F9 PR5 | AS-8 + AS-9 deprecation + builders | ✅ Merged at `3c86acda` |
| **F9 PR6** | **AS-M1 placeholder substitution** | **THIS PR** |
| F9 PR4 | AS-3 + AS-11 (BREAKING renames) | Independent — not yet started |
| F9 PR7 | AS-4 + AS-12 (token shape) | Spec refresh required first |

### Multi-agent pre-implementation consultation

Codex was consulted mid-implementation on the scope question (test fixture migration was larger than spec line 322's "ADDITIVE" classification anticipated). Codex verdict: proceed with full 4-substitution narrowing using **tidy typed fixtures** (not 25 raw `as never` casts). PR3 anticipated the substitution-time test breakage explicitly, so the migration is the planned cost of cashing in the placeholder types, not uncontrolled scope creep. Verdict applied — fixtures are typed and identity-equality assertions stay readable.

## Test plan

- [x] `pnpm -r run build` — all packages build clean
- [x] `pnpm -r run test` — all green: core 1193, redis 305, oauth 384, session 160 (+1 todo), oauth-token-exchange 94, federation-google 22, federation-github 20, foundation N, standalone 24
- [x] `pnpm -w run lint` — no new findings (18 warnings + 2 infos all pre-existing)
- [x] `pnpm -r exec tsc --noEmit` — clean
- [x] AS-M1 RED tests (4 substitution failures pre-fix verified)
- [x] AS-M1 deferred-pin tests (FederationProvider / ExchangeTokenValidator still `unknown`)
- [ ] Multi-agent review (Codex + Claude general-purpose)
- [ ] Copilot inline review

🤖 Generated with [Claude Code](https://claude.com/claude-code)