### PR TITLE
F11b: Add OIDC authorize mode and GET logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   same bearer-token validation, cache-control headers, session liveness checks,
   and scope-filtered claim response.
 
+### Fixed (Phase F — F11b OIDC authorize/logout compliance)
+
+- `/oauth/authorize` now rejects requests that omit the `openid` scope when
+  `oauth.jwt.issuer` is configured and `oauth.oidcMode = "oidc-required"`
+  (default). Operators can set `OAUTH_OIDC_MODE=dual` to keep accepting
+  OAuth-only authorization requests on the same endpoint.
+- The OIDC `end_session_endpoint` now supports GET as well as POST. GET with
+  a valid fresh `id_token_hint` performs the existing logout cascade; GET
+  without a valid hint renders a confirmation page instead of triggering
+  logout.
+
 ## [0.5.2] — 2026-05-09
 
 ### Changed (auth.utils dependency bump, v0.5.2)

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -73,6 +73,12 @@ oauth {
     authorization_code { enabled = true, enabled = ${?OAUTH_GRANTS_AUTHORIZATION_CODE_ENABLED} }
     refresh_token { enabled = true, enabled = ${?OAUTH_GRANTS_REFRESH_TOKEN_ENABLED} }
   }
+  # IH-6: when acting as an OIDC Provider (`oauth.jwt.issuer` set),
+  # require `openid` in /authorize scope by default. Set "dual" only for
+  # deployments that intentionally serve OAuth-only and OIDC clients from
+  # the same authorization endpoint.
+  oidcMode = "oidc-required"
+  oidcMode = ${?OAUTH_OIDC_MODE}
   # OR-9: adapter switch for the OAuth authorization-code repository.
   # Multi-replica production MUST set this to "redis" — the memory adapter
   # loses codes on restart and across replicas.

--- a/packages/core/src/__tests__/config-composition.test.mts
+++ b/packages/core/src/__tests__/config-composition.test.mts
@@ -40,6 +40,7 @@ const minimalCoreConfig = {
 			legacyRtPolicy: "reject",
 		},
 		grants: {},
+		oidcMode: "oidc-required",
 	},
 };
 
@@ -228,6 +229,7 @@ describe("AppConfigSchema backward compatibility", () => {
 					authorization_code: { enabled: true },
 					refresh_token: { enabled: true },
 				},
+				oidcMode: "oidc-required",
 			},
 			session: {
 				secret: "session-secret",

--- a/packages/core/src/__tests__/config.test.mts
+++ b/packages/core/src/__tests__/config.test.mts
@@ -36,6 +36,7 @@ describe("provider config", () => {
 		// is strict and supplies no defaults of its own (ADR 2026-04-30).
 		expect(local.algorithm).toBe("HS256");
 		expect(local.kid).toBe("v0");
+		expect(config.oauth.oidcMode).toBe("oidc-required");
 	});
 
 	it("fails validation when required fields are missing", () => {
@@ -56,6 +57,7 @@ describe("provider config", () => {
 				HTTP_PORT: "9090",
 				HTTP_TRUST_PROXY: "true",
 				SESSION_SECURE: "false",
+				OAUTH_OIDC_MODE: "dual",
 			},
 		});
 		const config = validate(raw, AppConfigSchema);
@@ -63,6 +65,7 @@ describe("provider config", () => {
 		expect(config.http.port).toBe(9090);
 		expect(config.http.trustProxy).toBe(true);
 		expect(config.session.secure).toBe(false);
+		expect(config.oauth.oidcMode).toBe("dual");
 		// federations.google.enabled env-var coercion is covered by the
 		// HOCON application.conf wiring; schema-level boolean coercion for
 		// federation entries is tested in federations-schema.test.mts.

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -188,6 +188,10 @@ export const CoreConfigSchema = z.object({
 			legacyTokenCompat: z.boolean().optional(),
 		}),
 		grants: z.object({}).passthrough(),
+		// IH-6 (v0.5.3): when acting as an OIDC OP, `/authorize` rejects
+		// requests that omit `openid` unless operators explicitly choose dual
+		// OAuth/OIDC mode. Shape-only; default lives in HOCON.
+		oidcMode: z.enum(["oidc-required", "dual"]),
 		// OR-9 (Wave 5d): adapter switch for the OAuth authorization-code
 		// repository. Multi-replica deployments MUST set this to `"redis"`;
 		// the in-memory variant loses codes on restart and across replicas.

--- a/packages/core/src/testing/fixtures/valid-config.mts
+++ b/packages/core/src/testing/fixtures/valid-config.mts
@@ -86,6 +86,7 @@ export function makeValidCoreConfig() {
 				legacyRtPolicy: "reject",
 			},
 			grants: {},
+			oidcMode: "oidc-required",
 		},
 	} satisfies CoreConfig;
 }

--- a/packages/oauth/src/__tests__/hooks.test.mts
+++ b/packages/oauth/src/__tests__/hooks.test.mts
@@ -40,6 +40,12 @@ const mockConfig = {
 		jwt: { issuer: "https://auth.example" },
 		accessToken: { expiresIn: 3600 },
 		refreshToken: { expiresIn: 86400 },
+		// These tests target audit / grantPolicy / rateLimit hooks at the
+		// authorize endpoint and do not request openid. oidcMode defaults to
+		// "oidc-required" with an issuer configured, which would reject every
+		// request as invalid_scope before the hook paths run. Opt out with
+		// dual mode so the hook behavior is the only variable under test.
+		oidcMode: "dual",
 	},
 	rateLimit: {
 		login: { windowMs: 60_000, limit: 100 },

--- a/packages/oauth/src/__tests__/logout.test.mts
+++ b/packages/oauth/src/__tests__/logout.test.mts
@@ -236,7 +236,9 @@ function expectLogoutConfirmation(res: Awaited<ReturnType<typeof getLogout>>) {
 	expect(res.headers["content-type"]).toMatch(/^text\/html/);
 	expect(res.text).toContain("<form");
 	expect(res.text).toContain('method="POST"');
-	expect(res.text).toContain('action="logout"');
+	// action="" submits to the current URL — avoids the relative-URL trap
+	// where action="logout" on /oauth/logout/ resolves to /oauth/logout/logout.
+	expect(res.text).toContain('action=""');
 }
 
 describe("POST /oauth/logout", () => {
@@ -258,6 +260,30 @@ describe("POST /oauth/logout", () => {
 			expect(sessionStore.delete).toHaveBeenCalledWith("sid-1");
 			// cascadeLogout step 2: federation tokens cleared
 			expect(fedTokenStore.removeBySid).toHaveBeenCalledWith("sid-1");
+		});
+
+		it("confirmed=1 form-submission shape (hint + confirmed + state) completes hint-based logout, not 400", async () => {
+			// Regression: the GET confirmation page submits a POST whose body
+			// includes `confirmed=1` plus the id_token_hint passed through as
+			// a hidden input. Previously the form did not include the hint,
+			// so the "Sign out" button always hit a 400 invalid_request. This
+			// asserts the same shape the form submits today reaches the
+			// hint-based logout path and returns 200.
+			const sessionStore = makeSessionStore();
+			const refreshFamilyRevocation = makeFamilyRevocation();
+			const app = buildApp({ sessionStore, refreshFamilyRevocation });
+			const token = await mintIdToken();
+
+			const res = await postLogout(app, {
+				id_token_hint: token,
+				confirmed: "1",
+				state: "round-trip",
+			});
+
+			expect(res.status).toBe(200);
+			expect(res.body).toEqual({ logged_out: true });
+			expect(refreshFamilyRevocation.revokeFamily).toHaveBeenCalledWith("fam-1");
+			expect(sessionStore.delete).toHaveBeenCalledWith("sid-1");
 		});
 	});
 
@@ -754,7 +780,10 @@ describe("GET /oauth/logout", () => {
 		expect(fedTokenStore.removeBySid).toHaveBeenCalledWith("sid-1");
 	});
 
-	it("renders confirmation HTML and does not log out when id_token_hint is missing", async () => {
+	it("returns 400 invalid_request when id_token_hint is missing (no hint to pass through)", async () => {
+		// With no id_token_hint, a confirmation page would render a "Sign out"
+		// button whose POST cannot satisfy the hint requirement, so reject
+		// directly rather than show a confirmation that always fails.
 		const sessionStore = makeSessionStore();
 		const refreshFamilyRevocation = makeFamilyRevocation();
 		const app = buildApp({ sessionStore, refreshFamilyRevocation });
@@ -763,7 +792,8 @@ describe("GET /oauth/logout", () => {
 			post_logout_redirect_uri: "https://rp.example/logged-out",
 		});
 
-		expectLogoutConfirmation(res);
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe("invalid_request");
 		expect(refreshFamilyRevocation.revokeFamily).not.toHaveBeenCalled();
 		expect(sessionStore.delete).not.toHaveBeenCalled();
 	});
@@ -776,6 +806,11 @@ describe("GET /oauth/logout", () => {
 		const res = await getLogout(app, { id_token_hint: "not.a.valid.jwt" });
 
 		expectLogoutConfirmation(res);
+		// Confirmation page must propagate the original logout params as
+		// hidden inputs so the confirmed POST can reach the hint-based path
+		// (regression: previously the POST saw no hint and returned 400, so
+		// the "Sign out" button was permanently broken).
+		expect(res.text).toContain('name="id_token_hint"');
 		expect(refreshFamilyRevocation.revokeFamily).not.toHaveBeenCalled();
 		expect(sessionStore.delete).not.toHaveBeenCalled();
 	});
@@ -786,11 +821,42 @@ describe("GET /oauth/logout", () => {
 		const app = buildApp({ sessionStore, refreshFamilyRevocation });
 		const token = await mintOldIdToken();
 
-		const res = await getLogout(app, { id_token_hint: token });
+		const res = await getLogout(app, {
+			id_token_hint: token,
+			post_logout_redirect_uri: "https://rp.example/logged-out",
+			state: "xyz",
+		});
 
 		expectLogoutConfirmation(res);
+		// All three params must round-trip into the form so a confirmed POST
+		// completes the standard hint-based logout (verification on POST has
+		// no staleness check, so the same hint will succeed there).
+		expect(res.text).toContain(`value="${token}"`);
+		expect(res.text).toContain('name="id_token_hint"');
+		expect(res.text).toContain('name="post_logout_redirect_uri"');
+		expect(res.text).toContain('value="https://rp.example/logged-out"');
+		expect(res.text).toContain('name="state"');
+		expect(res.text).toContain('value="xyz"');
 		expect(refreshFamilyRevocation.revokeFamily).not.toHaveBeenCalled();
 		expect(sessionStore.delete).not.toHaveBeenCalled();
+	});
+
+	it("HTML-escapes hidden input values to prevent attribute injection", async () => {
+		// state may carry attacker-influenced characters in the worst case;
+		// the GET-confirm path echoes it into an HTML attribute so it must
+		// be escaped (regression: `"` would break out of the value attr).
+		const sessionStore = makeSessionStore();
+		const refreshFamilyRevocation = makeFamilyRevocation();
+		const app = buildApp({ sessionStore, refreshFamilyRevocation });
+
+		const res = await getLogout(app, {
+			id_token_hint: "not.a.valid.jwt",
+			state: 'evil"><script>alert(1)</script>',
+		});
+
+		expectLogoutConfirmation(res);
+		expect(res.text).not.toContain('"><script>');
+		expect(res.text).toContain("&quot;");
 	});
 });
 

--- a/packages/oauth/src/__tests__/logout.test.mts
+++ b/packages/oauth/src/__tests__/logout.test.mts
@@ -55,6 +55,20 @@ async function mintIdToken(extra: Record<string, unknown> = {}): Promise<string>
 		.sign(secretKey);
 }
 
+async function mintOldIdToken(): Promise<string> {
+	const oldIat = Math.floor((Date.now() - 25 * 60 * 60 * 1000) / 1000);
+	return new SignJWT({
+		sub: "u-1",
+		aud: "client-1",
+		sid: "sid-1",
+	})
+		.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "id+jwt" })
+		.setExpirationTime("1h")
+		.setIssuedAt(oldIat)
+		.setIssuer("https://auth.example.com")
+		.sign(secretKey);
+}
+
 /**
  * Mint an access token (typ: at+jwt) for use with POST /oauth/federation/:name/logout.
  * Includes sid, sub, and family_id by default.
@@ -208,6 +222,21 @@ async function postLogout(
 		Object.entries(body).filter(([, v]) => v !== undefined),
 	) as Record<string, string>;
 	return req.send(filteredBody);
+}
+
+function getLogout(app: ReturnType<typeof express>, query: Record<string, string | undefined>) {
+	const filteredQuery = Object.fromEntries(
+		Object.entries(query).filter(([, v]) => v !== undefined),
+	) as Record<string, string>;
+	return request(app).get("/oauth/logout").query(filteredQuery);
+}
+
+function expectLogoutConfirmation(res: Awaited<ReturnType<typeof getLogout>>) {
+	expect(res.status).toBe(200);
+	expect(res.headers["content-type"]).toMatch(/^text\/html/);
+	expect(res.text).toContain("<form");
+	expect(res.text).toContain('method="POST"');
+	expect(res.text).toContain('action="logout"');
 }
 
 describe("POST /oauth/logout", () => {
@@ -688,6 +717,80 @@ describe("POST /oauth/logout", () => {
 				consoleWarnSpy.mockRestore();
 			}
 		});
+	});
+});
+
+describe("GET /oauth/logout", () => {
+	it("logs out and redirects to a registered post_logout_redirect_uri with state", async () => {
+		const sessionStore = makeSessionStore();
+		const refreshFamilyRevocation = makeFamilyRevocation();
+		const fedTokenStore = makeFedTokenStore();
+		const app = buildApp({
+			sessionStore,
+			refreshFamilyRevocation,
+			fedTokenStore,
+			clientRepo: makeClientRepo({
+				findById: vi.fn().mockResolvedValue({
+					clientId: "client-1",
+					tokenEndpointAuthMethod: "client_secret_basic",
+					allowedRedirectUris: ["https://example.test/cb"],
+					allowedScopes: ["openid"],
+					postLogoutRedirectUris: ["https://rp.example/logged-out"],
+				}),
+			}),
+		});
+		const token = await mintIdToken();
+
+		const res = await getLogout(app, {
+			id_token_hint: token,
+			post_logout_redirect_uri: "https://rp.example/logged-out",
+			state: "bye",
+		});
+
+		expect(res.status).toBe(303);
+		expect(res.headers.location).toBe("https://rp.example/logged-out?state=bye");
+		expect(refreshFamilyRevocation.revokeFamily).toHaveBeenCalledWith("fam-1");
+		expect(sessionStore.delete).toHaveBeenCalledWith("sid-1");
+		expect(fedTokenStore.removeBySid).toHaveBeenCalledWith("sid-1");
+	});
+
+	it("renders confirmation HTML and does not log out when id_token_hint is missing", async () => {
+		const sessionStore = makeSessionStore();
+		const refreshFamilyRevocation = makeFamilyRevocation();
+		const app = buildApp({ sessionStore, refreshFamilyRevocation });
+
+		const res = await getLogout(app, {
+			post_logout_redirect_uri: "https://rp.example/logged-out",
+		});
+
+		expectLogoutConfirmation(res);
+		expect(refreshFamilyRevocation.revokeFamily).not.toHaveBeenCalled();
+		expect(sessionStore.delete).not.toHaveBeenCalled();
+	});
+
+	it("renders confirmation HTML and does not log out when id_token_hint is invalid", async () => {
+		const sessionStore = makeSessionStore();
+		const refreshFamilyRevocation = makeFamilyRevocation();
+		const app = buildApp({ sessionStore, refreshFamilyRevocation });
+
+		const res = await getLogout(app, { id_token_hint: "not.a.valid.jwt" });
+
+		expectLogoutConfirmation(res);
+		expect(refreshFamilyRevocation.revokeFamily).not.toHaveBeenCalled();
+		expect(sessionStore.delete).not.toHaveBeenCalled();
+	});
+
+	it("renders confirmation HTML and does not log out when id_token_hint iat is stale", async () => {
+		const sessionStore = makeSessionStore();
+		const refreshFamilyRevocation = makeFamilyRevocation();
+		const app = buildApp({ sessionStore, refreshFamilyRevocation });
+		const token = await mintOldIdToken();
+
+		const res = await getLogout(app, { id_token_hint: token });
+
+		expectLogoutConfirmation(res);
+		expect(refreshFamilyRevocation.revokeFamily).not.toHaveBeenCalled();
+		expect(sessionStore.delete).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/oauth/src/__tests__/logout.test.mts
+++ b/packages/oauth/src/__tests__/logout.test.mts
@@ -798,19 +798,20 @@ describe("GET /oauth/logout", () => {
 		expect(sessionStore.delete).not.toHaveBeenCalled();
 	});
 
-	it("renders confirmation HTML and does not log out when id_token_hint is invalid", async () => {
+	it("returns 400 invalid_token when id_token_hint signature is invalid (no confirm page)", async () => {
+		// Invalid-signature / iss / typ id_token_hint: the POST verifier uses
+		// identical options to GET, so passing the same hint through hidden
+		// inputs would render a "Sign out" button that the confirmed POST
+		// can only re-fail with 400 invalid_token. Reject directly for GET
+		// as well as POST.
 		const sessionStore = makeSessionStore();
 		const refreshFamilyRevocation = makeFamilyRevocation();
 		const app = buildApp({ sessionStore, refreshFamilyRevocation });
 
 		const res = await getLogout(app, { id_token_hint: "not.a.valid.jwt" });
 
-		expectLogoutConfirmation(res);
-		// Confirmation page must propagate the original logout params as
-		// hidden inputs so the confirmed POST can reach the hint-based path
-		// (regression: previously the POST saw no hint and returned 400, so
-		// the "Sign out" button was permanently broken).
-		expect(res.text).toContain('name="id_token_hint"');
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe("invalid_token");
 		expect(refreshFamilyRevocation.revokeFamily).not.toHaveBeenCalled();
 		expect(sessionStore.delete).not.toHaveBeenCalled();
 	});
@@ -818,7 +819,17 @@ describe("GET /oauth/logout", () => {
 	it("renders confirmation HTML and does not log out when id_token_hint iat is stale", async () => {
 		const sessionStore = makeSessionStore();
 		const refreshFamilyRevocation = makeFamilyRevocation();
-		const app = buildApp({ sessionStore, refreshFamilyRevocation });
+		// Allowlist the redirect URI we will pass — exercises the round-trip
+		// path and confirms the value reaches the hidden input.
+		const clientRepo = makeClientRepo({
+			findById: vi.fn().mockResolvedValue({
+				clientId: "client-1",
+				allowedRedirectUris: [],
+				allowedScopes: [],
+				postLogoutRedirectUris: ["https://rp.example/logged-out"],
+			}),
+		});
+		const app = buildApp({ sessionStore, refreshFamilyRevocation, clientRepo });
 		const token = await mintOldIdToken();
 
 		const res = await getLogout(app, {
@@ -841,6 +852,39 @@ describe("GET /oauth/logout", () => {
 		expect(sessionStore.delete).not.toHaveBeenCalled();
 	});
 
+	it("drops post_logout_redirect_uri from the stale-iat confirm page when not allowlisted", async () => {
+		// Even though the post-cascade allowlist gate prevents an actual
+		// redirect to an attacker URL, reflecting the URL into the confirm
+		// page on the auth-provider origin weakens the invariant. Only
+		// allowlisted URIs round-trip into the form.
+		const sessionStore = makeSessionStore();
+		const refreshFamilyRevocation = makeFamilyRevocation();
+		const clientRepo = makeClientRepo({
+			findById: vi.fn().mockResolvedValue({
+				clientId: "client-1",
+				allowedRedirectUris: [],
+				allowedScopes: [],
+				postLogoutRedirectUris: ["https://rp.example/logged-out"],
+			}),
+		});
+		const app = buildApp({ sessionStore, refreshFamilyRevocation, clientRepo });
+		const token = await mintOldIdToken();
+
+		const res = await getLogout(app, {
+			id_token_hint: token,
+			post_logout_redirect_uri: "https://attacker.example/steal",
+			state: "xyz",
+		});
+
+		expectLogoutConfirmation(res);
+		expect(res.text).not.toContain("attacker.example");
+		expect(res.text).not.toContain('name="post_logout_redirect_uri"');
+		// The hint and state must still round-trip — only the redirect URI
+		// is dropped.
+		expect(res.text).toContain('name="id_token_hint"');
+		expect(res.text).toContain('name="state"');
+	});
+
 	it("HTML-escapes hidden input values to prevent attribute injection", async () => {
 		// state may carry attacker-influenced characters in the worst case;
 		// the GET-confirm path echoes it into an HTML attribute so it must
@@ -848,15 +892,38 @@ describe("GET /oauth/logout", () => {
 		const sessionStore = makeSessionStore();
 		const refreshFamilyRevocation = makeFamilyRevocation();
 		const app = buildApp({ sessionStore, refreshFamilyRevocation });
+		const token = await mintOldIdToken();
 
 		const res = await getLogout(app, {
-			id_token_hint: "not.a.valid.jwt",
+			id_token_hint: token,
 			state: 'evil"><script>alert(1)</script>',
 		});
 
 		expectLogoutConfirmation(res);
 		expect(res.text).not.toContain('"><script>');
 		expect(res.text).toContain("&quot;");
+	});
+
+	it("HTML-escapes ampersands in hidden input values (& → &amp;)", async () => {
+		// Regression: the previous test only exercised the `"` escape via
+		// quoted-attribute injection. State values commonly contain `&` in
+		// query-encoded round-tripping, so the entity escape needs an
+		// independent regression guard.
+		const sessionStore = makeSessionStore();
+		const refreshFamilyRevocation = makeFamilyRevocation();
+		const app = buildApp({ sessionStore, refreshFamilyRevocation });
+		const token = await mintOldIdToken();
+
+		const res = await getLogout(app, {
+			id_token_hint: token,
+			state: "a&b=1",
+		});
+
+		expectLogoutConfirmation(res);
+		expect(res.text).toContain("a&amp;b=1");
+		// Raw `a&b=1` must NOT appear unescaped — a regex-bounded check
+		// avoids matching the escaped form's substring.
+		expect(res.text).not.toMatch(/value="a&b=1"/);
 	});
 });
 

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -121,6 +121,7 @@ async function buildAuthorizeApp(opts: {
 	 * (the no-override path uses the `?? 256` fallback only).
 	 */
 	configOverride?: Partial<AppConfig>;
+	clientRepo?: ClientRepository;
 	logger?: Logger;
 }) {
 	const app = express();
@@ -170,7 +171,7 @@ async function buildAuthorizeApp(opts: {
 	const { router } = await createOAuthRouter(express, {
 		registry: new GrantRegistry(),
 		config: mergedConfig,
-		clientRepository: authorizeClientRepo,
+		clientRepository: opts.clientRepo ?? authorizeClientRepo,
 		codeRepository: codeRepo,
 		keyStore: createSymmetricKeyStore("test-secret-at-least-32-chars!!"),
 		logger: opts.logger,
@@ -638,7 +639,59 @@ describe("IH-6: /authorize openid scope gate", () => {
 		expect(location.searchParams.get("state")).toBe("state-missing-openid");
 		expect(captureCode).not.toHaveBeenCalled();
 		expect(logger.warn).toHaveBeenCalledWith(
-			{ clientId: "client-1", requestedScopes: ["profile"] },
+			{
+				clientId: "client-1",
+				requestedScopes: ["profile"],
+				allowedFilteredScopes: ["profile"],
+			},
+			"authorize_rejected_missing_openid_scope",
+		);
+	});
+
+	it("rejects when openid is requested but client allowlist filters it out (oidc-required bypass guard)", async () => {
+		// Regression: previously the gate only checked requestedScopes, so a
+		// client whose allowedScopes did not include `openid` would silently
+		// pass the gate even when the server is `oidc-required` and the
+		// request asked for openid — the request would then proceed as
+		// OAuth-only because allowedFilteredScopes drops openid.
+		const captureCode = vi.fn();
+		const logger = createMockLogger();
+		const restrictedClientRepo: ClientRepository = {
+			findById: async () => ({
+				clientId: "client-1",
+				allowedRedirectUris: ["https://example.test/cb"],
+				// openid is intentionally absent — emulates a non-OIDC client.
+				allowedScopes: ["profile"],
+			}),
+			authenticate: async () => null,
+		};
+		const app = await buildAuthorizeApp({
+			sessionFields: { sid: "sid-oidc-bypass" },
+			captureCode,
+			clientRepo: restrictedClientRepo,
+			logger,
+		});
+
+		const res = await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "client-1",
+			redirect_uri: "https://example.test/cb",
+			state: "state-bypass",
+			scope: "openid profile",
+		});
+
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers.location);
+		expect(location.searchParams.get("error")).toBe("invalid_scope");
+		expect(location.searchParams.get("error_description")).toMatch(/openid scope is required/i);
+		expect(location.searchParams.get("state")).toBe("state-bypass");
+		expect(captureCode).not.toHaveBeenCalled();
+		expect(logger.warn).toHaveBeenCalledWith(
+			{
+				clientId: "client-1",
+				requestedScopes: ["openid", "profile"],
+				allowedFilteredScopes: ["profile"],
+			},
 			"authorize_rejected_missing_openid_scope",
 		);
 	});

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -23,6 +23,7 @@ import {
 	type GrantDependencies,
 	type GrantPolicyHookBase,
 	GrantRegistry,
+	type Logger,
 	type RefreshTokenFamilyRotation,
 	type SessionFamilyIndex,
 	type SessionRPRegistry,
@@ -36,6 +37,7 @@ import { createAuthorizationGrant } from "#/grants/authorization.mjs";
 import { createRefreshTokenGrant } from "#/grants/refreshToken.mjs";
 import { oauthAuthorizationModule } from "#/oauthAuthorization.mjs";
 import { createOAuthRouter } from "#/routes.mjs";
+import { createMockLogger } from "./_helpers/mockLogger.mjs";
 
 // ---------------------------------------------------------------------------
 // Shared test-only stubs
@@ -92,6 +94,7 @@ const authorizeConfig = {
 		jwt: { issuer: "https://auth.example" },
 		accessToken: { expiresIn: 3600 },
 		refreshToken: { expiresIn: 86400 },
+		oidcMode: "oidc-required",
 	},
 	endpoints: {
 		login: { url: "/login" },
@@ -118,6 +121,7 @@ async function buildAuthorizeApp(opts: {
 	 * (the no-override path uses the `?? 256` fallback only).
 	 */
 	configOverride?: Partial<AppConfig>;
+	logger?: Logger;
 }) {
 	const app = express();
 	app.use(express.json());
@@ -169,6 +173,7 @@ async function buildAuthorizeApp(opts: {
 		clientRepository: authorizeClientRepo,
 		codeRepository: codeRepo,
 		keyStore: createSymmetricKeyStore("test-secret-at-least-32-chars!!"),
+		logger: opts.logger,
 	});
 	app.use("/oauth", router);
 	return app;
@@ -573,6 +578,7 @@ describe("authorize persists OIDC round-trip state on code record (TODO-F-3)", (
 			response_type: "code",
 			client_id: "client-1",
 			redirect_uri: "https://example.test/cb",
+			scope: "openid profile",
 			nonce: "nonce-xyz",
 		});
 
@@ -595,6 +601,7 @@ describe("authorize persists OIDC round-trip state on code record (TODO-F-3)", (
 			response_type: "code",
 			client_id: "client-1",
 			redirect_uri: "https://example.test/cb",
+			scope: "openid profile",
 			// no nonce
 		});
 
@@ -602,6 +609,145 @@ describe("authorize persists OIDC round-trip state on code record (TODO-F-3)", (
 		expect(captured?.nonce).toBeUndefined();
 		// sid is still captured even without nonce
 		expect(captured?.sid).toBe("sid-1");
+	});
+});
+
+describe("IH-6: /authorize openid scope gate", () => {
+	it("rejects missing openid in oidc-required mode when issuer is configured", async () => {
+		const captureCode = vi.fn();
+		const logger = createMockLogger();
+		const app = await buildAuthorizeApp({
+			sessionFields: { sid: "sid-oidc-required" },
+			captureCode,
+			logger,
+		});
+
+		const res = await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "client-1",
+			redirect_uri: "https://example.test/cb",
+			state: "state-missing-openid",
+			scope: "profile",
+		});
+
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers.location);
+		expect(location.origin + location.pathname).toBe("https://example.test/cb");
+		expect(location.searchParams.get("error")).toBe("invalid_scope");
+		expect(location.searchParams.get("error_description")).toMatch(/openid scope is required/i);
+		expect(location.searchParams.get("state")).toBe("state-missing-openid");
+		expect(captureCode).not.toHaveBeenCalled();
+		expect(logger.warn).toHaveBeenCalledWith(
+			{ clientId: "client-1", requestedScopes: ["profile"] },
+			"authorize_rejected_missing_openid_scope",
+		);
+	});
+
+	it("allows oidc-required requests that include openid", async () => {
+		let captured: Parameters<CodeRepository["createCode"]>[0] | undefined;
+		const app = await buildAuthorizeApp({
+			sessionFields: { sid: "sid-oidc-ok" },
+			captureCode: (p) => {
+				captured = p;
+			},
+		});
+
+		const res = await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "client-1",
+			redirect_uri: "https://example.test/cb",
+			scope: "openid profile",
+		});
+
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers.location);
+		expect(location.searchParams.get("code")).toBe("auth-code");
+		expect(location.searchParams.get("error")).toBeNull();
+		expect(captured?.grantedScope).toEqual(["openid", "profile"]);
+	});
+
+	it("allows OAuth-only requests in dual mode", async () => {
+		let captured: Parameters<CodeRepository["createCode"]>[0] | undefined;
+		const app = await buildAuthorizeApp({
+			sessionFields: { sid: "sid-dual-oauth" },
+			captureCode: (p) => {
+				captured = p;
+			},
+			configOverride: {
+				oauth: {
+					oidcMode: "dual",
+				},
+			} as unknown as Partial<AppConfig>,
+		});
+
+		const res = await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "client-1",
+			redirect_uri: "https://example.test/cb",
+			scope: "profile",
+		});
+
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers.location);
+		expect(location.searchParams.get("code")).toBe("auth-code");
+		expect(location.searchParams.get("error")).toBeNull();
+		expect(captured?.grantedScope).toEqual(["profile"]);
+	});
+
+	it("allows OIDC requests in dual mode", async () => {
+		let captured: Parameters<CodeRepository["createCode"]>[0] | undefined;
+		const app = await buildAuthorizeApp({
+			sessionFields: { sid: "sid-dual-oidc" },
+			captureCode: (p) => {
+				captured = p;
+			},
+			configOverride: {
+				oauth: {
+					oidcMode: "dual",
+				},
+			} as unknown as Partial<AppConfig>,
+		});
+
+		const res = await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "client-1",
+			redirect_uri: "https://example.test/cb",
+			scope: "openid profile",
+		});
+
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers.location);
+		expect(location.searchParams.get("code")).toBe("auth-code");
+		expect(location.searchParams.get("error")).toBeNull();
+		expect(captured?.grantedScope).toEqual(["openid", "profile"]);
+	});
+
+	it("rejects when requested scopes are all outside the client allowance", async () => {
+		const captureCode = vi.fn();
+		const app = await buildAuthorizeApp({
+			sessionFields: { sid: "sid-scope-filter-empty" },
+			captureCode,
+			configOverride: {
+				oauth: {
+					oidcMode: "dual",
+				},
+			} as unknown as Partial<AppConfig>,
+		});
+
+		const res = await request(app).get("/oauth/authorize").query({
+			response_type: "code",
+			client_id: "client-1",
+			redirect_uri: "https://example.test/cb",
+			state: "state-outside-scope",
+			scope: "email",
+		});
+
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers.location);
+		expect(location.searchParams.get("error")).toBe("invalid_scope");
+		expect(location.searchParams.get("error_description")).toMatch(/no requested scopes/i);
+		expect(location.searchParams.get("state")).toBe("state-outside-scope");
+		expect(captureCode).not.toHaveBeenCalled();
 	});
 });
 
@@ -630,6 +776,7 @@ describe("IH-16: /authorize nonce length + character-set validation", () => {
 			response_type: "code",
 			client_id: "client-1",
 			redirect_uri: "https://example.test/cb",
+			scope: "openid profile",
 			nonce,
 		});
 
@@ -655,6 +802,7 @@ describe("IH-16: /authorize nonce length + character-set validation", () => {
 			response_type: "code",
 			client_id: "client-1",
 			redirect_uri: "https://example.test/cb",
+			scope: "openid profile",
 			nonce,
 		});
 
@@ -823,11 +971,13 @@ describe("D-1 / CR-2: /authorize binds identity to code record, not Express sess
 				response_type: "code",
 				client_id: "client-1",
 				redirect_uri: "https://example.test/cb",
+				scope: "openid profile",
 			}),
 			request(app).get("/oauth/authorize").query({
 				response_type: "code",
 				client_id: "client-1",
 				redirect_uri: "https://example.test/cb",
+				scope: "openid profile",
 			}),
 		]);
 
@@ -913,6 +1063,7 @@ describe("D-6 (RFC 9700 §2.1.1): /authorize public-client PKCE/S256 mandatory",
 			client_id: "public-app",
 			redirect_uri: "https://spa.example.test/cb",
 			state: "state-abc",
+			scope: "openid profile",
 			// no code_challenge
 		});
 		expect(res.status).toBe(302);
@@ -932,6 +1083,7 @@ describe("D-6 (RFC 9700 §2.1.1): /authorize public-client PKCE/S256 mandatory",
 			client_id: "public-app",
 			redirect_uri: "https://spa.example.test/cb",
 			state: "state-plain",
+			scope: "openid profile",
 			code_challenge: VALID_S256_CHALLENGE,
 			code_challenge_method: "plain",
 		});
@@ -954,6 +1106,7 @@ describe("D-6 (RFC 9700 §2.1.1): /authorize public-client PKCE/S256 mandatory",
 			client_id: "public-app",
 			redirect_uri: "https://spa.example.test/cb",
 			state: "state-omit",
+			scope: "openid profile",
 			code_challenge: VALID_S256_CHALLENGE,
 			// no code_challenge_method → routes.mts treats absence as "plain"
 		});

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -687,10 +687,20 @@ export const createOAuthRouter = async (
 				if (
 					isActingAsOidcProvider &&
 					oidcMode === "oidc-required" &&
-					!requestedScopes.includes("openid")
+					// Two failure modes both undermine "OIDC required":
+					//   (a) the request itself omits openid;
+					//   (b) the request includes openid but the client allowlist
+					//       filters it out — without checking the filtered set
+					//       the request would silently proceed as OAuth-only
+					//       even though the server is configured oidc-required.
+					(!requestedScopes.includes("openid") || !allowedFilteredScopes.includes("openid"))
 				) {
 					logger.warn(
-						{ clientId: client_id, requestedScopes },
+						{
+							clientId: client_id,
+							requestedScopes,
+							allowedFilteredScopes,
+						},
 						"authorize_rejected_missing_openid_scope",
 					);
 					return redirectError(

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -679,6 +679,35 @@ export const createOAuthRouter = async (
 					requestedScopes.length > 0
 						? requestedScopes.filter((s) => allowedScopes.includes(s))
 						: allowedScopes;
+				const configuredIssuer = config.oauth.jwt.issuer;
+				const isActingAsOidcProvider =
+					typeof configuredIssuer === "string" && configuredIssuer.length > 0;
+				const oidcMode =
+					(config.oauth as { oidcMode?: "oidc-required" | "dual" }).oidcMode ?? "oidc-required";
+				if (
+					isActingAsOidcProvider &&
+					oidcMode === "oidc-required" &&
+					!requestedScopes.includes("openid")
+				) {
+					logger.warn(
+						{ clientId: client_id, requestedScopes },
+						"authorize_rejected_missing_openid_scope",
+					);
+					return redirectError(
+						redirect_uri,
+						"invalid_scope",
+						"openid scope is required when server is acting as an OIDC OP",
+						toStr(state),
+					);
+				}
+				if (allowedFilteredScopes.length === 0 && requestedScopes.length > 0) {
+					return redirectError(
+						redirect_uri,
+						"invalid_scope",
+						"no requested scopes are allowed for this client",
+						toStr(state),
+					);
+				}
 
 				// C-2: policy evaluation at /authorize (evaluate-once, persist on Code).
 				// The code exchange MUST NOT re-evaluate — it reads the narrowed values off

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -67,6 +67,44 @@ function supportsEndSession(
 	return typeof (provider as { endSession?: unknown }).endSession === "function";
 }
 
+function readLogoutParam(source: Record<string, unknown>, key: string): string | undefined {
+	const value = source[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+function extractLogoutParams(req: Request): {
+	idTokenHint: string | undefined;
+	postLogoutRedirectUri: string | undefined;
+	state: string | undefined;
+} {
+	const source =
+		req.method === "GET"
+			? (req.query as Record<string, unknown>)
+			: ((req.body ?? {}) as Record<string, unknown>);
+	return {
+		idTokenHint: readLogoutParam(source, "id_token_hint"),
+		postLogoutRedirectUri: readLogoutParam(source, "post_logout_redirect_uri"),
+		state: readLogoutParam(source, "state"),
+	};
+}
+
+function renderLogoutConfirmation(res: Response): Response {
+	const html = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Confirm Logout</title></head>
+<body>
+  <h1>Sign out</h1>
+  <p>Do you want to sign out from all applications?</p>
+  <form method="POST" action="logout">
+    <input type="hidden" name="confirmed" value="1" />
+    <button type="submit">Sign out</button>
+  </form>
+</body>
+</html>`;
+	res.setHeader("Content-Type", "text/html; charset=utf-8");
+	return res.status(200).send(html);
+}
+
 export interface LogoutRouterOptions {
 	keyStore: KeyStore;
 	/** Issuer URL of this auth provider — used for logout_token `iss` claim and iframe `iss` param. */
@@ -100,15 +138,16 @@ export interface LogoutRouterOptions {
 }
 
 /**
- * OIDC RP-Initiated Logout 1.0 — POST /oauth/logout
+ * OIDC RP-Initiated Logout 1.0 — GET/POST /oauth/logout
  *
- * Accepts application/x-www-form-urlencoded with:
+ * Accepts application/x-www-form-urlencoded POST body or GET query with:
  *   - id_token_hint (required)
  *   - post_logout_redirect_uri (optional)
  *   - state (optional)
  *
  * Flow:
- *   1. Verify id_token_hint via keyStore. Fail → 400 invalid_token.
+ *   1. Verify id_token_hint via keyStore. Fail → 400 invalid_token for POST,
+ *      confirmation HTML for GET.
  *   2. Extract `sid` and `aud` (= client_id). Missing sid → 400 invalid_request.
  *   3. Load session from userSessionStore. Missing → 200 JSON { logged_out: true } (no-op).
  *   4. Broadcast Back-Channel Logout to all registered RPs (best-effort).
@@ -376,244 +415,257 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 		},
 	);
 
-	// POST /logout — mounted under /oauth → POST /oauth/logout
-	router.post(
-		"/logout",
-		express.urlencoded({ extended: false }),
-		async (req: Request, res: Response) => {
-			// RFC 6749 §5.1 / RFC 9207: cache headers on every response path.
-			res.setHeader("Cache-Control", "no-store");
-			res.setHeader("Pragma", "no-cache");
+	const handleLogout = async (req: Request, res: Response) => {
+		// RFC 6749 §5.1 / RFC 9207: cache headers on every response path.
+		res.setHeader("Cache-Control", "no-store");
+		res.setHeader("Pragma", "no-cache");
 
-			const {
-				id_token_hint: idTokenHint,
-				post_logout_redirect_uri: postLogoutRedirectUri,
-				state,
-			} = req.body as Record<string, string | undefined>;
+		const { idTokenHint, postLogoutRedirectUri, state } = extractLogoutParams(req);
 
-			// Step 1: Verify id_token_hint.
-			if (typeof idTokenHint !== "string" || idTokenHint.length === 0) {
-				return res.status(400).json({
-					error: "invalid_request",
-					error_description: "id_token_hint is required",
-				});
+		// Step 1: Verify id_token_hint.
+		if (typeof idTokenHint !== "string" || idTokenHint.length === 0) {
+			if (req.method === "GET") {
+				return renderLogoutConfirmation(res);
 			}
+			return res.status(400).json({
+				error: "invalid_request",
+				error_description: "id_token_hint is required",
+			});
+		}
 
-			let payload: Record<string, unknown>;
-			try {
-				// SF-1: pin alg / iss / typ (=id+jwt) + signature. Audience is
-				// derived from the id_token's aud claim post-verification (the
-				// id_token was issued for a specific client); we can't pin aud
-				// before knowing the client, so the verifier records the gap.
-				const verified = await verifyJwt(idTokenHint, opts.keyStore, {
-					type: "id_token",
-					expectedIssuer: opts.issuer ?? "",
-					legacyTypAccept: opts.legacyTypAccept ?? true,
-					logger: opts.logger,
-				});
-				payload = verified.payload as Record<string, unknown>;
-			} catch {
-				return res.status(400).json({
-					error: "invalid_token",
-					error_description: "id_token_hint verification failed",
-				});
-			}
-
-			// Step 2: Extract sid and aud (client_id).
-			const sid = typeof payload.sid === "string" ? payload.sid : null;
-			const sub = typeof payload.sub === "string" ? payload.sub : null;
-			const rawAud = payload.aud;
-			const aud: string | null =
-				typeof rawAud === "string"
-					? rawAud
-					: Array.isArray(rawAud) && typeof rawAud[0] === "string"
-						? rawAud[0]
-						: null;
-
-			if (!sid) {
-				return res.status(400).json({
-					error: "invalid_request",
-					error_description: "id_token_hint missing sid claim",
-				});
-			}
-
-			// Step 3: Load session. Missing → defensive 200 no-op.
-			let session: Awaited<ReturnType<typeof opts.userSessionStore.get>>;
-			try {
-				session = await opts.userSessionStore.get(sid);
-			} catch (err) {
-				const logger = opts.logger ?? console;
-				logger.warn("POST /oauth/logout: userSessionStore.get failed", err);
-				return res.status(503).json({
-					error: "temporarily_unavailable",
-					error_description: "session store unavailable",
-				});
-			}
-
-			if (!session) {
-				return res.status(200).json({ logged_out: true });
-			}
-
-			// A4 §6.2 Step 1 (route-level read for pre-cascade ops):
-			//   - rps: needed by broadcastBackchannelLogout (best-effort, before cascade)
-			//   - federations: needed for IdP endSession redirect (route handler step 5)
-			// familyIds is read internally by cascadeLogout per §6.2 Step 1.
-			let rps: Awaited<ReturnType<typeof opts.sessionRPRegistry.listRPs>>;
-			let federations: ReadonlyArray<string>;
-			try {
-				[rps, federations] = await Promise.all([
-					opts.sessionRPRegistry.listRPs(sid),
-					opts.sessionFederationIndex.listFederations(sid),
-				]);
-			} catch (err) {
-				const logger = opts.logger ?? console;
-				logger.warn("POST /oauth/logout: reverse-index read failed", err);
-				return res.status(503).json({
-					error: "temporarily_unavailable",
-					error_description: "session store unavailable",
-				});
-			}
-
-			// Step 4: Broadcast Back-Channel Logout (best-effort — never throws).
-			if (sub) {
-				await broadcastBackchannelLogout({
-					rps,
-					issuer: opts.issuer,
-					sub,
-					sid,
-					keyStore: opts.keyStore,
-					fetchImpl: opts.fetchImpl,
-					logger: opts.logger,
-				});
-			}
-
-			// Step 5: Resolve IdP end-session URI for the FIRST federation (spec Open Issue #2).
-			// getFederationProviders() is called at request time so module init order does not matter.
-			let endSessionUri: string | undefined;
-			const firstFederation = federations[0];
-			if (firstFederation) {
-				const providers = opts.getFederationProviders();
-				const provider = providers?.get(firstFederation);
-				if (supportsEndSession(provider)) {
-					try {
-						let idTokenHintForIdP: string | undefined;
-						try {
-							const tokens = await opts.federationTokenStore.get(sid, firstFederation);
-							idTokenHintForIdP = tokens?.idToken ?? undefined;
-						} catch {
-							// Best-effort: if we can't get the federation token, proceed without idTokenHint
-						}
-						const result = await provider.endSession({
-							idTokenHint: idTokenHintForIdP,
-							postLogoutRedirectUri:
-								typeof postLogoutRedirectUri === "string" ? postLogoutRedirectUri : undefined,
-							state: typeof state === "string" ? state : undefined,
-						});
-						endSessionUri = result.url.toString();
-					} catch (err) {
-						// Best-effort: log and proceed without IdP redirect
-						const logger = opts.logger ?? console;
-						logger.warn(`POST /oauth/logout: federation ${firstFederation} endSession failed`, err);
-					}
-				}
-			}
-
-			// Step 6: Cascade logout.
-			const cascade = await cascadeLogout({
-				sid,
-				refreshTokenFamilyRevocation: opts.refreshTokenFamilyRevocation,
-				federationTokenStore: opts.federationTokenStore,
-				userSessionStore: opts.userSessionStore,
-				sessionRPRegistry: opts.sessionRPRegistry,
-				sessionFamilyIndex: opts.sessionFamilyIndex,
-				sessionFederationIndex: opts.sessionFederationIndex,
+		let payload: Record<string, unknown>;
+		try {
+			// SF-1: pin alg / iss / typ (=id+jwt) + signature. Audience is
+			// derived from the id_token's aud claim post-verification (the
+			// id_token was issued for a specific client); we can't pin aud
+			// before knowing the client, so the verifier records the gap.
+			const verified = await verifyJwt(idTokenHint, opts.keyStore, {
+				type: "id_token",
+				expectedIssuer: opts.issuer ?? "",
+				legacyTypAccept: opts.legacyTypAccept ?? true,
 				logger: opts.logger,
 			});
-
-			if (cascade.outcome === "failed") {
-				emitAuditEvent(opts.auditSink, {
-					timestamp: new Date(),
-					type: "logout.cascade_failed",
-					subject: sub ?? undefined,
-					ip: req.ip,
-					userAgent: req.get("user-agent"),
-					details: { sid, step: cascade.step },
-				});
-				return res.status(503).json({
-					error: "temporarily_unavailable",
-					error_description: "logout cascade failed",
-				});
+			payload = verified.payload as Record<string, unknown>;
+		} catch {
+			if (req.method === "GET") {
+				return renderLogoutConfirmation(res);
 			}
+			return res.status(400).json({
+				error: "invalid_token",
+				error_description: "id_token_hint verification failed",
+			});
+		}
 
-			// Step 7: Select response.
+		if (req.method === "GET") {
+			const iat = typeof payload.iat === "number" ? payload.iat : 0;
+			const maxAgeMs = 24 * 60 * 60 * 1000;
+			if (Date.now() - iat * 1000 > maxAgeMs) {
+				return renderLogoutConfirmation(res);
+			}
+		}
 
-			// Emit logout.success before all terminal success response paths.
-			// Placed here (after cascade, before response selection) so every
-			// success branch (HTML / IdP redirect / post-logout redirect / JSON)
-			// emits exactly once without duplicating the call.
+		// Step 2: Extract sid and aud (client_id).
+		const sid = typeof payload.sid === "string" ? payload.sid : null;
+		const sub = typeof payload.sub === "string" ? payload.sub : null;
+		const rawAud = payload.aud;
+		const aud: string | null =
+			typeof rawAud === "string"
+				? rawAud
+				: Array.isArray(rawAud) && typeof rawAud[0] === "string"
+					? rawAud[0]
+					: null;
+
+		if (!sid) {
+			return res.status(400).json({
+				error: "invalid_request",
+				error_description: "id_token_hint missing sid claim",
+			});
+		}
+
+		// Step 3: Load session. Missing → defensive 200 no-op.
+		let session: Awaited<ReturnType<typeof opts.userSessionStore.get>>;
+		try {
+			session = await opts.userSessionStore.get(sid);
+		} catch (err) {
+			const logger = opts.logger ?? console;
+			logger.warn(`${req.method} /oauth/logout: userSessionStore.get failed`, err);
+			return res.status(503).json({
+				error: "temporarily_unavailable",
+				error_description: "session store unavailable",
+			});
+		}
+
+		if (!session) {
+			return res.status(200).json({ logged_out: true });
+		}
+
+		// A4 §6.2 Step 1 (route-level read for pre-cascade ops):
+		//   - rps: needed by broadcastBackchannelLogout (best-effort, before cascade)
+		//   - federations: needed for IdP endSession redirect (route handler step 5)
+		// familyIds is read internally by cascadeLogout per §6.2 Step 1.
+		let rps: Awaited<ReturnType<typeof opts.sessionRPRegistry.listRPs>>;
+		let federations: ReadonlyArray<string>;
+		try {
+			[rps, federations] = await Promise.all([
+				opts.sessionRPRegistry.listRPs(sid),
+				opts.sessionFederationIndex.listFederations(sid),
+			]);
+		} catch (err) {
+			const logger = opts.logger ?? console;
+			logger.warn(`${req.method} /oauth/logout: reverse-index read failed`, err);
+			return res.status(503).json({
+				error: "temporarily_unavailable",
+				error_description: "session store unavailable",
+			});
+		}
+
+		// Step 4: Broadcast Back-Channel Logout (best-effort — never throws).
+		if (sub) {
+			await broadcastBackchannelLogout({
+				rps,
+				issuer: opts.issuer,
+				sub,
+				sid,
+				keyStore: opts.keyStore,
+				fetchImpl: opts.fetchImpl,
+				logger: opts.logger,
+			});
+		}
+
+		// Step 5: Resolve IdP end-session URI for the FIRST federation (spec Open Issue #2).
+		// getFederationProviders() is called at request time so module init order does not matter.
+		let endSessionUri: string | undefined;
+		const firstFederation = federations[0];
+		if (firstFederation) {
+			const providers = opts.getFederationProviders();
+			const provider = providers?.get(firstFederation);
+			if (supportsEndSession(provider)) {
+				try {
+					let idTokenHintForIdP: string | undefined;
+					try {
+						const tokens = await opts.federationTokenStore.get(sid, firstFederation);
+						idTokenHintForIdP = tokens?.idToken ?? undefined;
+					} catch {
+						// Best-effort: if we can't get the federation token, proceed without idTokenHint
+					}
+					const result = await provider.endSession({
+						idTokenHint: idTokenHintForIdP,
+						postLogoutRedirectUri:
+							typeof postLogoutRedirectUri === "string" ? postLogoutRedirectUri : undefined,
+						state: typeof state === "string" ? state : undefined,
+					});
+					endSessionUri = result.url.toString();
+				} catch (err) {
+					// Best-effort: log and proceed without IdP redirect
+					const logger = opts.logger ?? console;
+					logger.warn(
+						`${req.method} /oauth/logout: federation ${firstFederation} endSession failed`,
+						err,
+					);
+				}
+			}
+		}
+
+		// Step 6: Cascade logout.
+		const cascade = await cascadeLogout({
+			sid,
+			refreshTokenFamilyRevocation: opts.refreshTokenFamilyRevocation,
+			federationTokenStore: opts.federationTokenStore,
+			userSessionStore: opts.userSessionStore,
+			sessionRPRegistry: opts.sessionRPRegistry,
+			sessionFamilyIndex: opts.sessionFamilyIndex,
+			sessionFederationIndex: opts.sessionFederationIndex,
+			logger: opts.logger,
+		});
+
+		if (cascade.outcome === "failed") {
 			emitAuditEvent(opts.auditSink, {
 				timestamp: new Date(),
-				type: "logout.success",
+				type: "logout.cascade_failed",
 				subject: sub ?? undefined,
 				ip: req.ip,
 				userAgent: req.get("user-agent"),
-				details: { sid, federations },
+				details: { sid, step: cascade.step },
 			});
+			return res.status(503).json({
+				error: "temporarily_unavailable",
+				error_description: "logout cascade failed",
+			});
+		}
 
-			// Validate post_logout_redirect_uri against the initiating client's allowlist ONCE.
-			// Both the HTML branch (7a) and the redirect branch (7c) use this validated value.
-			// Invalid or missing URIs become undefined — fall through to JSON fallback.
-			let validatedPostLogoutRedirectUri: string | undefined;
-			if (typeof postLogoutRedirectUri === "string" && postLogoutRedirectUri.length > 0 && aud) {
-				try {
-					const client = await opts.clientRepository.findById(aud);
-					if (client?.postLogoutRedirectUris?.includes(postLogoutRedirectUri)) {
-						validatedPostLogoutRedirectUri = postLogoutRedirectUri;
-					}
-				} catch {
-					// Client repo throw → treat as unvalidated; fall through to JSON
+		// Step 7: Select response.
+
+		// Emit logout.success before all terminal success response paths.
+		// Placed here (after cascade, before response selection) so every
+		// success branch (HTML / IdP redirect / post-logout redirect / JSON)
+		// emits exactly once without duplicating the call.
+		emitAuditEvent(opts.auditSink, {
+			timestamp: new Date(),
+			type: "logout.success",
+			subject: sub ?? undefined,
+			ip: req.ip,
+			userAgent: req.get("user-agent"),
+			details: { sid, federations },
+		});
+
+		// Validate post_logout_redirect_uri against the initiating client's allowlist ONCE.
+		// Both the HTML branch (7a) and the redirect branch (7c) use this validated value.
+		// Invalid or missing URIs become undefined — fall through to JSON fallback.
+		let validatedPostLogoutRedirectUri: string | undefined;
+		if (typeof postLogoutRedirectUri === "string" && postLogoutRedirectUri.length > 0 && aud) {
+			try {
+				const client = await opts.clientRepository.findById(aud);
+				if (client?.postLogoutRedirectUris?.includes(postLogoutRedirectUri)) {
+					validatedPostLogoutRedirectUri = postLogoutRedirectUri;
 				}
+			} catch {
+				// Client repo throw → treat as unvalidated; fall through to JSON
 			}
+		}
 
-			// 7a: Front-channel logout — if Accept: text/html AND any RP has a frontchannelLogoutUri.
-			// Use q-weighted negotiation: application/json is first so Accept: */* defaults to JSON.
-			// Only when text/html explicitly outranks json (e.g. browser requests) do we serve HTML.
-			const negotiated = accepts(req).type(["application/json", "text/html"]);
-			const acceptsHtml = negotiated === "text/html";
-			const hasFrontchannel = rps.some(
-				(rp) => typeof rp.frontchannelLogoutUri === "string" && rp.frontchannelLogoutUri.length > 0,
-			);
-			if (acceptsHtml && hasFrontchannel) {
-				const html = renderFrontchannelLogoutHtml({
-					rps,
-					issuer: opts.issuer,
-					sid,
-					// Use the allowlist-validated URI — prevents open redirect via HTML branch.
-					postLogoutRedirectUri: validatedPostLogoutRedirectUri,
-					logger: opts.logger,
-				});
-				res.setHeader("Content-Type", "text/html; charset=utf-8");
-				return res.status(200).send(html);
+		// 7a: Front-channel logout — if Accept: text/html AND any RP has a frontchannelLogoutUri.
+		// Use q-weighted negotiation: application/json is first so Accept: */* defaults to JSON.
+		// Only when text/html explicitly outranks json (e.g. browser requests) do we serve HTML.
+		const negotiated = accepts(req).type(["application/json", "text/html"]);
+		const acceptsHtml = negotiated === "text/html";
+		const hasFrontchannel = rps.some(
+			(rp) => typeof rp.frontchannelLogoutUri === "string" && rp.frontchannelLogoutUri.length > 0,
+		);
+		if (acceptsHtml && hasFrontchannel) {
+			const html = renderFrontchannelLogoutHtml({
+				rps,
+				issuer: opts.issuer,
+				sid,
+				// Use the allowlist-validated URI — prevents open redirect via HTML branch.
+				postLogoutRedirectUri: validatedPostLogoutRedirectUri,
+				logger: opts.logger,
+			});
+			res.setHeader("Content-Type", "text/html; charset=utf-8");
+			return res.status(200).send(html);
+		}
+
+		// 7b: IdP end-session redirect.
+		if (endSessionUri) {
+			return res.redirect(303, endSessionUri);
+		}
+
+		// 7c: post_logout_redirect_uri — use the already-validated value (allowlist checked above).
+		if (validatedPostLogoutRedirectUri) {
+			const redirectUrl = new URL(validatedPostLogoutRedirectUri);
+			if (typeof state === "string" && state.length > 0) {
+				redirectUrl.searchParams.set("state", state);
 			}
+			return res.redirect(303, redirectUrl.toString());
+		}
 
-			// 7b: IdP end-session redirect.
-			if (endSessionUri) {
-				return res.redirect(303, endSessionUri);
-			}
+		// 7d: Default — JSON success.
+		return res.status(200).json({ logged_out: true });
+	};
 
-			// 7c: post_logout_redirect_uri — use the already-validated value (allowlist checked above).
-			if (validatedPostLogoutRedirectUri) {
-				const redirectUrl = new URL(validatedPostLogoutRedirectUri);
-				if (typeof state === "string" && state.length > 0) {
-					redirectUrl.searchParams.set("state", state);
-				}
-				return res.redirect(303, redirectUrl.toString());
-			}
-
-			// 7d: Default — JSON success.
-			return res.status(200).json({ logged_out: true });
-		},
-	);
+	// POST /logout — mounted under /oauth → POST /oauth/logout
+	router.post("/logout", express.urlencoded({ extended: false }), handleLogout);
+	// GET /logout — mounted under /oauth → GET /oauth/logout
+	router.get("/logout", handleLogout);
 
 	return router;
 }

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -88,15 +88,46 @@ function extractLogoutParams(req: Request): {
 	};
 }
 
-function renderLogoutConfirmation(res: Response): Response {
+const HTML_ESCAPE: Record<string, string> = {
+	"&": "&amp;",
+	"<": "&lt;",
+	">": "&gt;",
+	'"': "&quot;",
+	"'": "&#39;",
+};
+
+function escapeHtml(s: string): string {
+	return s.replace(/[&<>"']/g, (c) => HTML_ESCAPE[c] ?? c);
+}
+
+function hiddenInput(name: string, value: string | undefined): string {
+	if (typeof value !== "string" || value.length === 0) return "";
+	return `    <input type="hidden" name="${escapeHtml(name)}" value="${escapeHtml(value)}" />\n`;
+}
+
+function renderLogoutConfirmation(
+	res: Response,
+	params: {
+		idTokenHint?: string;
+		postLogoutRedirectUri?: string;
+		state?: string;
+	},
+): Response {
+	// Pass the original logout params through as hidden inputs so that the
+	// confirmed POST can complete the standard hint-based flow. Without this,
+	// the POST handler rejects with 400 invalid_request because id_token_hint
+	// is missing — the "Sign out" button would never actually log out.
+	// `action=""` posts to the current URL: this avoids a relative-URL trap
+	// when /oauth/logout is reached with a trailing slash (`/oauth/logout/`),
+	// where `action="logout"` would resolve to `/oauth/logout/logout`.
 	const html = `<!DOCTYPE html>
 <html lang="en">
 <head><meta charset="utf-8"><title>Confirm Logout</title></head>
 <body>
   <h1>Sign out</h1>
   <p>Do you want to sign out from all applications?</p>
-  <form method="POST" action="logout">
-    <input type="hidden" name="confirmed" value="1" />
+  <form method="POST" action="">
+${hiddenInput("id_token_hint", params.idTokenHint)}${hiddenInput("post_logout_redirect_uri", params.postLogoutRedirectUri)}${hiddenInput("state", params.state)}    <input type="hidden" name="confirmed" value="1" />
     <button type="submit">Sign out</button>
   </form>
 </body>
@@ -424,9 +455,9 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 
 		// Step 1: Verify id_token_hint.
 		if (typeof idTokenHint !== "string" || idTokenHint.length === 0) {
-			if (req.method === "GET") {
-				return renderLogoutConfirmation(res);
-			}
+			// No hint available — there is nothing to pass through to a
+			// confirmed POST, so the confirmation page would render a button
+			// that always fails the POST hint requirement. Reject directly.
 			return res.status(400).json({
 				error: "invalid_request",
 				error_description: "id_token_hint is required",
@@ -448,7 +479,11 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			payload = verified.payload as Record<string, unknown>;
 		} catch {
 			if (req.method === "GET") {
-				return renderLogoutConfirmation(res);
+				return renderLogoutConfirmation(res, {
+					idTokenHint,
+					postLogoutRedirectUri,
+					state,
+				});
 			}
 			return res.status(400).json({
 				error: "invalid_token",
@@ -460,7 +495,11 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			const iat = typeof payload.iat === "number" ? payload.iat : 0;
 			const maxAgeMs = 24 * 60 * 60 * 1000;
 			if (Date.now() - iat * 1000 > maxAgeMs) {
-				return renderLogoutConfirmation(res);
+				return renderLogoutConfirmation(res, {
+					idTokenHint,
+					postLogoutRedirectUri,
+					state,
+				});
 			}
 		}
 

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -478,29 +478,16 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			});
 			payload = verified.payload as Record<string, unknown>;
 		} catch {
-			if (req.method === "GET") {
-				return renderLogoutConfirmation(res, {
-					idTokenHint,
-					postLogoutRedirectUri,
-					state,
-				});
-			}
+			// Invalid signature / iss / typ. The POST verifier uses identical
+			// options, so a hint that fails GET verification will deterministically
+			// fail POST verification too — rendering a confirmation page with
+			// the same hint passed through hidden inputs would just produce a
+			// "Sign out" button that returns 400 invalid_token. Reject directly
+			// for GET as well as POST.
 			return res.status(400).json({
 				error: "invalid_token",
 				error_description: "id_token_hint verification failed",
 			});
-		}
-
-		if (req.method === "GET") {
-			const iat = typeof payload.iat === "number" ? payload.iat : 0;
-			const maxAgeMs = 24 * 60 * 60 * 1000;
-			if (Date.now() - iat * 1000 > maxAgeMs) {
-				return renderLogoutConfirmation(res, {
-					idTokenHint,
-					postLogoutRedirectUri,
-					state,
-				});
-			}
 		}
 
 		// Step 2: Extract sid and aud (client_id).
@@ -513,6 +500,36 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 				: Array.isArray(rawAud) && typeof rawAud[0] === "string"
 					? rawAud[0]
 					: null;
+
+		if (req.method === "GET") {
+			const iat = typeof payload.iat === "number" ? payload.iat : 0;
+			const maxAgeMs = 24 * 60 * 60 * 1000;
+			if (Date.now() - iat * 1000 > maxAgeMs) {
+				// Validate post_logout_redirect_uri against the initiating
+				// client's allowlist BEFORE echoing it into the confirm page.
+				// Even though the post-cascade allowlist gate (line ~657) is
+				// what actually controls the redirect, an unvalidated URL
+				// reflected on the auth-provider origin's confirmation page
+				// weakens the invariant that attacker-controlled URIs never
+				// appear on this origin. Only allowlisted URIs round-trip.
+				let safePostLogoutRedirectUri: string | undefined;
+				if (typeof postLogoutRedirectUri === "string" && postLogoutRedirectUri.length > 0 && aud) {
+					try {
+						const client = await opts.clientRepository.findById(aud);
+						if (client?.postLogoutRedirectUris?.includes(postLogoutRedirectUri)) {
+							safePostLogoutRedirectUri = postLogoutRedirectUri;
+						}
+					} catch {
+						// Client repo throw → treat as unvalidated; drop from form.
+					}
+				}
+				return renderLogoutConfirmation(res, {
+					idTokenHint,
+					postLogoutRedirectUri: safePostLogoutRedirectUri,
+					state,
+				});
+			}
+		}
 
 		if (!sid) {
 			return res.status(400).json({

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -91,6 +91,11 @@ oauth {
     }
     refresh_token { enabled = true, enabled = ${?OAUTH_GRANTS_REFRESH_TOKEN_ENABLED} }
   }
+  # IH-6: when oauth.jwt.issuer is configured, require `openid` in
+  # /authorize scope by default. Set OAUTH_OIDC_MODE=dual only if this OP
+  # intentionally also accepts OAuth-only authorization requests.
+  oidcMode = "oidc-required"
+  oidcMode = ${?OAUTH_OIDC_MODE}
   # OR-9: adapter switch for the OAuth authorization-code repository. When
   # set to "redis", the standalone composition root wires
   # `redisCodeRepositoryModule` against the shared ioredis socket

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -51,6 +51,7 @@ const config: AppConfig = {
 			legacyRtPolicy: "reject" as const,
 		},
 		grants: {},
+		oidcMode: "oidc-required",
 		// OR-9: explicit memory adapter for the smoke test. The legacy
 		// `repositories.code.type` fallback would also pick memory here,
 		// but the explicit setting documents the intent and avoids


### PR DESCRIPTION
## Summary
- add oauth.oidcMode with default oidc-required and OAUTH_OIDC_MODE override
- reject /oauth/authorize requests missing openid when issuer is configured and oidcMode is oidc-required; dual mode keeps OAuth-only requests working
- add GET /oauth/logout support using the existing logout cascade for fresh valid id_token_hint requests and confirmation HTML for missing/invalid/stale hints

## External spec verification
- OpenID Connect Core 1.0 Section 3.1.2.1/3.1.2.2 requires OpenID Connect requests to contain the openid scope and treats requests without it as non-OIDC: https://openid.net/specs/openid-connect-core-1_0-18.html
- OpenID Connect RP-Initiated Logout 1.0 Section 2 requires OPs to support HTTP GET and POST at the Logout Endpoint: https://openid.net/specs/openid-connect-rpinitiated-1_0.html

## Verification
- pnpm exec biome check CHANGELOG.md packages/core/src/config/application.schema.mts packages/core/config/application.conf packages/core/src/testing/fixtures/valid-config.mts packages/core/src/__tests__/config.test.mts packages/core/src/__tests__/config-composition.test.mts templates/standalone/config/application.conf templates/standalone/src/__tests__/smoke.test.mts packages/oauth/src/routes.mts packages/oauth/src/routes/logout.mts packages/oauth/src/__tests__/oauthAuthorization.test.mts packages/oauth/src/__tests__/logout.test.mts
- pnpm --filter @o3co/auth-provider-core test -- --runInBand src/__tests__/config.test.mts src/__tests__/config-composition.test.mts
- pnpm --filter @o3co/auth-provider-oauth exec vitest run src/__tests__/oauthAuthorization.test.mts src/__tests__/logout.test.mts
- pnpm --filter @o3co/auth-provider-core build
- pnpm --filter @o3co/auth-provider-oauth build
- pnpm -r run build
- pnpm --filter @o3co/auth-provider-standalone exec vitest run src/__tests__/smoke.test.mts

Stacked on #149.