### PR TITLE
F12a: Bound in-memory rate limiter buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   requested RFC 8707 resources to be represented in the effective issued-token
   audience.
 
+### Security (Phase F — F12a rate limiter hardening)
+
+- The built-in in-memory OAuth endpoint rate limiter now bounds its bucket map
+  with `memoryRateLimiter.maxBuckets` (default `10000`, env override
+  `MEMORY_RATE_LIMITER_MAX_BUCKETS`) and evicts expired or earliest-reset
+  buckets when the cap is reached.
+
 ## [0.5.2] — 2026-05-09
 
 ### Changed (auth.utils dependency bump, v0.5.2)

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -213,6 +213,14 @@ rateLimiter {
   adapter = ${?RATE_LIMITER_ADAPTER}
 }
 
+memoryRateLimiter {
+  # SF-10: bound the in-memory OAuth endpoint rate-limiter bucket map.
+  # Multi-replica production should use `rateLimiter.adapter = "redis"`;
+  # this cap keeps the single-process fallback from growing without limit.
+  maxBuckets = 10000
+  maxBuckets = ${?MEMORY_RATE_LIMITER_MAX_BUCKETS}
+}
+
 userSessionStores {
   adapter = "memory"
   adapter = ${?USER_SESSION_STORES_ADAPTER}

--- a/packages/core/src/__tests__/config.test.mts
+++ b/packages/core/src/__tests__/config.test.mts
@@ -102,6 +102,32 @@ describe("provider config", () => {
 		const config = validate(raw, AppConfigSchema);
 		expect(config.repositories.code.type).toBe("memory");
 	});
+
+	it("loads memoryRateLimiter.maxBuckets default and env override", () => {
+		const path = new URL("../../config/application.conf", import.meta.url).pathname;
+		const base = validate(
+			parseFile(path, {
+				env: {
+					OAUTH_JWT_SECRET: "test-secret",
+					SESSION_SECRET: "test-session-secret",
+				},
+			}),
+			AppConfigSchema,
+		);
+		expect(base.memoryRateLimiter?.maxBuckets).toBe(10_000);
+
+		const overridden = validate(
+			parseFile(path, {
+				env: {
+					OAUTH_JWT_SECRET: "test-secret",
+					SESSION_SECRET: "test-session-secret",
+					MEMORY_RATE_LIMITER_MAX_BUCKETS: "123",
+				},
+			}),
+			AppConfigSchema,
+		);
+		expect(overridden.memoryRateLimiter?.maxBuckets).toBe(123);
+	});
 });
 
 describe("jwt config schema", () => {

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -36,6 +36,11 @@ const rateLimitSchema = z.object({
 	limit: z.coerce.number(),
 });
 
+const rateLimitSpecSchema = z.object({
+	limit: z.coerce.number().int().positive(),
+	windowSeconds: z.coerce.number().int().positive(),
+});
+
 // IH-9: HS256 key rotation is symmetric — `previousSecrets` carries
 // shared secrets keyed by `kid`, distinct from the asymmetric
 // `previousKeys` shape (publicKey / publicKeyPath). The schema is split
@@ -364,6 +369,16 @@ export const fullSectionsSchema = z.object({
 	rateLimiter: z
 		.object({
 			adapter: z.enum(["memory", "redis"]).optional(),
+		})
+		.optional(),
+	// SF-10 (v0.5.3): module-internal config for `memoryRateLimiterModule`.
+	// Declared here so AppConfigSchema preserves HOCON/env overrides before
+	// module schema validation applies its defaults. Defaults live in HOCON.
+	memoryRateLimiter: z
+		.object({
+			limits: z.record(z.string(), rateLimitSpecSchema).optional(),
+			defaultLimit: rateLimitSpecSchema.optional(),
+			maxBuckets: z.coerce.number().int().positive().optional(),
 		})
 		.optional(),
 	// Wave 5d (OR-4): adapter switch for the four user-session stores

--- a/packages/core/src/ratelimit/__tests__/factory.test.mts
+++ b/packages/core/src/ratelimit/__tests__/factory.test.mts
@@ -78,6 +78,37 @@ describe("registerBuiltinRateLimiters (memory)", () => {
 		expect(first.allowed).toBe(true);
 		expect(second.allowed).toBe(false);
 	});
+
+	it("memory sink bounds bucket growth by evicting a bucket when full", async () => {
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(new Date("2026-05-09T00:00:00Z"));
+
+			const factory = createRateLimiterFactory();
+			registerBuiltinRateLimiters(factory);
+			const limiter = await factory.create({
+				type: "memory",
+				defaultLimit: { limit: 2, windowSeconds: 60 },
+				maxBuckets: 2,
+			});
+
+			await limiter.check("unknown:A", {});
+			vi.advanceTimersByTime(1);
+			await limiter.check("unknown:B", {});
+			vi.advanceTimersByTime(1);
+			await limiter.check("unknown:C", {});
+
+			const existingB = await limiter.check("unknown:B", {});
+			expect(existingB.allowed).toBe(true);
+			expect(existingB.remaining).toBe(0);
+
+			const recreatedA = await limiter.check("unknown:A", {});
+			expect(recreatedA.allowed).toBe(true);
+			expect(recreatedA.remaining).toBe(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 });
 
 describe("memory rate limiter — per-key isolation", () => {

--- a/packages/core/src/ratelimit/__tests__/factory.test.mts
+++ b/packages/core/src/ratelimit/__tests__/factory.test.mts
@@ -109,6 +109,30 @@ describe("registerBuiltinRateLimiters (memory)", () => {
 			vi.useRealTimers();
 		}
 	});
+
+	it("eviction makes progress even when bucket resetAt is non-finite (misconfigured windowSeconds)", async () => {
+		// Regression: a misconfigured spec with NaN windowSeconds produces
+		// NaN resetAt. evictEarliestResetBucket previously used `<` against
+		// POSITIVE_INFINITY, and `NaN < x` is false, so when every bucket
+		// had NaN resetAt no key was selected and the caller's
+		// `while (buckets.size >= maxBuckets)` loop pinned the event loop.
+		// This test would hang forever before the fix; vitest's default
+		// timeout makes the regression visible as a failure.
+		const factory = createRateLimiterFactory();
+		registerBuiltinRateLimiters(factory);
+		const limiter = await factory.create({
+			type: "memory",
+			defaultLimit: { limit: 1, windowSeconds: Number.NaN },
+			maxBuckets: 2,
+		});
+
+		// Fill: both buckets get resetAt = now + NaN*1000 = NaN.
+		await limiter.check("nan:A", {});
+		await limiter.check("nan:B", {});
+		// Trigger eviction: must return rather than spin-loop.
+		const result = await limiter.check("nan:C", {});
+		expect(result.allowed).toBe(true);
+	});
 });
 
 describe("memory rate limiter — per-key isolation", () => {

--- a/packages/core/src/ratelimit/__tests__/module.test.mts
+++ b/packages/core/src/ratelimit/__tests__/module.test.mts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { memoryRateLimiterModule } from "../module.mjs";
 
 describe("memoryRateLimiterModule", () => {
@@ -19,21 +19,63 @@ describe("memoryRateLimiterModule", () => {
 		expect(typeof memoryRateLimiterModule.provides?.rateLimiter).toBe("function");
 	});
 
+	it("defaults maxBuckets in module config schema", () => {
+		const parsed = memoryRateLimiterModule.configSchema?.parse({});
+		expect(parsed).toMatchObject({
+			memoryRateLimiter: {
+				maxBuckets: 10_000,
+			},
+		});
+	});
+
 	it("limits requests per the configured spec", async () => {
 		const cfg = {
 			memoryRateLimiter: {
 				limits: { "test.ip": { limit: 2, windowSeconds: 60 } },
 				defaultLimit: { limit: 60, windowSeconds: 60 },
+				maxBuckets: 10_000,
 			},
 		};
 		const limiter = memoryRateLimiterModule.provides?.rateLimiter?.({ config: cfg } as never);
 		expect(limiter).toBeDefined();
-		if (!limiter) return;
+		if (!limiter) throw new Error("rateLimiter provider missing");
 		const a = await limiter.check("test.ip:1.2.3.4", { ip: "1.2.3.4" });
 		expect(a.allowed).toBe(true);
 		const b = await limiter.check("test.ip:1.2.3.4", { ip: "1.2.3.4" });
 		expect(b.allowed).toBe(true);
 		const c = await limiter.check("test.ip:1.2.3.4", { ip: "1.2.3.4" });
 		expect(c.allowed).toBe(false);
+	});
+
+	it("bounds bucket growth with memoryRateLimiter.maxBuckets", async () => {
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(new Date("2026-05-09T00:00:00Z"));
+
+			const cfg = {
+				memoryRateLimiter: {
+					limits: {},
+					defaultLimit: { limit: 2, windowSeconds: 60 },
+					maxBuckets: 2,
+				},
+			};
+			const limiter = memoryRateLimiterModule.provides?.rateLimiter?.({ config: cfg } as never);
+			expect(limiter).toBeDefined();
+			if (!limiter) throw new Error("rateLimiter provider missing");
+
+			await limiter.check("test:A", {});
+			vi.advanceTimersByTime(1);
+			await limiter.check("test:B", {});
+			vi.advanceTimersByTime(1);
+			await limiter.check("test:C", {});
+
+			const existingB = await limiter.check("test:B", {});
+			expect(existingB.remaining).toBe(0);
+
+			const recreatedA = await limiter.check("test:A", {});
+			expect(recreatedA.remaining).toBe(1);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/packages/core/src/ratelimit/factory.mts
+++ b/packages/core/src/ratelimit/factory.mts
@@ -15,6 +15,7 @@
  */
 
 import { createAdapterFactory } from "../adapters/AdapterFactory.mjs";
+import { createMemoryRateLimiter, DEFAULT_MEMORY_RATE_LIMITER_MAX_BUCKETS } from "./memory.mjs";
 import type { RateLimiterBase, RateLimiterFactory, RateLimitSpec } from "./types.mjs";
 
 export function createRateLimiterFactory(): RateLimiterFactory {
@@ -25,6 +26,7 @@ interface MemoryRateLimiterConfig {
 	type: string;
 	limits?: Record<string, RateLimitSpec>;
 	defaultLimit?: RateLimitSpec;
+	maxBuckets?: number;
 }
 
 function normalizeLimits(raw: unknown): Record<string, RateLimitSpec> {
@@ -39,11 +41,6 @@ function normalizeLimits(raw: unknown): Record<string, RateLimitSpec> {
 		}
 	}
 	return result;
-}
-
-function keyPrefix(key: string): string {
-	const colon = key.indexOf(":");
-	return colon === -1 ? key : key.slice(0, colon);
 }
 
 /**
@@ -72,38 +69,13 @@ export function registerBuiltinRateLimiters(factory: RateLimiterFactory): void {
 			return { limit: 60, windowSeconds: 60 };
 		})();
 
-		interface BucketState {
-			count: number;
-			resetAt: number;
-		}
-		const buckets = new Map<string, BucketState>();
-
-		return {
-			kind: "memory",
-			async check(key) {
-				const now = Date.now();
-				const spec = limits[keyPrefix(key)] ?? defaultLimit;
-				const bucket = buckets.get(key);
-				if (!bucket || bucket.resetAt <= now) {
-					const fresh: BucketState = { count: 1, resetAt: now + spec.windowSeconds * 1000 };
-					buckets.set(key, fresh);
-					return { allowed: true, remaining: spec.limit - 1, resetAt: new Date(fresh.resetAt) };
-				}
-				if (bucket.count >= spec.limit) {
-					return {
-						allowed: false,
-						remaining: 0,
-						resetAt: new Date(bucket.resetAt),
-						reason: `limit:${keyPrefix(key)}`,
-					};
-				}
-				bucket.count += 1;
-				return {
-					allowed: true,
-					remaining: spec.limit - bucket.count,
-					resetAt: new Date(bucket.resetAt),
-				};
-			},
-		};
+		return createMemoryRateLimiter({
+			limits,
+			defaultLimit,
+			maxBuckets:
+				typeof config.maxBuckets === "number"
+					? config.maxBuckets
+					: DEFAULT_MEMORY_RATE_LIMITER_MAX_BUCKETS,
+		});
 	});
 }

--- a/packages/core/src/ratelimit/memory.mts
+++ b/packages/core/src/ratelimit/memory.mts
@@ -50,12 +50,30 @@ function evictEarliestResetBucket(buckets: Map<string, BucketState>): void {
 	let evictKey: string | undefined;
 	let earliestResetAt = Number.POSITIVE_INFINITY;
 	for (const [key, bucket] of buckets) {
+		// Non-finite resetAt (NaN / ±Infinity from a misconfigured
+		// windowSeconds) is highest priority for removal: drop it eagerly so
+		// the caller's `while (size >= max)` loop is guaranteed to make
+		// progress and cannot pin the event loop. Without this, NaN < x
+		// returns false for every comparison and evictKey stays undefined.
+		if (!Number.isFinite(bucket.resetAt)) {
+			buckets.delete(key);
+			return;
+		}
 		if (bucket.resetAt < earliestResetAt) {
 			evictKey = key;
 			earliestResetAt = bucket.resetAt;
 		}
 	}
-	if (evictKey !== undefined) buckets.delete(evictKey);
+	if (evictKey !== undefined) {
+		buckets.delete(evictKey);
+		return;
+	}
+	// Defensive fallback: should be unreachable once the non-finite drop
+	// above runs at least once per call, but keep eviction unconditionally
+	// progress-guaranteed by deleting the first map entry. Map iteration
+	// preserves insertion order, so this is the oldest bucket.
+	const firstKey = buckets.keys().next().value;
+	if (firstKey !== undefined) buckets.delete(firstKey);
 }
 
 export function createMemoryRateLimiter(options: MemoryRateLimiterOptions): RateLimiterBase {

--- a/packages/core/src/ratelimit/memory.mts
+++ b/packages/core/src/ratelimit/memory.mts
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { RateLimiterBase, RateLimitSpec } from "./types.mjs";
+
+export const DEFAULT_MEMORY_RATE_LIMITER_MAX_BUCKETS = 10_000;
+
+interface BucketState {
+	count: number;
+	resetAt: number;
+}
+
+export interface MemoryRateLimiterOptions {
+	limits: Record<string, RateLimitSpec>;
+	defaultLimit: RateLimitSpec;
+	maxBuckets?: number;
+}
+
+function keyPrefix(key: string): string {
+	const colon = key.indexOf(":");
+	return colon === -1 ? key : key.slice(0, colon);
+}
+
+function normalizeMaxBuckets(value: number | undefined): number {
+	return typeof value === "number" && Number.isInteger(value) && value > 0
+		? value
+		: DEFAULT_MEMORY_RATE_LIMITER_MAX_BUCKETS;
+}
+
+function pruneExpiredBuckets(buckets: Map<string, BucketState>, now: number): void {
+	for (const [key, bucket] of buckets) {
+		if (bucket.resetAt <= now) buckets.delete(key);
+	}
+}
+
+function evictEarliestResetBucket(buckets: Map<string, BucketState>): void {
+	let evictKey: string | undefined;
+	let earliestResetAt = Number.POSITIVE_INFINITY;
+	for (const [key, bucket] of buckets) {
+		if (bucket.resetAt < earliestResetAt) {
+			evictKey = key;
+			earliestResetAt = bucket.resetAt;
+		}
+	}
+	if (evictKey !== undefined) buckets.delete(evictKey);
+}
+
+export function createMemoryRateLimiter(options: MemoryRateLimiterOptions): RateLimiterBase {
+	const buckets = new Map<string, BucketState>();
+	const maxBuckets = normalizeMaxBuckets(options.maxBuckets);
+
+	return {
+		kind: "memory",
+		async check(key) {
+			const now = Date.now();
+			const spec = options.limits[keyPrefix(key)] ?? options.defaultLimit;
+			const bucket = buckets.get(key);
+			if (!bucket || bucket.resetAt <= now) {
+				if (!bucket && buckets.size >= maxBuckets) {
+					pruneExpiredBuckets(buckets, now);
+					while (buckets.size >= maxBuckets) evictEarliestResetBucket(buckets);
+				}
+				const fresh: BucketState = {
+					count: 1,
+					resetAt: now + spec.windowSeconds * 1000,
+				};
+				buckets.set(key, fresh);
+				return {
+					allowed: true,
+					remaining: spec.limit - 1,
+					resetAt: new Date(fresh.resetAt),
+				};
+			}
+			if (bucket.count >= spec.limit) {
+				return {
+					allowed: false,
+					remaining: 0,
+					resetAt: new Date(bucket.resetAt),
+					reason: `limit:${keyPrefix(key)}`,
+				};
+			}
+			bucket.count += 1;
+			return {
+				allowed: true,
+				remaining: spec.limit - bucket.count,
+				resetAt: new Date(bucket.resetAt),
+			};
+		},
+	};
+}

--- a/packages/core/src/ratelimit/module.mts
+++ b/packages/core/src/ratelimit/module.mts
@@ -5,63 +5,13 @@
 
 import { z } from "zod";
 import { defineModule } from "../modules/index.mjs";
-import type { RateLimiterBase, RateLimitSpec } from "./types.mjs";
-
-interface BucketState {
-	count: number;
-	resetAt: number;
-}
+import { createMemoryRateLimiter, DEFAULT_MEMORY_RATE_LIMITER_MAX_BUCKETS } from "./memory.mjs";
+import type { RateLimitSpec } from "./types.mjs";
 
 const rateLimitSpecSchema = z.object({
 	limit: z.number().int().positive(),
 	windowSeconds: z.number().int().positive(),
 });
-
-function keyPrefix(key: string): string {
-	const colon = key.indexOf(":");
-	return colon === -1 ? key : key.slice(0, colon);
-}
-
-function createMemoryRateLimiter(
-	limits: Record<string, RateLimitSpec>,
-	defaultLimit: RateLimitSpec,
-): RateLimiterBase {
-	const buckets = new Map<string, BucketState>();
-	return {
-		kind: "memory",
-		async check(key) {
-			const now = Date.now();
-			const spec = limits[keyPrefix(key)] ?? defaultLimit;
-			const bucket = buckets.get(key);
-			if (!bucket || bucket.resetAt <= now) {
-				const fresh: BucketState = {
-					count: 1,
-					resetAt: now + spec.windowSeconds * 1000,
-				};
-				buckets.set(key, fresh);
-				return {
-					allowed: true,
-					remaining: spec.limit - 1,
-					resetAt: new Date(fresh.resetAt),
-				};
-			}
-			if (bucket.count >= spec.limit) {
-				return {
-					allowed: false,
-					remaining: 0,
-					resetAt: new Date(bucket.resetAt),
-					reason: `limit:${keyPrefix(key)}`,
-				};
-			}
-			bucket.count += 1;
-			return {
-				allowed: true,
-				remaining: spec.limit - bucket.count,
-				resetAt: new Date(bucket.resetAt),
-			};
-		},
-	};
-}
 
 /**
  * In-memory RateLimiter module. Matches the existing memory branch of
@@ -78,8 +28,17 @@ export const memoryRateLimiterModule = defineModule({
 			.object({
 				limits: z.record(z.string(), rateLimitSpecSchema).default({}),
 				defaultLimit: rateLimitSpecSchema.default({ limit: 60, windowSeconds: 60 }),
+				maxBuckets: z.coerce
+					.number()
+					.int()
+					.positive()
+					.default(DEFAULT_MEMORY_RATE_LIMITER_MAX_BUCKETS),
 			})
-			.default({ limits: {}, defaultLimit: { limit: 60, windowSeconds: 60 } }),
+			.default({
+				limits: {},
+				defaultLimit: { limit: 60, windowSeconds: 60 },
+				maxBuckets: DEFAULT_MEMORY_RATE_LIMITER_MAX_BUCKETS,
+			}),
 	}),
 	provides: {
 		rateLimiter: (deps) => {
@@ -88,10 +47,15 @@ export const memoryRateLimiterModule = defineModule({
 					memoryRateLimiter: {
 						limits: Record<string, RateLimitSpec>;
 						defaultLimit: RateLimitSpec;
+						maxBuckets?: number;
 					};
 				}
 			).memoryRateLimiter;
-			return createMemoryRateLimiter(cfg.limits, cfg.defaultLimit);
+			return createMemoryRateLimiter({
+				limits: cfg.limits,
+				defaultLimit: cfg.defaultLimit,
+				maxBuckets: cfg.maxBuckets,
+			});
 		},
 	},
 });

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -229,6 +229,14 @@ rateLimiter {
   adapter = ${?RATE_LIMITER_ADAPTER}
 }
 
+memoryRateLimiter {
+  # SF-10: bound the in-memory OAuth endpoint rate-limiter bucket map.
+  # Multi-replica production should use `rateLimiter.adapter = "redis"`;
+  # this cap keeps the single-process fallback from growing without limit.
+  maxBuckets = 10000
+  maxBuckets = ${?MEMORY_RATE_LIMITER_MAX_BUCKETS}
+}
+
 userSessionStores {
   adapter = "memory"
   adapter = ${?USER_SESSION_STORES_ADAPTER}


### PR DESCRIPTION
## Summary
- Extract the built-in memory rate limiter into a shared bounded implementation used by both factory and module wiring
- Add memoryRateLimiter.maxBuckets with HOCON default 10000 and MEMORY_RATE_LIMITER_MAX_BUCKETS override
- Preserve AppConfigSchema passthrough for memoryRateLimiter module config and add eviction/config regression tests

## Verification
- pnpm exec biome check packages/core/src/ratelimit/memory.mts packages/core/src/ratelimit/factory.mts packages/core/src/ratelimit/module.mts packages/core/src/ratelimit/__tests__/factory.test.mts packages/core/src/ratelimit/__tests__/module.test.mts packages/core/src/config/application.schema.mts packages/core/src/__tests__/config.test.mts
- pnpm --filter @o3co/auth-provider-core test -- --runInBand src/ratelimit/__tests__/factory.test.mts src/ratelimit/__tests__/module.test.mts src/__tests__/config.test.mts
- pnpm --filter @o3co/auth-provider-core build
- pnpm -r run build

Stacked on #146 / worktree-f10-token-exchange-security.