### PR TITLE
M6 (1.0 GA): remove legacyRtPolicy="accept-with-warning" enum value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security (Phase G — M6 `legacyRtPolicy = "accept-with-warning"` removed, 1.0 GA)
+
+- **BREAKING**: The `accept-with-warning` value of
+  `oauth.refreshToken.legacyRtPolicy` was removed. Under SF-6, refresh
+  tokens lacking `jti` or `family_id` claims (when family rotation is
+  wired) are now **always** rejected with `invalid_grant` /
+  `missing_jti_or_family_id`. The migration-window opt-in that skipped
+  replay detection and emitted an audit log no longer exists.
+- Closes a `family_id`-absent acceptance window that allowed legacy
+  refresh tokens to bypass rotation entirely under operator opt-in.
+
+### Removed (Phase G — M6 `legacyRtPolicy = "accept-with-warning"` enum value, 1.0 GA)
+
+- **BREAKING**: `oauth.refreshToken.legacyRtPolicy` Zod schema tightened
+  from `z.enum(["reject", "accept-with-warning"])` to
+  `z.enum(["reject"])`. The `OAUTH_REFRESH_TOKEN_LEGACY_RT_POLICY`
+  env-var override line was also removed from `application.conf` — with
+  only one valid value, there is nothing to override.
+- Operators upgrading from v0.5.x who still set
+  `legacyRtPolicy = "accept-with-warning"` get a Zod
+  `invalid_enum_value` error pointing at the field, instead of having
+  the legacy path silently honored.
+- Migration: ensure all in-flight refresh tokens carry both `jti` and
+  `family_id` claims (true for tokens minted by v0.5.x or newer) before
+  upgrading. Remove any `legacyRtPolicy = "accept-with-warning"` line
+  from your HOCON. SF-6 (v0.5.1) documented this migration plan; 1.0
+  GA finalizes the cutover.
+- Affected APIs/config (removed): `accept-with-warning` enum value,
+  `OAUTH_REFRESH_TOKEN_LEGACY_RT_POLICY` env-var override, the
+  `legacy_rt_accepted_no_replay_protection` audit log event in
+  `packages/oauth/src/grants/refreshToken.mts` (the legacy branch
+  that emitted it is gone).
+
 ### Removed (Phase G — M4 `legacyTokenCompat` migration flag, 1.0 GA)
 
 - **BREAKING**: Removed the `oauth.refreshToken.legacyTokenCompat` config

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -55,13 +55,12 @@ oauth {
     # tokens are still in circulation).
     unknownFamilyPolicy = "reject"
     unknownFamilyPolicy = ${?OAUTH_REFRESH_TOKEN_UNKNOWN_FAMILY_POLICY}
-    # SF-6: handling for refresh tokens lacking jti or family_id claims when
-    # family rotation is wired. "reject" is safe-by-default. Use
-    # "accept-with-warning" only during a migration window where v0.4.x
-    # tokens (no jti) are still in circulation; that mode skips replay
-    # detection for the request and emits an audit log.
+    # SF-6 / 1.0 GA (Phase G / M6): refresh tokens lacking jti or
+    # family_id claims when family rotation is wired are always rejected.
+    # The `"accept-with-warning"` migration-window value was removed at
+    # 1.0 GA along with the env-var override — there is no longer an
+    # opt-in to bypass replay detection.
     legacyRtPolicy = "reject"
-    legacyRtPolicy = ${?OAUTH_REFRESH_TOKEN_LEGACY_RT_POLICY}
   }
   grants {
     session { enabled = true, enabled = ${?OAUTH_GRANTS_SESSION_ENABLED} }

--- a/packages/core/src/config/__tests__/refresh-token-schema.test.mts
+++ b/packages/core/src/config/__tests__/refresh-token-schema.test.mts
@@ -64,3 +64,29 @@ describe("oauth.refreshToken schema — removed-field preprocess (Phase G / M4)"
 		expect(issue?.message).toMatch(/v0\.5\.x or newer/);
 	});
 });
+
+describe("oauth.refreshToken schema — legacyRtPolicy enum tightening (Phase G / M6)", () => {
+	const validBase = {
+		expiresIn: 86400,
+		unknownFamilyPolicy: "reject" as const,
+	};
+
+	it("accepts legacyRtPolicy='reject' (the only remaining value)", () => {
+		const result = refreshTokenSchema.safeParse({ ...validBase, legacyRtPolicy: "reject" });
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects legacyRtPolicy='accept-with-warning' (removed at 1.0 GA)", () => {
+		const result = refreshTokenSchema.safeParse({
+			...validBase,
+			legacyRtPolicy: "accept-with-warning",
+		});
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		const flagged = result.error.issues.some(
+			(issue) =>
+				issue.path.includes("legacyRtPolicy") || issue.message.includes("accept-with-warning"),
+		);
+		expect(flagged).toBe(true);
+	});
+});

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -180,14 +180,13 @@ const refreshTokenSchemaBase = z.object({
 	// windows. Per the v0.5.1 ADR the literal default lives in
 	// `application.conf`, not here.
 	unknownFamilyPolicy: z.enum(["accept", "reject"]),
-	// SF-6 (v0.5.1): policy for refresh tokens lacking `jti` or
-	// `family_id` claims when family rotation is wired. `"reject"` is
-	// the safe default; `"accept-with-warning"` skips replay detection
-	// for the request and emits an audit log — intended only for time-
-	// bounded migration windows where v0.4.x tokens are still in
-	// circulation. Per the v0.5.1 ADR the literal default lives in
-	// `application.conf`, not here.
-	legacyRtPolicy: z.enum(["reject", "accept-with-warning"]),
+	// SF-6 (v0.5.1) / 1.0 GA (Phase G / M6): policy for refresh tokens
+	// lacking `jti` or `family_id` claims when family rotation is wired.
+	// The `"accept-with-warning"` migration-window value was removed at
+	// 1.0 GA; only `"reject"` remains. Operators upgrading from v0.5.x
+	// who still set `accept-with-warning` get a Zod
+	// `invalid_enum_value` error pointing at this field.
+	legacyRtPolicy: z.enum(["reject"]),
 });
 
 /**

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -946,80 +946,6 @@ describe("createRefreshTokenGrant", () => {
 			);
 		});
 
-		it("SF-6 short-circuits null-familyId tokens before CC-2's null guard (defense-in-depth invariant)", async () => {
-			// CC-2 Codex Delta 3 originally asked for a RED test exercising the
-			// `familyId === null` hard-reject guard inside the unknown_family
-			// branch when `unknownFamilyPolicy = "accept"`. With SF-6's gate
-			// in place, that guard is structurally unreachable: when familyId
-			// is null the SF-6 gate fires FIRST and either rejects (default)
-			// or short-circuits to issuance with `accept-with-warning` —
-			// rotation never runs, so the unknown_family branch is never
-			// entered with null familyId.
-			//
-			// This test pins the invariant by:
-			//   1. Setting BOTH `unknownFamilyPolicy = "accept"` (so the
-			//      CC-2 branch would issue tokens if reached) AND
-			//      `legacyRtPolicy = "accept-with-warning"` (so SF-6 doesn't
-			//      hard-reject upstream).
-			//   2. Asserting the SF-6 audit log fires (proves the gate
-			//      caught the null familyId before rotation).
-			//   3. Asserting the rotation stub is NOT called (proves the
-			//      else-branch with the unknown_family case never runs).
-			//   4. Asserting tokens are issued (the surface behaviour, also
-			//      asserted indirectly by the audit log).
-			//
-			// If a future change reorders gates so rotation runs with
-			// familyId === null, the rotation stub `unknownFamilyRotation`
-			// would be invoked (assertion 3 would fail), at which point
-			// the CC-2 null guard inside the unknown_family case would
-			// kick in. Either failure mode catches a regression.
-			const warn = vi.fn();
-			const logger = makeStubLogger(warn);
-			const rotateSpy = vi.fn().mockResolvedValue({ outcome: "unknown_family" });
-			const rotation: RefreshTokenFamilyRotation = {
-				async register() {},
-				rotate: rotateSpy,
-			};
-			const config = {
-				...mockConfig,
-				oauth: {
-					...mockConfig.oauth,
-					refreshToken: {
-						...mockConfig.oauth.refreshToken,
-						unknownFamilyPolicy: "accept",
-						legacyRtPolicy: "accept-with-warning",
-					},
-				},
-			} as unknown as GrantDependencies["config"];
-			const deps: GrantDependencies = {
-				config,
-				keyStore: mockDeps.keyStore,
-				refreshTokenFamilyRotation: rotation,
-				logger,
-			};
-			// RT with no family_id claim — familyId resolves to null
-			const rt = await new SignJWT({ sub: "u1" })
-				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
-				.setIssuer("localhost")
-				.setAudience(DEFAULT_CLIENT_ID)
-				.setExpirationTime("24h")
-				.setJti("jti-no-fam")
-				.sign(secretKey);
-
-			const { result } = await createRefreshTokenGrant(deps).handle({
-				...baseCtx,
-				body: { refresh_token: rt },
-			});
-
-			expect(result.status).toBe(200);
-			// Pin the invariant: SF-6 fired and rotation was skipped.
-			expect(warn).toHaveBeenCalledWith(
-				expect.objectContaining({ hasFamilyId: false }),
-				"legacy_rt_accepted_no_replay_protection",
-			);
-			expect(rotateSpy).not.toHaveBeenCalled();
-		});
-
 		it("still handles replayed outcome correctly (RED 4 — orthogonality)", async () => {
 			const replayedRotation: RefreshTokenFamilyRotation = {
 				async register() {},
@@ -1114,52 +1040,6 @@ describe("createRefreshTokenGrant", () => {
 			expect(result.status).toBe(400);
 			if (!("error" in result)) expect.fail("Expected error in result");
 			expect(result.errorDescription).toBe("missing_jti_or_family_id");
-		});
-
-		it("accepts legacy RT in accept-with-warning mode and skips rotation (RED 3)", async () => {
-			const warn = vi.fn();
-			const logger = makeStubLogger(warn);
-			const rotateSpy = vi.fn().mockResolvedValue({ outcome: "rotated" });
-			const rotation: RefreshTokenFamilyRotation = {
-				async register() {},
-				rotate: rotateSpy,
-			};
-			const config = {
-				...mockConfig,
-				oauth: {
-					...mockConfig.oauth,
-					refreshToken: {
-						...mockConfig.oauth.refreshToken,
-						legacyRtPolicy: "accept-with-warning",
-					},
-				},
-			} as unknown as GrantDependencies["config"];
-			const deps: GrantDependencies = {
-				config,
-				keyStore: mockDeps.keyStore,
-				refreshTokenFamilyRotation: rotation,
-				logger,
-			};
-			// Legacy token with no jti
-			const rt = await new SignJWT({ sub: "u1", scope: "read", family_id: "fam-1" })
-				.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
-				.setIssuer("localhost")
-				.setAudience(DEFAULT_CLIENT_ID)
-				.setExpirationTime("24h")
-				.sign(secretKey);
-
-			const { result } = await createRefreshTokenGrant(deps).handle({
-				...baseCtx,
-				body: { refresh_token: rt },
-			});
-
-			expect(result.status).toBe(200);
-			expect(warn).toHaveBeenCalledWith(
-				expect.objectContaining({ hasJti: false, hasFamilyId: true }),
-				"legacy_rt_accepted_no_replay_protection",
-			);
-			// SF-6 Codex Delta 3: rotation MUST be skipped in accept-with-warning
-			expect(rotateSpy).not.toHaveBeenCalled();
 		});
 
 		it("proceeds with normal rotation when RT has both jti and family_id (RED 4)", async () => {

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -317,189 +317,174 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			);
 
 			if (deps.refreshTokenFamilyRotation) {
-				// SF-6: when rotation is wired, refresh tokens MUST carry both
-				// jti AND family_id. Tokens lacking either bypass replay
-				// detection because the rotation block cannot match a previous
-				// jti or address a family record. The legacy gate either
-				// rejects (default, safe) or accepts with an audit log
-				// (migration window only) — never silently skips replay
-				// detection without operator awareness.
+				// SF-6 / 1.0 GA (Phase G / M6): when rotation is wired, refresh
+				// tokens MUST carry both jti AND family_id. Tokens lacking
+				// either bypass replay detection because the rotation block
+				// cannot match a previous jti or address a family record. The
+				// `accept-with-warning` migration-window opt-in was removed at
+				// 1.0 GA — rejection is now unconditional.
 				if (previousJti === null || familyId === null) {
-					const policy = config.oauth.refreshToken.legacyRtPolicy ?? "reject";
-					if (policy === "reject") {
-						logger?.warn(
-							{
-								clientId: authenticatedClientId,
-								hasJti: previousJti !== null,
-								hasFamilyId: familyId !== null,
-							},
-							"legacy_rt_rejected",
-						);
-						return {
-							result: {
-								status: 400,
-								error: "invalid_grant",
-								errorDescription: "missing_jti_or_family_id",
-							},
-						};
-					}
-					// "accept-with-warning": skip rotation entirely (legacy path)
-					// + emit audit log so operators can monitor migration progress.
 					logger?.warn(
 						{
 							clientId: authenticatedClientId,
 							hasJti: previousJti !== null,
 							hasFamilyId: familyId !== null,
 						},
-						"legacy_rt_accepted_no_replay_protection",
+						"legacy_rt_rejected",
 					);
-				} else {
-					const newRefreshPayload = decodeJwtPayload(newRefreshToken.token);
-					const newJti = newRefreshPayload.jti as string | undefined;
-					const newExp = newRefreshPayload.exp as number | undefined;
-					if (typeof newJti === "string" && typeof newExp === "number") {
-						// CP-17: fail-closed when the store is unavailable. Same
-						// rationale as CP-16 — we cannot atomically consume the old
-						// jti and register the new one, so replay detection cannot
-						// be guaranteed. Return 503 so the client retries rather
-						// than bubbling an unhandled 500 HTML from express.
-						let rotateResult: Awaited<ReturnType<typeof deps.refreshTokenFamilyRotation.rotate>>;
-						try {
-							rotateResult = await deps.refreshTokenFamilyRotation.rotate(
-								previousJti,
-								newJti,
-								newFamilyId,
-								newExp * 1000,
+					return {
+						result: {
+							status: 400,
+							error: "invalid_grant",
+							errorDescription: "missing_jti_or_family_id",
+						},
+					};
+				}
+				const newRefreshPayload = decodeJwtPayload(newRefreshToken.token);
+				const newJti = newRefreshPayload.jti as string | undefined;
+				const newExp = newRefreshPayload.exp as number | undefined;
+				if (typeof newJti === "string" && typeof newExp === "number") {
+					// CP-17: fail-closed when the store is unavailable. Same
+					// rationale as CP-16 — we cannot atomically consume the old
+					// jti and register the new one, so replay detection cannot
+					// be guaranteed. Return 503 so the client retries rather
+					// than bubbling an unhandled 500 HTML from express.
+					let rotateResult: Awaited<ReturnType<typeof deps.refreshTokenFamilyRotation.rotate>>;
+					try {
+						rotateResult = await deps.refreshTokenFamilyRotation.rotate(
+							previousJti,
+							newJti,
+							newFamilyId,
+							newExp * 1000,
+						);
+					} catch {
+						return {
+							result: {
+								status: 503,
+								error: "temporarily_unavailable",
+								errorDescription: "refresh token store unavailable",
+							},
+						};
+					}
+					// Exhaustive switch over the 4-outcome rotation union.
+					// Each case explicitly handles the security-relevant
+					// outcome; falling through to issuance (the v0.4.x
+					// behavior for unknown_family) is now an explicit
+					// policy decision under operator control (CC-2).
+					switch (rotateResult.outcome) {
+						case "rotated":
+							// Successful rotation — fall through to the
+							// success path below (token issuance).
+							break;
+						case "replayed": {
+							// PB-1: RFC 6819 §5.2.2 / OAuth 2.1 BCP §4.14.2
+							// require revoking the entire family on replay
+							// so siblings cannot continue to redeem. Fail
+							// closed when the revocation dep is missing or
+							// throws — silently rejecting only the present
+							// request would leave sibling RTs valid.
+							if (!deps.refreshTokenFamilyRevocation) {
+								logger?.error(
+									{ clientId: authenticatedClientId },
+									"rt_reuse_detected_but_no_revocation_dep",
+								);
+								return {
+									result: {
+										status: 503,
+										error: "temporarily_unavailable",
+										errorDescription: "refresh token family revocation not configured",
+									},
+								};
+							}
+							try {
+								await deps.refreshTokenFamilyRevocation.revokeFamily(newFamilyId);
+							} catch {
+								return {
+									result: {
+										status: 503,
+										error: "temporarily_unavailable",
+										errorDescription: "refresh token store unavailable",
+									},
+								};
+							}
+							logger?.warn(
+								{ familyId: newFamilyId, clientId: authenticatedClientId },
+								"rt_reuse_detected_family_revoked",
 							);
-						} catch {
 							return {
 								result: {
-									status: 503,
-									error: "temporarily_unavailable",
-									errorDescription: "refresh token store unavailable",
+									status: 400,
+									error: "invalid_grant",
+									errorDescription: "replay_detected",
 								},
 							};
 						}
-						// Exhaustive switch over the 4-outcome rotation union.
-						// Each case explicitly handles the security-relevant
-						// outcome; falling through to issuance (the v0.4.x
-						// behavior for unknown_family) is now an explicit
-						// policy decision under operator control (CC-2).
-						switch (rotateResult.outcome) {
-							case "rotated":
-								// Successful rotation — fall through to the
-								// success path below (token issuance).
-								break;
-							case "replayed": {
-								// PB-1: RFC 6819 §5.2.2 / OAuth 2.1 BCP §4.14.2
-								// require revoking the entire family on replay
-								// so siblings cannot continue to redeem. Fail
-								// closed when the revocation dep is missing or
-								// throws — silently rejecting only the present
-								// request would leave sibling RTs valid.
-								if (!deps.refreshTokenFamilyRevocation) {
-									logger?.error(
-										{ clientId: authenticatedClientId },
-										"rt_reuse_detected_but_no_revocation_dep",
-									);
-									return {
-										result: {
-											status: 503,
-											error: "temporarily_unavailable",
-											errorDescription: "refresh token family revocation not configured",
-										},
-									};
-								}
-								try {
-									await deps.refreshTokenFamilyRevocation.revokeFamily(newFamilyId);
-								} catch {
-									return {
-										result: {
-											status: 503,
-											error: "temporarily_unavailable",
-											errorDescription: "refresh token store unavailable",
-										},
-									};
-								}
+						case "revoked":
+							return {
+								result: {
+									status: 400,
+									error: "invalid_grant",
+									errorDescription: "family_revoked",
+								},
+							};
+						case "unknown_family": {
+							// CC-2: defense-in-depth — SF-6 already rejects
+							// tokens with familyId === null when rotation is
+							// wired, but if a future change reorders gates,
+							// fall through to a hard reject regardless of
+							// policy when there was never a family to consult.
+							if (familyId === null) {
 								logger?.warn(
-									{ familyId: newFamilyId, clientId: authenticatedClientId },
-									"rt_reuse_detected_family_revoked",
+									{ clientId: authenticatedClientId },
+									"unknown_family_rejected_no_family_id_claim",
 								);
 								return {
 									result: {
 										status: 400,
 										error: "invalid_grant",
-										errorDescription: "replay_detected",
+										errorDescription: "unknown_family",
 									},
 								};
 							}
-							case "revoked":
-								return {
-									result: {
-										status: 400,
-										error: "invalid_grant",
-										errorDescription: "family_revoked",
-									},
-								};
-							case "unknown_family": {
-								// CC-2: defense-in-depth — SF-6 already rejects
-								// tokens with familyId === null when rotation is
-								// wired, but if a future change reorders gates,
-								// fall through to a hard reject regardless of
-								// policy when there was never a family to consult.
-								if (familyId === null) {
-									logger?.warn(
-										{ clientId: authenticatedClientId },
-										"unknown_family_rejected_no_family_id_claim",
-									);
-									return {
-										result: {
-											status: 400,
-											error: "invalid_grant",
-											errorDescription: "unknown_family",
-										},
-									};
-								}
-								const policy = config.oauth.refreshToken.unknownFamilyPolicy ?? "reject";
-								if (policy === "reject") {
-									logger?.warn(
-										{
-											familyId: newFamilyId,
-											jti: previousJti,
-											clientId: authenticatedClientId,
-										},
-										"unknown_family_rejected",
-									);
-									return {
-										result: {
-											status: 400,
-											error: "invalid_grant",
-											errorDescription: "unknown_family",
-										},
-									};
-								}
-								// "accept" — legacy migration mode only; emit
-								// audit log and fall through to issuance.
+							const policy = config.oauth.refreshToken.unknownFamilyPolicy ?? "reject";
+							if (policy === "reject") {
 								logger?.warn(
 									{
 										familyId: newFamilyId,
 										jti: previousJti,
 										clientId: authenticatedClientId,
 									},
-									"unknown_family_accepted_legacy_mode",
+									"unknown_family_rejected",
 								);
-								break;
+								return {
+									result: {
+										status: 400,
+										error: "invalid_grant",
+										errorDescription: "unknown_family",
+									},
+								};
 							}
-							default: {
-								// Exhaustiveness guard: every outcome above
-								// either returns or breaks. A future addition
-								// to RefreshTokenFamilyRotationOutcome that
-								// forgets to update this switch will produce a
-								// compile error here rather than silently
-								// falling through to token issuance.
-								const _exhaustive: never = rotateResult;
-								throw new Error(`unhandled rotation outcome: ${JSON.stringify(_exhaustive)}`);
-							}
+							// "accept" — legacy migration mode only; emit
+							// audit log and fall through to issuance.
+							logger?.warn(
+								{
+									familyId: newFamilyId,
+									jti: previousJti,
+									clientId: authenticatedClientId,
+								},
+								"unknown_family_accepted_legacy_mode",
+							);
+							break;
+						}
+						default: {
+							// Exhaustiveness guard: every outcome above
+							// either returns or breaks. A future addition
+							// to RefreshTokenFamilyRotationOutcome that
+							// forgets to update this switch will produce a
+							// compile error here rather than silently
+							// falling through to token issuance.
+							const _exhaustive: never = rotateResult;
+							throw new Error(`unhandled rotation outcome: ${JSON.stringify(_exhaustive)}`);
 						}
 					}
 				}

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -276,6 +276,33 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				}
 			}
 
+			// SF-6 / 1.0 GA (Phase G / M6): when rotation is wired, refresh
+			// tokens MUST carry both jti AND family_id. Fail-fast BEFORE
+			// `generateToken()` runs so (a) we don't burn keystore signatures
+			// on a request that is going to be rejected anyway, and (b) a
+			// transient keystore failure cannot mask the deterministic
+			// `invalid_grant / missing_jti_or_family_id` response. Pre-M6
+			// the gate sat after token mint because the `accept-with-warning`
+			// branch needed the minted tokens; with M6 removing that branch,
+			// rejection is unconditional and the gate is free to move.
+			if (deps.refreshTokenFamilyRotation && (previousJti === null || familyId === null)) {
+				logger?.warn(
+					{
+						clientId: authenticatedClientId,
+						hasJti: previousJti !== null,
+						hasFamilyId: familyId !== null,
+					},
+					"legacy_rt_rejected",
+				);
+				return {
+					result: {
+						status: 400,
+						error: "invalid_grant",
+						errorDescription: "missing_jti_or_family_id",
+					},
+				};
+			}
+
 			// CP-15: empty string (e.g. requested=" ") normalizes to null so the
 			// token response omits scope rather than emitting `scope: ""`.
 			const scopeClaim = finalScope && finalScope.length > 0 ? finalScope : null;
@@ -317,28 +344,14 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			);
 
 			if (deps.refreshTokenFamilyRotation) {
-				// SF-6 / 1.0 GA (Phase G / M6): when rotation is wired, refresh
-				// tokens MUST carry both jti AND family_id. Tokens lacking
-				// either bypass replay detection because the rotation block
-				// cannot match a previous jti or address a family record. The
-				// `accept-with-warning` migration-window opt-in was removed at
-				// 1.0 GA — rejection is now unconditional.
+				// SF-6 fail-fast above already returned for missing
+				// jti/family_id when rotation is wired. The check below
+				// documents that invariant, narrows for TS, and acts as
+				// defense-in-depth if a future refactor moves the gate.
 				if (previousJti === null || familyId === null) {
-					logger?.warn(
-						{
-							clientId: authenticatedClientId,
-							hasJti: previousJti !== null,
-							hasFamilyId: familyId !== null,
-						},
-						"legacy_rt_rejected",
+					throw new Error(
+						"invariant violation: SF-6 fail-fast must run before refresh-token rotation block",
 					);
-					return {
-						result: {
-							status: 400,
-							error: "invalid_grant",
-							errorDescription: "missing_jti_or_family_id",
-						},
-					};
 				}
 				const newRefreshPayload = decodeJwtPayload(newRefreshToken.token);
 				const newJti = newRefreshPayload.jti as string | undefined;

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -60,13 +60,10 @@ oauth {
     # store to Redis with old tokens still in circulation. Operators set
     # OAUTH_REFRESH_TOKEN_UNKNOWN_FAMILY_POLICY for env-var override.
     # unknownFamilyPolicy = "reject"
-    # SF-6 (v0.5.1): handling for refresh tokens lacking jti or family_id
-    # claims when rotation is wired. "reject" (default) is safe. Use
-    # "accept-with-warning" only during a migration window where v0.4.x
-    # tokens (issued before claim standardization) are still in circulation;
-    # that mode skips replay detection for the request and emits an audit
-    # log. Pair with `unknownFamilyPolicy = "accept"` to avoid immediate
-    # rejection on the next refresh — see Phase F migration guide.
+    # SF-6 / 1.0 GA (Phase G / M6): refresh tokens lacking jti or
+    # family_id claims when rotation is wired are always rejected.
+    # The only valid value is "reject"; the `accept-with-warning`
+    # migration-window opt-in was removed at 1.0 GA.
     # legacyRtPolicy = "reject"
   }
   grants {


### PR DESCRIPTION
## Summary

Phase G M6 — Remove the `oauth.refreshToken.legacyRtPolicy = "accept-with-warning"` enum value, the env-var override, and the legacy branch in the refresh-grant. SF-6 added this migration-window opt-in in v0.5.1 to let operators accept `jti`/`family_id`-less refresh tokens with an audit log (skipping replay detection). At 1.0 GA the opt-in is removed; rejection is unconditional.

**Security tightening (BREAKING)**: closes a `family_id`-absent acceptance window. Under SF-6, refresh tokens lacking `jti` or `family_id` (when family rotation is wired) are now always rejected with `invalid_grant / missing_jti_or_family_id`. The legacy path that emitted `legacy_rt_accepted_no_replay_protection` and fell through to issuance is gone.

**Surface area removed**:
- `accept-with-warning` enum value (schema)
- `OAUTH_REFRESH_TOKEN_LEGACY_RT_POLICY` env-var override (`application.conf`)
- The `legacy_rt_accepted_no_replay_protection` audit log event (it was only emitted on the now-removed branch)

**Schema regression**: operators upgrading from v0.5.x who still set `legacyRtPolicy = "accept-with-warning"` get a Zod `invalid_enum_value` error pointing at the field (not silent strip — different from M4's removed-field case, but loud either way).

**Test restructure**:
- Deleted the SF-6 short-circuits test (the test relied on `accept-with-warning` to keep SF-6 from hard-rejecting upstream so it could exercise the CC-2 null-familyId guard; with the bypass gone, the test's premise no longer applies, and the RED 1/RED 2 tests immediately above already cover the structural invariant).
- Deleted RED 3 ("accepts legacy RT in accept-with-warning mode and skips rotation").
- Extended `__tests__/refresh-token-schema.test.mts` with a new describe block: `legacyRtPolicy = "reject"` passes; `legacyRtPolicy = "accept-with-warning"` fails parsing.

**Migration for operators**: ensure all in-flight refresh tokens carry both `jti` and `family_id` claims (true for tokens minted by v0.5.x or newer) before upgrading. Remove any `legacyRtPolicy = "accept-with-warning"` HOCON line. SF-6 (v0.5.1) documented this plan; 1.0 GA finalizes the cutover.

CHANGELOG includes dual `### Removed` + `### Security` sections per handoff guidance.

Phase G dispatch order: M1 (#155 ✅) → M2 (#156 ✅) → M3 (#157 ✅) → M4 (#158 ✅) → **M6 (this PR)** → M5 (getByCode rename) → S2.
See `auth/.claude/handoff/2026-05-09-v100-ga-codex-handoff.md`.

## Test plan

- [x] `pnpm -r run build` — green
- [x] `pnpm run lint` — only pre-existing warnings/infos, no new errors
- [x] `pnpm -r run test` — all packages green
  - core 1205/1205 (+2 schema-test additions: legacyRtPolicy reject/accept-with-warning assertions)
  - oauth 405/405 (-2: deleted SF-6 short-circuits + RED 3 accept-with-warning tests)
  - all other packages unchanged
- [x] `grep -rn accept-with-warning` shows only doc/comment references explaining the removal — no live `"accept-with-warning"` string literals in code
- [x] Diff stat: 212+/293- (net -81; mostly from the `else`-branch removal + one-tab de-indent of the rotation-eligible block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)