### PR TITLE
F9 PR7 — AS-4 + AS-12 token shape (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,52 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added (Phase F — F9 PR7 AS-12 legacyTokenCompat config flag, v0.5.1)
+
+- **`oauth.refreshToken.legacyTokenCompat` controls refresh-grant acceptance
+  of v0.4.x token shapes** (`@o3co/auth-provider-core` config,
+  `@o3co/auth-provider-oauth`, closes AS-12): default is `true`, preserving
+  current compatibility for tokens that use `payload.type = "refresh"` as a
+  header-typ substitute or `claims.user.id` as the subject fallback.
+
+- Setting `legacyTokenCompat = false` requires v0.5.x refresh-token shape for
+  the refresh grant: `payload.type = "refresh"` no longer substitutes for
+  missing `header.typ`, and `claims.user.id` is no longer accepted when
+  top-level `sub` is absent. This is opt-in and non-breaking while the default
+  remains `true`.
+
+- The pre-AS-12 strict marker requirement is preserved: a refresh token MUST
+  declare itself via either `header.typ === "rt+jwt"` or (when
+  `legacyTokenCompat = true`) `payload.type === "refresh"`. A typ-less JWT
+  with no `payload.type` is rejected at the refresh-grant gate regardless of
+  `legacyTokenCompat`, even when `oauth.jwt.legacyTypAccept = true` allows
+  it through SF-1's central verifier. This defends against AT-as-RT confusion
+  in deployments running `legacyTypAccept = true` during the v0.5.x transition
+  window.
+
+#### Migration
+
+Upgrade to v0.5.1 with the default `legacyTokenCompat = true`, wait for all
+v0.4.x refresh tokens to expire or be rotated into v0.5.x tokens, then set
+`oauth.refreshToken.legacyTokenCompat = false` and monitor for `invalid_grant`
+responses from clients still presenting legacy refresh tokens.
+
+#### Cross-spec coordination
+
+AS-12 is orthogonal to SF-1's `oauth.jwt.legacyTypAccept`: SF-1 owns whether
+missing `header.typ` is accepted by central JWT verification; AS-12 owns only
+the refresh-grant payload-level compatibility paths.
+
+### Documentation (Phase F — F9 PR7 AS-4 expiresAt two-tier design rationale, v0.5.1)
+
+- Added JSDoc explaining the intentional A4 `expiresAt: Date` / A3
+  `expiresAtMs: number` two-tier expiry design at all AS-4-listed sites:
+  `UserSession`, `CreateUserSessionInput`, `SessionRPRegistry.registerRP`,
+  `SessionFamilyIndex.addFamilyId`, `SessionFederationIndex.addFederation`,
+  `FederationTokens.expiresAt`, `MfaChallenge.expiresAt`, and
+  `MfaPendingTransaction.expiresAt`. Documentation-only; no runtime or type
+  behavior changes.
+
 ### Changed (Phase F — F9 PR4 AS-3 + AS-11 BREAKING method renames, v0.5.1)
 
 - **`FederationTokenStoreBase.deleteBySession(sid)` is renamed to

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -62,6 +62,11 @@ oauth {
     # detection for the request and emits an audit log.
     legacyRtPolicy = "reject"
     legacyRtPolicy = ${?OAUTH_REFRESH_TOKEN_LEGACY_RT_POLICY}
+    # AS-12: v0.5.x default accepts v0.4.x refresh-token shapes. Set false
+    # after all pre-v0.5 refresh tokens have expired to require header.typ
+    # and top-level standard subject claims.
+    legacyTokenCompat = true
+    legacyTokenCompat = ${?OAUTH_REFRESH_TOKEN_LEGACY_COMPAT}
   }
   grants {
     session { enabled = true, enabled = ${?OAUTH_GRANTS_SESSION_ENABLED} }

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -66,7 +66,7 @@ oauth {
     # after all pre-v0.5 refresh tokens have expired to require header.typ
     # and top-level standard subject claims.
     legacyTokenCompat = true
-    legacyTokenCompat = ${?OAUTH_REFRESH_TOKEN_LEGACY_COMPAT}
+    legacyTokenCompat = ${?OAUTH_REFRESH_TOKEN_LEGACY_TOKEN_COMPAT}
   }
   grants {
     session { enabled = true, enabled = ${?OAUTH_GRANTS_SESSION_ENABLED} }

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -176,6 +176,11 @@ export const CoreConfigSchema = z.object({
 			// circulation. Per the v0.5.1 ADR the literal default lives in
 			// `application.conf`, not here.
 			legacyRtPolicy: z.enum(["reject", "accept-with-warning"]),
+			// AS-12 (v0.5.1): refresh-grant compatibility gate for v0.4.x
+			// token shapes (`payload.type = "refresh"` and `claims.user.id`
+			// subject fallback). Per the v0.5.1 ADR the literal default lives
+			// in `application.conf`, not here.
+			legacyTokenCompat: z.boolean().optional(),
 		}),
 		grants: z.object({}).passthrough(),
 		// OR-9 (Wave 5d): adapter switch for the OAuth authorization-code

--- a/packages/core/src/federation-tokens/types.mts
+++ b/packages/core/src/federation-tokens/types.mts
@@ -20,6 +20,9 @@ export interface FederationTokens {
 	 * Consumers MUST treat `null` as "do not attempt refresh; reuse until the
 	 * provider explicitly invalidates". Required (no `undefined`) so adapters
 	 * are forced to make an explicit decision per provider.
+	 *
+	 * Expiry encoding: `Date` per A4 two-tier design — see {@link UserSession}
+	 * for rationale.
 	 */
 	readonly expiresAt: Date | null;
 	readonly tokenType?: string;

--- a/packages/core/src/mfa/types.mts
+++ b/packages/core/src/mfa/types.mts
@@ -19,6 +19,10 @@ import type { AdapterFactory } from "../adapters/AdapterFactory.mjs";
 export interface MfaChallenge {
 	readonly id: string;
 	readonly kind: string;
+	/**
+	 * Expiry encoding: `Date` per A4 two-tier design — see {@link UserSession}
+	 * for rationale.
+	 */
 	readonly expiresAt: Date;
 	readonly metadata?: Record<string, unknown>;
 }
@@ -110,6 +114,10 @@ export interface MfaPendingTransaction {
 	readonly subject: string;
 	readonly providerKind: string;
 	readonly challengeId: string;
+	/**
+	 * Expiry encoding: `Date` per A4 two-tier design — see {@link UserSession}
+	 * for rationale.
+	 */
 	readonly expiresAt: Date;
 	readonly resumeState: MfaResumeState;
 }

--- a/packages/core/src/user-sessions/types.mts
+++ b/packages/core/src/user-sessions/types.mts
@@ -55,9 +55,10 @@ export interface RegisteredRP {
  * for A4 aggregates. Per A3 §5.1: low-level storage primitives (A3:
  * ChallengeStore, RefreshTokenFamilyStore, ReplaySeenSet) use epoch-ms
  * `number` to eliminate Date mutation surface. A4 higher-level aggregates use
- * `Date` for ergonomics at the application layer. Callers bridging A3/A4
- * convert at the boundary (e.g. `new Date(family.expiresAtMs)` in cascade-
- * logout). This is a deliberate two-tier design, not an inconsistency.
+ * `Date` for ergonomics at the application layer. Callers bridging A3 and A4
+ * convert explicitly at the boundary (`new Date(epochMs)` to lift, or
+ * `someDate.getTime()` to lower) so the two encodings never alias the same
+ * field. This is a deliberate two-tier design, not an inconsistency.
  */
 export interface UserSession {
 	readonly sid: string;

--- a/packages/core/src/user-sessions/types.mts
+++ b/packages/core/src/user-sessions/types.mts
@@ -50,6 +50,14 @@ export interface RegisteredRP {
 /**
  * Authenticated user session aggregate. Post-create immutable at v0.5.0
  * (claims update deferred post-publish). Per A4 §5.1.
+ *
+ * Expiry encoding: `expiresAt: Date` (not `expiresAtMs: number`) is intentional
+ * for A4 aggregates. Per A3 §5.1: low-level storage primitives (A3:
+ * ChallengeStore, RefreshTokenFamilyStore, ReplaySeenSet) use epoch-ms
+ * `number` to eliminate Date mutation surface. A4 higher-level aggregates use
+ * `Date` for ergonomics at the application layer. Callers bridging A3/A4
+ * convert at the boundary (e.g. `new Date(family.expiresAtMs)` in cascade-
+ * logout). This is a deliberate two-tier design, not an inconsistency.
  */
 export interface UserSession {
 	readonly sid: string;
@@ -64,6 +72,9 @@ export interface UserSession {
  * Parameters for creating a new session. `federations` field DELETED vs
  * v0.4.x — federations are added separately via
  * `SessionFederationIndex.addFederation` after session create. Per A4 §5.1.
+ *
+ * Expiry encoding: `Date` per A4 two-tier design — see {@link UserSession}
+ * for rationale.
  */
 export interface CreateUserSessionInput {
 	readonly sid: string;
@@ -110,6 +121,10 @@ export interface UserSessionStore {
  */
 export interface SessionRPRegistry {
 	readonly kind: string;
+	/**
+	 * Expiry encoding: `Date` per A4 two-tier design — see {@link UserSession}
+	 * for rationale.
+	 */
 	registerRP(sid: string, rp: RegisteredRP, expiresAt: Date): Promise<void>;
 	listRPs(sid: string): Promise<ReadonlyArray<RegisteredRP>>;
 	removeBySid(sid: string): Promise<void>;
@@ -128,6 +143,10 @@ export interface SessionRPRegistry {
  */
 export interface SessionFamilyIndex {
 	readonly kind: string;
+	/**
+	 * Expiry encoding: `Date` per A4 two-tier design — see {@link UserSession}
+	 * for rationale.
+	 */
 	addFamilyId(sid: string, familyId: string, expiresAt: Date): Promise<void>;
 	listFamilyIds(sid: string): Promise<ReadonlyArray<string>>;
 	removeBySid(sid: string): Promise<void>;
@@ -153,6 +172,10 @@ export interface SessionFamilyIndex {
  */
 export interface SessionFederationIndex {
 	readonly kind: string;
+	/**
+	 * Expiry encoding: `Date` per A4 two-tier design — see {@link UserSession}
+	 * for rationale.
+	 */
 	addFederation(sid: string, federationName: string, expiresAt: Date): Promise<void>;
 	listFederations(sid: string): Promise<ReadonlyArray<string>>;
 	removeFederation(sid: string, federationName: string): Promise<void>;

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -519,7 +519,9 @@ describe("createRefreshTokenGrant", () => {
 				expect(result.error).toBe("invalid_grant");
 				expect(result.errorDescription).toBe("invalid refresh_token");
 			});
+		});
 
+		describe("legacyTokenCompat: backward compat (regression)", () => {
 			it("RT-4 regression: legacy path still works when legacyTokenCompat is true", async () => {
 				const legacyToken = await new SignJWT({
 					type: "refresh",

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -72,6 +72,19 @@ const mockDeps: GrantDependencies = {
 	keyStore,
 };
 
+function configWithLegacyTokenCompat(legacyTokenCompat: boolean): GrantDependencies["config"] {
+	return {
+		...mockConfig,
+		oauth: {
+			...mockConfig.oauth,
+			refreshToken: {
+				...mockConfig.oauth.refreshToken,
+				legacyTokenCompat,
+			},
+		},
+	} as unknown as GrantDependencies["config"];
+}
+
 // D-6 (v0.5.1): every test that hits the binding gate must supply both an
 // `aud` (or `azp`) on the signed RT and a matching `authenticatedClient` on
 // the GrantContext. We default both to "client1" so existing tests continue
@@ -390,6 +403,175 @@ describe("createRefreshTokenGrant", () => {
 
 			expect(result.status).toBe(200);
 			expect("tokens" in result).toBe(true);
+		});
+
+		describe("legacyTokenCompat: false", () => {
+			it("RT-1: rejects payload.type refresh as a typ substitute", async () => {
+				const legacyToken = await new SignJWT({ type: "refresh", sub: "u1" })
+					.setProtectedHeader({ alg: "HS256", kid: "v0" })
+					.setIssuer("localhost")
+					.setAudience(DEFAULT_CLIENT_ID)
+					.setExpirationTime("24h")
+					.sign(secretKey);
+				const handler = createRefreshTokenGrant({
+					...mockDeps,
+					config: configWithLegacyTokenCompat(false),
+				});
+
+				const { result } = await handler.handle({
+					body: { refresh_token: legacyToken },
+					session: {},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
+				});
+
+				expect(result.status).toBe(400);
+				if (!("error" in result)) expect.fail("Expected error in result");
+				expect(result.error).toBe("invalid_grant");
+				expect(result.errorDescription).toBe("invalid refresh_token");
+			});
+
+			it("RT-2: accepts header.typ rt+jwt with standard claims", async () => {
+				const modernToken = await makeRefreshToken({ sub: "u1", azp: DEFAULT_CLIENT_ID });
+				const handler = createRefreshTokenGrant({
+					...mockDeps,
+					config: configWithLegacyTokenCompat(false),
+				});
+
+				const { result } = await handler.handle({
+					body: { refresh_token: modernToken },
+					session: {},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
+				});
+
+				expect(result.status).toBe(200);
+				expect("tokens" in result).toBe(true);
+			});
+
+			it("RT-3: ignores claims.user.id fallback for sub", async () => {
+				const legacyClaimsToken = await new SignJWT({
+					type: "refresh",
+					user: { id: "u1" },
+					scope: "read",
+				})
+					.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+					.setIssuer("localhost")
+					.setAudience(DEFAULT_CLIENT_ID)
+					.setExpirationTime("24h")
+					.sign(secretKey);
+				const handler = createRefreshTokenGrant({
+					...mockDeps,
+					config: configWithLegacyTokenCompat(false),
+				});
+
+				const { result } = await handler.handle({
+					body: { refresh_token: legacyClaimsToken },
+					session: {},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
+				});
+
+				expect(result.status).toBe(400);
+				if (!("error" in result)) expect.fail("Expected error in result");
+				expect(result.error).toBe("invalid_grant");
+				expect(result.errorDescription).toBe("refresh token has no subject");
+			});
+
+			it("RT-OC: typ-less JWT with no refresh marker is rejected even when legacyTypAccept=true (strict gate preserved)", async () => {
+				// SF-1's legacyTypAccept=true allows a typ-less JWT through the
+				// central verifier. AS-12's gate must STILL reject it because
+				// the token declares no refresh marker (neither header.typ nor
+				// payload.type === "refresh"). Without this guard, any AT or
+				// non-refresh JWT signed with the same key could pass as a
+				// refresh token — that is the AT-as-RT confusion vector the
+				// strict marker check defends against. legacyTokenCompat is
+				// orthogonal: flipping it neither relaxes nor tightens this
+				// "some marker required" property.
+				const typLessUnmarkedToken = await new SignJWT({
+					sub: "u1",
+					azp: DEFAULT_CLIENT_ID,
+					scope: "read",
+				})
+					.setProtectedHeader({ alg: "HS256", kid: "v0" })
+					.setIssuer("localhost")
+					.setAudience(DEFAULT_CLIENT_ID)
+					.setExpirationTime("24h")
+					.sign(secretKey);
+				const handler = createRefreshTokenGrant({
+					...mockDeps,
+					config: configWithLegacyTokenCompat(false),
+				});
+
+				const { result } = await handler.handle({
+					body: { refresh_token: typLessUnmarkedToken },
+					session: {},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
+				});
+
+				expect(result.status).toBe(400);
+				if (!("error" in result)) expect.fail("Expected error in result");
+				expect(result.error).toBe("invalid_grant");
+				expect(result.errorDescription).toBe("invalid refresh_token");
+			});
+
+			it("RT-4 regression: legacy path still works when legacyTokenCompat is true", async () => {
+				const legacyToken = await new SignJWT({
+					type: "refresh",
+					user: { id: "u1" },
+					scope: "read",
+				})
+					.setProtectedHeader({ alg: "HS256", kid: "v0" })
+					.setIssuer("localhost")
+					.setAudience(DEFAULT_CLIENT_ID)
+					.setExpirationTime("24h")
+					.sign(secretKey);
+				const handler = createRefreshTokenGrant({
+					...mockDeps,
+					config: configWithLegacyTokenCompat(true),
+				});
+
+				const { result } = await handler.handle({
+					body: { refresh_token: legacyToken },
+					session: {},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
+				});
+
+				expect(result.status).toBe(200);
+				expect("tokens" in result).toBe(true);
+			});
+
+			it("RT-5 regression: legacyTokenCompat defaults to true when unset", async () => {
+				const legacyToken = await new SignJWT({
+					type: "refresh",
+					user: { id: "u1" },
+					scope: "read",
+				})
+					.setProtectedHeader({ alg: "HS256", kid: "v0" })
+					.setIssuer("localhost")
+					.setAudience(DEFAULT_CLIENT_ID)
+					.setExpirationTime("24h")
+					.sign(secretKey);
+				const handler = createRefreshTokenGrant(mockDeps);
+
+				const { result } = await handler.handle({
+					body: { refresh_token: legacyToken },
+					session: {},
+					issuer: "localhost",
+					metadata: { ip: "127.0.0.1" },
+					authenticatedClient: DEFAULT_AUTH_CLIENT,
+				});
+
+				expect(result.status).toBe(200);
+				expect("tokens" in result).toBe(true);
+			});
 		});
 
 		it("does not return sessionMutation", async () => {

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -65,7 +65,7 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				};
 			}
 			const authenticatedClientId = ctx.authenticatedClient.clientId;
-			const legacyCompatEnabled = config.oauth.refreshToken?.legacyTokenCompat !== false;
+			const legacyCompatEnabled = config.oauth.refreshToken.legacyTokenCompat !== false;
 
 			let tokenPayload: JWTPayload;
 			let typ: string | undefined;
@@ -113,6 +113,12 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			const legacyType = legacyCompatEnabled
 				? (tokenPayload as Record<string, unknown>).type
 				: undefined;
+			// Invariant — see RT-OC test: this gate keeps AT-as-RT confusion
+			// defended. A JWT with no `header.typ` AND no `payload.type` is
+			// rejected regardless of `legacyTokenCompat`, even when SF-1's
+			// `legacyTypAccept = true` allowed a typ-less token through the
+			// central verifier. Refactors that touch this condition MUST
+			// keep RT-OC green.
 			if (typ !== "rt+jwt" && legacyType !== "refresh") {
 				return {
 					result: {
@@ -309,11 +315,11 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 					audience: finalAudience,
 					subject: subjectStr ?? null,
 					// D-6: new token `azp` is the authenticated client. The legacy
-					// decoder path has been subsumed by the binding gate above
-					// (which proves the input token's azp/aud equalled
-					// `authenticatedClientId`), so reading from
-					// `ctx.authenticatedClient.clientId` is strictly equivalent and
-					// removes the body-spoofable surface.
+					// `tokenAzp` resolution (`claims.azp ?? tokenAud`) has been
+					// subsumed by the binding gate above (which proves the input
+					// token's azp/aud equalled `authenticatedClientId`), so
+					// reading from `ctx.authenticatedClient.clientId` is strictly
+					// equivalent and removes the body-spoofable surface.
 					authorizedParty: authenticatedClientId,
 					scope: scopeClaim,
 					tokenType: "at+jwt",

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -65,6 +65,7 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				};
 			}
 			const authenticatedClientId = ctx.authenticatedClient.clientId;
+			const legacyCompatEnabled = config.oauth.refreshToken?.legacyTokenCompat !== false;
 
 			let tokenPayload: JWTPayload;
 			let typ: string | undefined;
@@ -101,7 +102,17 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			// the central verifier's typ-skip would silently accept any AT lacking
 			// typ as a refresh token. v0.6+ flips legacyTypAccept=false at the
 			// verifier and removes this block.
-			const legacyType = (tokenPayload as Record<string, unknown>).type;
+			//
+			// AS-12 (v0.5.1): the legacy `payload.type === "refresh"` substitute
+			// is gated by `oauth.refreshToken.legacyTokenCompat`. When that flag
+			// is `false`, only `header.typ === "rt+jwt"` is accepted as a refresh
+			// marker. The strict-gate semantic (token MUST declare refresh via
+			// either marker) is preserved — AS-12 only narrows the *legacy*
+			// fallback path; it does NOT relax the requirement that some marker
+			// be present.
+			const legacyType = legacyCompatEnabled
+				? (tokenPayload as Record<string, unknown>).type
+				: undefined;
 			if (typ !== "rt+jwt" && legacyType !== "refresh") {
 				return {
 					result: {
@@ -135,7 +146,8 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			const subjectStr =
 				typeof tokenPayload.sub === "string"
 					? tokenPayload.sub
-					: typeof (claims.user as Record<string, unknown> | undefined)?.id === "string"
+					: legacyCompatEnabled &&
+							typeof (claims.user as Record<string, unknown> | undefined)?.id === "string"
 						? ((claims.user as Record<string, unknown>).id as string)
 						: undefined;
 			const scopeStr =
@@ -297,12 +309,11 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 					audience: finalAudience,
 					subject: subjectStr ?? null,
 					// D-6: new token `azp` is the authenticated client. The legacy
-					// `claims.azp ?? claims.client.id` decoder was the only other
-					// code path that could populate this slot; both have been
-					// subsumed by the binding gate above (which proves the input
-					// token's azp/aud equalled `authenticatedClientId`), so reading
-					// from `ctx.authenticatedClient.clientId` is strictly equivalent
-					// and removes the body-spoofable surface.
+					// decoder path has been subsumed by the binding gate above
+					// (which proves the input token's azp/aud equalled
+					// `authenticatedClientId`), so reading from
+					// `ctx.authenticatedClient.clientId` is strictly equivalent and
+					// removes the body-spoofable surface.
 					authorizedParty: authenticatedClientId,
 					scope: scopeClaim,
 					tokenType: "at+jwt",

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -68,6 +68,11 @@ oauth {
     # log. Pair with `unknownFamilyPolicy = "accept"` to avoid immediate
     # rejection on the next refresh — see Phase F migration guide.
     # legacyRtPolicy = "reject"
+    # AS-12 (v0.5.1): v0.5.x default accepts v0.4.x refresh tokens that use
+    # payload.type = "refresh" or claims.user.id as the subject. Set false
+    # only after all pre-v0.5 refresh tokens have expired; remaining legacy
+    # tokens will be rejected with invalid_grant.
+    # legacyTokenCompat = true
   }
   grants {
     session { enabled = true, enabled = ${?OAUTH_GRANTS_SESSION_ENABLED} }

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -71,7 +71,12 @@ oauth {
     # AS-12 (v0.5.1): v0.5.x default accepts v0.4.x refresh tokens that use
     # payload.type = "refresh" or claims.user.id as the subject. Set false
     # only after all pre-v0.5 refresh tokens have expired; remaining legacy
-    # tokens will be rejected with invalid_grant.
+    # tokens will be rejected with invalid_grant. The strict marker-required
+    # gate is preserved across both flag values: a typ-less JWT with no
+    # payload.type is rejected at the refresh-grant gate even when
+    # oauth.jwt.legacyTypAccept = true (AT-as-RT confusion stays defended).
+    # Operators set OAUTH_REFRESH_TOKEN_LEGACY_TOKEN_COMPAT for env-var
+    # override.
     # legacyTokenCompat = true
   }
   grants {


### PR DESCRIPTION
## Summary

Closes the AS-4 + AS-12 token shape spec subset of F9. Codex (workspace-write) drove the implementation against the refreshed spec; a human-led review afterwards restored a strict marker-required refresh gate that the spec's original RT-OC had inadvertently relaxed.

- **AS-4** (documentation only): JSDoc explaining the intentional A4 (`Date`) / A3 (`number`) two-tier `expiresAt` encoding at all 8 spec-listed sites (`UserSession`, `CreateUserSessionInput`, `SessionRPRegistry.registerRP`, `SessionFamilyIndex.addFamilyId`, `SessionFederationIndex.addFederation`, `FederationTokens.expiresAt`, `MfaChallenge.expiresAt`, `MfaPendingTransaction.expiresAt`). No runtime change.
- **AS-12**: introduces `oauth.refreshToken.legacyTokenCompat` (default `true`). When `false`, two v0.4.x legacy fallbacks at the refresh grant are gated:
  1. `payload.type === "refresh"` can no longer substitute for `header.typ`.
  2. `claims.user.id` is no longer accepted as a `sub` fallback when top-level `tokenPayload.sub` is absent.
- The pre-AS-12 strict marker requirement is preserved: a JWT with no `header.typ` AND no `payload.type` is rejected at the refresh-grant gate regardless of `legacyTokenCompat`, even when `legacyTypAccept=true` allows it through SF-1's central verifier. This defends against AT-as-RT confusion in deployments running `legacyTypAccept=true` during the v0.5.x transition window. The spec was updated with a "round 2 — strict-gate preservation" note explaining the reversal.

## Why is this safe in a patch release?

`legacyTokenCompat` defaults to `true`, preserving backward compatibility. Operators opt in to `false` once all v0.4.x refresh tokens have expired or been rotated. AS-4 is JSDoc only.

## Implementation flow (Codex-driven)

1. Spec refresh (Claude, 2 rounds): round 1 pruned dead `claims.client.id` references (D-6 PB-2 already eliminated that path); round 2 added a strict-gate-preservation note after the security review.
2. Codex prompt drafted in `/tmp/codex-io/2026-05-08-113137-implement-f9-pr7.in.md`; dispatched via `codex exec -s workspace-write < input > output`.
3. Codex implemented the schema / HOCON ×2 / code gate / 6 RED tests / CHANGELOG.
4. Human review caught a Codex logic bug + spec design flaw: the gate's middle conjunct was incorrectly tightening the safety net to "only reject when `payload.type === "refresh"` is present" (per spec RT-OC's relaxation); load-bearing safety comment had been deleted. Restored to the simpler form `if (typ !== "rt+jwt" && legacyType !== "refresh") reject`. RT-OC test rewritten to assert rejection of typ-less unmarked JWTs.
5. Spec updated with the "strict-gate preservation" note as a memory aid for future readers.

## Test plan

- [x] `pnpm -r run build` ✓
- [x] `pnpm -r run test` ✓ (oauth 384 → 390, +6 RT tests; core 1203 unchanged because AS-4 is JSDoc only)
- [x] `pnpm -w run lint` ✓ (exit 0)
- [x] `pnpm -r exec tsc --noEmit` ✓
- [x] RED → GREEN trace verified end-to-end for all 6 AS-12 tests; strict-gate restoration verified by rerunning RT-OC after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)