### PR TITLE
F9 PR4 — AS-3 + AS-11 BREAKING method renames (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed (Phase F — F9 PR4 AS-3 + AS-11 BREAKING method renames, v0.5.1)
+
+- **`FederationTokenStoreBase.deleteBySession(sid)` is renamed to
+  `removeBySid(sid)`** (`@o3co/auth-provider-core`, closes AS-3): aligns the
+  verb with the four sibling session stores (`UserSessionStore.removeBySid`,
+  `SessionRPRegistry.removeBySid`, `SessionFamilyIndex.removeBySid`,
+  `SessionFederationIndex.removeBySid`), which all use `removeBySid` for the
+  same "bulk-remove records scoped to a session id" responsibility. Callers
+  that previously mixed both verbs in adjacent lines (notably the logout
+  cascade) now read uniformly.
+
+- **`MfaTransactionStore.save(tx)` and `MfaTransactionStore.load(transactionId)`
+  are renamed to `set(tx)` and `get(transactionId)`** (`@o3co/auth-provider-core`,
+  closes AS-11): aligns the verbs with map-like store semantics
+  (`UserSessionStore`, `KeyStore` patterns); replaces the orphan `save` /
+  `load` verbs that did not appear on any peer store.
+
+#### BREAKING — migration
+
+The v0.5.1 hotfix policy explicitly permits these renames because both
+interfaces were new in v0.5.0 and have had no external consumers (the v0.5.0
+publish-to-hotfix window is days). No deprecation aliases are added.
+
+Downstream implementers of either interface must rename methods:
+
+| Interface | Old name | New name |
+|---|---|---|
+| `FederationTokenStoreBase` (and its canonical alias `FederationTokenStore`) | `deleteBySession(sid)` | `removeBySid(sid)` |
+| `MfaTransactionStore` | `save(tx)` | `set(tx)` |
+| `MfaTransactionStore` | `load(transactionId)` | `get(transactionId)` |
+
+Callers must update method names accordingly. The built-in adapters in
+`@o3co/auth-provider-core` and `@o3co/auth-provider-redis` are already
+migrated; consumers using only those adapters need no changes beyond
+upgrading to v0.5.1.
+
+#### Cross-spec coordination
+
+The `*Base` interface aliases added in F9 PR3 (AS-7) —
+`FederationTokenStore`, `RateLimiter`, `AuditSink`, `MfaProvider`,
+`GrantPolicyHook` — automatically pick up the AS-3 method rename through the
+underlying type alias. No additional action is required for consumers using
+the canonical names.
+
 ### Improved (Phase F — F9 PR6 AS-M1 contributes-map concrete-type substitution, v0.5.1)
 
 - **The four same-package contributes-map placeholders are now concrete

--- a/packages/core/src/federation-tokens/__tests__/memory.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/memory.test.mts
@@ -51,11 +51,11 @@ describe("in-memory FederationTokenStore", () => {
 		expect(await store.get("sid-1", "google")).toEqual(next);
 	});
 
-	it("deleteBySession removes all federation entries for sid", async () => {
+	it("removeBySid removes all federation entries for sid", async () => {
 		await store.attach("sid-1", "google", tokens);
 		await store.attach("sid-1", "github", tokens);
 		await store.attach("sid-2", "google", tokens);
-		await store.deleteBySession("sid-1");
+		await store.removeBySid("sid-1");
 		expect(await store.get("sid-1", "google")).toBeNull();
 		expect(await store.get("sid-1", "github")).toBeNull();
 		expect(await store.get("sid-2", "google")).toEqual(tokens);
@@ -69,8 +69,8 @@ describe("in-memory FederationTokenStore", () => {
 		expect(await store.get("sid-1", "github")).toEqual(tokens);
 	});
 
-	it("deleteBySession / delete are idempotent", async () => {
-		await expect(store.deleteBySession("nope")).resolves.toBeUndefined();
+	it("removeBySid / delete are idempotent", async () => {
+		await expect(store.removeBySid("nope")).resolves.toBeUndefined();
 		await expect(store.delete("nope", "google")).resolves.toBeUndefined();
 	});
 

--- a/packages/core/src/federation-tokens/__tests__/removeBySid-rename.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/removeBySid-rename.test.mts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { describe, expect, it } from "vitest";
+import { createInMemoryFederationTokenStore } from "../adapters/memory.mjs";
+
+describe("AS-3: FederationTokenStoreBase.deleteBySession → removeBySid (BREAKING rename)", () => {
+	it("in-memory store exposes removeBySid", () => {
+		const store = createInMemoryFederationTokenStore();
+		expect("removeBySid" in store).toBe(true);
+	});
+
+	it("in-memory store no longer exposes deleteBySession", () => {
+		const store = createInMemoryFederationTokenStore();
+		expect("deleteBySession" in store).toBe(false);
+	});
+
+	it("removeBySid removes all federation entries for sid (functional parity with old deleteBySession)", async () => {
+		const store = createInMemoryFederationTokenStore();
+		const tokens = {
+			accessToken: "at",
+			refreshToken: "rt",
+			idToken: "it",
+			expiresAt: new Date("2026-04-22"),
+		};
+		await store.attach("sid-1", "google", tokens);
+		await store.attach("sid-1", "github", tokens);
+		await store.attach("sid-2", "google", tokens);
+		await store.removeBySid("sid-1");
+		expect(await store.get("sid-1", "google")).toBeNull();
+		expect(await store.get("sid-1", "github")).toBeNull();
+		expect(await store.get("sid-2", "google")).toEqual(tokens);
+	});
+
+	it("removeBySid is idempotent on absent sid", async () => {
+		const store = createInMemoryFederationTokenStore();
+		await expect(store.removeBySid("nope")).resolves.toBeUndefined();
+	});
+});

--- a/packages/core/src/federation-tokens/__tests__/types.test.mts
+++ b/packages/core/src/federation-tokens/__tests__/types.test.mts
@@ -30,7 +30,7 @@ describe("supportsLock type guard", () => {
 			attach: async () => {},
 			delete: async () => {},
 			update: async () => {},
-			deleteBySession: async () => {},
+			removeBySid: async () => {},
 		};
 		expect(supportsLock(store as any)).toBe(false);
 	});
@@ -42,7 +42,7 @@ describe("supportsLock type guard", () => {
 			attach: async () => {},
 			delete: async () => {},
 			update: async () => {},
-			deleteBySession: async () => {},
+			removeBySid: async () => {},
 			acquireLock: async () => ({ acquired: true as const, release: async () => {} }),
 		};
 		expect(supportsLock(store as any)).toBe(true);

--- a/packages/core/src/federation-tokens/adapters/memory.mts
+++ b/packages/core/src/federation-tokens/adapters/memory.mts
@@ -19,7 +19,7 @@ const key = (sid: string, name: string) => `${sid}\u0000${name}`;
  * is the consumer's responsibility in F-6 flows.
  *
  * Cleanup of stale entries happens via UserSessionStore logout cascade, which
- * calls `deleteBySession(sid)` when a session ends. For process longevity
+ * calls `removeBySid(sid)` when a session ends. For process longevity
  * consider redis instead (production-grade TTL + cross-instance replication).
  */
 const cloneTokens = (t: FederationTokens): FederationTokens => ({
@@ -51,7 +51,7 @@ export function createInMemoryFederationTokenStore(): FederationTokenStoreBase &
 		async update(sid, name, tokens) {
 			store.set(key(sid, name), cloneTokens(tokens));
 		},
-		async deleteBySession(sid) {
+		async removeBySid(sid) {
 			for (const k of [...store.keys()]) {
 				if (k.startsWith(`${sid}\u0000`)) store.delete(k);
 			}

--- a/packages/core/src/federation-tokens/types.mts
+++ b/packages/core/src/federation-tokens/types.mts
@@ -52,8 +52,20 @@ export interface FederationTokenStoreBase {
 	/** Atomic replace. Called after a successful federation refresh. */
 	update(sid: string, federationName: string, tokens: FederationTokens): Promise<void>;
 
-	/** Delete all federation entries for a session. Idempotent. */
-	deleteBySession(sid: string): Promise<void>;
+	/**
+	 * Remove all federation entries for a session. Idempotent.
+	 *
+	 * Verb-aligned with sibling session stores
+	 * ({@link UserSessionStore}, sessionRPRegistry, sessionFamilyIndex,
+	 * sessionFederationIndex) which all expose `removeBySid(sid)` for the
+	 * same "bulk-remove records scoped to a session id" responsibility.
+	 *
+	 * Renamed from `deleteBySession` in v0.5.1 (AS-3); the old name is no
+	 * longer accepted because `FederationTokenStoreBase` was new in v0.5.0
+	 * and the v0.5.1 hotfix policy explicitly permits this rename for
+	 * interfaces that have had no external consumers.
+	 */
+	removeBySid(sid: string): Promise<void>;
 
 	/** Delete a specific (sid, federationName) entry. Idempotent. */
 	delete(sid: string, federationName: string): Promise<void>;

--- a/packages/core/src/federation-tokens/types.mts
+++ b/packages/core/src/federation-tokens/types.mts
@@ -56,9 +56,10 @@ export interface FederationTokenStoreBase {
 	 * Remove all federation entries for a session. Idempotent.
 	 *
 	 * Verb-aligned with sibling session stores
-	 * ({@link UserSessionStore}, sessionRPRegistry, sessionFamilyIndex,
-	 * sessionFederationIndex) which all expose `removeBySid(sid)` for the
-	 * same "bulk-remove records scoped to a session id" responsibility.
+	 * ({@link UserSessionStore}, {@link SessionRPRegistry},
+	 * {@link SessionFamilyIndex}, {@link SessionFederationIndex}) which all
+	 * expose `removeBySid(sid)` for the same "bulk-remove records scoped to
+	 * a session id" responsibility.
 	 *
 	 * Renamed from `deleteBySession` in v0.5.1 (AS-3); the old name is no
 	 * longer accepted because `FederationTokenStoreBase` was new in v0.5.0

--- a/packages/core/src/mfa/__tests__/fixtures.mts
+++ b/packages/core/src/mfa/__tests__/fixtures.mts
@@ -80,10 +80,10 @@ export function createTestMfaProviderWithCapabilities(options: {
 export function createInMemoryTransactionStore(): MfaTransactionStore {
 	const store = new Map<string, MfaPendingTransaction>();
 	return {
-		async save(tx) {
+		async set(tx) {
 			store.set(tx.transactionId, tx);
 		},
-		async load(transactionId) {
+		async get(transactionId) {
 			const tx = store.get(transactionId);
 			if (!tx) return null;
 			if (tx.expiresAt.getTime() <= Date.now()) return null;

--- a/packages/core/src/mfa/__tests__/route.test.mts
+++ b/packages/core/src/mfa/__tests__/route.test.mts
@@ -33,7 +33,7 @@ describe("/auth/mfa/verify", () => {
 			}),
 		);
 		const store = createInMemoryTransactionStore();
-		await store.save({
+		await store.set({
 			transactionId: "tx-1",
 			flow: "authorize",
 			subject: "user-1",
@@ -72,7 +72,7 @@ describe("/auth/mfa/verify", () => {
 		expect(res.status).toBe(200);
 		expect(res.body).toEqual({ resumed: "authorize", subject: "user-1", clientId: "client-1" });
 		expect(onAuthorizeResume).toHaveBeenCalledTimes(1);
-		expect(await store.load("tx-1")).toBeNull();
+		expect(await store.get("tx-1")).toBeNull();
 	});
 
 	it("rejects invalid proof with 401 and does not delete transaction (retry allowed)", async () => {
@@ -84,7 +84,7 @@ describe("/auth/mfa/verify", () => {
 			}),
 		);
 		const store = createInMemoryTransactionStore();
-		await store.save({
+		await store.set({
 			transactionId: "tx-retry",
 			flow: "login",
 			subject: "user-x",
@@ -110,7 +110,7 @@ describe("/auth/mfa/verify", () => {
 			.post("/auth/mfa/verify")
 			.send({ transaction_id: "tx-retry", proof: { code: "wrong" } });
 		expect(res.status).toBe(401);
-		expect(await store.load("tx-retry")).not.toBeNull();
+		expect(await store.get("tx-retry")).not.toBeNull();
 	});
 
 	it("rejects expired transaction even when store returns it (S-3)", async () => {
@@ -133,8 +133,8 @@ describe("/auth/mfa/verify", () => {
 		};
 		const deleteSpy = vi.fn(async () => {});
 		const unfilteringStore = {
-			async save() {},
-			async load() {
+			async set() {},
+			async get() {
 				return expiredTx;
 			},
 			delete: deleteSpy,
@@ -173,7 +173,7 @@ describe("/auth/mfa/verify", () => {
 			}),
 		);
 		const store = createInMemoryTransactionStore();
-		await store.save({
+		await store.set({
 			transactionId: "tx-boom",
 			flow: "login",
 			subject: "user-q",
@@ -202,14 +202,14 @@ describe("/auth/mfa/verify", () => {
 		expect(res.status).toBe(500);
 		expect(res.body.error).toBe("server_error");
 		// Transaction is deleted — cannot retry against a broken provider
-		expect(await store.load("tx-boom")).toBeNull();
+		expect(await store.get("tx-boom")).toBeNull();
 	});
 
 	it("returns controlled 500 + deletes tx when providerFactory.create throws (CP-7)", async () => {
 		const factory = createMfaProviderFactory();
 		// No provider registered for "totp" → factory.create throws
 		const store = createInMemoryTransactionStore();
-		await store.save({
+		await store.set({
 			transactionId: "tx-noprov",
 			flow: "login",
 			subject: "user-q",
@@ -237,7 +237,7 @@ describe("/auth/mfa/verify", () => {
 
 		expect(res.status).toBe(500);
 		expect(res.body.error).toBe("server_error");
-		expect(await store.load("tx-noprov")).toBeNull();
+		expect(await store.get("tx-noprov")).toBeNull();
 	});
 
 	it("returns invalid_grant for unknown/expired transaction", async () => {

--- a/packages/core/src/mfa/__tests__/transaction-store-set-get-rename.test.mts
+++ b/packages/core/src/mfa/__tests__/transaction-store-set-get-rename.test.mts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { describe, expect, it } from "vitest";
+import type { MfaPendingTransaction } from "../types.mjs";
+import { createInMemoryTransactionStore } from "./fixtures.mjs";
+
+const sampleTx: MfaPendingTransaction = {
+	transactionId: "tx-1",
+	flow: "authorize",
+	subject: "user-1",
+	providerKind: "totp",
+	challengeId: "ch-1",
+	expiresAt: new Date(Date.now() + 5 * 60 * 1000),
+	resumeState: {
+		flow: "authorize",
+		clientId: "client-1",
+		redirectUri: "https://app.example/cb",
+		responseType: "code",
+	},
+};
+
+describe("AS-11: MfaTransactionStore.save/load → set/get (BREAKING rename)", () => {
+	it("in-memory store exposes set", () => {
+		const store = createInMemoryTransactionStore();
+		expect("set" in store).toBe(true);
+	});
+
+	it("in-memory store exposes get", () => {
+		const store = createInMemoryTransactionStore();
+		expect("get" in store).toBe(true);
+	});
+
+	it("in-memory store no longer exposes save", () => {
+		const store = createInMemoryTransactionStore();
+		expect("save" in store).toBe(false);
+	});
+
+	it("in-memory store no longer exposes load", () => {
+		const store = createInMemoryTransactionStore();
+		expect("load" in store).toBe(false);
+	});
+
+	it("set/get round-trips a pending transaction (functional parity with old save/load)", async () => {
+		const store = createInMemoryTransactionStore();
+		await store.set(sampleTx);
+		expect(await store.get(sampleTx.transactionId)).toEqual(sampleTx);
+	});
+
+	it("get returns null for unknown transactionId", async () => {
+		const store = createInMemoryTransactionStore();
+		expect(await store.get("missing")).toBeNull();
+	});
+});

--- a/packages/core/src/mfa/route.mts
+++ b/packages/core/src/mfa/route.mts
@@ -48,7 +48,7 @@ export function createMfaRouter(express: { Router: () => Router }, deps: MfaRout
 				.status(400)
 				.json({ error: "invalid_request", error_description: "transaction_id required" });
 		}
-		const tx = await deps.transactionStore.load(transactionId);
+		const tx = await deps.transactionStore.get(transactionId);
 		if (!tx) {
 			return res.status(400).json({
 				error: "invalid_grant",

--- a/packages/core/src/mfa/types.mts
+++ b/packages/core/src/mfa/types.mts
@@ -127,8 +127,8 @@ export interface MfaTransactionStore {
 	/**
 	 * Retrieve a pending transaction by id. Implementations MAY filter expired
 	 * transactions (return null when `expiresAt <= now`); core also rejects
-	 * expired transactions post-load as defense in depth. Either behavior is
-	 * acceptable.
+	 * expired transactions after retrieval as defense in depth. Either
+	 * behavior is acceptable.
 	 *
 	 * Renamed from `load` in v0.5.1 (AS-11) — see {@link MfaTransactionStore.set}.
 	 */

--- a/packages/core/src/mfa/types.mts
+++ b/packages/core/src/mfa/types.mts
@@ -115,14 +115,24 @@ export interface MfaPendingTransaction {
 }
 
 export interface MfaTransactionStore {
-	save(tx: MfaPendingTransaction): Promise<void>;
 	/**
-	 * Load a pending transaction by id. Implementations MAY filter expired
+	 * Persist a pending MFA transaction.
+	 *
+	 * Renamed from `save` in v0.5.1 (AS-11) to align with map-like store
+	 * semantics ({@link UserSessionStore}, KeyStore). The old `save` name is
+	 * no longer accepted; the v0.5.1 hotfix policy explicitly permits this
+	 * rename for an interface that was new in v0.5.0.
+	 */
+	set(tx: MfaPendingTransaction): Promise<void>;
+	/**
+	 * Retrieve a pending transaction by id. Implementations MAY filter expired
 	 * transactions (return null when `expiresAt <= now`); core also rejects
 	 * expired transactions post-load as defense in depth. Either behavior is
 	 * acceptable.
+	 *
+	 * Renamed from `load` in v0.5.1 (AS-11) — see {@link MfaTransactionStore.set}.
 	 */
-	load(transactionId: string): Promise<MfaPendingTransaction | null>;
+	get(transactionId: string): Promise<MfaPendingTransaction | null>;
 	delete(transactionId: string): Promise<void>;
 }
 

--- a/packages/core/src/mfa/types.mts
+++ b/packages/core/src/mfa/types.mts
@@ -119,7 +119,7 @@ export interface MfaTransactionStore {
 	 * Persist a pending MFA transaction.
 	 *
 	 * Renamed from `save` in v0.5.1 (AS-11) to align with map-like store
-	 * semantics ({@link UserSessionStore}, KeyStore). The old `save` name is
+	 * semantics ({@link UserSessionStore}, {@link KeyStore}). The old `save` name is
 	 * no longer accepted; the v0.5.1 hotfix policy explicitly permits this
 	 * rename for an interface that was new in v0.5.0.
 	 */

--- a/packages/oauth/src/__tests__/federationToken.test.mts
+++ b/packages/oauth/src/__tests__/federationToken.test.mts
@@ -120,7 +120,7 @@ function makeFedTokenStore(override?: Partial<FederationTokenStoreBase>): Federa
 		attach: vi.fn(),
 		get: vi.fn().mockResolvedValue(baseFedTokens),
 		update: vi.fn().mockResolvedValue(undefined),
-		deleteBySession: vi.fn().mockResolvedValue(undefined),
+		removeBySid: vi.fn().mockResolvedValue(undefined),
 		delete: vi.fn().mockResolvedValue(undefined),
 		...override,
 	};

--- a/packages/oauth/src/__tests__/logout.test.mts
+++ b/packages/oauth/src/__tests__/logout.test.mts
@@ -142,7 +142,7 @@ function makeFedTokenStore(override?: Partial<FederationTokenStoreBase>): Federa
 		attach: vi.fn(),
 		get: vi.fn().mockResolvedValue(null),
 		update: vi.fn(),
-		deleteBySession: vi.fn().mockResolvedValue(undefined),
+		removeBySid: vi.fn().mockResolvedValue(undefined),
 		delete: vi.fn(),
 		...override,
 	};
@@ -228,7 +228,7 @@ describe("POST /oauth/logout", () => {
 			// cascadeLogout step 3: session deleted
 			expect(sessionStore.delete).toHaveBeenCalledWith("sid-1");
 			// cascadeLogout step 2: federation tokens cleared
-			expect(fedTokenStore.deleteBySession).toHaveBeenCalledWith("sid-1");
+			expect(fedTokenStore.removeBySid).toHaveBeenCalledWith("sid-1");
 		});
 	});
 

--- a/packages/oauth/src/__tests__/module.test.mts
+++ b/packages/oauth/src/__tests__/module.test.mts
@@ -418,7 +418,7 @@ describe("oauthModule — federation logout via typed deps", () => {
 			attach: vi.fn(),
 			get: vi.fn().mockResolvedValue({ idToken: "id-token-hint" }),
 			update: vi.fn(),
-			deleteBySession: vi.fn().mockResolvedValue(undefined),
+			removeBySid: vi.fn().mockResolvedValue(undefined),
 			delete: vi.fn().mockResolvedValue(undefined),
 		};
 		const refreshTokenFamilyRevocation: RefreshTokenFamilyRevocation = {
@@ -567,7 +567,7 @@ describe("oauthModule — federation logout via typed deps", () => {
 			attach: vi.fn(),
 			get: vi.fn(),
 			update: vi.fn(),
-			deleteBySession: vi.fn(),
+			removeBySid: vi.fn(),
 			delete: vi.fn(),
 		};
 		const refreshTokenFamilyRevocation: RefreshTokenFamilyRevocation = {

--- a/packages/oauth/src/logout/__tests__/cascadeLogout.test.mts
+++ b/packages/oauth/src/logout/__tests__/cascadeLogout.test.mts
@@ -30,7 +30,7 @@ function makeFedStore(override?: Partial<FederationTokenStoreBase>): FederationT
 		attach: vi.fn(),
 		get: vi.fn().mockResolvedValue(null),
 		update: vi.fn(),
-		deleteBySession: vi.fn().mockResolvedValue(undefined),
+		removeBySid: vi.fn().mockResolvedValue(undefined),
 		delete: vi.fn(),
 		...override,
 	} as unknown as FederationTokenStoreBase;
@@ -84,7 +84,7 @@ function makeSessionFederationIndex(
 // ---------------------------------------------------------------------------
 
 describe("cascadeLogout (A4 §6.2)", () => {
-	it("executes in §6.2 order: listFamilyIds → revokeFamily (each) → deleteBySession → removeBySid (×3) → delete → post-step-4 sessionFamilyIndex.removeBySid (CR-4)", async () => {
+	it("executes in §6.2 order: listFamilyIds → revokeFamily (each) → federationTokenStore.removeBySid → sessionStores.removeBySid (×3) → delete → post-step-4 sessionFamilyIndex.removeBySid (CR-4)", async () => {
 		const sessionFamilyIndex = makeSessionFamilyIndex({
 			listFamilyIds: vi.fn(async () => ["fam-1", "fam-2"]),
 		});
@@ -112,7 +112,7 @@ describe("cascadeLogout (A4 §6.2)", () => {
 		expect(rts.revokeFamily).toHaveBeenNthCalledWith(1, "fam-1");
 		expect(rts.revokeFamily).toHaveBeenNthCalledWith(2, "fam-2");
 		// Step 2: federation tokens deleted
-		expect(fts.deleteBySession).toHaveBeenCalledWith("sid-1");
+		expect(fts.removeBySid).toHaveBeenCalledWith("sid-1");
 		// Step 3: all three reverse-index removeBySid called.
 		expect(sessionRPRegistry.removeBySid).toHaveBeenCalledWith("sid-1");
 		expect(sessionFederationIndex.removeBySid).toHaveBeenCalledWith("sid-1");
@@ -143,7 +143,7 @@ describe("cascadeLogout (A4 §6.2)", () => {
 		});
 
 		expect(rts.revokeFamily).not.toHaveBeenCalled();
-		expect(fts.deleteBySession).toHaveBeenCalled();
+		expect(fts.removeBySid).toHaveBeenCalled();
 		expect(uss.delete).toHaveBeenCalled();
 	});
 
@@ -197,7 +197,7 @@ describe("cascadeLogout (A4 §6.2)", () => {
 		});
 
 		expect(rts.revokeFamily).not.toHaveBeenCalled();
-		expect(fts.deleteBySession).not.toHaveBeenCalled();
+		expect(fts.removeBySid).not.toHaveBeenCalled();
 		expect(sessionRPRegistry.removeBySid).not.toHaveBeenCalled();
 		expect(sessionFamilyIndex.removeBySid).not.toHaveBeenCalled();
 		expect(sessionFederationIndex.removeBySid).not.toHaveBeenCalled();
@@ -274,7 +274,7 @@ describe("cascadeLogout (A4 §6.2)", () => {
 			sid: "s",
 			refreshTokenFamilyRevocation: rts,
 			federationTokenStore: makeFedStore({
-				deleteBySession: vi.fn().mockRejectedValue(new Error("fed fail")),
+				removeBySid: vi.fn().mockRejectedValue(new Error("fed fail")),
 			}),
 			userSessionStore: makeUserSessionStore(),
 			sessionRPRegistry: makeSessionRPRegistry(),
@@ -287,14 +287,14 @@ describe("cascadeLogout (A4 §6.2)", () => {
 		expect(result.outcome).toBe("failed");
 		if (result.outcome === "failed") {
 			expect(result.step).toBe(2);
-			// 2 revokeFamily failures + 1 deleteBySession failure = 3 errors
+			// 2 revokeFamily failures + 1 removeBySid failure = 3 errors
 			expect(result.errors).toHaveLength(3);
 		}
 	});
 
-	it("Step 2 federationTokenStore.deleteBySession failure → outcome: failed, step:2 (no longer best-effort standalone)", async () => {
+	it("Step 2 federationTokenStore.removeBySid failure → outcome: failed, step:2 (no longer best-effort standalone)", async () => {
 		const fts = makeFedStore({
-			deleteBySession: vi.fn().mockRejectedValue(new Error("net")),
+			removeBySid: vi.fn().mockRejectedValue(new Error("net")),
 		});
 		const uss = makeUserSessionStore();
 		const result = await cascadeLogout({

--- a/packages/oauth/src/logout/cascadeLogout.mts
+++ b/packages/oauth/src/logout/cascadeLogout.mts
@@ -53,7 +53,7 @@ export type CascadeLogoutResult =
  *           Fail → return failed step:1 (steps 2–4 skipped; retry safe).
  *   Step 2: Fanout — collect-and-tally.
  *           - revokeFamily loop (per family; continues on per-op failure, tallies errors)
- *           - federationTokenStore.deleteBySession (tallied on failure)
+ *           - federationTokenStore.removeBySid (tallied on failure)
  *           If ANY failure → return failed step:2 with all errors (HALT before step 3).
  *           §6.2 critical rule: HALT preserves bookkeeping for retry. Running step 3
  *           would erase reverse-index entries and silently mark the cascade complete
@@ -117,11 +117,11 @@ export async function cascadeLogout(opts: CascadeLogoutOptions): Promise<Cascade
 	}
 
 	try {
-		await opts.federationTokenStore.deleteBySession(opts.sid);
+		await opts.federationTokenStore.removeBySid(opts.sid);
 	} catch (error) {
 		stepTwoFailures.push(error);
 		logger.warn(
-			`cascadeLogout: federationTokenStore.deleteBySession(${opts.sid}) failed (continuing tally):`,
+			`cascadeLogout: federationTokenStore.removeBySid(${opts.sid}) failed (continuing tally):`,
 			error,
 		);
 	}

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -113,7 +113,7 @@ export interface LogoutRouterOptions {
  *   3. Load session from userSessionStore. Missing → 200 JSON { logged_out: true } (no-op).
  *   4. Broadcast Back-Channel Logout to all registered RPs (best-effort).
  *   5. Resolve IdP end-session URI for the first federation (if any, if provider supportsEndSession).
- *   6. Cascade logout (revokeFamily + deleteBySession + delete session).
+ *   6. Cascade logout (revokeFamily + removeBySid + delete session).
  *   7. Respond: front-channel HTML | IdP redirect | post-logout redirect | 200 JSON.
  *
  * /oauth/federation/:name/logout is handled in Task 6b (not this file).

--- a/packages/redis/__tests__/federation-tokens-removeBySid-rename.test.mts
+++ b/packages/redis/__tests__/federation-tokens-removeBySid-rename.test.mts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { FederationTokenStoreClient } from "../src/clients.mjs";
+import { createRedisFederationTokenStore } from "../src/federation-tokens.mjs";
+
+function createFakeRedis() {
+	const data = new Map<string, string>();
+	const ttls = new Map<string, number>();
+	return {
+		data,
+		ttls,
+		get: vi.fn(async (k: string) => data.get(k) ?? null),
+		set: vi.fn(
+			async (
+				k: string,
+				v: string,
+				_mode: "PX",
+				ttl: number,
+				condition?: "NX",
+			): Promise<"OK" | null> => {
+				if (condition === "NX" && data.has(k)) return null;
+				data.set(k, v);
+				ttls.set(k, ttl);
+				return "OK";
+			},
+		),
+		del: vi.fn(async (...keys: string[]) => {
+			let n = 0;
+			for (const k of keys) if (data.delete(k)) n += 1;
+			return n;
+		}),
+		scanIterator: vi.fn((opts: { MATCH: string; COUNT?: number }) => {
+			const prefix = opts.MATCH.endsWith("*") ? opts.MATCH.slice(0, -1) : opts.MATCH;
+			const matched = [...data.keys()].filter((k) => k.startsWith(prefix));
+			return (async function* () {
+				for (const k of matched) yield k;
+			})();
+		}),
+		compareAndDelete: vi.fn(async (k: string, expected: string): Promise<boolean> => {
+			const stored = data.get(k);
+			if (stored !== undefined && stored === expected) {
+				data.delete(k);
+				return true;
+			}
+			return false;
+		}),
+	} satisfies FederationTokenStoreClient & { data: Map<string, string>; ttls: Map<string, number> };
+}
+
+const encryptionKey = Buffer.alloc(32, 7);
+const tokens = {
+	accessToken: "at",
+	refreshToken: "rt-secret",
+	idToken: "it",
+	expiresAt: new Date(Date.now() + 3600_000),
+};
+
+describe("AS-3: redis FederationTokenStore.deleteBySession → removeBySid (BREAKING rename)", () => {
+	it("redis store exposes removeBySid", () => {
+		const store = createRedisFederationTokenStore({
+			client: createFakeRedis(),
+			encryption: { mode: "required", key: encryptionKey },
+		});
+		expect("removeBySid" in store).toBe(true);
+	});
+
+	it("redis store no longer exposes deleteBySession", () => {
+		const store = createRedisFederationTokenStore({
+			client: createFakeRedis(),
+			encryption: { mode: "required", key: encryptionKey },
+		});
+		expect("deleteBySession" in store).toBe(false);
+	});
+
+	it("removeBySid removes all federation entries for sid (functional parity)", async () => {
+		const redis = createFakeRedis();
+		const store = createRedisFederationTokenStore({
+			client: redis,
+			encryption: { mode: "required", key: encryptionKey },
+		});
+		await store.attach("sid-1", "google", tokens);
+		await store.attach("sid-1", "github", tokens);
+		await store.attach("sid-2", "google", tokens);
+		await store.removeBySid("sid-1");
+		expect(await store.get("sid-1", "google")).toBeNull();
+		expect(await store.get("sid-1", "github")).toBeNull();
+		expect(await store.get("sid-2", "google")).toEqual(tokens);
+	});
+});

--- a/packages/redis/__tests__/federation-tokens-removeBySid-rename.test.mts
+++ b/packages/redis/__tests__/federation-tokens-removeBySid-rename.test.mts
@@ -90,4 +90,12 @@ describe("AS-3: redis FederationTokenStore.deleteBySession → removeBySid (BREA
 		expect(await store.get("sid-1", "github")).toBeNull();
 		expect(await store.get("sid-2", "google")).toEqual(tokens);
 	});
+
+	it("removeBySid is idempotent on absent sid (parity with in-memory adapter)", async () => {
+		const store = createRedisFederationTokenStore({
+			client: createFakeRedis(),
+			encryption: { mode: "required", key: encryptionKey },
+		});
+		await expect(store.removeBySid("nope")).resolves.toBeUndefined();
+	});
 });

--- a/packages/redis/__tests__/federation-tokens.test.mts
+++ b/packages/redis/__tests__/federation-tokens.test.mts
@@ -97,7 +97,7 @@ describe("redis FederationTokenStore (encryption = required)", () => {
 		expect(await store.get("sid-1", "google")).toEqual(tokens);
 	});
 
-	it("deleteBySession removes all federations for sid", async () => {
+	it("removeBySid removes all federations for sid", async () => {
 		const store = createRedisFederationTokenStore({
 			client: redis,
 			encryption: { mode: "required", key: encryptionKey },
@@ -105,7 +105,7 @@ describe("redis FederationTokenStore (encryption = required)", () => {
 		await store.attach("sid-1", "google", tokens);
 		await store.attach("sid-1", "github", tokens);
 		await store.attach("sid-2", "google", tokens);
-		await store.deleteBySession("sid-1");
+		await store.removeBySid("sid-1");
 		expect(await store.get("sid-1", "google")).toBeNull();
 		expect(await store.get("sid-1", "github")).toBeNull();
 		expect(await store.get("sid-2", "google")).toEqual(tokens);

--- a/packages/redis/src/clients.mts
+++ b/packages/redis/src/clients.mts
@@ -212,7 +212,7 @@ export interface SessionSidSortedSetClient {
  * Backing client for FederationTokenStore adapters. Declares `get`, `set`
  * (two overloads: PX form, and PX+NX form for atomic insert-only),
  * variadic `del`, `scanIterator` for the cursor-based key scan used by
- * `deleteBySession`, and `compareAndDelete` for atomic advisory-lock
+ * `removeBySid`, and `compareAndDelete` for atomic advisory-lock
  * release.
  *
  * The plain-PX `set` overload always succeeds with `"OK"` per Redis

--- a/packages/redis/src/federation-tokens.mts
+++ b/packages/redis/src/federation-tokens.mts
@@ -214,7 +214,7 @@ export function createRedisFederationTokenStore(
 		async update(sid, name, tokens) {
 			await writeEnv(sid, name, toEnvelope(tokens));
 		},
-		async deleteBySession(sid) {
+		async removeBySid(sid) {
 			// Use SCAN (non-blocking) instead of KEYS (O(N), blocking). Each
 			// batch of scanned keys is deleted before we await the next batch.
 			const keysBatch: string[] = [];

--- a/packages/session/src/__tests__/module.test.mts
+++ b/packages/session/src/__tests__/module.test.mts
@@ -65,7 +65,7 @@ function makeFederationTokenStore(): FederationTokenStoreBase {
 			return null;
 		},
 		async update() {},
-		async deleteBySession() {},
+		async removeBySid() {},
 		async delete() {},
 	} as unknown as FederationTokenStoreBase;
 }

--- a/packages/session/src/routes/__tests__/Federation.test.mts
+++ b/packages/session/src/routes/__tests__/Federation.test.mts
@@ -208,7 +208,7 @@ function makeFederationTokenStore(): FederationTokenStoreBase & {
 		attach: vi.fn(async () => {}),
 		get: vi.fn(async () => null),
 		update: vi.fn(async () => {}),
-		deleteBySession: vi.fn(async () => {}),
+		removeBySid: vi.fn(async () => {}),
 		delete: vi.fn(async () => {}),
 	};
 }


### PR DESCRIPTION
## Summary

Two BREAKING method renames closing AS-3 and AS-11. Permitted by the v0.5.1 hotfix policy because both interfaces were new in v0.5.0 and have had no external consumers.

- **AS-3**: `FederationTokenStoreBase.deleteBySession(sid)` → `removeBySid(sid)` — verb-aligns with the four sibling session stores (`UserSessionStore`, `SessionRPRegistry`, `SessionFamilyIndex`, `SessionFederationIndex`), all of which already use `removeBySid` for the same "bulk-remove records scoped to a session id" responsibility. The logout cascade previously had to read both verbs in adjacent lines.
- **AS-11**: `MfaTransactionStore.save` / `load` → `set` / `get` — aligns with map-like store semantics (`UserSessionStore`, `KeyStore`); replaces the orphan `save` / `load` verbs.

The canonical aliases added in F9 PR3 (`FederationTokenStore`, `MfaProvider`, etc.) automatically inherit AS-3's method rename through their type alias.

## Why is this safe in a patch release?

Per spec [`auth/.claude/superpowers/specs/2026-05-05-as-naming-batch.md`](https://github.com/o3co/auth.provider/blob/develop/auth/.claude/superpowers/specs/2026-05-05-as-naming-batch.md) §"Migration / breaking changes": v0.5.1 is a security hotfix release that explicitly permits breaking API corrections for interfaces introduced in v0.5.0. `FederationTokenStoreBase` and `MfaTransactionStore` were both new in v0.5.0; the publish-to-hotfix window has been days, with no external consumers in the wild. CHANGELOG calls these out under a `BREAKING — migration` block.

## Files touched

- **Production**: `core/federation-tokens/{types,adapters/memory}.mts`, `core/mfa/{types,route,__tests__/fixtures}.mts`, `redis/{src/{clients,federation-tokens},__tests__/federation-tokens}.mts`, `oauth/{logout/cascadeLogout,routes/logout}.mts`
- **New TDD-RED tests** (3 files): `core/federation-tokens/__tests__/removeBySid-rename.test.mts`, `redis/__tests__/federation-tokens-removeBySid-rename.test.mts`, `core/mfa/__tests__/transaction-store-set-get-rename.test.mts`
- **Test-fixture migrations** (~14 AS-3 + 8 AS-11 sites across 10 test files)
- `CHANGELOG.md` BREAKING entry

## Test plan

- [x] `pnpm -r run build` ✓
- [x] `pnpm -r run test` ✓ — core 1203, redis 308, oauth 384, session 160, federation-google 22, federation-github 20, foundation 14, oauth-token-exchange 94, create-app 77, standalone 24
- [x] `pnpm -w run lint` ✓ (exit 0)
- [x] `pnpm -r exec tsc --noEmit` ✓
- [x] RED → GREEN trace verified: 13 new RED assertions failing for the right reasons before rename, all green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)