### PR TITLE
M4 (1.0 GA): remove legacyTokenCompat migration flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Removed (Phase G — M4 `legacyTokenCompat` migration flag, 1.0 GA)
+
+- **BREAKING**: Removed the `oauth.refreshToken.legacyTokenCompat` config
+  flag (HOCON `application.conf` + Zod schema in `application.schema.mts`)
+  and the `OAUTH_REFRESH_TOKEN_LEGACY_TOKEN_COMPAT` env-var override. The
+  flag was introduced in v0.5.2 (AS-12) with default `true` to accept
+  v0.4.x refresh-token shapes during the migration window. v0.5.x is now
+  out of the bounded window; 1.0 GA enforces the strict shape
+  unconditionally.
+  - Refresh-grant rejection gate now accepts **only** `header.typ ===
+    "rt+jwt"` as the refresh marker. Tokens carrying the legacy
+    `payload.type === "refresh"` substitute (no `rt+jwt` typ header) are
+    rejected with `invalid_grant` / `invalid refresh_token`.
+  - The legacy `claims.user.id` subject-fallback path is removed. Refresh
+    tokens MUST carry a top-level standard `sub` claim; tokens without
+    one are rejected with `invalid_grant` / `refresh token has no
+    subject`.
+  - AT-as-RT defense (RT-OC invariant) is preserved and now structurally
+    guaranteed by the single-marker requirement.
+  - Migration: operators must ensure all in-flight refresh tokens were
+    minted by v0.5.x or newer (which emit both `header.typ = "rt+jwt"`
+    and a top-level `sub`) before upgrading. v0.5.2 documented this
+    migration plan in its Migration note; 1.0 GA finalizes the cutover.
+  - Affected APIs/config (removed):
+    `oauth.refreshToken.legacyTokenCompat`,
+    `OAUTH_REFRESH_TOKEN_LEGACY_TOKEN_COMPAT`,
+    `RefreshTokenConfig.legacyTokenCompat` (Zod schema field).
+
 ### Removed (Phase G — M3 `allowPolicyWidening` migration flag, 1.0 GA)
 
 - **BREAKING**: Removed the `allowPolicyWidening?: boolean` field from

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -62,11 +62,6 @@ oauth {
     # detection for the request and emits an audit log.
     legacyRtPolicy = "reject"
     legacyRtPolicy = ${?OAUTH_REFRESH_TOKEN_LEGACY_RT_POLICY}
-    # AS-12: v0.5.x default accepts v0.4.x refresh-token shapes. Set false
-    # after all pre-v0.5 refresh tokens have expired to require header.typ
-    # and top-level standard subject claims.
-    legacyTokenCompat = true
-    legacyTokenCompat = ${?OAUTH_REFRESH_TOKEN_LEGACY_TOKEN_COMPAT}
   }
   grants {
     session { enabled = true, enabled = ${?OAUTH_GRANTS_SESSION_ENABLED} }

--- a/packages/core/src/config/__tests__/refresh-token-schema.test.mts
+++ b/packages/core/src/config/__tests__/refresh-token-schema.test.mts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import { CoreConfigSchema } from "../application.schema.mjs";
+
+/**
+ * Access the refreshToken sub-schema directly so we can test the
+ * preprocess wrapper that flags removed fields without standing up a
+ * full AppConfig fixture.
+ */
+const refreshTokenSchema = CoreConfigSchema.shape.oauth.shape.refreshToken;
+
+describe("oauth.refreshToken schema — removed-field preprocess (Phase G / M4)", () => {
+	const validBase = {
+		expiresIn: 86400,
+		unknownFamilyPolicy: "reject" as const,
+		legacyRtPolicy: "reject" as const,
+	};
+
+	it("accepts a config without any removed fields", () => {
+		const result = refreshTokenSchema.safeParse(validBase);
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects a config that still sets legacyTokenCompat", () => {
+		const result = refreshTokenSchema.safeParse({
+			...validBase,
+			legacyTokenCompat: true,
+		});
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		const flagged = result.error.issues.some(
+			(issue) =>
+				issue.path.includes("legacyTokenCompat") ||
+				issue.message.includes("legacyTokenCompat"),
+		);
+		expect(flagged).toBe(true);
+	});
+
+	it("rejects legacyTokenCompat=false (the value is irrelevant — presence is the failure)", () => {
+		const result = refreshTokenSchema.safeParse({
+			...validBase,
+			legacyTokenCompat: false,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("error message points operators to the migration plan", () => {
+		const result = refreshTokenSchema.safeParse({
+			...validBase,
+			legacyTokenCompat: true,
+		});
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		const issue = result.error.issues.find((i) => i.message.includes("legacyTokenCompat"));
+		expect(issue?.message).toMatch(/1\.0 GA/);
+		expect(issue?.message).toMatch(/v0\.5\.x or newer/);
+	});
+});

--- a/packages/core/src/config/__tests__/refresh-token-schema.test.mts
+++ b/packages/core/src/config/__tests__/refresh-token-schema.test.mts
@@ -39,8 +39,7 @@ describe("oauth.refreshToken schema — removed-field preprocess (Phase G / M4)"
 		if (result.success) return;
 		const flagged = result.error.issues.some(
 			(issue) =>
-				issue.path.includes("legacyTokenCompat") ||
-				issue.message.includes("legacyTokenCompat"),
+				issue.path.includes("legacyTokenCompat") || issue.message.includes("legacyTokenCompat"),
 		);
 		expect(flagged).toBe(true);
 	});

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -114,6 +114,23 @@ const LEGACY_JWT_FIELDS = [
 	"previousSecrets",
 ] as const;
 
+/**
+ * Fields removed from `oauth.refreshToken` at 1.0 GA. Detected on the raw
+ * input by the preprocess wrapper below so that operators upgrading from
+ * v0.5.x get a targeted error instead of having their flag silently
+ * stripped by Zod's default `unknown-key strip` behavior.
+ */
+const REMOVED_REFRESH_TOKEN_FIELDS: ReadonlyArray<{ name: string; removedIn: string; note: string }> = [
+	{
+		name: "legacyTokenCompat",
+		removedIn: "1.0 GA (Phase G / M4)",
+		note:
+			"v0.4.x refresh-token shape compat (payload.type, claims.user.id fallback) is no " +
+			"longer accepted. Ensure all in-flight refresh tokens were minted by v0.5.x or newer " +
+			"(header.typ = 'rt+jwt' and top-level sub) before upgrading.",
+	},
+];
+
 const jwtSchemaBase = z.object({
 	issuer: z.string().optional(),
 	signingKey: signingKeySchema,
@@ -150,6 +167,50 @@ const jwtSchema = z.preprocess((raw, ctx) => {
 	return raw;
 }, jwtSchemaBase);
 
+const refreshTokenSchemaBase = z.object({
+	expiresIn: z.coerce.number(),
+	// CC-2 (v0.5.1): policy for refresh tokens whose `family_id` does not
+	// match a known family record. `"reject"` is the safe default; the
+	// pre-fix behavior was implicit `"accept"` (silent fall-through to
+	// success). `"accept"` is intended only for time-bounded migration
+	// windows. Per the v0.5.1 ADR the literal default lives in
+	// `application.conf`, not here.
+	unknownFamilyPolicy: z.enum(["accept", "reject"]),
+	// SF-6 (v0.5.1): policy for refresh tokens lacking `jti` or
+	// `family_id` claims when family rotation is wired. `"reject"` is
+	// the safe default; `"accept-with-warning"` skips replay detection
+	// for the request and emits an audit log — intended only for time-
+	// bounded migration windows where v0.4.x tokens are still in
+	// circulation. Per the v0.5.1 ADR the literal default lives in
+	// `application.conf`, not here.
+	legacyRtPolicy: z.enum(["reject", "accept-with-warning"]),
+});
+
+/**
+ * Detects fields removed from `oauth.refreshToken` and emits a targeted
+ * Zod issue. Zod's default behavior strips unknown keys before
+ * superRefine runs, so without this preprocess wrapper an operator's
+ * stale config line (e.g. `legacyTokenCompat = true`) would be silently
+ * ignored on upgrade.
+ */
+const refreshTokenSchema = z.preprocess((raw, ctx) => {
+	if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
+		const rawObj = raw as Record<string, unknown>;
+		for (const removed of REMOVED_REFRESH_TOKEN_FIELDS) {
+			if (removed.name in rawObj) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message:
+						`oauth.refreshToken.${removed.name} was removed in ${removed.removedIn}. ` +
+						`${removed.note} Remove this field from your config.`,
+					path: [removed.name],
+				});
+			}
+		}
+	}
+	return raw;
+}, refreshTokenSchemaBase);
+
 /**
  * Minimal always-required config for the auth provider core.
  * Token-only deployments (no session, no federation) only need these sections.
@@ -164,24 +225,7 @@ export const CoreConfigSchema = z.object({
 		accessToken: z.object({
 			expiresIn: z.coerce.number(),
 		}),
-		refreshToken: z.object({
-			expiresIn: z.coerce.number(),
-			// CC-2 (v0.5.1): policy for refresh tokens whose `family_id` does not
-			// match a known family record. `"reject"` is the safe default; the
-			// pre-fix behavior was implicit `"accept"` (silent fall-through to
-			// success). `"accept"` is intended only for time-bounded migration
-			// windows. Per the v0.5.1 ADR the literal default lives in
-			// `application.conf`, not here.
-			unknownFamilyPolicy: z.enum(["accept", "reject"]),
-			// SF-6 (v0.5.1): policy for refresh tokens lacking `jti` or
-			// `family_id` claims when family rotation is wired. `"reject"` is
-			// the safe default; `"accept-with-warning"` skips replay detection
-			// for the request and emits an audit log — intended only for time-
-			// bounded migration windows where v0.4.x tokens are still in
-			// circulation. Per the v0.5.1 ADR the literal default lives in
-			// `application.conf`, not here.
-			legacyRtPolicy: z.enum(["reject", "accept-with-warning"]),
-		}),
+		refreshToken: refreshTokenSchema,
 		grants: z.object({}).passthrough(),
 		// IH-6 (v0.5.3): when acting as an OIDC OP, `/authorize` rejects
 		// requests that omit `openid` unless operators explicitly choose dual

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -181,11 +181,6 @@ export const CoreConfigSchema = z.object({
 			// circulation. Per the v0.5.1 ADR the literal default lives in
 			// `application.conf`, not here.
 			legacyRtPolicy: z.enum(["reject", "accept-with-warning"]),
-			// AS-12 (v0.5.1): refresh-grant compatibility gate for v0.4.x
-			// token shapes (`payload.type = "refresh"` and `claims.user.id`
-			// subject fallback). Per the v0.5.1 ADR the literal default lives
-			// in `application.conf`, not here.
-			legacyTokenCompat: z.boolean().optional(),
 		}),
 		grants: z.object({}).passthrough(),
 		// IH-6 (v0.5.3): when acting as an OIDC OP, `/authorize` rejects

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -120,7 +120,11 @@ const LEGACY_JWT_FIELDS = [
  * v0.5.x get a targeted error instead of having their flag silently
  * stripped by Zod's default `unknown-key strip` behavior.
  */
-const REMOVED_REFRESH_TOKEN_FIELDS: ReadonlyArray<{ name: string; removedIn: string; note: string }> = [
+const REMOVED_REFRESH_TOKEN_FIELDS: ReadonlyArray<{
+	name: string;
+	removedIn: string;
+	note: string;
+}> = [
 	{
 		name: "legacyTokenCompat",
 		removedIn: "1.0 GA (Phase G / M4)",

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -72,19 +72,6 @@ const mockDeps: GrantDependencies = {
 	keyStore,
 };
 
-function configWithLegacyTokenCompat(legacyTokenCompat: boolean): GrantDependencies["config"] {
-	return {
-		...mockConfig,
-		oauth: {
-			...mockConfig.oauth,
-			refreshToken: {
-				...mockConfig.oauth.refreshToken,
-				legacyTokenCompat,
-			},
-		},
-	} as unknown as GrantDependencies["config"];
-}
-
 // D-6 (v0.5.1): every test that hits the binding gate must supply both an
 // `aud` (or `azp`) on the signed RT and a matching `authenticatedClient` on
 // the GrantContext. We default both to "client1" so existing tests continue
@@ -359,31 +346,7 @@ describe("createRefreshTokenGrant", () => {
 			}
 		});
 
-		it("accepts legacy tokens with type payload instead of typ header", async () => {
-			// Tokens issued before claims standardization use type: "refresh" in payload
-			// instead of typ: "rt+jwt" in the protected header.
-			const legacyToken = await new SignJWT({ type: "refresh", sub: "u1" })
-				.setProtectedHeader({ alg: "HS256", kid: "v0" })
-				.setIssuer("localhost")
-				.setAudience(DEFAULT_CLIENT_ID)
-				.setExpirationTime("24h")
-				.sign(secretKey);
-			const handler = createRefreshTokenGrant(mockDeps);
-			const ctx: GrantContext = {
-				body: { refresh_token: legacyToken },
-				session: {},
-				issuer: "localhost",
-				metadata: { ip: "127.0.0.1" },
-				authenticatedClient: DEFAULT_AUTH_CLIENT,
-			};
-
-			const { result } = await handler.handle(ctx);
-
-			expect(result.status).toBe(200);
-			expect("tokens" in result).toBe(true);
-		});
-
-		it("accepts legacy tokens without kid header", async () => {
+		it("accepts tokens without kid header (kid is optional)", async () => {
 			const legacyToken = await new SignJWT({ sub: "u1" })
 				.setProtectedHeader({ alg: "HS256", typ: "rt+jwt" })
 				.setIssuer("localhost")
@@ -405,18 +368,15 @@ describe("createRefreshTokenGrant", () => {
 			expect("tokens" in result).toBe(true);
 		});
 
-		describe("legacyTokenCompat: false", () => {
-			it("RT-1: rejects payload.type refresh as a typ substitute", async () => {
+		describe("refresh-token strict gate (header.typ === rt+jwt required)", () => {
+			it("RT-1: rejects payload.type=refresh as a typ substitute", async () => {
 				const legacyToken = await new SignJWT({ type: "refresh", sub: "u1" })
 					.setProtectedHeader({ alg: "HS256", kid: "v0" })
 					.setIssuer("localhost")
 					.setAudience(DEFAULT_CLIENT_ID)
 					.setExpirationTime("24h")
 					.sign(secretKey);
-				const handler = createRefreshTokenGrant({
-					...mockDeps,
-					config: configWithLegacyTokenCompat(false),
-				});
+				const handler = createRefreshTokenGrant(mockDeps);
 
 				const { result } = await handler.handle({
 					body: { refresh_token: legacyToken },
@@ -434,10 +394,7 @@ describe("createRefreshTokenGrant", () => {
 
 			it("RT-2: accepts header.typ rt+jwt with standard claims", async () => {
 				const modernToken = await makeRefreshToken({ sub: "u1", azp: DEFAULT_CLIENT_ID });
-				const handler = createRefreshTokenGrant({
-					...mockDeps,
-					config: configWithLegacyTokenCompat(false),
-				});
+				const handler = createRefreshTokenGrant(mockDeps);
 
 				const { result } = await handler.handle({
 					body: { refresh_token: modernToken },
@@ -462,10 +419,7 @@ describe("createRefreshTokenGrant", () => {
 					.setAudience(DEFAULT_CLIENT_ID)
 					.setExpirationTime("24h")
 					.sign(secretKey);
-				const handler = createRefreshTokenGrant({
-					...mockDeps,
-					config: configWithLegacyTokenCompat(false),
-				});
+				const handler = createRefreshTokenGrant(mockDeps);
 
 				const { result } = await handler.handle({
 					body: { refresh_token: legacyClaimsToken },
@@ -481,16 +435,14 @@ describe("createRefreshTokenGrant", () => {
 				expect(result.errorDescription).toBe("refresh token has no subject");
 			});
 
-			it("RT-OC: typ-less JWT with no refresh marker is rejected even when legacyTypAccept=true (strict gate preserved)", async () => {
+			it("RT-OC: typ-less JWT is rejected even when legacyTypAccept=true (AT-as-RT defended)", async () => {
 				// SF-1's legacyTypAccept=true allows a typ-less JWT through the
-				// central verifier. AS-12's gate must STILL reject it because
-				// the token declares no refresh marker (neither header.typ nor
-				// payload.type === "refresh"). Without this guard, any AT or
-				// non-refresh JWT signed with the same key could pass as a
-				// refresh token — that is the AT-as-RT confusion vector the
-				// strict marker check defends against. legacyTokenCompat is
-				// orthogonal: flipping it neither relaxes nor tightens this
-				// "some marker required" property.
+				// central verifier. This grant-level gate must STILL reject it
+				// because the token declares no refresh marker (header.typ is
+				// the only accepted marker after M4). Without this guard, any
+				// AT or non-refresh JWT signed with the same key could pass as
+				// a refresh token — that is the AT-as-RT confusion vector the
+				// strict marker check defends against.
 				const typLessUnmarkedToken = await new SignJWT({
 					sub: "u1",
 					azp: DEFAULT_CLIENT_ID,
@@ -501,10 +453,7 @@ describe("createRefreshTokenGrant", () => {
 					.setAudience(DEFAULT_CLIENT_ID)
 					.setExpirationTime("24h")
 					.sign(secretKey);
-				const handler = createRefreshTokenGrant({
-					...mockDeps,
-					config: configWithLegacyTokenCompat(false),
-				});
+				const handler = createRefreshTokenGrant(mockDeps);
 
 				const { result } = await handler.handle({
 					body: { refresh_token: typLessUnmarkedToken },
@@ -518,61 +467,6 @@ describe("createRefreshTokenGrant", () => {
 				if (!("error" in result)) expect.fail("Expected error in result");
 				expect(result.error).toBe("invalid_grant");
 				expect(result.errorDescription).toBe("invalid refresh_token");
-			});
-		});
-
-		describe("legacyTokenCompat: backward compat (regression)", () => {
-			it("RT-4 regression: legacy path still works when legacyTokenCompat is true", async () => {
-				const legacyToken = await new SignJWT({
-					type: "refresh",
-					user: { id: "u1" },
-					scope: "read",
-				})
-					.setProtectedHeader({ alg: "HS256", kid: "v0" })
-					.setIssuer("localhost")
-					.setAudience(DEFAULT_CLIENT_ID)
-					.setExpirationTime("24h")
-					.sign(secretKey);
-				const handler = createRefreshTokenGrant({
-					...mockDeps,
-					config: configWithLegacyTokenCompat(true),
-				});
-
-				const { result } = await handler.handle({
-					body: { refresh_token: legacyToken },
-					session: {},
-					issuer: "localhost",
-					metadata: { ip: "127.0.0.1" },
-					authenticatedClient: DEFAULT_AUTH_CLIENT,
-				});
-
-				expect(result.status).toBe(200);
-				expect("tokens" in result).toBe(true);
-			});
-
-			it("RT-5 regression: legacyTokenCompat defaults to true when unset", async () => {
-				const legacyToken = await new SignJWT({
-					type: "refresh",
-					user: { id: "u1" },
-					scope: "read",
-				})
-					.setProtectedHeader({ alg: "HS256", kid: "v0" })
-					.setIssuer("localhost")
-					.setAudience(DEFAULT_CLIENT_ID)
-					.setExpirationTime("24h")
-					.sign(secretKey);
-				const handler = createRefreshTokenGrant(mockDeps);
-
-				const { result } = await handler.handle({
-					body: { refresh_token: legacyToken },
-					session: {},
-					issuer: "localhost",
-					metadata: { ip: "127.0.0.1" },
-					authenticatedClient: DEFAULT_AUTH_CLIENT,
-				});
-
-				expect(result.status).toBe(200);
-				expect("tokens" in result).toBe(true);
 			});
 		});
 

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -65,7 +65,6 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				};
 			}
 			const authenticatedClientId = ctx.authenticatedClient.clientId;
-			const legacyCompatEnabled = config.oauth.refreshToken.legacyTokenCompat !== false;
 
 			let tokenPayload: JWTPayload;
 			let typ: string | undefined;
@@ -96,30 +95,12 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				};
 			}
 
-			// SF-1 retains this gate so a typ-less but signature-valid v0.4 token
-			// (legacyTypAccept=true at the verifier) is still required to declare
-			// "refresh" via the legacy `type` payload field. Without this guard
-			// the central verifier's typ-skip would silently accept any AT lacking
-			// typ as a refresh token. v0.6+ flips legacyTypAccept=false at the
-			// verifier and removes this block.
-			//
-			// AS-12 (v0.5.1): the legacy `payload.type === "refresh"` substitute
-			// is gated by `oauth.refreshToken.legacyTokenCompat`. When that flag
-			// is `false`, only `header.typ === "rt+jwt"` is accepted as a refresh
-			// marker. The strict-gate semantic (token MUST declare refresh via
-			// either marker) is preserved — AS-12 only narrows the *legacy*
-			// fallback path; it does NOT relax the requirement that some marker
-			// be present.
-			const legacyType = legacyCompatEnabled
-				? (tokenPayload as Record<string, unknown>).type
-				: undefined;
 			// Invariant — see RT-OC test: this gate keeps AT-as-RT confusion
-			// defended. A JWT with no `header.typ` AND no `payload.type` is
-			// rejected regardless of `legacyTokenCompat`, even when SF-1's
-			// `legacyTypAccept = true` allowed a typ-less token through the
-			// central verifier. Refactors that touch this condition MUST
-			// keep RT-OC green.
-			if (typ !== "rt+jwt" && legacyType !== "refresh") {
+			// defended. A JWT with no `header.typ === "rt+jwt"` is rejected
+			// even when SF-1's `legacyTypAccept = true` allowed a typ-less
+			// token through the central verifier. Refactors that touch this
+			// condition MUST keep RT-OC green.
+			if (typ !== "rt+jwt") {
 				return {
 					result: {
 						status: 400,
@@ -148,14 +129,7 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				};
 			}
 
-			// Read standard claims, with legacy fallback for pre-standardization tokens
-			const subjectStr =
-				typeof tokenPayload.sub === "string"
-					? tokenPayload.sub
-					: legacyCompatEnabled &&
-							typeof (claims.user as Record<string, unknown> | undefined)?.id === "string"
-						? ((claims.user as Record<string, unknown>).id as string)
-						: undefined;
+			const subjectStr = typeof tokenPayload.sub === "string" ? tokenPayload.sub : undefined;
 			const scopeStr =
 				typeof claims.scope === "string"
 					? (claims.scope as string)

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -68,16 +68,6 @@ oauth {
     # log. Pair with `unknownFamilyPolicy = "accept"` to avoid immediate
     # rejection on the next refresh — see Phase F migration guide.
     # legacyRtPolicy = "reject"
-    # AS-12 (v0.5.1): v0.5.x default accepts v0.4.x refresh tokens that use
-    # payload.type = "refresh" or claims.user.id as the subject. Set false
-    # only after all pre-v0.5 refresh tokens have expired; remaining legacy
-    # tokens will be rejected with invalid_grant. The strict marker-required
-    # gate is preserved across both flag values: a typ-less JWT with no
-    # payload.type is rejected at the refresh-grant gate even when
-    # oauth.jwt.legacyTypAccept = true (AT-as-RT confusion stays defended).
-    # Operators set OAUTH_REFRESH_TOKEN_LEGACY_TOKEN_COMPAT for env-var
-    # override.
-    # legacyTokenCompat = true
   }
   grants {
     session { enabled = true, enabled = ${?OAUTH_GRANTS_SESSION_ENABLED} }


### PR DESCRIPTION
## Summary

Phase G M4 — Remove `oauth.refreshToken.legacyTokenCompat` (HOCON + Zod + env-var override) and the legacy refresh-token shape compat paths in the refresh-grant. v0.5.2 (AS-12) shipped the flag with default `true` to accept v0.4.x token shapes during a bounded migration window; 1.0 GA cuts over to strict-only.

**Production behavior changes (BREAKING)**:
- Refresh-grant rejection gate accepts only `header.typ === "rt+jwt"` as the refresh marker. Tokens with the legacy `payload.type === "refresh"` substitute (no `rt+jwt` typ header) are now rejected with `invalid_grant` / `invalid refresh_token`.
- `claims.user.id` subject fallback removed. Refresh tokens MUST carry a top-level standard `sub` claim; missing → `invalid_grant` / `refresh token has no subject`.
- AT-as-RT defense (RT-OC invariant) is **preserved** and now structurally guaranteed by the single-marker requirement.

**Surface area removed**:
- `oauth.refreshToken.legacyTokenCompat` (HOCON)
- `OAUTH_REFRESH_TOKEN_LEGACY_TOKEN_COMPAT` (env-var override)
- `RefreshTokenConfig.legacyTokenCompat` (Zod schema field)
- Legacy code paths in `packages/oauth/src/grants/refreshToken.mts`

**Migration for operators**: ensure all in-flight refresh tokens were minted by v0.5.x or newer (which emit both `header.typ = "rt+jwt"` and top-level `sub`) before upgrading. v0.5.2 documented this plan in its Migration note; 1.0 GA finalizes the cutover.

**Test restructure** (per handoff rule "Sub-describe placement: regression tests for 'flag false' must NOT live under describe('flag: true')"):
- Removed `configWithLegacyTokenCompat` helper.
- Renamed `describe("legacyTokenCompat: false")` → `describe("refresh-token strict gate (header.typ === rt+jwt required)")` — what was the flag-false mode is now the canonical behavior. Inner tests no longer wrap config; they use `mockDeps`.
- Deleted `describe("legacyTokenCompat: backward compat (regression)")` block (RT-4 + RT-5) — both asserted removed behavior.
- Deleted the AS-12-era top-level test that asserted legacy `payload.type=refresh` accept; renamed the sibling kid-less test for clarity (the original name was misleading; behavior was unrelated to legacyTokenCompat).

Phase G dispatch order: M1 (#155 ✅) → M2 (#156 ✅) → M3 (#157 ✅) → **M4 (this PR)** → M6 (legacyRtPolicy enum) / M5 (getByCode rename) pending → S2.
See `auth/.claude/handoff/2026-05-09-v100-ga-codex-handoff.md`.

## Test plan

- [x] `pnpm -r run build` — green
- [x] `pnpm run lint` — only pre-existing warnings, no new findings
- [x] `pnpm -r run test` — all packages green
  - core 1199/1199, oauth 407/407, oauth-token-exchange 106/106, session 162+1, redis 315+2, federation-google 22/22, federation-github 20/20, foundation 14/14, create-app 77/77, standalone-template 25/25
- [x] RT-OC invariant still green (AT-as-RT defense)
- [x] No remaining references to `legacyTokenCompat` / `LEGACY_TOKEN_COMPAT` / `legacyCompatEnabled` / `configWithLegacyTokenCompat` across the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)