### PR TITLE
F12b: Reduce user repository timing oracle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Security (Phase F — F12b user repository timing)
 
-- `InMemoryUserRepository.authenticate()` now performs a dummy bcrypt compare
-  for unknown usernames before returning `null`, reducing username-enumeration
-  timing differences against bcrypt-backed password entries.
+- `InMemoryUserRepository.authenticate()` now performs a bcrypt comparison
+  on every authentication attempt — including unknown usernames and
+  plain-text password entries — equalizing timing across all paths so
+  username-enumeration signals are reduced regardless of whether deployments
+  use bcrypt-hashed or plain-text password entries.
 
 ## [0.5.2] — 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `MEMORY_RATE_LIMITER_MAX_BUCKETS`) and evicts expired or earliest-reset
   buckets when the cap is reached.
 
+### Security (Phase F — F12b user repository timing)
+
+- `InMemoryUserRepository.authenticate()` now performs a dummy bcrypt compare
+  for unknown usernames before returning `null`, reducing username-enumeration
+  timing differences against bcrypt-backed password entries.
+
 ## [0.5.2] — 2026-05-09
 
 ### Changed (auth.utils dependency bump, v0.5.2)

--- a/packages/core/src/repositories/InMemoryUserRepository.mts
+++ b/packages/core/src/repositories/InMemoryUserRepository.mts
@@ -58,6 +58,10 @@ export class InMemoryUserRepository implements UserRepository {
 		if (isBcrypt) {
 			match = await bcrypt.compare(password, stored);
 		} else {
+			// Pay the bcrypt cost on the plain-text path too, so that timing
+			// converges across unknown-user / known-bcrypt / known-plain. The
+			// result is discarded — correctness comes from timingSafeEqual.
+			await bcrypt.compare(password, DUMMY_BCRYPT_PASSWORD_HASH);
 			const a = Buffer.from(password);
 			const b = Buffer.from(stored);
 			match = a.length === b.length && crypto.timingSafeEqual(a, b);

--- a/packages/core/src/repositories/InMemoryUserRepository.mts
+++ b/packages/core/src/repositories/InMemoryUserRepository.mts
@@ -20,6 +20,9 @@ import { z } from "zod";
 import type { User } from "./types.mjs";
 import type { UserRepository } from "./UserRepository.mjs";
 
+const DUMMY_BCRYPT_PASSWORD_HASH = "$2b$10$39.FBAWt.ck.rbQbPhmLOOPkwFxWEPZEYA3HR07Lr2k5OYqk.vRSi";
+const BCRYPT_HASH_RE = /^\$2[aby]\$/;
+
 export const UserEntrySchema = z
 	.object({
 		password: z.string().min(1),
@@ -47,10 +50,9 @@ export class InMemoryUserRepository implements UserRepository {
 
 	async authenticate(username: string, password: string): Promise<User | null> {
 		const entry = this.users.get(username);
-		if (!entry) return null;
 
-		const stored = entry.password;
-		const isBcrypt = /^\$2[aby]\$/.test(stored);
+		const stored = entry?.password ?? DUMMY_BCRYPT_PASSWORD_HASH;
+		const isBcrypt = BCRYPT_HASH_RE.test(stored);
 
 		let match: boolean;
 		if (isBcrypt) {
@@ -61,6 +63,7 @@ export class InMemoryUserRepository implements UserRepository {
 			match = a.length === b.length && crypto.timingSafeEqual(a, b);
 		}
 
+		if (!entry) return null;
 		if (!match) return null;
 		return this.toUser(username, entry);
 	}

--- a/packages/core/src/repositories/__tests__/InMemoryUserRepository.test.mts
+++ b/packages/core/src/repositories/__tests__/InMemoryUserRepository.test.mts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import bcrypt from "bcrypt";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { InMemoryUserRepository } from "#/repositories/InMemoryUserRepository.mjs";
 
 describe("InMemoryUserRepository", () => {
@@ -47,6 +47,26 @@ describe("InMemoryUserRepository", () => {
 			const user = await repo.authenticate("bob", "secret123");
 
 			expect(user).toBeNull();
+		});
+
+		it("runs a dummy bcrypt compare for unknown usernames", async () => {
+			const compareSpy = vi.spyOn(bcrypt, "compare").mockResolvedValue(false);
+			const hash = "$2b$10$39.FBAWt.ck.rbQbPhmLOOPkwFxWEPZEYA3HR07Lr2k5OYqk.vRSi";
+			const repo = new InMemoryUserRepository(new Map([["alice", { password: hash, id: "u1" }]]));
+			try {
+				const [wrongPassword, unknownUser] = await Promise.all([
+					repo.authenticate("alice", "wrong"),
+					repo.authenticate("bob", "wrong"),
+				]);
+
+				expect(wrongPassword).toBeNull();
+				expect(unknownUser).toBeNull();
+				expect(compareSpy).toHaveBeenCalledTimes(2);
+				expect(compareSpy).toHaveBeenCalledWith("wrong", hash);
+				expect(compareSpy).toHaveBeenCalledWith("wrong", expect.stringMatching(/^\$2[aby]\$/));
+			} finally {
+				compareSpy.mockRestore();
+			}
 		});
 
 		it("supports bcrypt hashed passwords", async () => {

--- a/packages/core/src/repositories/__tests__/InMemoryUserRepository.test.mts
+++ b/packages/core/src/repositories/__tests__/InMemoryUserRepository.test.mts
@@ -51,7 +51,10 @@ describe("InMemoryUserRepository", () => {
 
 		it("runs a dummy bcrypt compare for unknown usernames", async () => {
 			const compareSpy = vi.spyOn(bcrypt, "compare").mockResolvedValue(false);
-			const hash = "$2b$10$39.FBAWt.ck.rbQbPhmLOOPkwFxWEPZEYA3HR07Lr2k5OYqk.vRSi";
+			// Use a hash deliberately distinct from the source's dummy hash so
+			// the regression assertion below can verify the unknown-user path
+			// uses a different bcrypt input than the real entry.
+			const hash = await bcrypt.hash("secret123", 10);
 			const repo = new InMemoryUserRepository(new Map([["alice", { password: hash, id: "u1" }]]));
 			try {
 				const [wrongPassword, unknownUser] = await Promise.all([
@@ -62,8 +65,41 @@ describe("InMemoryUserRepository", () => {
 				expect(wrongPassword).toBeNull();
 				expect(unknownUser).toBeNull();
 				expect(compareSpy).toHaveBeenCalledTimes(2);
-				expect(compareSpy).toHaveBeenCalledWith("wrong", hash);
-				expect(compareSpy).toHaveBeenCalledWith("wrong", expect.stringMatching(/^\$2[aby]\$/));
+				const realCall = compareSpy.mock.calls[0];
+				const dummyCall = compareSpy.mock.calls[1];
+				expect(realCall?.[0]).toBe("wrong");
+				expect(realCall?.[1]).toBe(hash);
+				expect(dummyCall?.[0]).toBe("wrong");
+				expect(dummyCall?.[1]).toMatch(/^\$2[aby]\$/);
+				// Unknown-user path MUST use a hash distinct from the real entry's
+				// hash — otherwise timingSafeEqual on the bcrypt result would still
+				// leak username existence on a single targeted user.
+				expect(dummyCall?.[1]).not.toBe(hash);
+			} finally {
+				compareSpy.mockRestore();
+			}
+		});
+
+		it("runs a bcrypt compare on the plain-text path to equalize timing", async () => {
+			const compareSpy = vi.spyOn(bcrypt, "compare").mockResolvedValue(false);
+			const repo = new InMemoryUserRepository(
+				new Map([["alice", { password: "secret123", id: "u1" }]]),
+			);
+			try {
+				const [knownPlain, unknownUser] = await Promise.all([
+					repo.authenticate("alice", "wrong"),
+					repo.authenticate("bob", "wrong"),
+				]);
+
+				expect(knownPlain).toBeNull();
+				expect(unknownUser).toBeNull();
+				// Both paths must call bcrypt.compare so that plain-text and
+				// unknown-user cases converge on the same cost. Without this,
+				// plain-text deployments leak username existence via timing.
+				expect(compareSpy).toHaveBeenCalledTimes(2);
+				for (const call of compareSpy.mock.calls) {
+					expect(call?.[1]).toMatch(/^\$2[aby]\$/);
+				}
 			} finally {
 				compareSpy.mockRestore();
 			}


### PR DESCRIPTION
## Summary
- Run a dummy bcrypt comparison for unknown usernames in InMemoryUserRepository.authenticate()
- Keep returned semantics unchanged: unknown usernames and wrong passwords still return null
- Add a regression test that exercises wrong-password and unknown-user paths in parallel and verifies both hit bcrypt.compare

## Verification
- pnpm exec biome check packages/core/src/repositories/InMemoryUserRepository.mts packages/core/src/repositories/__tests__/InMemoryUserRepository.test.mts
- pnpm --filter @o3co/auth-provider-core test -- --runInBand src/repositories/__tests__/InMemoryUserRepository.test.mts
- pnpm --filter @o3co/auth-provider-core build
- pnpm -r run build

Stacked on #147 / worktree-f12a-rate-limiter-bounded.