### PR TITLE
F11a: Add JWKS discovery and UserInfo POST compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   username-enumeration signals are reduced regardless of whether deployments
   use bcrypt-hashed or plain-text password entries.
 
+### Fixed (Phase F — F11a OIDC discovery/UserInfo compliance)
+
+- OIDC discovery now always advertises `jwks_uri`, with symmetric HS256-only
+  deployments serving an empty JWK Set instead of a 404 so the advertised
+  endpoint remains dereferenceable without exposing shared secrets.
+- The OIDC UserInfo endpoint now accepts both GET and POST requests with the
+  same bearer-token validation, cache-control headers, session liveness checks,
+  and scope-filtered claim response.
+
 ## [0.5.2] — 2026-05-09
 
 ### Changed (auth.utils dependency bump, v0.5.2)

--- a/packages/core/src/routes/Jwks.mts
+++ b/packages/core/src/routes/Jwks.mts
@@ -22,7 +22,7 @@ export const createRouter = (express: { Router: () => Router }, keyStore: KeySto
 
 	router.get("/.well-known/jwks.json", async (_req: Request, res: Response) => {
 		if (keyStore.algorithm === "HS256") {
-			return res.sendStatus(404);
+			return res.json({ keys: [] });
 		}
 		const managedKeys = await keyStore.getVerificationKeys();
 		const keys = await Promise.all(

--- a/packages/core/src/routes/__tests__/Jwks.test.mts
+++ b/packages/core/src/routes/__tests__/Jwks.test.mts
@@ -14,20 +14,23 @@
  * limitations under the License.
  */
 
+import type { Request, Response, Router } from "express";
 import { exportPKCS8, exportSPKI, generateKeyPair } from "jose";
 import { describe, expect, it } from "vitest";
 import { createAsymmetricKeyStore, createSymmetricKeyStore } from "#/keys/KeyStore.mjs";
 import { createRouter } from "#/routes/Jwks.mjs";
 
+type RouteHandler = (req: Request, res: Response) => unknown | Promise<unknown>;
+
 function createMockExpress() {
-	const routes: Record<string, Function> = {};
+	const routes: Record<string, RouteHandler> = {};
 	const router = {
-		get(path: string, handler: Function) {
+		get(path: string, handler: RouteHandler) {
 			routes[path] = handler;
 			return router;
 		},
 	};
-	return { Router: () => router, routes };
+	return { Router: () => router as unknown as Router, routes };
 }
 
 function createMockRes() {
@@ -52,14 +55,15 @@ function createMockRes() {
 }
 
 describe("JWKS endpoint", () => {
-	it("returns 404 for HS256", () => {
+	it("returns an empty JWK set for HS256 without exposing shared secrets", async () => {
 		const ks = createSymmetricKeyStore("test-secret");
 		const express = createMockExpress();
-		createRouter(express as any, ks);
+		createRouter(express, ks);
 		const handler = express.routes["/.well-known/jwks.json"];
 		const res = createMockRes();
-		handler({}, res);
-		expect(res.getStatusCode()).toBe(404);
+		await handler({} as Request, res as unknown as Response);
+		expect(res.getStatusCode()).toBe(200);
+		expect(res.getBody()).toEqual({ keys: [] });
 	});
 
 	it("returns JWK set for ES256", async () => {
@@ -71,10 +75,10 @@ describe("JWKS endpoint", () => {
 			publicKeyPem: await exportSPKI(publicKey),
 		});
 		const express = createMockExpress();
-		createRouter(express as any, ks);
+		createRouter(express, ks);
 		const handler = express.routes["/.well-known/jwks.json"];
 		const res = createMockRes();
-		await handler({}, res);
+		await handler({} as Request, res as unknown as Response);
 		const body = res.getBody() as { keys: Array<Record<string, unknown>> };
 		expect(body.keys).toHaveLength(1);
 		expect(body.keys[0].kid).toBe("test-key");
@@ -101,9 +105,9 @@ describe("JWKS endpoint", () => {
 			],
 		});
 		const express = createMockExpress();
-		createRouter(express as any, ks);
+		createRouter(express, ks);
 		const res = createMockRes();
-		await express.routes["/.well-known/jwks.json"]({}, res);
+		await express.routes["/.well-known/jwks.json"]({} as Request, res as unknown as Response);
 		const body = res.getBody() as { keys: Array<Record<string, unknown>> };
 		expect(body.keys).toHaveLength(2);
 		expect(body.keys.map((k) => k.kid)).toContain("current");
@@ -127,9 +131,9 @@ describe("JWKS endpoint", () => {
 			],
 		});
 		const express = createMockExpress();
-		createRouter(express as any, ks);
+		createRouter(express, ks);
 		const res = createMockRes();
-		await express.routes["/.well-known/jwks.json"]({}, res);
+		await express.routes["/.well-known/jwks.json"]({} as Request, res as unknown as Response);
 		const body = res.getBody() as { keys: Array<Record<string, unknown>> };
 		expect(body.keys).toHaveLength(1);
 		expect(body.keys[0].kid).toBe("current");

--- a/packages/oauth-token-exchange/README.md
+++ b/packages/oauth-token-exchange/README.md
@@ -109,7 +109,7 @@ const handle = await createApp({
 
 5. **Policy hook widening is rejected by default.** The `GrantPolicyHook.evaluate()` result's `grantedScope` and `grantedAudience` are still allowed to override the request-derived values, but the handler re-checks them against the validated `subject_token` boundary before minting. Scope or audience widening returns `invalid_target` with `scope_widening_not_allowed` or `audience_widening_not_allowed`. Direct callers of `createTokenExchangeGrant()` can set the deprecated `allowPolicyWidening` migration escape hatch while replacing old widening policies; module wiring keeps the safe default.
 
-6. **Resource indicators must be represented in the issued audience.** When the request includes RFC 8707 `resource`, every requested resource must appear in the effective `grantedAudience` used for the exchange. A resource/audience mismatch returns `invalid_target` with `requested_resources_not_in_audience`.
+6. **Resource indicators must equal the issued-token audience.** When the request includes RFC 8707 `resource`, every requested resource must equal `audienceForToken` — the single value that will be minted into the issued token's `aud` claim (typically `grantedAudience[0]`). Multi-resource requests whose resources cannot all be represented in the single-valued `aud` are rejected with `invalid_target` / `requested_resources_not_in_audience`. This avoids issuing a token whose `aud` silently disagrees with the requested resource (RFC 8707 §3).
 
 7. **Impersonation vs delegation.** An exchange without `actor_token` issues an impersonation token (no `act` claim). Deployments that require audit trails should add a `GrantPolicyHook` that rejects requests lacking `actor_token`:
 

--- a/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
+++ b/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
@@ -14,18 +14,21 @@
  * limitations under the License.
  */
 
+import type { Request, Response, Router } from "express";
 import { describe, expect, it } from "vitest";
 import { createRouter } from "#/routes/OpenidConfiguration.mjs";
 
+type RouteHandler = (req: Request, res: Response) => unknown | Promise<unknown>;
+
 function createMockExpress() {
-	const routes: Record<string, Function> = {};
+	const routes: Record<string, RouteHandler> = {};
 	const router = {
-		get(path: string, handler: Function) {
+		get(path: string, handler: RouteHandler) {
 			routes[path] = handler;
 			return router;
 		},
 	};
-	return { Router: () => router, routes };
+	return { Router: () => router as unknown as Router, routes };
 }
 
 function createMockRes() {
@@ -55,10 +58,10 @@ async function callRoute(opts: {
 	logoutSupported?: boolean;
 }): Promise<Record<string, unknown>> {
 	const express = createMockExpress();
-	createRouter(express as any, opts);
+	createRouter(express, opts);
 	const handler = express.routes["/.well-known/openid-configuration"];
 	const res = createMockRes();
-	await handler({}, res);
+	await handler({} as Request, res as unknown as Response);
 	return res.getBody() as Record<string, unknown>;
 }
 
@@ -158,9 +161,9 @@ describe("GET /.well-known/openid-configuration", () => {
 		expect(body.token_endpoint).toBe("https://auth.example.com/oauth/token");
 	});
 
-	it("omits jwks_uri for HS256-only deployments (JWKS route returns 404 for symmetric keys)", async () => {
+	it("advertises jwks_uri for HS256-only deployments", async () => {
 		const body = await callRoute({ issuer: "https://auth.example.com", signingAlgs: ["HS256"] });
-		expect(body.jwks_uri).toBeUndefined();
+		expect(body.jwks_uri).toBe("https://auth.example.com/.well-known/jwks.json");
 	});
 
 	it("advertises jwks_uri when any asymmetric alg is configured (RS256 alongside HS256)", async () => {

--- a/packages/oauth/src/__tests__/userinfo.test.mts
+++ b/packages/oauth/src/__tests__/userinfo.test.mts
@@ -45,6 +45,7 @@ async function mintAT(extra: Record<string, unknown> = {}): Promise<string> {
 
 interface CallOptions {
 	token: string | null;
+	method?: "get" | "post";
 	userSessionStore?: Partial<UserSessionStore>;
 	refreshTokenFamilyRevocation?: Partial<RefreshTokenFamilyRevocation>;
 }
@@ -73,7 +74,10 @@ async function callUserinfo(opts: CallOptions) {
 		userSessionStore: opts.userSessionStore,
 		refreshTokenFamilyRevocation: opts.refreshTokenFamilyRevocation,
 	});
-	const req = request(app).get("/oauth/userinfo");
+	const req =
+		opts.method === "post"
+			? request(app).post("/oauth/userinfo")
+			: request(app).get("/oauth/userinfo");
 	if (opts.token !== null) {
 		req.set("Authorization", `Bearer ${opts.token}`);
 	}
@@ -333,5 +337,45 @@ describe("GET /oauth/userinfo", () => {
 		expect(errRes.status).toBe(401);
 		expect(errRes.headers["cache-control"]).toBe("no-store");
 		expect(errRes.headers.pragma).toBe("no-cache");
+	});
+});
+
+describe("POST /oauth/userinfo", () => {
+	it("returns the same scope-filtered claims as GET for a valid Bearer access_token", async () => {
+		const token = await mintAT({ family_id: "fam-1", sid: "sid-1", scope: "openid email" });
+
+		const res = await callUserinfo({
+			method: "post",
+			token,
+			userSessionStore: {
+				kind: "memory",
+				get: vi.fn().mockResolvedValue(baseSession),
+				create: vi.fn(),
+				delete: vi.fn(),
+			},
+			refreshTokenFamilyRevocation: {
+				isFamilyRevoked: vi.fn().mockResolvedValue(false),
+				revokeFamily: vi.fn(),
+			},
+		});
+
+		expect(res.status).toBe(200);
+		expect(res.body).toEqual({
+			sub: "u-1",
+			email: "alice@example.com",
+			email_verified: true,
+		});
+		expect(res.headers["cache-control"]).toBe("no-store");
+		expect(res.headers.pragma).toBe("no-cache");
+	});
+
+	it("rejects missing Bearer tokens with the same error semantics as GET", async () => {
+		const res = await callUserinfo({ method: "post", token: null });
+
+		expect(res.status).toBe(401);
+		expect(res.headers["www-authenticate"]).toMatch(/^Bearer/);
+		expect(res.body.error).toBe("invalid_token");
+		expect(res.headers["cache-control"]).toBe("no-store");
+		expect(res.headers.pragma).toBe("no-cache");
 	});
 });

--- a/packages/oauth/src/routes/OpenidConfiguration.mts
+++ b/packages/oauth/src/routes/OpenidConfiguration.mts
@@ -39,11 +39,6 @@ export function createRouter(express: ExpressLike, opts: OidcConfigRouterOptions
 
 	router.get("/.well-known/openid-configuration", (_req: Request, res: Response) => {
 		const iss = opts.issuer.replace(/\/+$/, "");
-		// JWKS is not served for symmetric-only deployments (HS256): the
-		// public-key set is empty, so advertising jwks_uri would point
-		// consumers at a 404. Only include jwks_uri when at least one
-		// asymmetric alg is configured.
-		const hasAsymmetricAlg = opts.signingAlgs.some((alg) => alg !== "HS256");
 		return res.status(200).json({
 			// Return the normalized issuer so it matches the `iss` claim minted
 			// on tokens (both use trailing-slash-stripped form). Returning the
@@ -53,7 +48,7 @@ export function createRouter(express: ExpressLike, opts: OidcConfigRouterOptions
 			authorization_endpoint: `${iss}/oauth/authorize`,
 			token_endpoint: `${iss}/oauth/token`,
 			userinfo_endpoint: `${iss}/oauth/userinfo`,
-			...(hasAsymmetricAlg ? { jwks_uri: `${iss}/.well-known/jwks.json` } : {}),
+			jwks_uri: `${iss}/.well-known/jwks.json`,
 			introspection_endpoint: `${iss}/oauth/introspect`,
 			// Logout discovery fields are only advertised when the logout router is mounted.
 			// opts.logoutSupported defaults to false (explicit opt-in); oauthModule sets it

--- a/packages/oauth/src/routes/userinfo.mts
+++ b/packages/oauth/src/routes/userinfo.mts
@@ -57,7 +57,7 @@ export interface UserinfoRouterOptions {
 export function createRouter(express: ExpressLike, opts: UserinfoRouterOptions): Router {
 	const router = express.Router();
 
-	router.get("/userinfo", async (req: Request, res: Response) => {
+	const handleUserinfo = async (req: Request, res: Response) => {
 		// RFC 6750 §5.3 + §6.1: bearer-authenticated responses MUST NOT be cached
 		// by intermediaries. Set this once at the top so it applies to every
 		// response path (200 success, 401 error).
@@ -156,7 +156,10 @@ export function createRouter(express: ExpressLike, opts: UserinfoRouterOptions):
 			typeof payload.scope === "string" ? payload.scope.split(" ").filter(Boolean) : [];
 		const filtered = filterClaimsByScope(session.claims, scopes);
 		return res.status(200).json({ sub, ...filtered });
-	});
+	};
+
+	router.get("/userinfo", handleUserinfo);
+	router.post("/userinfo", handleUserinfo);
 
 	return router;
 }


### PR DESCRIPTION
## Summary
- always advertise OIDC discovery jwks_uri and make HS256-only JWKS dereferenceable as an empty JWK Set
- register POST /oauth/userinfo with the same bearer-token validation, cache controls, revocation/session checks, and scope-filtered response as GET
- update tests for HS256 JWKS, discovery metadata, and UserInfo POST

## External spec verification
- OpenID Connect Discovery 1.0 Section 3 lists jwks_uri as REQUIRED: https://openid.net/specs/openid-connect-discovery-1_0-22.html
- OpenID Connect Core 1.0 Section 5.3 says UserInfo MUST support HTTP GET and POST: https://openid.net/specs/openid-connect-core-1_0-18.html

## Verification
- pnpm exec biome check CHANGELOG.md packages/core/src/routes/Jwks.mts packages/core/src/routes/__tests__/Jwks.test.mts packages/oauth/src/routes/OpenidConfiguration.mts packages/oauth/src/__tests__/OpenidConfiguration.test.mts packages/oauth/src/routes/userinfo.mts packages/oauth/src/__tests__/userinfo.test.mts
- pnpm --filter @o3co/auth-provider-core test -- --runInBand src/routes/__tests__/Jwks.test.mts
- pnpm --filter @o3co/auth-provider-oauth exec vitest run src/__tests__/OpenidConfiguration.test.mts src/__tests__/userinfo.test.mts
- pnpm --filter @o3co/auth-provider-core build
- pnpm --filter @o3co/auth-provider-oauth build
- pnpm -r run build

Stacked on #148.