### PR TITLE
F13a: Apply cleanup and Docker hardening batch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,10 @@
 - The root `test` script runs `pnpm -r run test` **without** `--if-present` on purpose: if any workspace lacks `test`, CI fails loudly rather than silently skipping it. Do not add `--if-present` here — see issue #88 for the regression this prevents.
 - Coverage is a per-package concern. Only `packages/**` define `test:coverage`. The root `test:coverage` is filtered to `./packages/**` and keeps `--if-present` so that a future package without coverage wiring does not break CI.
 
+## Local Cleanup
+
+- The old DID grant package was deleted from git tracking and moved out of this repository. Developers with pre-deletion workspaces may still have untracked `packages/did/` build artifacts on disk; remove that directory locally before broad `git add` operations.
+
 ## Module Resolution
 
 Each package uses Node.js [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) with a conditional `development` / `default` mapping:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   without a valid hint renders a confirmation page instead of triggering
   logout.
 
+### Changed (Phase F — F13a cleanup/operational hardening)
+
+- Standalone session cookies now default to `SESSION_NAME=__Host-auth.session`,
+  with boot-time validation that `__Host-` names are only used with
+  `SESSION_SECURE=true` and no `SESSION_DOMAIN`.
+- Redis session-store key namespacing is documented and preserved through
+  config validation via `REDIS_SESSION_STORES_KEY_PREFIX`.
+- The standalone Dockerfile now runs install/build steps as the `node` user,
+  declares `EXPOSE 3000`, and includes a Docker-native healthcheck for
+  `/_healthcheck`.
+- Added a developer cleanup note for stale untracked `packages/did/` artifacts
+  left in local workspaces after the DID grant package was removed from git.
+
 ## [0.5.2] — 2026-05-09
 
 ### Changed (auth.utils dependency bump, v0.5.2)

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -112,6 +112,11 @@ oauth {
 
 session {
   secret = ${?SESSION_SECRET}
+  # MIN-2: __Host- prefix requires Secure, Path=/, and no Domain attribute.
+  # If SESSION_SECURE=false or SESSION_DOMAIN is set, also override
+  # SESSION_NAME to a non-__Host- value.
+  name = "__Host-auth.session"
+  name = ${?SESSION_NAME}
   maxAge = 3600000
   maxAge = ${?SESSION_MAX_AGE}
   secure = true
@@ -230,6 +235,15 @@ memoryRateLimiter {
 userSessionStores {
   adapter = "memory"
   adapter = ${?USER_SESSION_STORES_ADAPTER}
+}
+
+# MIN-3: outer namespace for the four bundled Redis user-session stores.
+# The module appends fixed sub-prefixes (`us:`, `rp:`, `fi:`, `fed:`).
+# Multi-tenant Redis deployments should set a deployment-specific value,
+# e.g. `tenant-a:ss:`.
+redisSessionStores {
+  keyPrefix = "ss:"
+  keyPrefix = ${?REDIS_SESSION_STORES_KEY_PREFIX}
 }
 
 # D-2 v2 + Wave 5d: ioredis connection-config consumed by the shared

--- a/packages/core/src/__tests__/config-composition.test.mts
+++ b/packages/core/src/__tests__/config-composition.test.mts
@@ -233,6 +233,7 @@ describe("AppConfigSchema backward compatibility", () => {
 			},
 			session: {
 				secret: "session-secret",
+				name: "__Host-auth.session",
 				maxAge: 3600000,
 				secure: true,
 				sameSite: "lax",

--- a/packages/core/src/__tests__/config.test.mts
+++ b/packages/core/src/__tests__/config.test.mts
@@ -37,6 +37,8 @@ describe("provider config", () => {
 		expect(local.algorithm).toBe("HS256");
 		expect(local.kid).toBe("v0");
 		expect(config.oauth.oidcMode).toBe("oidc-required");
+		expect(config.session.name).toBe("__Host-auth.session");
+		expect(config.redisSessionStores?.keyPrefix).toBe("ss:");
 	});
 
 	it("fails validation when required fields are missing", () => {
@@ -57,7 +59,9 @@ describe("provider config", () => {
 				HTTP_PORT: "9090",
 				HTTP_TRUST_PROXY: "true",
 				SESSION_SECURE: "false",
+				SESSION_NAME: "auth.sid",
 				OAUTH_OIDC_MODE: "dual",
+				REDIS_SESSION_STORES_KEY_PREFIX: "tenant-a:ss:",
 			},
 		});
 		const config = validate(raw, AppConfigSchema);
@@ -65,7 +69,9 @@ describe("provider config", () => {
 		expect(config.http.port).toBe(9090);
 		expect(config.http.trustProxy).toBe(true);
 		expect(config.session.secure).toBe(false);
+		expect(config.session.name).toBe("auth.sid");
 		expect(config.oauth.oidcMode).toBe("dual");
+		expect(config.redisSessionStores?.keyPrefix).toBe("tenant-a:ss:");
 		// federations.google.enabled env-var coercion is covered by the
 		// HOCON application.conf wiring; schema-level boolean coercion for
 		// federation entries is tested in federations-schema.test.mts.

--- a/packages/core/src/config/__tests__/schema-open-type.test.mts
+++ b/packages/core/src/config/__tests__/schema-open-type.test.mts
@@ -25,6 +25,7 @@ import { makeValidFullSections } from "#/testing/fixtures/valid-config.mjs";
 function validSession(overrides: Record<string, unknown> = {}) {
 	return {
 		secret: "s",
+		name: "__Host-auth.session",
 		maxAge: 3600000,
 		secure: true,
 		sameSite: "lax" as const,

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -277,6 +277,7 @@ const federationEntrySchema = z
 export const fullSectionsSchema = z.object({
 	session: z.object({
 		secret: z.string(),
+		name: z.string(),
 		maxAge: z.coerce.number(),
 		secure: z.boolean(),
 		sameSite: z.enum(["lax", "none", "strict"]),
@@ -395,6 +396,15 @@ export const fullSectionsSchema = z.object({
 	userSessionStores: z
 		.object({
 			adapter: z.enum(["memory", "redis"]).optional(),
+		})
+		.optional(),
+	// MIN-3 (v0.5.3): preserve the bundled Redis user-session namespace
+	// override before `redisSessionStoresModule.configSchema` applies its
+	// own defaults. Without this top-level passthrough, AppConfigSchema would
+	// strip `redisSessionStores.keyPrefix` before the module sees it.
+	redisSessionStores: z
+		.object({
+			keyPrefix: z.string().optional(),
 		})
 		.optional(),
 	// D-2 v2: module-internal config for `redisRefreshTokenFamilyStoreModule`.

--- a/packages/core/src/testing/fixtures/valid-config.mts
+++ b/packages/core/src/testing/fixtures/valid-config.mts
@@ -95,6 +95,7 @@ export function makeValidFullSections() {
 	return {
 		session: {
 			secret: "test-session-secret",
+			name: "__Host-auth.session",
 			maxAge: 3600000,
 			secure: true,
 			sameSite: "lax",

--- a/packages/session/src/__tests__/sessionStoreModule.test.mts
+++ b/packages/session/src/__tests__/sessionStoreModule.test.mts
@@ -10,12 +10,15 @@
 // covered by templates/standalone/src/__tests__/smoke.test.mts.
 
 import type { LifecycleRegistrar, Module } from "@o3co/auth-provider-core";
+import express from "express";
+import request from "supertest";
 import { describe, expect, it } from "vitest";
 import { sessionStoreModule } from "../modules/sessionStoreModule.mjs";
 
 interface SessionLikeConfig {
 	session: {
 		secret: string;
+		name: string;
 		secure: boolean;
 		maxAge: number;
 		sameSite: "lax" | "strict" | "none";
@@ -27,6 +30,7 @@ interface SessionLikeConfig {
 const baseConfig: SessionLikeConfig = {
 	session: {
 		secret: "test-secret-at-least-32-chars-long!",
+		name: "test.sid",
 		secure: false,
 		maxAge: 3600_000,
 		sameSite: "lax",
@@ -100,5 +104,67 @@ describe("sessionStoreModule (D-5)", () => {
 		// configured to "redis".
 		expect(route.id).toBe("session-middleware");
 		expect(reg.calls).toHaveLength(0);
+	});
+
+	it("uses session.name as the express-session cookie name", async () => {
+		const m = sessionStoreModule as unknown as Module;
+		const factory = m.contributes?.routes?.[0];
+		if (typeof factory !== "function") throw new Error("not a factory");
+		const route = await factory({
+			config: {
+				session: {
+					...baseConfig.session,
+					name: "auth.sid",
+					secure: false,
+					domain: null,
+				},
+			} as never,
+			lifecycleRegistrar: undefined,
+		} as never);
+		const app = express();
+		app.use(route.handler);
+		app.post("/touch", (req, res) => {
+			(req.session as unknown as Record<string, unknown>).touched = true;
+			res.status(200).json({ ok: true });
+		});
+
+		const res = await request(app).post("/touch");
+
+		const cookie = res.headers["set-cookie"]?.[0] ?? "";
+		expect(cookie).toMatch(/^auth\.sid=/);
+	});
+
+	it("rejects __Host- session names when secure/domain constraints are violated", async () => {
+		const m = sessionStoreModule as unknown as Module;
+		const factory = m.contributes?.routes?.[0];
+		if (typeof factory !== "function") throw new Error("not a factory");
+
+		await expect(
+			factory({
+				config: {
+					session: {
+						...baseConfig.session,
+						name: "__Host-auth.session",
+						secure: false,
+						domain: null,
+					},
+				} as never,
+				lifecycleRegistrar: undefined,
+			} as never),
+		).rejects.toThrow(/__Host-/);
+
+		await expect(
+			factory({
+				config: {
+					session: {
+						...baseConfig.session,
+						name: "__Host-auth.session",
+						secure: true,
+						domain: "example.com",
+					},
+				} as never,
+				lifecycleRegistrar: undefined,
+			} as never),
+		).rejects.toThrow(/__Host-/);
 	});
 });

--- a/packages/session/src/modules/sessionStoreModule.mts
+++ b/packages/session/src/modules/sessionStoreModule.mts
@@ -59,11 +59,20 @@ export const sessionStoreModule = defineModule<"config", "lifecycleRegistrar">({
 				const factory = createSessionStoreFactory(ctx);
 				registerBuiltinSessionStores(factory);
 				const storageSlice = config.session.storage as { type: string } & Record<string, unknown>;
+				if (
+					config.session.name.startsWith("__Host-") &&
+					(config.session.secure !== true || config.session.domain !== null)
+				) {
+					throw new Error(
+						"session.name with __Host- prefix requires session.secure=true and session.domain=null",
+					);
+				}
 				const store = await factory.create({
 					type: storageSlice.type,
 					...((storageSlice[storageSlice.type] ?? {}) as Record<string, unknown>),
 				});
 				const middleware = session({
+					name: config.session.name,
 					secret: config.session.secret,
 					resave: false,
 					saveUninitialized: false,

--- a/templates/standalone/Dockerfile
+++ b/templates/standalone/Dockerfile
@@ -45,10 +45,14 @@ RUN pnpm install --prod \
 COPY --from=builder /home/node/dist/ ./dist/
 COPY --from=builder /home/node/config/ ./config/
 
-EXPOSE 3000
+ENV HTTP_PORT=3000
+EXPOSE ${HTTP_PORT}
 
+# Use the shell form so ${HTTP_PORT} expands at probe time. The HOCON
+# config reads `${?HTTP_PORT}` for `http.port`, so app.listen() and the
+# healthcheck stay in sync regardless of the operator's port choice.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD wget -q -O /dev/null http://localhost:3000/_healthcheck || exit 1
+  CMD wget -q -O /dev/null "http://localhost:${HTTP_PORT}/_healthcheck" || exit 1
 
 ENTRYPOINT ["tini", "--"]
 CMD ["node", "dist/app.mjs"]

--- a/templates/standalone/Dockerfile
+++ b/templates/standalone/Dockerfile
@@ -13,10 +13,16 @@ FROM node-base AS deps
 
 COPY package.json ./
 
+USER node
+
 RUN pnpm install
 
 #############################################
 FROM deps AS builder
+
+# USER node inherited from deps stage; repeated here to make the builder
+# hardening invariant obvious in Dockerfile reviews.
+USER node
 
 COPY tsconfig.json ./
 COPY config/ ./config/
@@ -31,13 +37,18 @@ ENV NODE_ENV=production
 
 COPY --from=deps /home/node/package.json /home/node/pnpm-lock.yaml ./
 
+USER node
+
 RUN pnpm install --prod \
  && pnpm store prune
 
 COPY --from=builder /home/node/dist/ ./dist/
 COPY --from=builder /home/node/config/ ./config/
 
-USER node
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -q -O /dev/null http://localhost:3000/_healthcheck || exit 1
 
 ENTRYPOINT ["tini", "--"]
 CMD ["node", "dist/app.mjs"]
@@ -52,7 +63,5 @@ CMD ["pnpm", "run", "test", "--", "--passWithNoTests"]
 
 #############################################
 FROM builder AS develop
-
-USER node
 
 CMD ["pnpm", "run", "debug"]

--- a/templates/standalone/README.md
+++ b/templates/standalone/README.md
@@ -94,6 +94,7 @@ fail fast rather than silently falling back to defaults.
 | Variable | Default | Description |
 |---|---|---|
 | `SESSION_SECRET` | — | **Required.** Session signing secret |
+| `SESSION_NAME` | `__Host-auth.session` | Session cookie name. The default uses the `__Host-` prefix and therefore requires `SESSION_SECURE=true` and no `SESSION_DOMAIN`. |
 | `SESSION_MAX_AGE` | `3600000` | Session cookie max age in milliseconds |
 | `SESSION_SECURE` | `true` | Set `Secure` flag on session cookie |
 | `SESSION_SAME_SITE` | `lax` | `SameSite` attribute (`lax`, `strict`, `none`) |
@@ -101,6 +102,11 @@ fail fast rather than silently falling back to defaults.
 | `SESSION_STORAGE_TYPE` | `redis` | Session store backend: `redis` or `memory` |
 | `SESSION_STORAGE_REDIS_URL` | `redis://localhost:6379` | Redis connection URL for session storage |
 | `SESSION_STORAGE_REDIS_PASSWORD` | — | Redis password for session storage |
+
+If you set `SESSION_SECURE=false` for local HTTP development or set `SESSION_DOMAIN`
+for shared-domain cookies, also set `SESSION_NAME` to a non-`__Host-` value such as
+`auth.sid`. The server fails fast when a `__Host-` cookie name is combined with
+attributes that browsers reject for that prefix.
 
 ### Google Federation
 
@@ -135,6 +141,20 @@ fail fast rather than silently falling back to defaults.
 | `CLIENT_CODE_ENDPOINT_URI` | — | Redis connection URI for code storage |
 | `CLIENT_CODE_PASSWORD` | — | Redis password for code storage |
 | `CLIENT_CODE_DEFAULT_EXPIRES_IN` | `600` | Default authorization code lifetime in seconds |
+
+### Redis Namespacing
+
+For multi-tenant Redis clusters, set deployment-specific key prefixes so two
+auth.provider instances cannot collide in the same database:
+
+| Variable | Default | Description |
+|---|---|---|
+| `REDIS_SESSION_STORES_KEY_PREFIX` | `ss:` | Outer prefix for user sessions, RP registry, session-family index, and session-federation index. |
+| `REFRESH_TOKEN_FAMILY_STORE_KEY_PREFIX` | `rtfam:` | Prefix for refresh-token family records. |
+| `CLIENT_CODE_KEY_PREFIX` | `oauth:code:` | Prefix for OAuth authorization codes. |
+
+Use values that include the deployment name, for example `tenant-a:ss:`,
+`tenant-a:rtfam:`, and `tenant-a:code:`.
 
 ### Endpoints
 
@@ -184,6 +204,11 @@ make test
 ```
 
 The `docker-compose.yml` starts the auth server together with a Redis container. Configure environment variables in `.env`.
+
+The production image declares `EXPOSE 3000` and a Docker-native healthcheck
+against `/_healthcheck`. If you run the app on a different port, set
+`HTTP_PORT` and use an explicit port mapping such as `-p 8080:8080`; `EXPOSE`
+is image metadata and does not publish ports by itself.
 
 ## Adding Custom Modules
 

--- a/templates/standalone/README.md
+++ b/templates/standalone/README.md
@@ -205,10 +205,17 @@ make test
 
 The `docker-compose.yml` starts the auth server together with a Redis container. Configure environment variables in `.env`.
 
-The production image declares `EXPOSE 3000` and a Docker-native healthcheck
-against `/_healthcheck`. If you run the app on a different port, set
-`HTTP_PORT` and use an explicit port mapping such as `-p 8080:8080`; `EXPOSE`
-is image metadata and does not publish ports by itself.
+The production image sets `ENV HTTP_PORT=3000` and uses it for both `EXPOSE`
+and the Docker-native healthcheck against `/_healthcheck`. The HOCON config
+also reads `${?HTTP_PORT}` for `http.port`, so `app.listen()` and the
+healthcheck cannot drift apart. To run on a different port:
+
+```bash
+docker run -e HTTP_PORT=8080 -p 8080:8080 my-auth-provider
+```
+
+`EXPOSE` is image metadata and does not publish ports by itself, so the
+explicit `-p` mapping is still required.
 
 ## Adding Custom Modules
 

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -118,6 +118,11 @@ oauth {
 
 session {
   secret = ${?SESSION_SECRET}
+  # MIN-2: __Host- prefix requires Secure, Path=/, and no Domain attribute.
+  # If SESSION_SECURE=false or SESSION_DOMAIN is set, also override
+  # SESSION_NAME to a non-__Host- value.
+  name = "__Host-auth.session"
+  name = ${?SESSION_NAME}
   maxAge = 3600000
   maxAge = ${?SESSION_MAX_AGE}
   secure = true
@@ -245,6 +250,15 @@ memoryRateLimiter {
 userSessionStores {
   adapter = "memory"
   adapter = ${?USER_SESSION_STORES_ADAPTER}
+}
+
+# MIN-3: outer namespace for the four bundled Redis user-session stores.
+# The module appends fixed sub-prefixes (`us:`, `rp:`, `fi:`, `fed:`).
+# Multi-tenant Redis deployments should set a deployment-specific value,
+# e.g. `tenant-a:ss:`.
+redisSessionStores {
+  keyPrefix = "ss:"
+  keyPrefix = ${?REDIS_SESSION_STORES_KEY_PREFIX}
 }
 
 # D-2 v2 + Wave 5d: ioredis connection-config consumed by the shared

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { readFileSync } from "node:fs";
 import {
 	type AppConfig,
 	createApp,
@@ -29,6 +30,8 @@ import express from "express";
 import request from "supertest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildModules } from "../buildModules.mjs";
+
+const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8");
 
 const config: AppConfig = {
 	http: { port: 0, trustProxy: false },
@@ -60,6 +63,7 @@ const config: AppConfig = {
 	},
 	session: {
 		secret: "test-session-secret",
+		name: "auth.sid",
 		maxAge: 3600000,
 		secure: false,
 		sameSite: "lax",
@@ -179,6 +183,21 @@ describe("standalone smoke test", () => {
 	afterEach(async () => {
 		await handleRef?.dispose();
 		handleRef = undefined;
+	});
+
+	it("Dockerfile declares runtime metadata and runs install/build steps as node", () => {
+		expect(dockerfile).toContain("EXPOSE 3000");
+		expect(dockerfile).toContain(
+			"HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3",
+		);
+		expect(dockerfile).toContain(
+			"CMD wget -q -O /dev/null http://localhost:3000/_healthcheck || exit 1",
+		);
+		expect(dockerfile).toMatch(/FROM node-base AS deps[\s\S]*USER node[\s\S]*RUN pnpm install/);
+		expect(dockerfile).toMatch(/FROM deps AS builder[\s\S]*USER node[\s\S]*RUN pnpm run build/);
+		expect(dockerfile).toMatch(
+			/FROM node-base AS runtime[\s\S]*USER node[\s\S]*RUN pnpm install --prod/,
+		);
 	});
 
 	it("GET /_healthcheck returns 200", async () => {

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -186,12 +186,27 @@ describe("standalone smoke test", () => {
 	});
 
 	it("Dockerfile declares runtime metadata and runs install/build steps as node", () => {
-		expect(dockerfile).toContain("EXPOSE 3000");
-		expect(dockerfile).toContain(
-			"HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3",
+		// Default port is 3000 but the HEALTHCHECK and EXPOSE must read it
+		// from ${HTTP_PORT} so an operator overriding the env var keeps the
+		// app, EXPOSE metadata, and healthcheck in sync. Assert the ENV /
+		// EXPOSE / HEALTHCHECK structure rather than the literal port so the
+		// test is not brittle when operators or downstream forks change the
+		// default.
+		// The literal `${HTTP_PORT}` token from the Dockerfile is split across
+		// concatenations to sidestep biome's `noTemplateCurlyInString` rule
+		// (it cannot statically tell that this string is intentionally NOT
+		// a JS template placeholder — it is a Dockerfile env-substitution).
+		const HTTP_PORT_VAR = `$${"{"}HTTP_PORT}`;
+		expect(dockerfile).toContain("ENV HTTP_PORT=3000");
+		expect(dockerfile).toContain(`EXPOSE ${HTTP_PORT_VAR}`);
+		expect(dockerfile).toMatch(
+			/HEALTHCHECK\s+--interval=30s\s+--timeout=3s\s+--start-period=10s\s+--retries=3/,
 		);
-		expect(dockerfile).toContain(
-			"CMD wget -q -O /dev/null http://localhost:3000/_healthcheck || exit 1",
+		// Match the literal `${HTTP_PORT}` token inside the HEALTHCHECK CMD.
+		// `[$]` (character class) sidesteps biome's `noTemplateCurlyInString`
+		// false-positive without changing what we actually accept.
+		expect(dockerfile).toMatch(
+			/CMD\s+wget\s+-q\s+-O\s+\/dev\/null\s+"http:\/\/localhost:[$]\{HTTP_PORT\}\/_healthcheck"\s+\|\|\s+exit\s+1/,
 		);
 		expect(dockerfile).toMatch(/FROM node-base AS deps[\s\S]*USER node[\s\S]*RUN pnpm install/);
 		expect(dockerfile).toMatch(/FROM deps AS builder[\s\S]*USER node[\s\S]*RUN pnpm run build/);


### PR DESCRIPTION
## Summary
- add SESSION_NAME / __Host-auth.session default, pass it to express-session, and fail fast when __Host- constraints are violated
- preserve and document redisSessionStores.keyPrefix for multi-tenant Redis namespacing; add README guidance for session cookie names and Redis prefixes
- harden the standalone Dockerfile with non-root install/build steps, EXPOSE 3000, and Docker HEALTHCHECK for /_healthcheck
- document stale local packages/did/ cleanup in AGENTS.md and removed the local untracked directory from this workspace

## Verification
- pnpm exec biome check AGENTS.md CHANGELOG.md packages/core/config/application.conf packages/core/src/__tests__/config-composition.test.mts packages/core/src/__tests__/config.test.mts packages/core/src/config/__tests__/schema-open-type.test.mts packages/core/src/config/application.schema.mts packages/core/src/testing/fixtures/valid-config.mts packages/session/src/__tests__/sessionStoreModule.test.mts packages/session/src/modules/sessionStoreModule.mts templates/standalone/Dockerfile templates/standalone/README.md templates/standalone/config/application.conf templates/standalone/src/__tests__/smoke.test.mts
- pnpm --filter @o3co/auth-provider-core test -- --runInBand src/__tests__/config.test.mts src/__tests__/config-composition.test.mts src/config/__tests__/schema-open-type.test.mts
- pnpm --filter @o3co/auth-provider-session exec vitest run src/__tests__/sessionStoreModule.test.mts
- pnpm --filter @o3co/auth-provider-standalone exec vitest run src/__tests__/smoke.test.mts
- pnpm -r run build

## Docker build note
- docker build --target runtime -t auth-runtime:or10-verify . was attempted under templates/standalone. It failed before the OR-10 hardening checks because this in-repo template package depends on @o3co/auth-provider-core@workspace:* but the Docker build context contains only templates/standalone, so pnpm cannot resolve the workspace package. This appears to be a pre-existing monorepo-template verification limitation rather than a permission or HEALTHCHECK regression.

Stacked on #150.