### PR TITLE
F10: Harden token exchange security boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security (Phase F — F10 Token Exchange hardening)
+
+- Token Exchange now rejects policy hook scope/audience widening by default,
+  enforces `may_act` actor constraints when present, bounds nested RFC 8693
+  actor chains via `oauth.tokenExchange.maxActorChainDepth`, and requires
+  requested RFC 8707 resources to be represented in the effective issued-token
+  audience.
+
 ## [0.5.2] — 2026-05-09
 
 ### Changed (auth.utils dependency bump, v0.5.2)

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -95,6 +95,13 @@ oauth {
     maxLength = 256
     maxLength = ${?OAUTH_NONCE_MAX_LENGTH}
   }
+  # F10: maximum existing RFC 8693 actor chain depth accepted before adding
+  # the current actor. Depth 3 allows one current actor plus two prior nested
+  # actors; lower for stricter delegation environments.
+  tokenExchange {
+    maxActorChainDepth = 3
+    maxActorChainDepth = ${?OAUTH_TOKEN_EXCHANGE_MAX_ACTOR_CHAIN_DEPTH}
+  }
 }
 
 session {

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -209,6 +209,14 @@ export const CoreConfigSchema = z.object({
 				maxLength: z.coerce.number().int().positive(),
 			})
 			.optional(),
+		// F10 (v0.5.3): bound RFC 8693 actor delegation chains so repeated
+		// token exchanges cannot grow unbounded nested `act` claims. Shape-only —
+		// defaults live in HOCON, not zod.
+		tokenExchange: z
+			.object({
+				maxActorChainDepth: z.coerce.number().int().positive(),
+			})
+			.optional(),
 	}),
 });
 

--- a/packages/oauth-token-exchange/README.md
+++ b/packages/oauth-token-exchange/README.md
@@ -107,9 +107,11 @@ const handle = await createApp({
 
 4. **Cross-client audience confusion defense.** When the `audience` request parameter is omitted, the handler inherits `subject_token.aud` only if it is in `client.allowedAudiences ∪ { client.clientId }`. Otherwise it falls back to `clientId`. This prevents a malicious client from exchanging a stolen token outside its intended audience just by omitting the audience parameter.
 
-5. **Policy hook widening is permitted by design.** The `GrantPolicyHook.evaluate()` result's `grantedScope` and `grantedAudience` override the handler's pre-narrowed values without re-verification. A first-party consumer policy CAN widen scope or audience if it wants to — this is the intentional escape hatch for operational needs (e.g., an admin flow that grants a superset). Consumers own the consequences of widening policies. If you want strict narrowing-only policies, write your `evaluate()` method defensively and never return `grantedScope`/`grantedAudience` that exceeds what you were given.
+5. **Policy hook widening is rejected by default.** The `GrantPolicyHook.evaluate()` result's `grantedScope` and `grantedAudience` are still allowed to override the request-derived values, but the handler re-checks them against the validated `subject_token` boundary before minting. Scope or audience widening returns `invalid_target` with `scope_widening_not_allowed` or `audience_widening_not_allowed`. Direct callers of `createTokenExchangeGrant()` can set the deprecated `allowPolicyWidening` migration escape hatch while replacing old widening policies; module wiring keeps the safe default.
 
-6. **Impersonation vs delegation.** An exchange without `actor_token` issues an impersonation token (no `act` claim). Deployments that require audit trails should add a `GrantPolicyHook` that rejects requests lacking `actor_token`:
+6. **Resource indicators must be represented in the issued audience.** When the request includes RFC 8707 `resource`, every requested resource must appear in the effective `grantedAudience` used for the exchange. A resource/audience mismatch returns `invalid_target` with `requested_resources_not_in_audience`.
+
+7. **Impersonation vs delegation.** An exchange without `actor_token` issues an impersonation token (no `act` claim). Deployments that require audit trails should add a `GrantPolicyHook` that rejects requests lacking `actor_token`:
 
    ```ts
    async evaluate(req) {
@@ -121,15 +123,19 @@ const handle = await createApp({
    }
    ```
 
-7. **Family cascade.** Issued access_tokens inherit the subject's `family_id` claim. Revoking the subject's family (e.g. on logout) automatically invalidates every token exchanged from it. This is the same mechanism auth.provider's introspect and userinfo endpoints use.
+8. **`may_act` is enforced when present.** If a subject token carries a `may_act` claim, the supplied `actor_token` must match one of its `{ sub?, iss? }` constraints. Malformed or non-matching `may_act` values fail closed with `may_act_violation`; subject tokens without `may_act` continue to use the existing policy-hook boundary.
 
-8. **Refresh / ID tokens are never issued.** Per RFC 8693 §4.2.2 the handler only returns an access_token. The response always carries `issued_token_type: "urn:ietf:params:oauth:token-type:access_token"`.
+9. **Actor chains are bounded.** `oauth.tokenExchange.maxActorChainDepth` defaults to `3` and can be overridden with `OAUTH_TOKEN_EXCHANGE_MAX_ACTOR_CHAIN_DEPTH`. When an `actor_token` would add to an already-full nested `act` chain, the handler rejects the request with `actor_chain_too_deep`.
 
-9. **Missing subject claim rejection.** Self-issued access_tokens without a `sub` claim (or with an empty-string `sub`) are rejected with `invalid_grant`. This prevents a silently-anonymous token from reaching downstream services.
+10. **Family cascade.** Issued access_tokens inherit the subject's `family_id` claim. Revoking the subject's family (e.g. on logout) automatically invalidates every token exchanged from it. This is the same mechanism auth.provider's introspect and userinfo endpoints use.
 
-10. **Validator contributions are immutable after boot.** The boot planner aggregates `tokenExchangeValidators` contributions, freezes the world during activation, and exposes only a read-only resolver to the grant handler. Post-boot mutation cannot replace the built-in validator at runtime.
+11. **Refresh / ID tokens are never issued.** Per RFC 8693 §4.2.2 the handler only returns an access_token. The response always carries `issued_token_type: "urn:ietf:params:oauth:token-type:access_token"`.
 
-11. **Confidential clients only (v0.5.0).** The handler requires `client_secret` and authenticates via `clientRepository.authenticate()`. Requests without a secret are rejected with `invalid_client` (401). The core `Client` type carries `clientSecret: string` as a required field and `PublicClient = Omit<Client, "clientSecret">`, so `findById()` alone cannot tell a "no secret configured" client from "secret omitted by caller" — accepting the unauthenticated path would let an attacker exchange a stolen `subject_token` under any client's allowlist. Public-client support is deferred until a `Client.public` flag (or equivalent) lands in core.
+12. **Missing subject claim rejection.** Self-issued access_tokens without a `sub` claim (or with an empty-string `sub`) are rejected with `invalid_grant`. This prevents a silently-anonymous token from reaching downstream services.
+
+13. **Validator contributions are immutable after boot.** The boot planner aggregates `tokenExchangeValidators` contributions, freezes the world during activation, and exposes only a read-only resolver to the grant handler. Post-boot mutation cannot replace the built-in validator at runtime.
+
+14. **Confidential clients only (v0.5.0).** The handler requires `client_secret` and authenticates via `clientRepository.authenticate()`. Requests without a secret are rejected with `invalid_client` (401). The core `Client` type carries `clientSecret: string` as a required field and `PublicClient = Omit<Client, "clientSecret">`, so `findById()` alone cannot tell a "no secret configured" client from "secret omitted by caller" — accepting the unauthenticated path would let an attacker exchange a stolen `subject_token` under any client's allowlist. Public-client support is deferred until a `Client.public` flag (or equivalent) lands in core.
 
 ## Registration pattern summary
 

--- a/packages/oauth-token-exchange/src/__tests__/grant-integration.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant-integration.test.mts
@@ -110,6 +110,7 @@ describe("token_exchange — integration", () => {
 		const subjectToken = await signSelfIssuedAccessToken({
 			family_id: "fam-1",
 			scope: "read write",
+			aud: "billing",
 		});
 
 		const { result } = await handler.handle(

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -67,6 +67,7 @@ function buildGrant(
 		validatorRefreshStore?: ReturnType<typeof makeFamilyRevocation> | null;
 		config?: AppConfig;
 		grantPolicy?: GrantPolicyHookBase;
+		allowPolicyWidening?: boolean;
 	} = {},
 ) {
 	const registry = overrides.validatorRegistry ?? new ExchangeTokenValidatorRegistry();
@@ -99,6 +100,9 @@ function buildGrant(
 		// test scaffolding even though it is no longer publicly exported.
 		tokenExchangeValidatorResolver: registry,
 		clientRepository: overrides.clientRepository ?? mockClientRepository(),
+		...(overrides.allowPolicyWidening !== undefined
+			? { allowPolicyWidening: overrides.allowPolicyWidening }
+			: {}),
 		...(overrides.grantPolicy ? { grantPolicy: overrides.grantPolicy } : {}),
 	});
 }
@@ -498,7 +502,10 @@ describe("createTokenExchangeGrant — narrowing checks", () => {
 				publicClient({ allowedAudiences: ["billing", "inventory"] }),
 			),
 		});
-		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const token = await signSelfIssuedAccessToken({
+			family_id: "fam-1",
+			aud: ["billing", "inventory"],
+		});
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
@@ -509,6 +516,27 @@ describe("createTokenExchangeGrant — narrowing checks", () => {
 			}),
 		);
 		expect(result.status).toBe(200);
+	});
+
+	it("rejects audience that is client-allowed but outside the subject audience", async () => {
+		const g = buildGrant({
+			clientRepository: mockClientRepository(publicClient({ allowedAudiences: ["inventory"] })),
+		});
+		const token = await signSelfIssuedAccessToken({ aud: "billing", family_id: "fam-1" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				audience: "inventory",
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_target",
+			errorDescription: expect.stringMatching(/audience_widening_not_allowed/),
+		});
 	});
 
 	it("mints a token when audience is empty array (treated as no audience requested)", async () => {
@@ -578,6 +606,90 @@ describe("createTokenExchangeGrant — narrowing checks", () => {
 		expect(result.status).toBe(200);
 		if (result.status !== 200) return;
 		expect(result.tokens.scope).toBe("read write");
+	});
+});
+
+describe("createTokenExchangeGrant — SF-5 policy subset enforcement", () => {
+	it("rejects when policy hook widens scope beyond subject scope by default", async () => {
+		const wideningPolicy: GrantPolicyHookBase = {
+			kind: "scope-widening",
+			async evaluate() {
+				return {
+					outcome: "allow",
+					grantedScope: ["read", "write"],
+				};
+			},
+		};
+		const g = buildGrant({ grantPolicy: wideningPolicy });
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1", scope: "read" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_target",
+			errorDescription: expect.stringMatching(/scope_widening_not_allowed/),
+		});
+	});
+
+	it("rejects when policy hook widens audience beyond subject aud by default", async () => {
+		const wideningPolicy: GrantPolicyHookBase = {
+			kind: "audience-widening",
+			async evaluate() {
+				return {
+					outcome: "allow",
+					grantedAudience: ["billing", "inventory"],
+				};
+			},
+		};
+		const g = buildGrant({ grantPolicy: wideningPolicy });
+		const token = await signSelfIssuedAccessToken({
+			aud: "billing",
+			family_id: "fam-1",
+		});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_target",
+			errorDescription: expect.stringMatching(/audience_widening_not_allowed/),
+		});
+	});
+
+	it("allows explicit policy widening only when allowPolicyWidening=true", async () => {
+		const wideningPolicy: GrantPolicyHookBase = {
+			kind: "widening-opt-in",
+			async evaluate() {
+				return {
+					outcome: "allow",
+					grantedScope: ["read", "write", "admin"],
+				};
+			},
+		};
+		const g = buildGrant({ grantPolicy: wideningPolicy, allowPolicyWidening: true });
+		const token = await signSelfIssuedAccessToken({ family_id: "fam-1", scope: "read" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		expect(result.tokens.scope).toBe("read write admin");
 	});
 });
 
@@ -833,6 +945,157 @@ describe("createTokenExchangeGrant — happy path", () => {
 		expect(payload.act).toEqual({ sub: "svc-b", act: { sub: "svc-upstream" } });
 	});
 
+	it("rejects actor delegation when subject may_act does not authorize actor.sub", async () => {
+		const g = buildGrant();
+		const subject = await signSelfIssuedAccessToken({
+			family_id: "fam-1",
+			may_act: [{ sub: "svc-allowed" }],
+		});
+		const actor = await signSelfIssuedAccessToken({ sub: "svc-attacker" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: subject,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token: actor,
+				actor_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_request",
+			errorDescription: expect.stringMatching(/may_act_violation/),
+		});
+	});
+
+	it("accepts actor delegation when actor matches may_act sub and iss", async () => {
+		const g = buildGrant();
+		const subject = await signSelfIssuedAccessToken({
+			family_id: "fam-1",
+			may_act: [{ sub: "svc-a", iss: ISSUER }],
+		});
+		const actor = await signSelfIssuedAccessToken({ sub: "svc-a", iss: ISSUER });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: subject,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token: actor,
+				actor_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.act).toEqual({ sub: "svc-a" });
+	});
+
+	it("rejects actor delegation when may_act iss does not match actor iss", async () => {
+		const g = buildGrant();
+		const subject = await signSelfIssuedAccessToken({
+			family_id: "fam-1",
+			may_act: [{ sub: "svc-a", iss: "https://trusted.example" }],
+		});
+		const actor = await signSelfIssuedAccessToken({ sub: "svc-a", iss: ISSUER });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: subject,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token: actor,
+				actor_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_request",
+			errorDescription: expect.stringMatching(/may_act_violation/),
+		});
+	});
+
+	it("rejects actor delegation when may_act is an empty actor list", async () => {
+		const g = buildGrant();
+		const subject = await signSelfIssuedAccessToken({
+			family_id: "fam-1",
+			may_act: [],
+		});
+		const actor = await signSelfIssuedAccessToken({ sub: "svc-a" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: subject,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token: actor,
+				actor_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_request",
+			errorDescription: expect.stringMatching(/may_act_violation/),
+		});
+	});
+
+	it("rejects actor delegation fail-closed when may_act is malformed", async () => {
+		const g = buildGrant();
+		const subject = await signSelfIssuedAccessToken({
+			family_id: "fam-1",
+			may_act: "svc-a",
+		});
+		const actor = await signSelfIssuedAccessToken({ sub: "svc-a" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: subject,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token: actor,
+				actor_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_request",
+			errorDescription: expect.stringMatching(/may_act_violation/),
+		});
+	});
+
+	it("rejects actor delegation when adding actor would exceed maxActorChainDepth", async () => {
+		const g = buildGrant({
+			config: {
+				...mockConfig,
+				oauth: {
+					...mockConfig.oauth,
+					tokenExchange: { maxActorChainDepth: 2 },
+				},
+			} as unknown as AppConfig,
+		});
+		const subject = await signSelfIssuedAccessToken({
+			family_id: "fam-1",
+			act: { sub: "svc-2", act: { sub: "svc-1" } },
+		});
+		const actor = await signSelfIssuedAccessToken({ sub: "svc-3" });
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: subject,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				actor_token: actor,
+				actor_token_type: ACCESS_TOKEN_TYPE,
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_request",
+			errorDescription: expect.stringMatching(/actor_chain_too_deep/),
+		});
+	});
+
 	it("inherits family_id from subject (cascade revoke)", async () => {
 		const g = buildGrant();
 		const token = await signSelfIssuedAccessToken({ family_id: "fam-xyz" });
@@ -873,7 +1136,11 @@ describe("createTokenExchangeGrant — policy hook", () => {
 				publicClient({ allowedAudiences: ["billing", "inventory"] }),
 			),
 		});
-		const token = await signSelfIssuedAccessToken({ family_id: "fam-1", scope: "read write" });
+		const token = await signSelfIssuedAccessToken({
+			family_id: "fam-1",
+			scope: "read write",
+			aud: ["billing", "inventory"],
+		});
 		const { result } = await g.handle(
 			ctx({
 				client_id: "client-a",
@@ -911,11 +1178,7 @@ describe("createTokenExchangeGrant — policy hook", () => {
 		expect(result).toMatchObject({ status: 503, error: "temporarily_unavailable" });
 	});
 
-	it("documents that policy hook may widen scope beyond subject (by design — see spec §8.1 rule 4)", async () => {
-		// This test documents the intentional widening behavior. The built-in
-		// scope subset check (requested ⊆ subject) is NOT re-applied to policy
-		// hook output. Consumers who install a widening policy accept the
-		// consequences per spec §8.1.
+	it("documents that policy hook widening requires explicit allowPolicyWidening opt-in", async () => {
 		const wideningPolicy: GrantPolicyHookBase = {
 			kind: "widening",
 			async evaluate() {
@@ -925,7 +1188,7 @@ describe("createTokenExchangeGrant — policy hook", () => {
 				};
 			},
 		};
-		const g = buildGrant({ grantPolicy: wideningPolicy });
+		const g = buildGrant({ grantPolicy: wideningPolicy, allowPolicyWidening: true });
 		const token = await signSelfIssuedAccessToken({ family_id: "fam-1", scope: "read" });
 		const { result } = await g.handle(
 			ctx({
@@ -937,7 +1200,6 @@ describe("createTokenExchangeGrant — policy hook", () => {
 		);
 		expect(result.status).toBe(200);
 		if (result.status !== 200) return;
-		// Policy successfully widened scope — this is the documented behavior.
 		expect(result.tokens.scope).toBe("read write admin");
 	});
 
@@ -947,11 +1209,14 @@ describe("createTokenExchangeGrant — policy hook", () => {
 			kind: "capture",
 			async evaluate(req) {
 				captured = req;
-				return { outcome: "allow" };
+				return { outcome: "allow", grantedAudience: ["https://api.example.com"] };
 			},
 		};
 		const g = buildGrant({ grantPolicy: capturing });
-		const token = await signSelfIssuedAccessToken({ family_id: "fam-1" });
+		const token = await signSelfIssuedAccessToken({
+			aud: ["https://api.example.com"],
+			family_id: "fam-1",
+		});
 		await g.handle(
 			ctx({
 				client_id: "client-a",
@@ -963,6 +1228,64 @@ describe("createTokenExchangeGrant — policy hook", () => {
 		);
 		expect(captured).not.toBeNull();
 		expect(captured?.resource).toEqual(["https://api.example.com"]);
+	});
+
+	it("rejects resource when it is missing from the issued-token audience", async () => {
+		const policy: GrantPolicyHookBase = {
+			kind: "resource-missing",
+			async evaluate() {
+				return { outcome: "allow", grantedAudience: ["https://other.example.com"] };
+			},
+		};
+		const g = buildGrant({ grantPolicy: policy });
+		const token = await signSelfIssuedAccessToken({
+			aud: ["https://api.example.com", "https://other.example.com"],
+			family_id: "fam-1",
+		});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				resource: "https://api.example.com",
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_target",
+			errorDescription: expect.stringMatching(/requested_resources_not_in_audience/),
+		});
+	});
+
+	it("mints a token when all requested resources are in the policy-returned audience", async () => {
+		const policy: GrantPolicyHookBase = {
+			kind: "resource-ok",
+			async evaluate() {
+				return {
+					outcome: "allow",
+					grantedAudience: ["https://api.example.com/users", "https://api.example.com/orders"],
+				};
+			},
+		};
+		const g = buildGrant({ grantPolicy: policy });
+		const token = await signSelfIssuedAccessToken({
+			aud: ["https://api.example.com/users", "https://api.example.com/orders"],
+			family_id: "fam-1",
+		});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				resource: ["https://api.example.com/users", "https://api.example.com/orders"],
+			}),
+		);
+		expect(result.status).toBe(200);
+		if (result.status !== 200) return;
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.aud).toBe("https://api.example.com/users");
 	});
 });
 

--- a/packages/oauth-token-exchange/src/__tests__/grant.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/grant.test.mts
@@ -1258,9 +1258,9 @@ describe("createTokenExchangeGrant — policy hook", () => {
 		});
 	});
 
-	it("mints a token when all requested resources are in the policy-returned audience", async () => {
+	it("rejects resources that are only present in non-issued policy audience entries", async () => {
 		const policy: GrantPolicyHookBase = {
-			kind: "resource-ok",
+			kind: "resource-non-issued-aud",
 			async evaluate() {
 				return {
 					outcome: "allow",
@@ -1280,6 +1280,37 @@ describe("createTokenExchangeGrant — policy hook", () => {
 				subject_token: token,
 				subject_token_type: ACCESS_TOKEN_TYPE,
 				resource: ["https://api.example.com/users", "https://api.example.com/orders"],
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			error: "invalid_target",
+			errorDescription: expect.stringMatching(/requested_resources_not_in_audience/),
+		});
+	});
+
+	it("mints a token when requested resource equals the issued-token audience", async () => {
+		const policy: GrantPolicyHookBase = {
+			kind: "resource-ok",
+			async evaluate() {
+				return {
+					outcome: "allow",
+					grantedAudience: ["https://api.example.com/users"],
+				};
+			},
+		};
+		const g = buildGrant({ grantPolicy: policy });
+		const token = await signSelfIssuedAccessToken({
+			aud: ["https://api.example.com/users"],
+			family_id: "fam-1",
+		});
+		const { result } = await g.handle(
+			ctx({
+				client_id: "client-a",
+				client_secret: "any",
+				subject_token: token,
+				subject_token_type: ACCESS_TOKEN_TYPE,
+				resource: "https://api.example.com/users",
 			}),
 		);
 		expect(result.status).toBe(200);

--- a/packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts
+++ b/packages/oauth-token-exchange/src/__tests__/selfIssuedAccessToken.test.mts
@@ -100,6 +100,18 @@ describe("createSelfIssuedAccessTokenValidator", () => {
 		expect(result?.act).toEqual({ sub: "service-upstream" });
 	});
 
+	it("projects may_act only when every array entry is an object", async () => {
+		const valid = await signSelfIssuedAccessToken({ may_act: [{ sub: "svc-a" }] });
+		const validResult = await validator().validate(valid, { role: "subject" });
+		expect(validResult?.may_act).toEqual([{ sub: "svc-a" }]);
+
+		const mixed = await signSelfIssuedAccessToken({ may_act: [{ sub: "svc-a" }, "svc-b"] });
+		const mixedResult = await validator().validate(mixed, { role: "subject" });
+		expect(mixedResult).not.toBeNull();
+		expect(mixedResult?.claims.may_act).toEqual([{ sub: "svc-a" }, "svc-b"]);
+		expect(mixedResult?.may_act).toBeUndefined();
+	});
+
 	it("applies identical validation for role=actor (does not branch on role)", async () => {
 		const token = await signSelfIssuedAccessToken({});
 		const result = await validator().validate(token, { role: "actor" });

--- a/packages/oauth-token-exchange/src/act.mts
+++ b/packages/oauth-token-exchange/src/act.mts
@@ -16,6 +16,10 @@
 
 import type { ValidatedToken } from "./validator/types.mjs";
 
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
  * Build the `act` claim for the token being issued, per RFC 8693 §4.1.
  *
@@ -39,4 +43,51 @@ export function buildActClaim(args: {
 		result.act = subject.act;
 	}
 	return result;
+}
+
+/**
+ * Count an existing RFC 8693 `act` delegation chain.
+ *
+ * Depth 0 means no subject `act`; depth N means N nested actor records.
+ * Malformed nested `act` values stop the count rather than throwing.
+ */
+export function countActorChainDepth(act: Readonly<Record<string, unknown>> | undefined): number {
+	if (!act) return 0;
+	let depth = 1;
+	let current = act.act;
+	while (isRecord(current)) {
+		depth += 1;
+		current = current.act;
+	}
+	return depth;
+}
+
+function mayActEntryMatches(
+	actor: ValidatedToken,
+	entry: Readonly<Record<string, unknown>>,
+): boolean {
+	const hasSub = "sub" in entry;
+	const hasIss = "iss" in entry;
+	if (!hasSub && !hasIss) return false;
+	if (hasSub && typeof entry.sub !== "string") return false;
+	if (hasIss && typeof entry.iss !== "string") return false;
+	if (typeof entry.sub === "string" && entry.sub !== actor.sub) return false;
+	if (typeof entry.iss === "string" && entry.iss !== actor.claims.iss) return false;
+	return true;
+}
+
+/**
+ * Check whether an actor satisfies a subject token's RFC 8693 `may_act` claim.
+ *
+ * Supported shape for v0.5.x: a single `{ sub?, iss? }` object or an array of
+ * those objects. Malformed values fail closed so a bad `may_act` claim cannot
+ * silently disable subject-declared delegation constraints.
+ */
+export function matchesMayAct(actor: ValidatedToken, mayAct: unknown): boolean {
+	if (Array.isArray(mayAct)) {
+		if (mayAct.length === 0) return false;
+		return mayAct.some((entry) => isRecord(entry) && mayActEntryMatches(actor, entry));
+	}
+	if (!isRecord(mayAct)) return false;
+	return mayActEntryMatches(actor, mayAct);
 }

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -26,7 +26,7 @@ import type {
 	PublicClient,
 } from "@o3co/auth-provider-core";
 import { formatObject, generateToken, generateTokenResponse } from "@o3co/auth-provider-core";
-import { buildActClaim } from "./act.mjs";
+import { buildActClaim, countActorChainDepth, matchesMayAct } from "./act.mjs";
 import { ACCESS_TOKEN_TYPE } from "./validator/selfIssuedAccessToken.mjs";
 import type { ExchangeTokenValidator, ValidatedToken } from "./validator/types.mjs";
 
@@ -47,6 +47,11 @@ export interface ExchangeTokenValidatorResolver {
 export interface TokenExchangeDependencies extends GrantDependencies {
 	tokenExchangeValidatorResolver: ExchangeTokenValidatorResolver;
 	clientRepository: ClientRepository;
+	/**
+	 * Deprecated migration escape hatch. The default fail-closed behavior rejects
+	 * policy hook scope/audience outputs that exceed the validated subject token.
+	 */
+	allowPolicyWidening?: boolean;
 }
 
 export function createTokenExchangeGrant(deps: TokenExchangeDependencies): GrantHandler {
@@ -380,6 +385,51 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 				}
 			}
 
+			if (actorValidated) {
+				const subjectMayAct = subjectValidated.claims.may_act;
+				if (
+					subjectMayAct !== undefined &&
+					subjectMayAct !== null &&
+					!matchesMayAct(actorValidated, subjectMayAct)
+				) {
+					deps.logger?.warn(
+						{
+							subject: subjectValidated.sub,
+							actor: actorValidated.sub,
+						},
+						"token_exchange_may_act_violation",
+					);
+					return {
+						result: {
+							status: 400,
+							error: "invalid_request",
+							errorDescription: "may_act_violation: actor not authorized by subject token",
+						},
+					};
+				}
+
+				const maxActorChainDepth = getMaxActorChainDepth(deps);
+				const currentActorChainDepth = countActorChainDepth(subjectValidated.act);
+				if (currentActorChainDepth >= maxActorChainDepth) {
+					deps.logger?.warn(
+						{
+							subject: subjectValidated.sub,
+							actor: actorValidated.sub,
+							currentActorChainDepth,
+							maxActorChainDepth,
+						},
+						"token_exchange_actor_chain_too_deep",
+					);
+					return {
+						result: {
+							status: 400,
+							error: "invalid_request",
+							errorDescription: "actor_chain_too_deep: actor chain depth limit exceeded",
+						},
+					};
+				}
+			}
+
 			// Scope narrowing: requested scope ⊆ subject scope.
 			const subjectScope = subjectValidated.scope?.split(" ").filter(Boolean) ?? [];
 			const requestedScopeStr = typeof body.scope === "string" ? body.scope : null;
@@ -469,21 +519,61 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 						},
 					};
 				}
-				// By design: policy hook output is trusted without re-verification against
-				// the subject's scope/audience. Widening is permitted because the hook is
-				// a first-party consumer-installed extension (spec §8.1 rule 4). If a
-				// consumer's policy accidentally widens scope, the token reflects that
-				// intent — detect via tests, not runtime checks.
 				if (decision.grantedScope) grantedScope = decision.grantedScope;
 				if (decision.grantedAudience) grantedAudience = decision.grantedAudience;
+			}
+
+			if (!deps.allowPolicyWidening) {
+				const subjectScopeSet = new Set(subjectScope);
+				const widenedScopes = grantedScope?.filter((scope) => !subjectScopeSet.has(scope)) ?? [];
+				if (widenedScopes.length > 0) {
+					deps.logger?.warn(
+						{
+							subject: subjectValidated.sub,
+							clientId: client.clientId,
+							widenedScopes,
+						},
+						"token_exchange_scope_widening_rejected",
+					);
+					return {
+						result: {
+							status: 400,
+							error: "invalid_target",
+							errorDescription: `scope_widening_not_allowed: ${widenedScopes.join(" ")}`,
+						},
+					};
+				}
+
+				const subjectAudienceSet = new Set(
+					subjectAudienceBoundary(subjectValidated.aud, client.clientId),
+				);
+				const widenedAudiences =
+					grantedAudience?.filter((audience) => !subjectAudienceSet.has(audience)) ?? [];
+				if (widenedAudiences.length > 0) {
+					deps.logger?.warn(
+						{
+							subject: subjectValidated.sub,
+							clientId: client.clientId,
+							widenedAudiences,
+						},
+						"token_exchange_audience_widening_rejected",
+					);
+					return {
+						result: {
+							status: 400,
+							error: "invalid_target",
+							errorDescription: `audience_widening_not_allowed: ${widenedAudiences.join(" ")}`,
+						},
+					};
+				}
 			}
 
 			// Audience derivation (spec §8.1 rule 2):
 			//   explicit narrowed audience  → use grantedAudience (first element).
 			//     Note: grantedAudience reflects either the allowlist-validated request
-			//     parameter OR a policy hook override. Policy overrides are NOT re-
-			//     validated against the client allowlist by design (spec §8.1 rule 4);
-			//     consumers with strict policies must enforce the boundary themselves.
+			//     parameter OR a policy hook override. Unless the deprecated
+			//     allowPolicyWidening escape hatch is set, policy overrides are
+			//     checked against the validated subject token boundary above.
 			//   omitted + subject single    → inherit subject.aud IFF in allowlist;
 			//                                   else fall back to clientId (prevents
 			//                                   cross-client audience confusion when a
@@ -520,6 +610,32 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 				}
 				return client.clientId;
 			})();
+
+			if (requestedResource && requestedResource.length > 0) {
+				const tokenAudienceSet = new Set(
+					grantedAudience && grantedAudience.length > 0 ? grantedAudience : [audienceForToken],
+				);
+				const missingResources = requestedResource.filter(
+					(resource) => !tokenAudienceSet.has(resource),
+				);
+				if (missingResources.length > 0) {
+					deps.logger?.warn(
+						{
+							subject: subjectValidated.sub,
+							clientId: client.clientId,
+							missingResources,
+						},
+						"token_exchange_resource_not_in_audience",
+					);
+					return {
+						result: {
+							status: 400,
+							error: "invalid_target",
+							errorDescription: `requested_resources_not_in_audience: ${missingResources.join(" ")}`,
+						},
+					};
+				}
+			}
 
 			const act = buildActClaim({
 				subject: subjectValidated,
@@ -570,6 +686,32 @@ function getExpiresIn(deps: TokenExchangeDependencies): number {
 	// for Token Exchange should wrap createTokenExchangeGrant() instead.
 	const top = (deps.config.oauth.accessToken as { expiresIn?: number } | undefined)?.expiresIn;
 	return typeof top === "number" && top > 0 ? top : 300;
+}
+
+function getMaxActorChainDepth(deps: TokenExchangeDependencies): number {
+	const tokenExchange = deps.config.oauth.tokenExchange as
+		| { maxActorChainDepth?: unknown }
+		| undefined;
+	const maxActorChainDepth = tokenExchange?.maxActorChainDepth;
+	return typeof maxActorChainDepth === "number" &&
+		Number.isInteger(maxActorChainDepth) &&
+		maxActorChainDepth > 0
+		? maxActorChainDepth
+		: 3;
+}
+
+function subjectAudienceBoundary(
+	audience: ValidatedToken["aud"],
+	clientId: string,
+): readonly string[] {
+	if (typeof audience === "string" && audience.length > 0) return [audience];
+	if (Array.isArray(audience)) {
+		const values = audience.filter(
+			(value): value is string => typeof value === "string" && value.length > 0,
+		);
+		return values.length > 0 ? values : [clientId];
+	}
+	return [clientId];
 }
 
 function normalizeArrayParam(value: unknown): string[] | null {

--- a/packages/oauth-token-exchange/src/grant.mts
+++ b/packages/oauth-token-exchange/src/grant.mts
@@ -612,17 +612,15 @@ export function createTokenExchangeGrant(deps: TokenExchangeDependencies): Grant
 			})();
 
 			if (requestedResource && requestedResource.length > 0) {
-				const tokenAudienceSet = new Set(
-					grantedAudience && grantedAudience.length > 0 ? grantedAudience : [audienceForToken],
-				);
 				const missingResources = requestedResource.filter(
-					(resource) => !tokenAudienceSet.has(resource),
+					(resource) => resource !== audienceForToken,
 				);
 				if (missingResources.length > 0) {
 					deps.logger?.warn(
 						{
 							subject: subjectValidated.sub,
 							clientId: client.clientId,
+							audienceForToken,
 							missingResources,
 						},
 						"token_exchange_resource_not_in_audience",

--- a/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
+++ b/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
@@ -117,6 +117,11 @@ export function createSelfIssuedAccessTokenValidator(
 				const revoked = await refreshTokenFamilyRevocation.isFamilyRevoked(familyId);
 				if (revoked) return null;
 			}
+			const mayAct =
+				isRecord(payload.may_act) ||
+				(Array.isArray(payload.may_act) && payload.may_act.every(isRecord))
+					? payload.may_act
+					: undefined;
 
 			return {
 				sub: payload.sub,
@@ -129,9 +134,9 @@ export function createSelfIssuedAccessTokenValidator(
 				...(payload.act && typeof payload.act === "object" && !Array.isArray(payload.act)
 					? { act: payload.act as Record<string, unknown> }
 					: {}),
-				...(isRecord(payload.may_act) || Array.isArray(payload.may_act)
+				...(mayAct !== undefined
 					? {
-							may_act: payload.may_act as
+							may_act: mayAct as
 								| Readonly<Record<string, unknown>>
 								| readonly Readonly<Record<string, unknown>>[],
 						}

--- a/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
+++ b/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
@@ -28,6 +28,10 @@ import type {
 
 export const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
 
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export interface CreateSelfIssuedAccessTokenValidatorOptions {
 	keyStore: KeyStore;
 	refreshTokenFamilyRevocation?: RefreshTokenFamilyRevocation;
@@ -124,6 +128,13 @@ export function createSelfIssuedAccessTokenValidator(
 				...(familyId ? { familyId } : {}),
 				...(payload.act && typeof payload.act === "object" && !Array.isArray(payload.act)
 					? { act: payload.act as Record<string, unknown> }
+					: {}),
+				...(isRecord(payload.may_act) || Array.isArray(payload.may_act)
+					? {
+							may_act: payload.may_act as
+								| Readonly<Record<string, unknown>>
+								| readonly Readonly<Record<string, unknown>>[],
+						}
 					: {}),
 			};
 		},

--- a/packages/oauth-token-exchange/src/validator/types.mts
+++ b/packages/oauth-token-exchange/src/validator/types.mts
@@ -21,6 +21,12 @@
  */
 export interface ExchangeTokenValidationContext {
 	readonly role: "subject" | "actor";
+	/**
+	 * Reserved for validators that need request-resource context in a future
+	 * contract. The built-in grant handler enforces resource/audience binding
+	 * after policy evaluation, so v0.5.x validators should not rely on this.
+	 */
+	readonly requestedResources?: readonly string[];
 }
 
 export interface ExchangeTokenValidator {
@@ -68,6 +74,9 @@ export interface ExchangeTokenValidator {
  *     self-issued access_tokens.
  *   - `act`: nested actor chain from a prior exchange. The grant handler
  *     preserves this when applicable (RFC 8693 §4.1).
+ *   - `may_act`: structured delegation constraint from the subject token. The
+ *     grant handler reads the raw `claims.may_act` value so validators can
+ *     preserve malformed claims for fail-closed handling.
  */
 export interface ValidatedToken {
 	readonly sub: string;
@@ -75,5 +84,8 @@ export interface ValidatedToken {
 	readonly aud?: string | readonly string[];
 	readonly familyId?: string;
 	readonly act?: Readonly<Record<string, unknown>>;
+	readonly may_act?:
+		| Readonly<Record<string, unknown>>
+		| readonly Readonly<Record<string, unknown>>[];
 	readonly claims: Readonly<Record<string, unknown>>;
 }

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -102,6 +102,13 @@ oauth {
     adapter = "redis"
     adapter = ${?OAUTH_CODE_ADAPTER}
   }
+  # F10: maximum existing RFC 8693 actor chain depth accepted before adding
+  # the current actor. Depth 3 allows one current actor plus two prior nested
+  # actors; lower for stricter delegation environments.
+  tokenExchange {
+    maxActorChainDepth = 3
+    maxActorChainDepth = ${?OAUTH_TOKEN_EXCHANGE_MAX_ACTOR_CHAIN_DEPTH}
+  }
 }
 
 session {


### PR DESCRIPTION
## Summary
- Reject Token Exchange policy scope/audience widening by default, with deprecated direct-construction opt-in for migration
- Enforce subject may_act when actor_token is supplied and bound nested act chains with oauth.tokenExchange.maxActorChainDepth
- Require RFC 8707 resource values to be represented in the effective issued-token audience
- Add config defaults/schema, README/CHANGELOG notes, and focused regression tests

## Verification
- pnpm --filter @o3co/auth-provider-oauth-token-exchange test -- --runInBand
- pnpm --filter @o3co/auth-provider-oauth-token-exchange build
- pnpm --filter @o3co/auth-provider-core test -- --runInBand
- pnpm -r run build
- targeted biome check on changed source/test files

Note: full pnpm run lint still reports pre-existing unrelated diagnostics outside this PR scope.