### PR TITLE
F13b: add residual TD coverage and RP envelope guard

### DIFF
--- a/packages/oauth/src/__tests__/introspectCascade.test.mts
+++ b/packages/oauth/src/__tests__/introspectCascade.test.mts
@@ -335,6 +335,40 @@ describe("/introspect — SF-8: token_type + access-only enforcement", () => {
 		expect(res.body.active).toBe(true);
 		expect(res.body.client_id).toBe("client1");
 	});
+
+	it("TD-5: active access-token response carries RFC 7662 fields without leaking family_id", async () => {
+		const token = await makeAccessToken({
+			sub: "user-td5",
+			aud: "https://resource.example",
+			azp: "client-td5",
+			scope: "openid profile",
+			iat: 1_772_000_000,
+			jti: "jti-td5",
+			family_id: "family-internal",
+		});
+		const refreshTokenFamilyRevocation: RefreshTokenFamilyRevocation = {
+			revokeFamily: vi.fn(),
+			isFamilyRevoked: vi.fn().mockResolvedValue(false),
+		};
+		const app = await buildApp(refreshTokenFamilyRevocation);
+		const res = await introspect(app, token);
+
+		expect(res.status).toBe(200);
+		expect(res.body).toMatchObject({
+			active: true,
+			iss: "https://auth.example",
+			aud: "https://resource.example",
+			sub: "user-td5",
+			azp: "client-td5",
+			client_id: "client-td5",
+			scope: "openid profile",
+			token_type: "Bearer",
+			jti: "jti-td5",
+			iat: 1_772_000_000,
+		});
+		expect(typeof res.body.exp).toBe("number");
+		expect(res.body.family_id).toBeUndefined();
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/oauth/src/__tests__/routes.test.mts
+++ b/packages/oauth/src/__tests__/routes.test.mts
@@ -21,8 +21,14 @@ import {
 	type ClientRepository,
 	type CodeRepository,
 	createSymmetricKeyStore,
+	type FederationTokenStoreBase,
 	type GrantHandler,
 	GrantRegistry,
+	type RefreshTokenFamilyRevocation,
+	type SessionFamilyIndex,
+	type SessionFederationIndex,
+	type SessionRPRegistry,
+	type UserSessionStore,
 } from "@o3co/auth-provider-core";
 import express, { type Router } from "express";
 import request from "supertest";
@@ -88,6 +94,36 @@ const mockExpress = {
 	urlencoded: () => vi.fn(),
 };
 
+function createTrackingExpress() {
+	const calls: { get: unknown[][]; post: unknown[][]; use: unknown[][] } = {
+		get: [],
+		post: [],
+		use: [],
+	};
+	const expressLike = {
+		Router: () => {
+			const router = {
+				use: vi.fn((...args: unknown[]) => {
+					calls.use.push(args);
+					return router;
+				}),
+				get: vi.fn((...args: unknown[]) => {
+					calls.get.push(args);
+					return router;
+				}),
+				post: vi.fn((...args: unknown[]) => {
+					calls.post.push(args);
+					return router;
+				}),
+			} as unknown as Router;
+			return router;
+		},
+		json: () => vi.fn(),
+		urlencoded: () => vi.fn(),
+	};
+	return { calls, expressLike };
+}
+
 describe("createOAuthRouter", () => {
 	it("returns a router", async () => {
 		const result = await createOAuthRouter(mockExpress, {
@@ -137,6 +173,61 @@ describe("createOAuthRouter", () => {
 
 		// The second arg (index 1) is the rate-limit middleware — it must be a function
 		expect(typeof introspectCall[1]).toBe("function");
+	});
+
+	it("applies rate limit middleware to POST /token", async () => {
+		const { calls, expressLike } = createTrackingExpress();
+
+		await createOAuthRouter(expressLike, {
+			registry: new GrantRegistry(),
+			config: mockConfig,
+			clientRepository: {} as ClientRepository,
+			codeRepository: {} as CodeRepository,
+			keyStore: createSymmetricKeyStore("test-secret"),
+		});
+
+		const tokenCall = calls.post.find((args) => args[0] === "/token");
+		expect(tokenCall).toBeDefined();
+		if (!tokenCall) return;
+		expect(tokenCall.length).toBeGreaterThanOrEqual(4);
+		expect(typeof tokenCall[1]).toBe("function");
+	});
+
+	it("registers authorize and UserInfo GET/POST routes", async () => {
+		const { calls, expressLike } = createTrackingExpress();
+
+		await createOAuthRouter(expressLike, {
+			registry: new GrantRegistry(),
+			config: mockConfig,
+			clientRepository: {} as ClientRepository,
+			codeRepository: {} as CodeRepository,
+			keyStore: createSymmetricKeyStore("test-secret"),
+		});
+
+		expect(calls.get.some((args) => args[0] === "/authorize")).toBe(true);
+		expect(calls.get.some((args) => args[0] === "/userinfo")).toBe(true);
+		expect(calls.post.some((args) => args[0] === "/userinfo")).toBe(true);
+	});
+
+	it("registers GET /logout when logout dependencies are wired", async () => {
+		const { calls, expressLike } = createTrackingExpress();
+
+		await createOAuthRouter(expressLike, {
+			registry: new GrantRegistry(),
+			config: fullConfig,
+			clientRepository: {} as ClientRepository,
+			codeRepository: {} as CodeRepository,
+			keyStore: createSymmetricKeyStore("test-secret"),
+			userSessionStore: {} as UserSessionStore,
+			sessionRPRegistry: {} as SessionRPRegistry,
+			sessionFamilyIndex: {} as SessionFamilyIndex,
+			sessionFederationIndex: {} as SessionFederationIndex,
+			federationTokenStore: {} as FederationTokenStoreBase,
+			refreshTokenFamilyRevocation: {} as RefreshTokenFamilyRevocation,
+		});
+
+		expect(calls.get.some((args) => args[0] === "/logout")).toBe(true);
+		expect(calls.post.some((args) => args[0] === "/logout")).toBe(true);
 	});
 
 	// D-6 (v0.5.1) integration coverage: exercise the full /oauth/token pipeline

--- a/packages/redis/__tests__/code-repository.test.mts
+++ b/packages/redis/__tests__/code-repository.test.mts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import Redis from "ioredis";
+import { GenericContainer, type StartedTestContainer } from "testcontainers";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const KEY_PREFIX = "oauth:code:";
 
@@ -23,6 +25,7 @@ const store = new Map<string, string>();
 
 import type { CodeRepositoryClient } from "../src/clients.mjs";
 import { RedisCodeRepository } from "../src/code-repository.mjs";
+import { makeIoredisClients } from "../src/ioredis.mjs";
 
 // OR-9: the public `RedisCodeRepository` constructor accepts a typed
 // `CodeRepositoryClient` wrapper, not a node-redis client. The mock satisfies
@@ -353,5 +356,71 @@ describe("RedisCodeRepository", () => {
 			expect(found?.sid).toBe("sid-xyz");
 			expect(found?.nonce).toBe("nonce-abc");
 		});
+	});
+});
+
+const describeWithRedis = process.env.REDIS_TESTCONTAINERS === "true" ? describe : describe.skip;
+
+describeWithRedis("RedisCodeRepository with real Redis", () => {
+	let container: StartedTestContainer | undefined;
+	let raw: Redis | undefined;
+
+	beforeAll(async () => {
+		container = await new GenericContainer("redis:7.2-alpine").withExposedPorts(6379).start();
+		raw = new Redis({ host: container.getHost(), port: container.getMappedPort(6379) });
+	}, 60_000);
+
+	afterAll(async () => {
+		if (raw) {
+			await raw.quit().catch(() => {
+				raw?.disconnect();
+			});
+		}
+		await container?.stop();
+	});
+
+	it("expires authorization codes according to the Redis PX TTL", async () => {
+		if (!raw) throw new Error("Redis test container did not start");
+		const keyPrefix = `td4:ttl:${Date.now()}:`;
+		const { codeRepositoryClient } = makeIoredisClients(raw);
+		const repo = new RedisCodeRepository(codeRepositoryClient, {
+			keyPrefix,
+			defaultExpiresIn: 1,
+		});
+
+		const created = await repo.createCode({
+			client_id: "test-client",
+			redirect_uri: "https://rp.example/cb",
+		});
+		const ttl = await raw.pttl(`${keyPrefix}${created.code}`);
+		expect(ttl).toBeGreaterThan(0);
+		expect(ttl).toBeLessThanOrEqual(1000);
+
+		await new Promise((resolve) => setTimeout(resolve, 1100));
+		expect(await repo.getByCode(created.code)).toBeNull();
+	});
+
+	it("round-trips sid, nonce, redirect_uri, grantedScope, and grantedAudience through Redis", async () => {
+		if (!raw) throw new Error("Redis test container did not start");
+		const keyPrefix = `td4:fields:${Date.now()}:`;
+		const { codeRepositoryClient } = makeIoredisClients(raw);
+		const repo = new RedisCodeRepository(codeRepositoryClient, { keyPrefix });
+
+		const created = await repo.createCode({
+			client_id: "client-real",
+			redirect_uri: "https://rp.example/callback",
+			sid: "sid-real",
+			nonce: "nonce-real",
+			grantedScope: ["openid", "profile"],
+			grantedAudience: ["https://api.example"],
+		});
+		const consumed = await repo.consumeByCode(created.code);
+
+		expect(consumed?.client_id).toBe("client-real");
+		expect(consumed?.redirect_uri).toBe("https://rp.example/callback");
+		expect(consumed?.sid).toBe("sid-real");
+		expect(consumed?.nonce).toBe("nonce-real");
+		expect(consumed?.grantedScope).toEqual(["openid", "profile"]);
+		expect(consumed?.grantedAudience).toEqual(["https://api.example"]);
 	});
 });

--- a/packages/redis/__tests__/sessionRPRegistry.unit.test.mts
+++ b/packages/redis/__tests__/sessionRPRegistry.unit.test.mts
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Logger } from "@o3co/auth-provider-core";
+import { describe, expect, it, vi } from "vitest";
+import type { SessionRPRegistryClient, SessionRPRegistryMultiClient } from "../src/clients.mjs";
+import { createRedisSessionRPRegistry } from "../src/sessionRPRegistry.mjs";
+
+function createMockLogger(): Logger {
+	const logger = {
+		trace: vi.fn(),
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		fatal: vi.fn(),
+		child: vi.fn(),
+	} as unknown as Logger;
+	(logger.child as unknown as ReturnType<typeof vi.fn>).mockReturnValue(logger);
+	return logger;
+}
+
+function createMockClient(values: string[]): SessionRPRegistryClient {
+	const multi: SessionRPRegistryMultiClient = {
+		hSet: vi.fn(() => multi),
+		pExpireAt: vi.fn(() => multi),
+		pExpireGT: vi.fn(() => multi),
+		exec: vi.fn(async () => []),
+	};
+	return {
+		del: vi.fn(async () => 0),
+		hSet: vi.fn(async () => 1),
+		hVals: vi.fn(async () => values),
+		multi: vi.fn(() => multi),
+		pExpireAt: vi.fn(async () => 1),
+		pExpireGT: vi.fn(async () => 1),
+	};
+}
+
+describe("RedisSessionRPRegistry corrupt envelope handling", () => {
+	it("filters corrupt envelopes instead of returning Invalid Date records", async () => {
+		const registeredAtMs = Date.now();
+		const logger = createMockLogger();
+		const registry = createRedisSessionRPRegistry({
+			client: createMockClient([
+				JSON.stringify({ clientId: "rp-valid", registeredAtMs }),
+				JSON.stringify({ clientId: "rp-missing-date" }),
+				JSON.stringify({ clientId: "rp-string-date", registeredAtMs: "not-a-number" }),
+				JSON.stringify({ clientId: "rp-nan-date", registeredAtMs: Number.NaN }),
+				JSON.stringify({ registeredAtMs }),
+				"{not-json",
+			]),
+			keyPrefix: "test:rp:",
+			logger,
+		});
+
+		const rps = await registry.listRPs("sid-1");
+
+		expect(rps).toHaveLength(1);
+		expect(rps[0]?.clientId).toBe("rp-valid");
+		expect(rps[0]?.registeredAt.getTime()).toBe(registeredAtMs);
+		expect(logger.warn).toHaveBeenCalledTimes(5);
+	});
+});

--- a/packages/redis/__tests__/sessionRPRegistry.unit.test.mts
+++ b/packages/redis/__tests__/sessionRPRegistry.unit.test.mts
@@ -17,7 +17,10 @@
 import type { Logger } from "@o3co/auth-provider-core";
 import { describe, expect, it, vi } from "vitest";
 import type { SessionRPRegistryClient, SessionRPRegistryMultiClient } from "../src/clients.mjs";
-import { createRedisSessionRPRegistry } from "../src/sessionRPRegistry.mjs";
+import {
+	createRedisSessionRPRegistry,
+	redisSessionRPRegistryBuilder,
+} from "../src/sessionRPRegistry.mjs";
 
 function createMockLogger(): Logger {
 	const logger = {
@@ -73,5 +76,95 @@ describe("RedisSessionRPRegistry corrupt envelope handling", () => {
 		expect(rps[0]?.clientId).toBe("rp-valid");
 		expect(rps[0]?.registeredAt.getTime()).toBe(registeredAtMs);
 		expect(logger.warn).toHaveBeenCalledTimes(5);
+	});
+
+	it("rejects array-shaped JSON payloads via the !Array.isArray envelope guard", async () => {
+		// Regression: previously isRecord accepted arrays (typeof [] === "object"
+		// && [] !== null). Without an explicit array guard, a payload like
+		// `["client-1", ...]` would only fail by accident when subsequent field
+		// accesses returned undefined — fail-closed at the shape-check layer
+		// instead, matching the userSessionStore envelope guard pattern.
+		const logger = createMockLogger();
+		const registry = createRedisSessionRPRegistry({
+			client: createMockClient([JSON.stringify(["client-array", 12345])]),
+			keyPrefix: "test:rp:",
+			logger,
+		});
+
+		const rps = await registry.listRPs("sid-array");
+
+		expect(rps).toHaveLength(0);
+		expect(logger.warn).toHaveBeenCalledWith(
+			{ sid: "sid-array", reason: "shape_invalid" },
+			expect.stringContaining("session_rp_registry_corrupt_envelope"),
+		);
+	});
+
+	it("emits structured corrupt-envelope warns with sid + reason + cause (no raw JSON)", async () => {
+		// Mirror the userSessionStore corrupt-envelope warn shape so operators
+		// see consistent fields across sibling adapters and the raw JSON
+		// payload — which may contain attacker-controlled or sensitive data
+		// — never reaches log sinks.
+		const logger = createMockLogger();
+		const registry = createRedisSessionRPRegistry({
+			client: createMockClient(["{not-json", JSON.stringify({ clientId: "rp-no-date" })]),
+			keyPrefix: "test:rp:",
+			logger,
+		});
+
+		await registry.listRPs("sid-corrupt");
+
+		expect(logger.warn).toHaveBeenCalledWith(
+			{ sid: "sid-corrupt", reason: "json_parse", cause: expect.any(SyntaxError) },
+			expect.stringContaining("JSON.parse failed"),
+		);
+		expect(logger.warn).toHaveBeenCalledWith(
+			{ sid: "sid-corrupt", reason: "shape_invalid" },
+			expect.stringContaining("shape invalid"),
+		);
+		// The raw payload snippet must NOT appear in any warn invocation —
+		// previously the implementation logged `{ json: json.slice(0, 100) }`
+		// which risked leaking sensitive data.
+		const allWarnCalls = (logger.warn as ReturnType<typeof vi.fn>).mock.calls;
+		for (const [payload] of allWarnCalls) {
+			expect(payload).not.toHaveProperty("json");
+		}
+	});
+});
+
+describe("redisSessionRPRegistryBuilder", () => {
+	it("forwards config.logger to the adapter so corrupt-envelope warns can fire", async () => {
+		const logger = createMockLogger();
+		const client = createMockClient(["{not-json"]);
+		const registry = redisSessionRPRegistryBuilder(
+			{ client, logger },
+			{} as Parameters<typeof redisSessionRPRegistryBuilder>[1],
+		);
+
+		await registry.listRPs("sid-builder");
+
+		expect(logger.warn).toHaveBeenCalledWith(
+			{ sid: "sid-builder", reason: "json_parse", cause: expect.any(SyntaxError) },
+			expect.stringContaining("session_rp_registry_corrupt_envelope"),
+		);
+	});
+
+	it("omits logger field when caller does not supply one (exactOptionalPropertyTypes)", () => {
+		// Builder must not pass an explicit `logger: undefined` to the adapter;
+		// the spread idiom drops the field entirely so the adapter sees
+		// `opts.logger === undefined` via "absent" rather than "explicit".
+		const client = createMockClient([]);
+		expect(() =>
+			redisSessionRPRegistryBuilder(
+				{ client },
+				{} as Parameters<typeof redisSessionRPRegistryBuilder>[1],
+			),
+		).not.toThrow();
+	});
+
+	it("throws at boot when client option is missing", () => {
+		expect(() =>
+			redisSessionRPRegistryBuilder({}, {} as Parameters<typeof redisSessionRPRegistryBuilder>[1]),
+		).toThrow(/client.+required/i);
 	});
 });

--- a/packages/redis/src/sessionRPRegistry.mts
+++ b/packages/redis/src/sessionRPRegistry.mts
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
-import type { AdapterBuilder, RegisteredRP, SessionRPRegistry } from "@o3co/auth-provider-core";
+import type {
+	AdapterBuilder,
+	Logger,
+	RegisteredRP,
+	SessionRPRegistry,
+} from "@o3co/auth-provider-core";
 import type { SessionRPRegistryClient } from "./clients.mjs";
 import { createRedisSidHash } from "./internal/redisSidHash.mjs";
 
 export interface RedisSessionRPRegistryOptions {
 	readonly client: SessionRPRegistryClient;
 	readonly keyPrefix: string;
+	readonly logger?: Logger;
 }
 
 /**
@@ -57,8 +63,32 @@ function serialize(rp: RegisteredRP): string {
 	return JSON.stringify(env);
 }
 
-function deserialize(json: string): RegisteredRP {
-	const env = JSON.parse(json) as RPEnvelope;
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isValidRPEnvelope(env: unknown): env is RPEnvelope {
+	if (!isRecord(env)) return false;
+	return (
+		typeof env.clientId === "string" &&
+		typeof env.registeredAtMs === "number" &&
+		Number.isFinite(env.registeredAtMs)
+	);
+}
+
+function deserialize(json: string, logger?: Logger): RegisteredRP | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(json);
+	} catch {
+		logger?.warn({ json: json.slice(0, 100) }, "sessionRPRegistry_invalid_json");
+		return null;
+	}
+	if (!isValidRPEnvelope(parsed)) {
+		logger?.warn({ json: json.slice(0, 100) }, "sessionRPRegistry_invalid_envelope");
+		return null;
+	}
+	const env = parsed;
 	return {
 		clientId: env.clientId,
 		registeredAt: new Date(env.registeredAtMs),
@@ -98,6 +128,7 @@ export function createRedisSessionRPRegistry(
 	opts: RedisSessionRPRegistryOptions,
 ): SessionRPRegistry {
 	const hash = createRedisSidHash({ client: opts.client, keyPrefix: opts.keyPrefix });
+	const logger = opts.logger;
 	return {
 		kind: "redis",
 		async registerRP(sid, rp, expiresAt) {
@@ -105,7 +136,9 @@ export function createRedisSessionRPRegistry(
 		},
 		async listRPs(sid) {
 			const values = await hash.listValues(sid);
-			return values.map(deserialize);
+			return values
+				.map((value) => deserialize(value, logger))
+				.filter((rp): rp is RegisteredRP => rp !== null);
 		},
 		async removeBySid(sid) {
 			await hash.removeBySid(sid);

--- a/packages/redis/src/sessionRPRegistry.mts
+++ b/packages/redis/src/sessionRPRegistry.mts
@@ -64,7 +64,14 @@ function serialize(rp: RegisteredRP): string {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
+	// Reject arrays explicitly: `typeof [] === "object"` and `[] !== null`,
+	// so without this guard a JSON payload like `["client-1", ...]` would
+	// pass isRecord and be probed as an envelope (the field accesses would
+	// return undefined and `isValidRPEnvelope` would reject, but only by
+	// accident). Match the userSessionStore envelope guard's explicit
+	// `!Array.isArray(...)` so the shape check fails closed at the same
+	// layer as its sibling adapter.
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isValidRPEnvelope(env: unknown): env is RPEnvelope {
@@ -76,16 +83,28 @@ function isValidRPEnvelope(env: unknown): env is RPEnvelope {
 	);
 }
 
-function deserialize(json: string, logger?: Logger): RegisteredRP | null {
+function deserialize(json: string, sid: string, logger?: Logger): RegisteredRP | null {
+	// Mirror the userSessionStore corrupt-envelope warn shape: object-first
+	// `{ sid, reason, cause? }` so `sid` and `reason` are reliably emitted
+	// as structured fields, and the parse error context is preserved as
+	// `cause`. The previous implementation logged a raw JSON snippet,
+	// which risked leaking sensitive data if a corrupt value happened to
+	// contain credentials — drop it entirely.
 	let parsed: unknown;
 	try {
 		parsed = JSON.parse(json);
-	} catch {
-		logger?.warn({ json: json.slice(0, 100) }, "sessionRPRegistry_invalid_json");
+	} catch (cause) {
+		logger?.warn(
+			{ sid, reason: "json_parse", cause },
+			"session_rp_registry_corrupt_envelope: JSON.parse failed",
+		);
 		return null;
 	}
 	if (!isValidRPEnvelope(parsed)) {
-		logger?.warn({ json: json.slice(0, 100) }, "sessionRPRegistry_invalid_envelope");
+		logger?.warn(
+			{ sid, reason: "shape_invalid" },
+			"session_rp_registry_corrupt_envelope: shape invalid",
+		);
 		return null;
 	}
 	const env = parsed;
@@ -137,7 +156,7 @@ export function createRedisSessionRPRegistry(
 		async listRPs(sid) {
 			const values = await hash.listValues(sid);
 			return values
-				.map((value) => deserialize(value, logger))
+				.map((value) => deserialize(value, sid, logger))
 				.filter((rp): rp is RegisteredRP => rp !== null);
 		},
 		async removeBySid(sid) {
@@ -156,15 +175,26 @@ export function createRedisSessionRPRegistry(
  *
  * Mirrors the boot-time guard pattern of `redisChallengeStoreBuilder`
  * (TS-M2): missing `client` throws at boot rather than crashing at first
- * Redis op.
+ * Redis op. Optional `logger` is forwarded to the adapter for the
+ * corrupt-envelope warn path emitted inside `listRPs()`; the
+ * fail-closed behavior (corrupt entries are dropped from the result)
+ * is independent of logger presence — when the logger is absent the
+ * warn is silently swallowed but the security gate still triggers. The
+ * spread idiom omits the field when the caller did not supply one
+ * (preserves "absent" semantics under `exactOptionalPropertyTypes`).
  */
 export const redisSessionRPRegistryBuilder: AdapterBuilder<SessionRPRegistry> = (config, _ctx) => {
-	const c = config as { client?: SessionRPRegistryClient; keyPrefix?: string };
+	const c = config as {
+		client?: SessionRPRegistryClient;
+		keyPrefix?: string;
+		logger?: Logger;
+	};
 	if (!c.client) {
 		throw new Error("redisSessionRPRegistryBuilder: 'client' option is required");
 	}
 	return createRedisSessionRPRegistry({
 		client: c.client,
 		keyPrefix: c.keyPrefix ?? "ss:rp:",
+		...(c.logger !== undefined ? { logger: c.logger } : {}),
 	});
 };


### PR DESCRIPTION
## Summary
- Add TD-4 opt-in testcontainers coverage for RedisCodeRepository TTL and extended field round-trip.
- Add TD-5 and TD-10 residual OAuth route/introspection regression coverage.
- Add TS-5 runtime validation for Redis SessionRPRegistry envelopes so corrupt records are logged and filtered instead of returning Invalid Date records.

## Notes
- TD-8 HTTP integration coverage was already present in oauthAuthorization tests on the current stack, so this PR does not add duplicate cases.
- TD-10 JWKS coverage lives in core because the implemented route is /.well-known/jwks.json outside createOAuthRouter.

## Verification
- pnpm exec biome check packages/redis/src/sessionRPRegistry.mts packages/redis/__tests__/sessionRPRegistry.unit.test.mts packages/redis/__tests__/code-repository.test.mts packages/oauth/src/__tests__/introspectCascade.test.mts packages/oauth/src/__tests__/routes.test.mts
- pnpm --filter @o3co/auth-provider-redis exec vitest run __tests__/code-repository.test.mts __tests__/sessionRPRegistry.unit.test.mts
- REDIS_TESTCONTAINERS=true pnpm --filter @o3co/auth-provider-redis exec vitest run __tests__/code-repository.test.mts
- pnpm --filter @o3co/auth-provider-oauth exec vitest run src/__tests__/introspectCascade.test.mts src/__tests__/routes.test.mts
- pnpm --filter @o3co/auth-provider-core build
- pnpm --filter @o3co/auth-provider-redis build
- pnpm --filter @o3co/auth-provider-oauth build
- pnpm -r run build