### PR TITLE
[v1.0 GA] M1: remove GrantRegistry/GrantRegistryError from core public export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Removed (Phase G — M1 GrantRegistry public export, 1.0 GA)
+
+- **BREAKING**: Removed `GrantRegistry` and `GrantRegistryError` from
+  `@o3co/auth-provider-core`'s public exports (closes AS-8). Both were
+  deprecated as public re-exports in v0.5.1 per A2-γ §3.3; the classes
+  remain as internal implementation detail of the boot planner.
+  - Migration: consumer code that previously instantiated
+    `new GrantRegistry()` or caught `GrantRegistryError` should declare
+    grants on a module via `contributes.grants` instead. The boot planner
+    (`createApp`) handles register / replace / freeze internally and
+    propagates registration failures as `BootError` (A2-β) rather than
+    `GrantRegistryError`.
+  - Affected APIs (no longer importable from
+    `@o3co/auth-provider-core`): `GrantRegistry`, `GrantRegistryError`.
+
 ## [0.5.3] — 2026-05-09
 
 ### Security (Phase F — F10 Token Exchange hardening)

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -41,7 +41,7 @@ const config: AppConfig = AppConfigSchema.parse(rawConfig);
 
 ### グラントシステム
 
-グラントシステムは OAuth 2.0 グラントタイプの拡張ポイントです。各グラントタイプは `GrantHandler` として実装し、`GrantRegistry` に登録します。
+グラントシステムは OAuth 2.0 グラントタイプの拡張ポイントです。各グラントタイプは `GrantHandler` として実装し、モジュールの `contributes.grants` で宣言します。ハンドラーの実体化と登録は boot planner が内部で行います。
 
 #### インターフェースと型
 
@@ -104,18 +104,13 @@ interface GrantModule {
 }
 ```
 
-#### GrantRegistry
+#### グラントハンドラーの登録
 
-```typescript
-class GrantRegistry {
-  register(grantType: string, handler: GrantHandler): void;
-  get(grantType: string): GrantHandler | undefined;
-  addModule(module: GrantModule, deps: GrantDependencies): void;
-  cleanup(): void;
-}
-```
+グラントハンドラーは `defineModule` マニフェストの `contributes.grants` から boot planner に渡されます（A2-γ §3.3 参照）。Boot planner が各 `GrantFactory` を実体化し、ハンドラーを登録した後、全モジュール処理を終えてから `freeze()` を呼び出すため、boot 後の変異は loud に throw します。
 
-`addModule` はモジュール内のすべての `GrantFactory` を実行してハンドラーを登録します。`cleanup()` は legacy のシャットダウンフックで、登録された各 grant handler の `cleanup()` メソッド（存在する場合）を呼び出します。新規コードは `createApp` が返す `handle.dispose()` を使うこと — `AppHandle.dispose()` は A2-β §8.1 に従い、コンポーネント単位の `lifecycle[K].cleanup` コールバックを reverse-topological 順で実行します。`GrantRegistry.cleanup()` は backwards compatibility のため残してありますが、将来の minor で削除予定です。
+コンシューマコードはレジストリクラスを import / 実体化する必要はありません。グラントハンドラーのクリーンアップは `createApp` が返す `handle.dispose()` に統合されており、`AppHandle.dispose()` は A2-β §8.1 に従い、コンポーネント単位の `lifecycle[K].cleanup` コールバックを reverse-topological 順で実行します。
+
+> **1.0 GA で削除**: `GrantRegistry` / `GrantRegistryError` クラス（v0.5.1 で AS-8 に基づき public re-export として deprecated 済み）は `@o3co/auth-provider-core` から export されなくなりました。クラスは boot planner の internal 実装として残っています。v0.4.x の `new GrantRegistry()` パターンを使っていたコンシューマは、モジュールの `contributes.grants` 宣言に移行してください。
 
 ### トークンユーティリティ
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -41,7 +41,7 @@ Top-level fields:
 
 ### Grant System
 
-The grant system is the extension point for OAuth 2.0 grant types. Each grant type is implemented as a `GrantHandler` and registered via `GrantRegistry`.
+The grant system is the extension point for OAuth 2.0 grant types. Each grant type is implemented as a `GrantHandler` and declared on a module via `contributes.grants`; the boot planner instantiates and registers handlers internally.
 
 #### Interfaces and types
 
@@ -104,18 +104,13 @@ interface GrantModule {
 }
 ```
 
-#### GrantRegistry
+#### Grant registration
 
-```typescript
-class GrantRegistry {
-  register(grantType: string, handler: GrantHandler): void;
-  get(grantType: string): GrantHandler | undefined;
-  addModule(module: GrantModule, deps: GrantDependencies): void;
-  cleanup(): void;
-}
-```
+Grant handlers are wired into the boot planner via `contributes.grants` on a module's `defineModule` manifest (see A2-γ §3.3). The boot planner instantiates each `GrantFactory`, registers the resulting handler, and (after `addModule` for all modules) calls `freeze()` so post-boot mutation throws loudly.
 
-`addModule` instantiates all `GrantFactory` entries in the module and registers them. `cleanup()` is the legacy shutdown hook: it iterates registered grant handlers and invokes each handler's optional `cleanup()` method. New code should use `handle.dispose()` (returned by `createApp`) instead — `AppHandle.dispose()` runs per-component `lifecycle[K].cleanup` callbacks in reverse-topological order per A2-β §8.1. `GrantRegistry.cleanup()` is retained for backwards compatibility and will be removed in a future minor.
+Consumer code does NOT need to import or instantiate any registry class. Cleanup of grant handlers runs through the unified `handle.dispose()` returned by `createApp` — `AppHandle.dispose()` runs per-component `lifecycle[K].cleanup` callbacks in reverse-topological order per A2-β §8.1.
+
+> **Removed at 1.0 GA**: the `GrantRegistry` and `GrantRegistryError` classes (deprecated as public re-exports in v0.5.1 per AS-8) are no longer exported from `@o3co/auth-provider-core`. They remain as internal implementation detail of the boot planner. Existing consumers of the v0.4.x `new GrantRegistry()` pattern should migrate to module-based `contributes.grants` declarations.
 
 ### Token Utilities
 

--- a/packages/core/src/__tests__/index.test.mts
+++ b/packages/core/src/__tests__/index.test.mts
@@ -9,7 +9,6 @@ import {
 	createRepositoryFactories,
 	createSymmetricKeyStore,
 	formatObject,
-	GrantRegistry,
 	InMemoryClientRepository,
 	InMemoryCodeRepository,
 	InMemoryUserRepository,
@@ -24,11 +23,6 @@ describe("public API", () => {
 
 	it("exports AppConfigSchema", () => {
 		expect(AppConfigSchema).toBeDefined();
-	});
-
-	it("exports GrantRegistry class", () => {
-		expect(GrantRegistry).toBeDefined();
-		expect(typeof GrantRegistry).toBe("function");
 	});
 
 	it("exports InMemoryUserRepository class", () => {

--- a/packages/core/src/grants/registry.mts
+++ b/packages/core/src/grants/registry.mts
@@ -65,15 +65,13 @@ export class GrantRegistryError extends Error {
  * declarations. Phase 9 (A2-γ caller migration) internalises the registry
  * and removes it from the public API. Phase 3 establishes the contract.
  *
- * Public-export deprecation status (AS-8, v0.5.1): `GrantRegistry` is
- * deprecated only as a *public API symbol*. The `@deprecated` JSDoc tag
- * lives on the `export {}` site in `packages/core/src/index.mts` so
- * internal boot-planner usage of this class does not trip the IDE
- * deprecation diagnostic on every `new GrantRegistry()` call. External
- * consumers importing `GrantRegistry` / `GrantRegistryError` from
- * `@o3co/auth-provider-core` see the deprecation via the re-export. The
- * public re-export will be removed at 1.0 GA — migrate to module-based
- * `contributes.grants` declarations per A2-γ §3.3.
+ * Public-export removal status (AS-8, 1.0 GA): the public re-export of
+ * `GrantRegistry` / `GrantRegistryError` from `@o3co/auth-provider-core`
+ * was removed at 1.0 GA per A2-γ §3.3. Both classes remain as internal
+ * implementation detail of the boot planner; external consumers wire
+ * grants through module-based `contributes.grants` declarations.
+ *
+ * @internal
  */
 export class GrantRegistry {
 	private handlers = new Map<string, GrantHandler>();

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -114,20 +114,13 @@ export {
 	type GenerateLogoutTokenOptions,
 	generateLogoutToken,
 } from "./grants/logoutToken.mjs";
-// Grant types and interfaces
-/**
- * @deprecated Since v0.5.1 (AS-8). The `GrantRegistry` class export AND its
- * companion `GrantRegistryError` are both deprecated as PUBLIC re-exports
- * from `@o3co/auth-provider-core` and will be removed at 1.0 GA per A2-γ
- * §3.3. The `@deprecated` tag on this `export {}` site annotates BOTH names
- * — TypeScript / IDE diagnostics fire on import for either symbol. Replace
- * direct `new GrantRegistry()` / `register()` wiring with module-based
- * `contributes.grants` declarations on module definitions; the boot
- * planner runs `register` / `replace` / `freeze` (and may throw
- * `GrantRegistryError`) internally on your behalf, so consumer code no
- * longer needs to reference either symbol.
- */
-export { GrantRegistry, GrantRegistryError } from "./grants/registry.mjs";
+// Grant types and interfaces.
+//
+// `GrantRegistry` and `GrantRegistryError` (deprecated public re-exports
+// in v0.5.1 per AS-8) were removed at 1.0 GA per A2-γ §3.3. The classes
+// remain as internal implementation detail of the boot planner; consumer
+// code wires grants via module-based `contributes.grants` declarations
+// instead.
 // Token formatting utility (used by oauth package)
 export {
 	formatObject,

--- a/packages/core/src/testing/index.mts
+++ b/packages/core/src/testing/index.mts
@@ -32,6 +32,22 @@
  * major.
  */
 
+/**
+ * Internal `GrantRegistry` class re-exported through the `./testing`
+ * subpath for OAuth/integration tests that construct a registry directly
+ * (rather than through `createApp` + module-based `contributes.grants`).
+ *
+ * The public re-export from `@o3co/auth-provider-core` (the package root)
+ * was removed at 1.0 GA per AS-8 / A2-γ §3.3. Production code MUST NOT
+ * import these symbols — wire grants on a module's `defineModule`
+ * manifest and let the boot planner own the registry.
+ *
+ * This re-export exists solely so existing OAuth route tests that depend
+ * on direct registry construction can continue to compile without a
+ * mass-refactor to the module-based pattern. New tests SHOULD prefer the
+ * `createApp` / module-based wiring.
+ */
+export { GrantRegistry, GrantRegistryError } from "../grants/registry.mjs";
 export { createTestApp, type TestAppHandle } from "./create-test-app.mjs";
 export {
 	makeValidAppConfig,

--- a/packages/oauth/README.ja.md
+++ b/packages/oauth/README.ja.md
@@ -77,13 +77,13 @@ grant レジストリに `"authorization_code"` および `"refresh_token"` gran
 function createOAuthRouter(
   express: ExpressLike,
   options: {
-    registry: GrantRegistry;
+    registry: GrantHandlerResolver;
     config: AppConfig;
     clientRepository: ClientRepository;
     codeRepository: CodeRepository;
     keyStore: KeyStore;
   }
-): Promise<{ router: Router; registry: GrantRegistry }>;
+): Promise<{ router: Router; registry: GrantHandlerResolver }>;
 ```
 
 低レベルのファクトリ関数。Express ルーターと設定済み grant レジストリを生成する。通常は `oauthModule` 内部で呼び出される。構築後のレジストリインスタンスに直接アクセスしたい場合に使用する。`/oauth/introspect` のクライアント認証は `createClientAuthMiddleware(clientRepository)` が担う — Passport 依存なし。
@@ -314,4 +314,4 @@ v0.4.0 ではこのパッケージから passport を削除した。`/oauth/intr
 ## 関連
 
 - [`@o3co/auth-provider-session`](../session/README.ja.md) — セッションログイン / フェデレーションルート
-- [`@o3co/auth-provider-core`](../core/README.ja.md) — 共有型定義 (`Module`、`GrantRegistry`、`ClientRepository`、`CodeRepository`、`KeyStore`)
+- [`@o3co/auth-provider-core`](../core/README.ja.md) — 共有型定義 (`Module`、`GrantHandlerResolver`、`ClientRepository`、`CodeRepository`、`KeyStore`)

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -77,13 +77,13 @@ Registers the `"authorization_code"` and `"refresh_token"` grant types in the gr
 function createOAuthRouter(
   express: ExpressLike,
   options: {
-    registry: GrantRegistry;
+    registry: GrantHandlerResolver;
     config: AppConfig;
     clientRepository: ClientRepository;
     codeRepository: CodeRepository;
     keyStore: KeyStore;
   }
-): Promise<{ router: Router; registry: GrantRegistry }>;
+): Promise<{ router: Router; registry: GrantHandlerResolver }>;
 ```
 
 Low-level factory. Creates the Express router and the fully-configured grant registry. Called internally by `oauthModule`; use directly when you need access to the registry instance after construction. Client authentication at `/oauth/introspect` is handled by `createClientAuthMiddleware(clientRepository)` — no Passport dependency required.
@@ -315,4 +315,4 @@ If you extend or replace the middleware for custom client-auth schemes, import `
 ## See Also
 
 - [`@o3co/auth-provider-session`](../session/README.md) — session login / federation routes
-- [`@o3co/auth-provider-core`](../core/README.md) — shared types (`Module`, `GrantRegistry`, `ClientRepository`, `CodeRepository`, `KeyStore`)
+- [`@o3co/auth-provider-core`](../core/README.md) — shared types (`Module`, `GrantHandlerResolver`, `ClientRepository`, `CodeRepository`, `KeyStore`)

--- a/packages/oauth/src/__tests__/hooks.test.mts
+++ b/packages/oauth/src/__tests__/hooks.test.mts
@@ -23,10 +23,10 @@ import {
 	type CodeRepository,
 	createSymmetricKeyStore,
 	type GrantPolicyHookBase,
-	GrantRegistry,
 	type Logger,
 	type RateLimiterBase,
 } from "@o3co/auth-provider-core";
+import { GrantRegistry } from "@o3co/auth-provider-core/testing";
 import express from "express";
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";

--- a/packages/oauth/src/__tests__/introspectCascade.test.mts
+++ b/packages/oauth/src/__tests__/introspectCascade.test.mts
@@ -22,10 +22,9 @@ import {
 	type CodeRepository,
 	createSymmetricKeyStore,
 	defineModule,
-	GrantRegistry,
 	type RefreshTokenFamilyRevocation,
 } from "@o3co/auth-provider-core";
-import { createTestApp, makeValidAppConfig } from "@o3co/auth-provider-core/testing";
+import { createTestApp, GrantRegistry, makeValidAppConfig } from "@o3co/auth-provider-core/testing";
 import express from "express";
 import { SignJWT } from "jose";
 import request from "supertest";

--- a/packages/oauth/src/__tests__/oauthAuthorization.test.mts
+++ b/packages/oauth/src/__tests__/oauthAuthorization.test.mts
@@ -22,14 +22,13 @@ import {
 	defineModule,
 	type GrantDependencies,
 	type GrantPolicyHookBase,
-	GrantRegistry,
 	type Logger,
 	type RefreshTokenFamilyRotation,
 	type SessionFamilyIndex,
 	type SessionRPRegistry,
 	type UserSessionStore,
 } from "@o3co/auth-provider-core";
-import { createTestApp, makeValidAppConfig } from "@o3co/auth-provider-core/testing";
+import { createTestApp, GrantRegistry, makeValidAppConfig } from "@o3co/auth-provider-core/testing";
 import express from "express";
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";

--- a/packages/oauth/src/__tests__/routes.test.mts
+++ b/packages/oauth/src/__tests__/routes.test.mts
@@ -23,13 +23,13 @@ import {
 	createSymmetricKeyStore,
 	type FederationTokenStoreBase,
 	type GrantHandler,
-	GrantRegistry,
 	type RefreshTokenFamilyRevocation,
 	type SessionFamilyIndex,
 	type SessionFederationIndex,
 	type SessionRPRegistry,
 	type UserSessionStore,
 } from "@o3co/auth-provider-core";
+import { GrantRegistry } from "@o3co/auth-provider-core/testing";
 import express, { type Router } from "express";
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";

--- a/packages/oauth/src/module.mts
+++ b/packages/oauth/src/module.mts
@@ -19,7 +19,6 @@ import {
 	consoleLogger,
 	defineModule,
 	type FederationProviderHandle,
-	type GrantRegistry,
 	type Module,
 	type ProviderDeps,
 } from "@o3co/auth-provider-core";
@@ -99,8 +98,8 @@ export const oauthModule = (params: { config: AppConfig }): Module => {
 	// type level.
 	//
 	// createOAuthRouter retains its legacy explicit-deps signature
-	// (`registry: GrantRegistry`, `getFederationProviders: () => ...`). The
-	// route factory bridges typed `deps` to that shape per plan line 710 —
+	// (`registry: GrantHandlerResolver`, `getFederationProviders: () => ...`).
+	// The route factory bridges typed `deps` to that shape per plan line 710 —
 	// the router internals are NOT redesigned in this task.
 	//
 	// Explicit `defineModule<R, O>` generics: needed so contextual typing
@@ -146,11 +145,11 @@ export const oauthModule = (params: { config: AppConfig }): Module => {
 			routes: [
 				// oauth-endpoints — always contributed (Theme D: const shape).
 				async (deps) => {
-					// GrantHandlerResolver exposes `.get(grantType)`; routes.mts:171
-					// only consumes that single method, so structural compat is
-					// sufficient. The cast bridges the typed planner shape to the
-					// legacy registry param without redesigning createOAuthRouter.
-					const registry = deps.grantHandlerResolver as unknown as GrantRegistry;
+					// GrantHandlerResolver is what the synthetic key resolves to
+					// and what createOAuthRouter's `registry` param accepts —
+					// the type-level read-only projection that exposes
+					// `.get(grantType)`, which routes.mts only consumes.
+					const registry = deps.grantHandlerResolver;
 					const { router } = await createOAuthRouter(express, {
 						registry,
 						config: deps.config,

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -25,8 +25,8 @@ import {
 	type FederationProviderHandle,
 	type FederationTokenStoreBase,
 	formatObject,
+	type GrantHandlerResolver,
 	type GrantPolicyHookBase,
-	type GrantRegistry,
 	JwtVerificationError,
 	type KeyStore,
 	type Logger,
@@ -88,7 +88,7 @@ export const createOAuthRouter = async (
 		getFederationProviders = () => undefined,
 		logger = consoleLogger,
 	}: {
-		registry: GrantRegistry;
+		registry: GrantHandlerResolver;
 		config: AppConfig;
 		clientRepository: ClientRepository;
 		codeRepository: CodeRepository;
@@ -110,7 +110,7 @@ export const createOAuthRouter = async (
 		getFederationProviders?: () => ReadonlyMap<string, FederationProviderHandle> | undefined;
 		logger?: Logger;
 	},
-): Promise<{ router: Router; registry: GrantRegistry }> => {
+): Promise<{ router: Router; registry: GrantHandlerResolver }> => {
 	const router = express.Router();
 
 	// Construct once at router-creation time so the closure is not re-allocated per request.


### PR DESCRIPTION
## Summary

**BREAKING.** Closes [AS-8](.claude/superpowers/specs/2026-05-05-as-export-pattern-batch.md). Deprecated as public re-exports in v0.5.1 per A2-γ §3.3; this PR removes them at 1.0 GA.

- **Removed**: `GrantRegistry` and `GrantRegistryError` from `@o3co/auth-provider-core` public exports
- **Internal**: both classes remain inside `packages/core/src/grants/registry.mts` for the boot planner's use
- **Test escape hatch**: re-exported from `@o3co/auth-provider-core/testing` (with JSDoc warning that production code MUST NOT use them) so existing OAuth integration tests keep compiling without a mass refactor
- **oauth caller migration**: `createOAuthRouter`'s `registry` parameter type changed from `GrantRegistry` to `GrantHandlerResolver` — the synthetic read-only projection the boot planner already injects; routes.mts only ever consumed `.get`, so structural compatibility holds

## Migration for consumers

Before (v0.5.x):

```typescript
import { GrantRegistry } from "@o3co/auth-provider-core";

const registry = new GrantRegistry();
registry.register("authorization_code", authorizationCodeHandler);
// hand-rolled wiring to createOAuthRouter...
```

After (v1.0 GA):

```typescript
import { createApp, defineModule } from "@o3co/auth-provider-core";

const myGrantModule = defineModule({
  name: "my-grants",
  contributes: {
    grants: { authorization_code: authorizationCodeFactory },
  },
});

const { handle } = await createApp({ modules: [oauthModule, myGrantModule, ...] });
```

The boot planner instantiates the registry internally, calls `register` / `replace` / `freeze`, and propagates registration failures as `BootError` (A2-β) rather than `GrantRegistryError`.

## Files

- `packages/core/src/index.mts` — drop public re-export
- `packages/core/src/grants/registry.mts` — JSDoc: `@deprecated` → `@internal` + removal note
- `packages/core/src/testing/index.mts` — add test-only re-export
- `packages/core/src/__tests__/index.test.mts` — drop public-API smoke test
- `packages/oauth/src/{routes,module}.mts` — `GrantRegistry` → `GrantHandlerResolver` type refs; drop redundant cast
- `packages/oauth/src/__tests__/{routes,hooks,oauthAuthorization,introspectCascade}.test.mts` — switch `GrantRegistry` import to `/testing` subpath
- `packages/core/README.{md,ja.md}` — rewrite Grant System / registry sections
- `packages/oauth/README.{md,ja.md}` — update `createOAuthRouter` signature snippet
- `CHANGELOG.md` — `[Unreleased]/Removed` entry

## Verification

- `pnpm install --frozen-lockfile` → Already up to date
- `pnpm -r run build` → all packages + `templates/standalone` build
- `pnpm -r run typecheck` → all packages pass
- `pnpm run lint` → 9 warnings / 2 infos, no new errors
- `pnpm run audit` → No known vulnerabilities found
- `pnpm run test` → all suites pass

## Bump target

`1.0.0-rc.1` (M-series mechanical removals per [v1.0 GA Codex handoff](.claude/handoff/2026-05-09-v100-ga-codex-handoff.md)).