### PR TITLE
chore: prepare v0.5.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.5.3] — 2026-05-09
+
 ### Security (Phase F — F10 Token Exchange hardening)
 
 - Token Exchange now rejects policy hook scope/audience widening by default,
@@ -61,6 +63,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `/_healthcheck`.
 - Added a developer cleanup note for stale untracked `packages/did/` artifacts
   left in local workspaces after the DID grant package was removed from git.
+
+### Fixed (Phase F — F13b residual test coverage + sessionRPRegistry hardening)
+
+- Added regression coverage: testcontainers integration for `RedisCodeRepository`
+  TTL / extended-field round-trip (TD-4), residual OAuth route + introspection-
+  cascade tests (TD-5 / TD-10), and unit tests for the `SessionRPRegistry`
+  envelope guard.
+- `RedisSessionRPRegistry` now validates JSON envelope shape (rejecting array
+  payloads + non-finite `registeredAtMs`) and logs corrupt records with the
+  structured `{ sid, reason, cause? }` shape used by the sibling
+  `UserSessionStore` adapter. The previous `{ json: ... }` snippet field is
+  dropped to avoid leaking sensitive payloads on log sinks. The Redis
+  adapter builder now forwards optional `logger` so the corrupt-envelope
+  warn path is reachable from the builder construction route.
 
 ## [0.5.2] — 2026-05-09
 


### PR DESCRIPTION
## Summary
- Stamp `[Unreleased]` as `[0.5.3] — 2026-05-09` and add a new empty `[Unreleased]` placeholder
- Retroactively document F13b under the v0.5.3 block (PR #152 did not add a CHANGELOG entry, so this PR fills the gap)
- No source / dependency changes — CHANGELOG-only

## v0.5.3 train
- **Security**: F10 Token Exchange hardening (#146), F12a memory rate limiter bucket cap (#147), F12b InMemoryUserRepository timing equalization (#148)
- **Fixed**: F11a OIDC discovery + UserInfo POST compliance (#149), F11b OIDC authorize gate + GET logout (#150), F13b residual test coverage + sessionRPRegistry envelope guard (#152)
- **Changed**: F13a standalone Docker / session cookie / Redis prefix cleanup (#151)

## Verification
- `git diff develop..HEAD -- CHANGELOG.md` — only block stamping + F13b retro entry
- No code or dependency edits, so no test rerun needed beyond develop's already-green CI

## Release notes
- After merge, tag `v0.5.3` to trigger the existing release CI (Trusted Publisher OIDC)
- Cross-repo prerequisite `@o3co/auth.utils` minimum stays at `^0.0.4` (unchanged from v0.5.2)