### PR TITLE
S2 (1.0 GA): flip legacyTypAccept default true → false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security (Phase G — S2 `legacyTypAccept` default flipped `true → false`, 1.0 GA)
+
+- **BREAKING**: `oauth.jwt.legacyTypAccept` default flipped from `true`
+  (v0.5.x) to `false` (1.0 GA). The central JWT verifier now rejects
+  tokens whose `typ` header is absent **by default**. Previously,
+  typ-less tokens were accepted with a `jwt_verify_legacy_typ`
+  deprecation warning so v0.4.x tokens (issued before the
+  `at+jwt`/`rt+jwt`/`id+jwt` convention) kept verifying through the
+  v0.5.x migration window.
+- **Why this is a security tightening**: an absent `typ` header is a
+  hard signal of either operator misconfiguration or a downgrade attack
+  attempting to repurpose a non-JWT token as a JWT. Rejecting by default
+  closes the acceptance window operationally; the flag stays as an
+  explicit operator opt-in for deployments still completing their v0.4.x
+  rollover.
+- **Migration**: operators with v0.4.x tokens still in circulation can
+  set `OAUTH_JWT_LEGACY_TYP_ACCEPT=true` (or `oauth.jwt.legacyTypAccept
+  = true` in HOCON) to opt back into legacy acceptance for their own
+  bounded migration window. The recommended path is to ensure all
+  in-flight tokens were minted by v0.5.x or newer (which emit
+  `header.typ` per type) before upgrading, then leave the new default
+  in place.
+- **Code-level default match**: every `?? true` fallback in routes,
+  grants, and validators is flipped to `?? false` so that partial-config
+  test fixtures and edge code paths behave consistently with HOCON.
+- Affected sites: `packages/core/config/application.conf`,
+  `templates/standalone/config/application.conf`,
+  `packages/core/src/jwt/verify.mts` (default arg + JSDoc), and the
+  `?? false` fallbacks in `packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts`,
+  `packages/oauth/src/routes.mts`,
+  `packages/oauth/src/grants/refreshToken.mts`,
+  `packages/oauth/src/routes/{federationToken,logout,userinfo}.mts`.
+
 ### Changed (Phase G — M5 `CodeRepository.getByCode` → `findByCode` rename, 1.0 GA)
 
 - **BREAKING**: `CodeRepository.getByCode(code)` renamed to

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -8,13 +8,16 @@ http {
 oauth {
   jwt {
     issuer = ${?OAUTH_JWT_ISSUER}
-    # SF-1 (v0.5.1): the central JWT verifier accepts tokens whose `typ`
-    # header is absent, emitting a `jwt_verify_legacy_typ` warning. This
-    # exists so v0.4.x tokens (issued before the at+jwt/rt+jwt/id+jwt
-    # convention) keep verifying through the v0.5.x transition window.
-    # Operators MUST flip this to false in v0.6+ so typ-less tokens are
-    # rejected as a hard signal of misconfiguration or downgrade attack.
-    legacyTypAccept = true
+    # SF-1 / 1.0 GA (Phase G / S2): the central JWT verifier rejects
+    # tokens whose `typ` header is absent. The previous v0.5.x default
+    # accepted typ-less tokens (with a `jwt_verify_legacy_typ` warning)
+    # to keep v0.4.x tokens verifying through the migration window; at
+    # 1.0 GA that window is closed by default. Operators with v0.4.x
+    # tokens still in circulation can opt back via
+    # `OAUTH_JWT_LEGACY_TYP_ACCEPT=true` for their own bounded migration
+    # window, but the safe default is now `false` (reject typ-less tokens
+    # as a hard signal of misconfiguration or downgrade attack).
+    legacyTypAccept = false
     legacyTypAccept = ${?OAUTH_JWT_LEGACY_TYP_ACCEPT}
     signingKey {
       provider = "local"

--- a/packages/core/src/jwt/verify.mts
+++ b/packages/core/src/jwt/verify.mts
@@ -125,9 +125,14 @@ export interface JwtVerifyOptions {
 	 */
 	readonly logger?: Logger;
 	/**
-	 * v0.5.1 transition: when `true` (default), tokens whose `typ` header is
-	 * absent are accepted with a `jwt_verify_legacy_typ` warning. Set to
-	 * `false` in v0.6+ to enforce typ presence on all tokens.
+	 * SF-1 transition flag for the v0.4.x→v0.5.x typ-header rollout.
+	 *
+	 * The 1.0 GA default is `false`: tokens whose `typ` header is absent
+	 * are rejected. Operators with v0.4.x tokens still in circulation can
+	 * set this to `true` for their own bounded migration window — when
+	 * true, typ-less tokens are accepted and emit a
+	 * `jwt_verify_legacy_typ` warning. The v0.5.x default was `true`;
+	 * 1.0 GA flips it as part of Phase G S2.
 	 */
 	readonly legacyTypAccept?: boolean;
 }
@@ -195,7 +200,7 @@ export async function verifyJwt(
 		expectedTyp,
 		expectedAlgs,
 		logger,
-		legacyTypAccept = true,
+		legacyTypAccept = false,
 	} = options;
 
 	let header: ProtectedHeaderParameters;

--- a/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
+++ b/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
@@ -37,8 +37,11 @@ export interface CreateSelfIssuedAccessTokenValidatorOptions {
 	refreshTokenFamilyRevocation?: RefreshTokenFamilyRevocation;
 	issuer: string;
 	/**
-	 * SF-1 (v0.5.1): when true (default), the central JWT verifier accepts
-	 * tokens whose `typ` header is absent and emits a deprecation warning.
+	 * SF-1 / 1.0 GA (Phase G / S2): when true, the central JWT verifier
+	 * accepts tokens whose `typ` header is absent and emits a
+	 * `jwt_verify_legacy_typ` deprecation warning. 1.0 GA default is
+	 * `false` (typ-less tokens rejected); `true` is an explicit
+	 * legacy-acceptance opt-in. The v0.5.x default was `true`.
 	 */
 	legacyTypAccept?: boolean;
 	logger?: Logger;

--- a/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
+++ b/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
@@ -98,7 +98,7 @@ export function createSelfIssuedAccessTokenValidator(
 				const verified = await verifyJwt(token, keyStore, {
 					type: "access_token",
 					expectedIssuer: issuer,
-					legacyTypAccept: legacyTypAccept ?? true,
+					legacyTypAccept: legacyTypAccept ?? false,
 					logger,
 				});
 				payload = verified.payload as Record<string, unknown>;

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -80,7 +80,7 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				const verified = await verifyJwt(refreshTokenValue, keyStore, {
 					type: "refresh_token",
 					expectedIssuer: issuer ?? "",
-					legacyTypAccept: config.oauth.jwt.legacyTypAccept ?? true,
+					legacyTypAccept: config.oauth.jwt.legacyTypAccept ?? false,
 					logger,
 				});
 				tokenPayload = verified.payload;
@@ -97,9 +97,10 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 
 			// Invariant — see RT-OC test: this gate keeps AT-as-RT confusion
 			// defended. A JWT with no `header.typ === "rt+jwt"` is rejected
-			// even when SF-1's `legacyTypAccept = true` allowed a typ-less
-			// token through the central verifier. Refactors that touch this
-			// condition MUST keep RT-OC green.
+			// even when SF-1's `legacyTypAccept = true` opt-in lets a typ-less
+			// token through the central verifier (1.0 GA flipped the default
+			// to false but operators can still opt back). Refactors that touch
+			// this condition MUST keep RT-OC green.
 			if (typ !== "rt+jwt") {
 				return {
 					result: {

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -119,9 +119,10 @@ export const createOAuthRouter = async (
 	// canonical issuer (or this router is constructed in a partial-config test
 	// fixture), the middleware falls back to the literal "oauth".
 	const issuerForRealm = (config as { oauth?: { jwt?: { issuer?: string } } }).oauth?.jwt?.issuer;
-	// SF-1: legacyTypAccept default is `true` for v0.5.x. Use the same
-	// defensive cast as `issuerForRealm` so partial-config test fixtures
-	// (no `oauth.jwt` block at all) don't throw at router construction.
+	// SF-1 / 1.0 GA (Phase G / S2): legacyTypAccept default is `false`
+	// (v0.5.x was `true`). Use the same defensive cast as `issuerForRealm`
+	// so partial-config test fixtures (no `oauth.jwt` block at all) don't
+	// throw at router construction.
 	const legacyTypAcceptOpt = (config as { oauth?: { jwt?: { legacyTypAccept?: boolean } } }).oauth
 		?.jwt?.legacyTypAccept;
 	// `/oauth/token` MUST accept public clients (`tokenEndpointAuthMethod: "none"`)
@@ -338,7 +339,7 @@ export const createOAuthRouter = async (
 						await verifyJwt(bearerToken, keyStore, {
 							type: "access_token",
 							expectedIssuer: issuerForRealm ?? "",
-							legacyTypAccept: legacyTypAcceptOpt ?? true,
+							legacyTypAccept: legacyTypAcceptOpt ?? false,
 							logger,
 						});
 						return next();
@@ -377,7 +378,7 @@ export const createOAuthRouter = async (
 						type: "access_token",
 						expectedIssuer: issuerForRealm ?? "",
 						...(req.oauthClient ? { expectedAudience: req.oauthClient.clientId } : {}),
-						legacyTypAccept: legacyTypAcceptOpt ?? true,
+						legacyTypAccept: legacyTypAcceptOpt ?? false,
 						logger,
 					});
 					const { payload } = verified;

--- a/packages/oauth/src/routes/federationToken.mts
+++ b/packages/oauth/src/routes/federationToken.mts
@@ -154,8 +154,12 @@ export interface FederationTokenRouterOptions {
 	/** Configured issuer — pinned by the SF-1 central verifier. */
 	issuer?: string;
 	/**
-	 * SF-1 (v0.5.1): when true (default), accept tokens whose `typ` header is
-	 * absent and emit a deprecation warning. v0.6+ should set this to false.
+	 * SF-1 / 1.0 GA (Phase G / S2): when true, accept tokens whose `typ`
+	 * header is absent (a `jwt_verify_legacy_typ` deprecation warning is
+	 * emitted). 1.0 GA default is `false` (typ-less tokens rejected);
+	 * `true` is an explicit legacy-acceptance opt-in for deployments
+	 * still completing their v0.4.x rollover. The v0.5.x default was
+	 * `true`.
 	 */
 	legacyTypAccept?: boolean;
 }

--- a/packages/oauth/src/routes/federationToken.mts
+++ b/packages/oauth/src/routes/federationToken.mts
@@ -203,7 +203,7 @@ export function createRouter(express: ExpressLike, opts: FederationTokenRouterOp
 			const verified = await verifyJwt(token, opts.keyStore, {
 				type: "access_token",
 				expectedIssuer: opts.issuer ?? "",
-				legacyTypAccept: opts.legacyTypAccept ?? true,
+				legacyTypAccept: opts.legacyTypAccept ?? false,
 				logger: opts.logger,
 			});
 			payload = verified.payload as Record<string, unknown>;

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -161,9 +161,12 @@ export interface LogoutRouterOptions {
 	/** Audit sink for operator observability events. No-op when undefined. */
 	auditSink?: AuditSink;
 	/**
-	 * SF-1 (v0.5.1): when true (default), the central JWT verifier accepts
-	 * tokens whose `typ` header is absent and emits a deprecation warning.
-	 * Forwarded to `verifyJwt` for the bearer AT and id_token_hint paths.
+	 * SF-1 / 1.0 GA (Phase G / S2): when true, the central JWT verifier
+	 * accepts tokens whose `typ` header is absent and emits a
+	 * `jwt_verify_legacy_typ` deprecation warning. 1.0 GA default is
+	 * `false` (typ-less tokens rejected); `true` is an explicit
+	 * legacy-acceptance opt-in. The v0.5.x default was `true`. Forwarded
+	 * to `verifyJwt` for the bearer AT and id_token_hint paths.
 	 */
 	legacyTypAccept?: boolean;
 }

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -234,7 +234,7 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 				const verified = await verifyJwt(token, opts.keyStore, {
 					type: "access_token",
 					expectedIssuer: opts.issuer ?? "",
-					legacyTypAccept: opts.legacyTypAccept ?? true,
+					legacyTypAccept: opts.legacyTypAccept ?? false,
 					logger: opts.logger,
 				});
 				payload = verified.payload as Record<string, unknown>;
@@ -473,7 +473,7 @@ export function createRouter(express: ExpressLike, opts: LogoutRouterOptions): R
 			const verified = await verifyJwt(idTokenHint, opts.keyStore, {
 				type: "id_token",
 				expectedIssuer: opts.issuer ?? "",
-				legacyTypAccept: opts.legacyTypAccept ?? true,
+				legacyTypAccept: opts.legacyTypAccept ?? false,
 				logger: opts.logger,
 			});
 			payload = verified.payload as Record<string, unknown>;

--- a/packages/oauth/src/routes/userinfo.mts
+++ b/packages/oauth/src/routes/userinfo.mts
@@ -85,7 +85,7 @@ export function createRouter(express: ExpressLike, opts: UserinfoRouterOptions):
 			const verified = await verifyJwt(token, opts.keyStore, {
 				type: "access_token",
 				expectedIssuer: opts.issuer ?? "",
-				legacyTypAccept: opts.legacyTypAccept ?? true,
+				legacyTypAccept: opts.legacyTypAccept ?? false,
 				logger: opts.logger,
 			});
 			payload = verified.payload as Record<string, unknown>;

--- a/packages/oauth/src/routes/userinfo.mts
+++ b/packages/oauth/src/routes/userinfo.mts
@@ -37,8 +37,12 @@ export interface UserinfoRouterOptions {
 	/** Configured issuer — pinned by the SF-1 central verifier. */
 	issuer?: string;
 	/**
-	 * SF-1 (v0.5.1): when true, accept tokens whose `typ` header is absent
-	 * (a deprecation warning is emitted). Defaults to true through v0.5.x.
+	 * SF-1 / 1.0 GA (Phase G / S2): when true, accept tokens whose `typ`
+	 * header is absent (a `jwt_verify_legacy_typ` deprecation warning is
+	 * emitted). 1.0 GA default is `false` (typ-less tokens rejected);
+	 * `true` is an explicit legacy-acceptance opt-in for deployments
+	 * still completing their v0.4.x rollover. The v0.5.x default was
+	 * `true`.
 	 */
 	legacyTypAccept?: boolean;
 	logger?: Logger;

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -8,15 +8,15 @@ http {
 oauth {
   jwt {
     issuer = ${?OAUTH_JWT_ISSUER}
-    # SF-1 (v0.5.1): legacy typ acceptance for the central JWT verifier.
-    # When true (default), tokens whose `typ` header is absent are
-    # accepted with a `jwt_verify_legacy_typ` warning so v0.4.x tokens
-    # keep verifying through the v0.5.x transition window. Flip to false
-    # in v0.6+ to reject typ-less tokens. Active default per the v0.5.1
-    # ADR: literal default lives in HOCON (zod has no `.default()`).
-    # Operators set OAUTH_JWT_LEGACY_TYP_ACCEPT to override (set "false"
-    # to enforce strict mode early).
-    legacyTypAccept = true
+    # SF-1 / 1.0 GA (Phase G / S2): legacy typ acceptance for the
+    # central JWT verifier. The 1.0 GA default is `false`: tokens whose
+    # `typ` header is absent are rejected. Operators with v0.4.x tokens
+    # still in circulation can opt back to legacy acceptance with
+    # `OAUTH_JWT_LEGACY_TYP_ACCEPT=true` for their own bounded migration
+    # window — when set, typ-less tokens verify with a
+    # `jwt_verify_legacy_typ` warning. Per the v0.5.1 ADR the literal
+    # default lives in HOCON (zod has no `.default()`).
+    legacyTypAccept = false
     legacyTypAccept = ${?OAUTH_JWT_LEGACY_TYP_ACCEPT}
     signingKey {
       provider = "local"

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -15,7 +15,9 @@ oauth {
     # `OAUTH_JWT_LEGACY_TYP_ACCEPT=true` for their own bounded migration
     # window — when set, typ-less tokens verify with a
     # `jwt_verify_legacy_typ` warning. Per the v0.5.1 ADR the literal
-    # default lives in HOCON (zod has no `.default()`).
+    # default lives in HOCON, not the Zod schema — this keeps a single
+    # source of truth so the env-var override path and the file default
+    # don't drift.
     legacyTypAccept = false
     legacyTypAccept = ${?OAUTH_JWT_LEGACY_TYP_ACCEPT}
     signingKey {


### PR DESCRIPTION
## Summary

Phase G S2 — Final BREAKING change before 1.0 GA. Flip `oauth.jwt.legacyTypAccept` default from `true` (v0.5.x) to `false` (1.0 GA). The central JWT verifier now rejects tokens whose `typ` header is absent **by default**; the flag itself stays as an explicit operator opt-in for deployments still completing their v0.4.x rollover.

**Security tightening (BREAKING)**:
- An absent `typ` header is a hard signal of either operator misconfiguration or a downgrade attack repurposing a non-JWT token as a JWT.
- Rejecting by default closes the operational acceptance window.

**Migration**:
- Operators whose v0.4.x tokens have all expired (which is now the normal case after several months of v0.5.x circulation) get the safer default automatically.
- Operators with v0.4.x tokens still alive can set `OAUTH_JWT_LEGACY_TYP_ACCEPT=true` (or HOCON `oauth.jwt.legacyTypAccept = true`) to opt back into legacy acceptance for their own bounded migration window. Recommended: rotate to v0.5.x+ tokens, then leave the new default in place.

**Scope**:
- `packages/core/config/application.conf` + `templates/standalone/config/application.conf`: HOCON default flipped + SF-1 commentary rewritten.
- `packages/core/src/jwt/verify.mts`: destructured-options default arg flipped + JSDoc rewritten to put 1.0 GA default first.
- All 7 `?? true` fallbacks in routes / grants / validators flipped to `?? false` so partial-config code paths stay consistent with HOCON.
- Comment refresh in `oauth/src/routes.mts` and `oauth/src/grants/refreshToken.mts` (RT-OC invariant note).
- CHANGELOG `[Unreleased] / Security (Phase G — S2)` per Keep-a-Changelog convention.

**Tests**: no breakage. Tests that exercise legacy behavior pass `legacyTypAccept: true` explicitly; tests that exercise strict mode pass `false`; the rest construct tokens with proper `typ` headers and don't exercise the flag. No test patches needed.

Phase G dispatch order completes here:
- S1 (#154 ✅) lockfile policy
- A1/A2/A3 audits closed
- M1 (#155 ✅) GrantRegistry
- M2 (#156 ✅) *Base aliases × 5
- M3 (#157 ✅) allowPolicyWidening
- M4 (#158 ✅) legacyTokenCompat + z.preprocess pattern
- M6 (#159 ✅) legacyRtPolicy accept-with-warning + fail-fast SF-6
- M5 (#160 ✅) getByCode → findByCode rename
- **S2 (this PR)**

After merge, `develop` is ready for the `1.0.0-rc.1` RC cut decision per the handoff (`auth/.claude/handoff/2026-05-09-v100-ga-codex-handoff.md`).

Spec: `auth/.claude/superpowers/specs/2026-05-05-sf1-jwt-verify-pinning.md`.

## Test plan

- [x] `pnpm -r run build` — green
- [x] `pnpm run lint` — pre-existing warnings/infos only
- [x] `pnpm -r run test` — all packages green, no test changes needed
  - core 1205/1205, oauth 405/405, oauth-token-exchange 106/106, session 162+1, redis 315+2, federation-google 22/22, federation-github 20/20, foundation 14/14, create-app 77/77, standalone-template 25/25
- [x] Tests that pin `legacyTypAccept=true` semantics (Test 6 + Test 7b in `core/src/jwt/__tests__/verify.test.mts`, RT-OC in `refreshToken.test.mts`) still pass — they set `legacyTypAccept: true` explicitly and continue to exercise the opt-in path
- [x] Tests that pin strict semantics (Test 5 + Test 7 in `verify.test.mts`) still pass — they set `legacyTypAccept: false` explicitly
- [x] No production caller relies on the old default — every `?? true` was updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)