### PR TITLE
chore: forward-version label sweep + adopt auth-scope release policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Security (Phase G — S2 `legacyTypAccept` default flipped `true → false`, 1.0 GA)
+### Security (Phase G — S2 `legacyTypAccept` default flipped `true → false`, v0.6.0)
 
 - **BREAKING**: `oauth.jwt.legacyTypAccept` default flipped from `true`
-  (v0.5.x) to `false` (1.0 GA). The central JWT verifier now rejects
+  (v0.5.x) to `false` (v0.6.0). The central JWT verifier now rejects
   tokens whose `typ` header is absent **by default**. Previously,
   typ-less tokens were accepted with a `jwt_verify_legacy_typ`
   deprecation warning so v0.4.x tokens (issued before the
@@ -39,7 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `packages/oauth/src/grants/refreshToken.mts`,
   `packages/oauth/src/routes/{federationToken,logout,userinfo}.mts`.
 
-### Changed (Phase G — M5 `CodeRepository.getByCode` → `findByCode` rename, 1.0 GA)
+### Changed (Phase G — M5 `CodeRepository.getByCode` → `findByCode` rename, v0.6.0)
 
 - **BREAKING**: `CodeRepository.getByCode(code)` renamed to
   `findByCode(code)`. The signature (`Promise<Code | null>`) and
@@ -51,7 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   operation-specific names like `consumeByCode` (atomic single-use) for
   non-lookup operations. `get*` idiomatically implies throw-on-missing,
   which mismatches this method's nullable return. The v0.5.2 JSDoc
-  (AS-10) flagged this for renaming at 1.0 GA.
+  (AS-10) flagged this for renaming at v0.6.0.
 - Migration: consumers implementing `CodeRepository` (custom storage
   adapters) must rename their `getByCode` method to `findByCode`. The
   in-memory adapter (`InMemoryCodeRepository`) and Redis adapter
@@ -59,7 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Affected APIs: `CodeRepository.getByCode` (removed) →
   `CodeRepository.findByCode` (added). No transitional alias.
 
-### Security (Phase G — M6 `legacyRtPolicy = "accept-with-warning"` removed, 1.0 GA)
+### Security (Phase G — M6 `legacyRtPolicy = "accept-with-warning"` removed, v0.6.0)
 
 - **BREAKING**: The `accept-with-warning` value of
   `oauth.refreshToken.legacyRtPolicy` was removed. Under SF-6, refresh
@@ -70,7 +70,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Closes a `family_id`-absent acceptance window that allowed legacy
   refresh tokens to bypass rotation entirely under operator opt-in.
 
-### Removed (Phase G — M6 `legacyRtPolicy = "accept-with-warning"` enum value, 1.0 GA)
+### Removed (Phase G — M6 `legacyRtPolicy = "accept-with-warning"` enum value, v0.6.0)
 
 - **BREAKING**: `oauth.refreshToken.legacyRtPolicy` Zod schema tightened
   from `z.enum(["reject", "accept-with-warning"])` to
@@ -92,14 +92,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `packages/oauth/src/grants/refreshToken.mts` (the legacy branch
   that emitted it is gone).
 
-### Removed (Phase G — M4 `legacyTokenCompat` migration flag, 1.0 GA)
+### Removed (Phase G — M4 `legacyTokenCompat` migration flag, v0.6.0)
 
 - **BREAKING**: Removed the `oauth.refreshToken.legacyTokenCompat` config
   flag (HOCON `application.conf` + Zod schema in `application.schema.mts`)
   and the `OAUTH_REFRESH_TOKEN_LEGACY_TOKEN_COMPAT` env-var override. The
   flag was introduced in v0.5.2 (AS-12) with default `true` to accept
   v0.4.x refresh-token shapes during the migration window. v0.5.x is now
-  out of the bounded window; 1.0 GA enforces the strict shape
+  out of the bounded window; v0.6.0 enforces the strict shape
   unconditionally.
   - Refresh-grant rejection gate now accepts **only** `header.typ ===
     "rt+jwt"` as the refresh marker. Tokens carrying the legacy
@@ -114,13 +114,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Migration: operators must ensure all in-flight refresh tokens were
     minted by v0.5.x or newer (which emit both `header.typ = "rt+jwt"`
     and a top-level `sub`) before upgrading. v0.5.2 documented this
-    migration plan in its Migration note; 1.0 GA finalizes the cutover.
+    migration plan in its Migration note; v0.6.0 finalizes the cutover.
   - Affected APIs/config (removed):
     `oauth.refreshToken.legacyTokenCompat`,
     `OAUTH_REFRESH_TOKEN_LEGACY_TOKEN_COMPAT`,
     `RefreshTokenConfig.legacyTokenCompat` (Zod schema field).
 
-### Removed (Phase G — M3 `allowPolicyWidening` migration flag, 1.0 GA)
+### Removed (Phase G — M3 `allowPolicyWidening` migration flag, v0.6.0)
 
 - **BREAKING**: Removed the `allowPolicyWidening?: boolean` field from
   `TokenExchangeDependencies` (RFC 8693 Token Exchange grant). The
@@ -137,16 +137,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     token has no usable `aud`. `client.allowedAudiences` is **not** part
     of the policy-output boundary — that allowlist is enforced earlier
     on the `audience` request parameter, not on policy outputs. There is
-    no opt-in to bypass this check at 1.0 GA.
+    no opt-in to bypass this check at v0.6.0.
   - Affected APIs:
     `TokenExchangeDependencies.allowPolicyWidening` (removed).
 
-### Removed (Phase G — M2 *Base interface aliases, 1.0 GA)
+### Removed (Phase G — M2 *Base interface aliases, v0.6.0)
 
 - **BREAKING**: Removed the `*Base` suffix from the 5 extension-point
   interfaces (closes AS-7). The canonical names without the suffix were
   added as type aliases in v0.5.1; both names coexisted with `@deprecated`
-  JSDoc on the `*Base` form. At 1.0 GA the canonical names ARE the
+  JSDoc on the `*Base` form. At v0.6.0 the canonical names ARE the
   interfaces; the `*Base` aliases are removed.
   - `AuditSinkBase` → `AuditSink`
   - `FederationTokenStoreBase` → `FederationTokenStore`
@@ -166,7 +166,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     drops the `GrantPolicyHookBase` form. `GrantPolicyHookFactory<Deps>`
     in the manifest still produces a `GrantPolicyHookContribution`.
 
-### Removed (Phase G — M1 GrantRegistry public export, 1.0 GA)
+### Removed (Phase G — M1 GrantRegistry public export, v0.6.0)
 
 - **BREAKING**: Removed `GrantRegistry` and `GrantRegistryError` from
   `@o3co/auth-provider-core`'s public exports (closes AS-8). Both were

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Security (Phase G — S2 `legacyTypAccept` default flipped `true → false`, v0.6.0)
+### Security (Phase G — S2 `legacyTypAccept` default flipped `true → false`)
 
 - **BREAKING**: `oauth.jwt.legacyTypAccept` default flipped from `true`
-  (v0.5.x) to `false` (v0.6.0). The central JWT verifier now rejects
+  (v0.5.x) to `false`. The central JWT verifier now rejects
   tokens whose `typ` header is absent **by default**. Previously,
   typ-less tokens were accepted with a `jwt_verify_legacy_typ`
   deprecation warning so v0.4.x tokens (issued before the
@@ -39,7 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `packages/oauth/src/grants/refreshToken.mts`,
   `packages/oauth/src/routes/{federationToken,logout,userinfo}.mts`.
 
-### Changed (Phase G — M5 `CodeRepository.getByCode` → `findByCode` rename, v0.6.0)
+### Changed (Phase G — M5 `CodeRepository.getByCode` → `findByCode` rename)
 
 - **BREAKING**: `CodeRepository.getByCode(code)` renamed to
   `findByCode(code)`. The signature (`Promise<Code | null>`) and
@@ -51,7 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   operation-specific names like `consumeByCode` (atomic single-use) for
   non-lookup operations. `get*` idiomatically implies throw-on-missing,
   which mismatches this method's nullable return. The v0.5.2 JSDoc
-  (AS-10) flagged this for renaming at v0.6.0.
+  (AS-10) flagged this for renaming.
 - Migration: consumers implementing `CodeRepository` (custom storage
   adapters) must rename their `getByCode` method to `findByCode`. The
   in-memory adapter (`InMemoryCodeRepository`) and Redis adapter
@@ -59,7 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Affected APIs: `CodeRepository.getByCode` (removed) →
   `CodeRepository.findByCode` (added). No transitional alias.
 
-### Security (Phase G — M6 `legacyRtPolicy = "accept-with-warning"` removed, v0.6.0)
+### Security (Phase G — M6 `legacyRtPolicy = "accept-with-warning"` removed)
 
 - **BREAKING**: The `accept-with-warning` value of
   `oauth.refreshToken.legacyRtPolicy` was removed. Under SF-6, refresh
@@ -70,7 +70,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Closes a `family_id`-absent acceptance window that allowed legacy
   refresh tokens to bypass rotation entirely under operator opt-in.
 
-### Removed (Phase G — M6 `legacyRtPolicy = "accept-with-warning"` enum value, v0.6.0)
+### Removed (Phase G — M6 `legacyRtPolicy = "accept-with-warning"` enum value)
 
 - **BREAKING**: `oauth.refreshToken.legacyRtPolicy` Zod schema tightened
   from `z.enum(["reject", "accept-with-warning"])` to
@@ -92,14 +92,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `packages/oauth/src/grants/refreshToken.mts` (the legacy branch
   that emitted it is gone).
 
-### Removed (Phase G — M4 `legacyTokenCompat` migration flag, v0.6.0)
+### Removed (Phase G — M4 `legacyTokenCompat` migration flag)
 
 - **BREAKING**: Removed the `oauth.refreshToken.legacyTokenCompat` config
   flag (HOCON `application.conf` + Zod schema in `application.schema.mts`)
   and the `OAUTH_REFRESH_TOKEN_LEGACY_TOKEN_COMPAT` env-var override. The
   flag was introduced in v0.5.2 (AS-12) with default `true` to accept
   v0.4.x refresh-token shapes during the migration window. v0.5.x is now
-  out of the bounded window; v0.6.0 enforces the strict shape
+  out of the bounded window; this release enforces the strict shape
   unconditionally.
   - Refresh-grant rejection gate now accepts **only** `header.typ ===
     "rt+jwt"` as the refresh marker. Tokens carrying the legacy
@@ -114,13 +114,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Migration: operators must ensure all in-flight refresh tokens were
     minted by v0.5.x or newer (which emit both `header.typ = "rt+jwt"`
     and a top-level `sub`) before upgrading. v0.5.2 documented this
-    migration plan in its Migration note; v0.6.0 finalizes the cutover.
+    migration plan in its Migration note; this release finalizes the cutover.
   - Affected APIs/config (removed):
     `oauth.refreshToken.legacyTokenCompat`,
     `OAUTH_REFRESH_TOKEN_LEGACY_TOKEN_COMPAT`,
     `RefreshTokenConfig.legacyTokenCompat` (Zod schema field).
 
-### Removed (Phase G — M3 `allowPolicyWidening` migration flag, v0.6.0)
+### Removed (Phase G — M3 `allowPolicyWidening` migration flag)
 
 - **BREAKING**: Removed the `allowPolicyWidening?: boolean` field from
   `TokenExchangeDependencies` (RFC 8693 Token Exchange grant). The
@@ -137,16 +137,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     token has no usable `aud`. `client.allowedAudiences` is **not** part
     of the policy-output boundary — that allowlist is enforced earlier
     on the `audience` request parameter, not on policy outputs. There is
-    no opt-in to bypass this check at v0.6.0.
+    no opt-in to bypass this check.
   - Affected APIs:
     `TokenExchangeDependencies.allowPolicyWidening` (removed).
 
-### Removed (Phase G — M2 *Base interface aliases, v0.6.0)
+### Removed (Phase G — M2 *Base interface aliases)
 
 - **BREAKING**: Removed the `*Base` suffix from the 5 extension-point
   interfaces (closes AS-7). The canonical names without the suffix were
   added as type aliases in v0.5.1; both names coexisted with `@deprecated`
-  JSDoc on the `*Base` form. At v0.6.0 the canonical names ARE the
+  JSDoc on the `*Base` form. In this release the canonical names ARE the
   interfaces; the `*Base` aliases are removed.
   - `AuditSinkBase` → `AuditSink`
   - `FederationTokenStoreBase` → `FederationTokenStore`
@@ -166,7 +166,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     drops the `GrantPolicyHookBase` form. `GrantPolicyHookFactory<Deps>`
     in the manifest still produces a `GrantPolicyHookContribution`.
 
-### Removed (Phase G — M1 GrantRegistry public export, v0.6.0)
+### Removed (Phase G — M1 GrantRegistry public export)
 
 - **BREAKING**: Removed `GrantRegistry` and `GrantRegistryError` from
   `@o3co/auth-provider-core`'s public exports (closes AS-8). Both were

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -12,11 +12,11 @@
 
 ## Why this policy exists
 
-Pre-2026-05-12, this project anchored multi-release planning on future version labels ("v0.6.0", "1.0 GA") written into specs, CHANGELOG forward-promises, JSDoc `@deprecated removed-in` annotations, PR titles, and validation error message strings. As actual release cuts diverged from plan, those labels drifted: features were rebucketed mechanically, internal memos became self-contradictory, and at least two operator-facing artifacts (v0.5.2/v0.5.3 CHANGELOGs and `removedIn` Zod validation error metadata) shipped forward-references that no longer match the actual release where the change lands.
+Pre-2026-05-12, the auth scope anchored multi-release planning on future version labels (specifically "1.0 GA") written into specs, CHANGELOG forward-promises, JSDoc `@deprecated removed-in` annotations, PR titles, and validation error message strings. As actual release cuts in `auth.provider` diverged from plan, those labels drifted: features were rebucketed mechanically, internal memos became self-contradictory, and operator-facing artifacts shipped forward-references to a release that was never cut.
 
-The "1.0 GA" planning anchor used pre-2026-05-12 has been **retired**. Removals previously labeled "1.0 GA" in v0.5.x CHANGELOGs and JSDoc land in **v0.6.0**.
+The "1.0 GA" planning anchor has been **retired**. The release that the affected changes actually land in is recorded in the relevant repo's `CHANGELOG.md` under the corresponding release section (filled in at the moment of release cut, not pre-stamped).
 
-This policy codifies how to handle release labels going forward so the same drift cannot recur silently.
+This policy codifies how to handle release labels going forward so the same drift cannot recur silently. It applies uniformly to all 4 in-scope OSS repos regardless of each repo's individual release history.
 
 ## Core rule
 
@@ -36,7 +36,7 @@ This policy codifies how to handle release labels going forward so the same drif
 | Error message strings | ✅ | ❌ (this is the worst — operator sees the lie at error time) |
 | PR title | ✅ (post-merge facts) | ❌ (do not pre-label PR with "for vX.Y") |
 | GitHub issue body | ✅ | ⚠️ (acceptable for tracking, but use milestones for the "when" — labels rot less than text) |
-| Internal planning memos (`.claude/`) | ✅ | ⚠️ (acceptable for short-lived plans, but add "labels may shift" disclaimer if doc lives >1 release cycle) |
+| Internal planning artifacts (specs, design docs, agent memos) | ✅ | ⚠️ (acceptable for short-lived plans, but add "labels may shift" disclaimer if doc lives >1 release cycle) |
 
 ## The six concrete rules (R1-R6)
 
@@ -44,24 +44,24 @@ This policy codifies how to handle release labels going forward so the same drif
 
 code / JSDoc / public docs (README, migration guide) / config comments / error message strings reference **only** released version tags.
 
-**Bad**: `@deprecated since v0.5.1, removed in 1.0` / `error: field X was removed in 1.0 GA`
-**Good**: `@deprecated since v0.5.1; see CHANGELOG for removal version` / `error: field X was removed in v0.6.0`
+**Bad**: `@deprecated since vX.Y, removed in 1.0` / `error: field foo was removed in NEXT_RELEASE`
+**Good**: `@deprecated since vX.Y; see CHANGELOG for removal version` / `error: field foo was removed in vX.Y.Z` (where `vX.Y.Z` is the released tag that performed the removal — filled in at release-cut time)
 
 ### R2. CHANGELOG uses `## [Unreleased]` until cut
 
-Follow Keep a Changelog convention. The Unreleased section accumulates entries describing what changed on HEAD. **Do not pre-stamp** "## [0.6.0]" or "## [1.0.0]" before the tag is cut. At cut time, rename `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` in a single commit that also creates the git tag.
+Follow Keep a Changelog convention. The Unreleased section accumulates entries describing what changed on HEAD. **Do not pre-stamp** specific version numbers (e.g., `## [0.6.0]`, `## [1.0.0]`, `## [0.0.4] — Unreleased`) before the tag is cut. At cut time, rename `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` in a single commit; then create the git tag pointing at that commit (the tag and the rename commit are separate git operations, but happen as one atomic release-cut step).
 
 When tagging a release, also grep for forward-version references in the Unreleased body and either rewrite to the actual version or generalize. **Specifically**: any "removed in NEXT" / "deprecated will be removed in X" / "before X" forward-promise must be resolved to the actual release where it lands.
 
 ### R3. JSDoc `@deprecated` says "since" only
 
 ```typescript
-/** @deprecated since v0.5.1 */          // ✅
-/** @deprecated since v0.5.1, removed in v1.0 */   // ❌
-/** @deprecated since v0.5.1 — see MIGRATION.md */ // ✅ alternative
+/** @deprecated since vX.Y */                    // ✅
+/** @deprecated since vX.Y, removed in v1.0 */   // ❌ (don't pre-stamp removal version)
+/** @deprecated since vX.Y — see CHANGELOG */    // ✅ alternative
 ```
 
-Removal timing belongs in CHANGELOG and MIGRATION.md, not in JSDoc. JSDoc annotations are read by IDEs to flag deprecated usage; they should warn users *that* something is deprecated, not bind us to a specific removal date.
+Removal timing belongs in CHANGELOG (and migration guides, when the repo provides one), not in JSDoc. JSDoc annotations are read by IDEs to flag deprecated usage; they should warn users *that* something is deprecated, not bind us to a specific removal date.
 
 ### R4. PR titles describe what was done, not what release
 
@@ -77,38 +77,49 @@ Milestones can be used for "when" tracking — milestones are mutable and don't 
 
 ### R5. Validation error message strings: factual, not predictive
 
-Operator-facing strings (Zod issues, error messages, structured log fields) must use **released** version names only.
+Operator-facing strings (Zod issues, error messages, structured log fields) must use **released** version names only — or omit the version entirely.
 
 ```typescript
-// ❌
+// ❌ — refers to a label that was never released
 removedIn: "1.0 GA (Phase G / M4)"
-// Error: "oauth.refreshToken.legacyTokenCompat was removed in 1.0 GA (Phase G / M4). ..."
 
-// ✅
-removedIn: "v0.6.0 (Phase G / M4)"
-// Error: "oauth.refreshToken.legacyTokenCompat was removed in v0.6.0 (Phase G / M4). ..."
+// ❌ — pre-stamps a version that hasn't been cut yet
+removedIn: "vX.Y.Z (Phase G / M4)"   // when vX.Y.Z is still pending
+
+// ✅ — neutral wording, no forward reference
+removedIn: "this release (Phase G / M4)"
+// or omit the version entirely:
+removedIn: "(Phase G / M4)"
+
+// ✅ — released tag, post-cut (R6 audit at cut time fills this in)
+removedIn: "vA.B.C (Phase G / M4)"   // where vA.B.C is the tag that landed this removal
 ```
 
-If a removal is announced in advance (deprecated now, will be removed later), the error path during the deprecated window emits a *deprecation warning* (not yet an error), and the removed-in version is filled in **at the release that actually removes it**. Do not pre-stamp the removed-in string before that release is cut.
+If a removal is announced in advance (deprecated now, will be removed later), the error path during the deprecated window emits a *deprecation warning* (not yet an error). The removed-in version is filled in **at the release-cut PR that actually performs the removal** (per R6, step 5), not at the sweep/refactor PR before it. Operators running the release that contains the removal naturally know their own version; the "in version X" context inside the error message is optional and can be omitted to avoid pre-stamping pressure.
 
 ### R6. Release-cut audit pass (mandatory checklist before tagging)
 
 Before tagging a release `vX.Y.Z`:
 
-1. `git grep -i -E "(removed|deprecated|planned).*(1\.0 GA|next major|in v[0-9]+\.[0-9]+)"` — review every match and resolve
-2. Replace `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` in CHANGELOG
-3. In CHANGELOG Unreleased body: replace any forward-version reference (e.g., "removed in 1.0 GA") with the actual release name (`vX.Y.Z`)
-4. JSDoc / code comments / config comments: replace forward-version references with `vX.Y.Z` or genericize
-5. Schema metadata strings (Zod `removedIn`, etc.): replace forward-version references with `vX.Y.Z`
-6. PR title for the release-cut PR uses "release: vX.Y.Z" (no Phase / GA labels)
-7. Release notes (gh release create body) include a brief retirement note if any pre-existing label was retired in this cut
+1. `git grep -i -E "(removed|deprecated|planned).*(1\.0 GA|next major|next release|in v[0-9]+\.[0-9]+)"` — review every match and resolve
+2. Replace `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` in CHANGELOG (where `X.Y.Z` is the tag being cut)
+3. In CHANGELOG body (now the named release section): replace any forward-version reference (e.g., "removed in 1.0 GA", "this release", "next release") with the actual release name `X.Y.Z`
+4. JSDoc / code comments / config comments: replace forward-version references with `X.Y.Z` or remove the version mention entirely
+5. Schema metadata strings (Zod `removedIn`, etc.): replace neutral / forward-version values with `X.Y.Z` so operator error messages name the release that actually removed the field
+6. PR title for the release-cut PR uses "release: vX.Y.Z" (no Phase / GA / "next-release" labels)
+7. Release notes (`gh release create` body) include a brief retirement note if any pre-existing label was retired in this cut
 
 ## "1.0 GA" label retirement (2026-05-12)
 
 Prior to 2026-05-12, the auth scope's planning artifacts anchored multi-release commitments on the label "1.0 GA". That label was retired because bookkeeping drift made it internally contradictory and silently dropped originally-committed features.
 
-Removals, renames, and default flips previously labeled "1.0 GA" in v0.5.x CHANGELOGs, JSDoc, configuration comments, schema-validation error metadata, and PR titles land in the **v0.6.0** release of the affected package(s). The specific list of changes that were re-labeled (with corresponding PR references) is recorded in each affected repo's `CHANGELOG.md` under the v0.6.0 entry. Consumers who installed v0.5.2 or v0.5.3 from npm and read CHANGELOG entries promising "will be removed at 1.0 GA" should expect those removals in v0.6.0; there is no separate "1.0 GA" release.
+Impact varies by repo:
 
-The next major version (whether labeled `0.7.0`, `1.0.0`, or otherwise) will be decided through a feature inventory process after v0.6.0 cut, not anchored on the retired "1.0 GA" framing.
+- `auth.provider` had substantive drift — CHANGELOG entries in tagged v0.5.x releases promising "will be removed at 1.0 GA", operator-facing schema error metadata referencing the same label, and JSDoc/code comments scattered throughout the source tree. The cleanup and the actual landing release are recorded in `auth.provider`'s own `CHANGELOG.md`, with the version filled in at release-cut time per R6.
+- `auth.utils`, `auth.proxy`, `auth.policy-verifier` had no forward-version drift in source code. They adopt this policy going forward; the historical narrative above describes the scope-wide reason it exists.
+
+Consumers who installed `auth.provider` v0.5.2 or v0.5.3 from npm and read CHANGELOG entries promising "will be removed at 1.0 GA" should consult the current `CHANGELOG.md` on `develop` (or the latest released tag) for the actual release that performed those removals — there is no separate "1.0 GA" release.
+
+The next major version (whether labeled `0.7.0`, `1.0.0`, or otherwise, for any of the in-scope repos) will be decided through a feature inventory process, not anchored on the retired "1.0 GA" framing.
 
 Merged PR titles in git history that contain "(1.0 GA)" labels are retained as historical artifacts; they cannot be rewritten without rewriting shared git history.

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -1,0 +1,114 @@
+# Release Labeling Policy
+
+**Scope (4 OSS repos)**: `auth.utils` / `auth.provider` / `auth.policy-verifier` / `auth.proxy`. These four share the auth-scope release cadence and migration story; this policy applies uniformly to all four.
+
+**Out of scope**:
+
+- `protobuf.interceptors` — Go-based, separate release cadence and ecosystem (Go semver convention differs)
+- `ts.hocon` / `go.hocon` / `rs.hocon` — HOCON library implementations; their release cadence is independent
+- Private composition roots and archived repositories are not subject to this policy
+
+---
+
+## Why this policy exists
+
+Pre-2026-05-12, this project anchored multi-release planning on future version labels ("v0.6.0", "1.0 GA") written into specs, CHANGELOG forward-promises, JSDoc `@deprecated removed-in` annotations, PR titles, and validation error message strings. As actual release cuts diverged from plan, those labels drifted: features were rebucketed mechanically, internal memos became self-contradictory, and at least two operator-facing artifacts (v0.5.2/v0.5.3 CHANGELOGs and `removedIn` Zod validation error metadata) shipped forward-references that no longer match the actual release where the change lands.
+
+The "1.0 GA" planning anchor used pre-2026-05-12 has been **retired**. Removals previously labeled "1.0 GA" in v0.5.x CHANGELOGs and JSDoc land in **v0.6.0**.
+
+This policy codifies how to handle release labels going forward so the same drift cannot recur silently.
+
+## Core rule
+
+**Past version numbers are facts. Future version numbers are predictions. Treat them differently.**
+
+| Where | Past version OK? | Future version OK? |
+| --- | --- | --- |
+| Tagged release notes / CHANGELOG section heading | ✅ (the version itself) | ❌ |
+| CHANGELOG entry body, current release | ✅ (cross-reference past releases) | ❌ |
+| CHANGELOG `## [Unreleased]` body | ✅ (cross-reference past releases) | ❌ (do NOT write "removed in vX.Y" predictions) |
+| JSDoc `@deprecated since` | ✅ | — |
+| JSDoc `@deprecated removed-in` | ❌ (do not predict) | ❌ |
+| Code comments (line or block) | ✅ (cross-reference past) | ❌ |
+| HOCON / YAML config comments | ✅ | ❌ |
+| README forward statements | ✅ (history) | ⚠️ (only with "subject to change", and never specific version numbers) |
+| Migration guide forward statements | ✅ | ⚠️ (use "next major" / "future release", not specific version) |
+| Error message strings | ✅ | ❌ (this is the worst — operator sees the lie at error time) |
+| PR title | ✅ (post-merge facts) | ❌ (do not pre-label PR with "for vX.Y") |
+| GitHub issue body | ✅ | ⚠️ (acceptable for tracking, but use milestones for the "when" — labels rot less than text) |
+| Internal planning memos (`.claude/`) | ✅ | ⚠️ (acceptable for short-lived plans, but add "labels may shift" disclaimer if doc lives >1 release cycle) |
+
+## The six concrete rules (R1-R6)
+
+### R1. Past-only rule (code + public docs)
+
+code / JSDoc / public docs (README, migration guide) / config comments / error message strings reference **only** released version tags.
+
+**Bad**: `@deprecated since v0.5.1, removed in 1.0` / `error: field X was removed in 1.0 GA`
+**Good**: `@deprecated since v0.5.1; see CHANGELOG for removal version` / `error: field X was removed in v0.6.0`
+
+### R2. CHANGELOG uses `## [Unreleased]` until cut
+
+Follow Keep a Changelog convention. The Unreleased section accumulates entries describing what changed on HEAD. **Do not pre-stamp** "## [0.6.0]" or "## [1.0.0]" before the tag is cut. At cut time, rename `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` in a single commit that also creates the git tag.
+
+When tagging a release, also grep for forward-version references in the Unreleased body and either rewrite to the actual version or generalize. **Specifically**: any "removed in NEXT" / "deprecated will be removed in X" / "before X" forward-promise must be resolved to the actual release where it lands.
+
+### R3. JSDoc `@deprecated` says "since" only
+
+```typescript
+/** @deprecated since v0.5.1 */          // ✅
+/** @deprecated since v0.5.1, removed in v1.0 */   // ❌
+/** @deprecated since v0.5.1 — see MIGRATION.md */ // ✅ alternative
+```
+
+Removal timing belongs in CHANGELOG and MIGRATION.md, not in JSDoc. JSDoc annotations are read by IDEs to flag deprecated usage; they should warn users *that* something is deprecated, not bind us to a specific removal date.
+
+### R4. PR titles describe what was done, not what release
+
+```text
+feat(oauth): rename CodeRepository.getByCode → findByCode    // ✅
+feat(oauth)!: rename CodeRepository.getByCode → findByCode   // ✅ (semver-major signal)
+M5 (1.0 GA): rename CodeRepository.getByCode → findByCode    // ❌ (label drift)
+```
+
+The PR's eventual release is determined by which tag includes the merge commit. The PR title should not predict.
+
+Milestones can be used for "when" tracking — milestones are mutable and don't end up in git history.
+
+### R5. Validation error message strings: factual, not predictive
+
+Operator-facing strings (Zod issues, error messages, structured log fields) must use **released** version names only.
+
+```typescript
+// ❌
+removedIn: "1.0 GA (Phase G / M4)"
+// Error: "oauth.refreshToken.legacyTokenCompat was removed in 1.0 GA (Phase G / M4). ..."
+
+// ✅
+removedIn: "v0.6.0 (Phase G / M4)"
+// Error: "oauth.refreshToken.legacyTokenCompat was removed in v0.6.0 (Phase G / M4). ..."
+```
+
+If a removal is announced in advance (deprecated now, will be removed later), the error path during the deprecated window emits a *deprecation warning* (not yet an error), and the removed-in version is filled in **at the release that actually removes it**. Do not pre-stamp the removed-in string before that release is cut.
+
+### R6. Release-cut audit pass (mandatory checklist before tagging)
+
+Before tagging a release `vX.Y.Z`:
+
+1. `git grep -i -E "(removed|deprecated|planned).*(1\.0 GA|next major|in v[0-9]+\.[0-9]+)"` — review every match and resolve
+2. Replace `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` in CHANGELOG
+3. In CHANGELOG Unreleased body: replace any forward-version reference (e.g., "removed in 1.0 GA") with the actual release name (`vX.Y.Z`)
+4. JSDoc / code comments / config comments: replace forward-version references with `vX.Y.Z` or genericize
+5. Schema metadata strings (Zod `removedIn`, etc.): replace forward-version references with `vX.Y.Z`
+6. PR title for the release-cut PR uses "release: vX.Y.Z" (no Phase / GA labels)
+7. Release notes (gh release create body) include a brief retirement note if any pre-existing label was retired in this cut
+
+## "1.0 GA" label retirement (2026-05-12)
+
+Prior to 2026-05-12, the auth scope's planning artifacts anchored multi-release commitments on the label "1.0 GA". That label was retired because bookkeeping drift made it internally contradictory and silently dropped originally-committed features.
+
+Removals, renames, and default flips previously labeled "1.0 GA" in v0.5.x CHANGELOGs, JSDoc, configuration comments, schema-validation error metadata, and PR titles land in the **v0.6.0** release of the affected package(s). The specific list of changes that were re-labeled (with corresponding PR references) is recorded in each affected repo's `CHANGELOG.md` under the v0.6.0 entry. Consumers who installed v0.5.2 or v0.5.3 from npm and read CHANGELOG entries promising "will be removed at 1.0 GA" should expect those removals in v0.6.0; there is no separate "1.0 GA" release.
+
+The next major version (whether labeled `0.7.0`, `1.0.0`, or otherwise) will be decided through a feature inventory process after v0.6.0 cut, not anchored on the retired "1.0 GA" framing.
+
+Merged PR titles in git history that contain "(1.0 GA)" labels are retained as historical artifacts; they cannot be rewritten without rewriting shared git history.

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -110,7 +110,7 @@ interface GrantModule {
 
 コンシューマコードはレジストリクラスを import / 実体化する必要はありません。グラントハンドラーのクリーンアップは `createApp` が返す `handle.dispose()` に統合されており、`AppHandle.dispose()` は A2-β §8.1 に従い、コンポーネント単位の `lifecycle[K].cleanup` コールバックを reverse-topological 順で実行します。
 
-> **v0.6.0 で削除**: `GrantRegistry` / `GrantRegistryError` クラス（v0.5.1 で AS-8 に基づき public re-export として deprecated 済み）は `@o3co/auth-provider-core` から export されなくなりました。クラスは boot planner の internal 実装として残っています。v0.4.x の `new GrantRegistry()` パターンを使っていたコンシューマは、モジュールの `contributes.grants` 宣言に移行してください。
+> **削除済み**: `GrantRegistry` / `GrantRegistryError` クラス（v0.5.1 で AS-8 に基づき public re-export として deprecated 済み）は `@o3co/auth-provider-core` から export されなくなりました。クラスは boot planner の internal 実装として残っています。v0.4.x の `new GrantRegistry()` パターンを使っていたコンシューマは、モジュールの `contributes.grants` 宣言に移行してください。削除を行ったリリースは CHANGELOG を参照。
 
 ### トークンユーティリティ
 

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -110,7 +110,7 @@ interface GrantModule {
 
 コンシューマコードはレジストリクラスを import / 実体化する必要はありません。グラントハンドラーのクリーンアップは `createApp` が返す `handle.dispose()` に統合されており、`AppHandle.dispose()` は A2-β §8.1 に従い、コンポーネント単位の `lifecycle[K].cleanup` コールバックを reverse-topological 順で実行します。
 
-> **1.0 GA で削除**: `GrantRegistry` / `GrantRegistryError` クラス（v0.5.1 で AS-8 に基づき public re-export として deprecated 済み）は `@o3co/auth-provider-core` から export されなくなりました。クラスは boot planner の internal 実装として残っています。v0.4.x の `new GrantRegistry()` パターンを使っていたコンシューマは、モジュールの `contributes.grants` 宣言に移行してください。
+> **v0.6.0 で削除**: `GrantRegistry` / `GrantRegistryError` クラス（v0.5.1 で AS-8 に基づき public re-export として deprecated 済み）は `@o3co/auth-provider-core` から export されなくなりました。クラスは boot planner の internal 実装として残っています。v0.4.x の `new GrantRegistry()` パターンを使っていたコンシューマは、モジュールの `contributes.grants` 宣言に移行してください。
 
 ### トークンユーティリティ
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -110,7 +110,7 @@ Grant handlers are wired into the boot planner via `contributes.grants` on a mod
 
 Consumer code does NOT need to import or instantiate any registry class. Cleanup of grant handlers runs through the unified `handle.dispose()` returned by `createApp` — `AppHandle.dispose()` runs per-component `lifecycle[K].cleanup` callbacks in reverse-topological order per A2-β §8.1.
 
-> **Removed at 1.0 GA**: the `GrantRegistry` and `GrantRegistryError` classes (deprecated as public re-exports in v0.5.1 per AS-8) are no longer exported from `@o3co/auth-provider-core`. They remain as internal implementation detail of the boot planner. Existing consumers of the v0.4.x `new GrantRegistry()` pattern should migrate to module-based `contributes.grants` declarations.
+> **Removed at v0.6.0**: the `GrantRegistry` and `GrantRegistryError` classes (deprecated as public re-exports in v0.5.1 per AS-8) are no longer exported from `@o3co/auth-provider-core`. They remain as internal implementation detail of the boot planner. Existing consumers of the v0.4.x `new GrantRegistry()` pattern should migrate to module-based `contributes.grants` declarations.
 
 ### Token Utilities
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -110,7 +110,7 @@ Grant handlers are wired into the boot planner via `contributes.grants` on a mod
 
 Consumer code does NOT need to import or instantiate any registry class. Cleanup of grant handlers runs through the unified `handle.dispose()` returned by `createApp` — `AppHandle.dispose()` runs per-component `lifecycle[K].cleanup` callbacks in reverse-topological order per A2-β §8.1.
 
-> **Removed at v0.6.0**: the `GrantRegistry` and `GrantRegistryError` classes (deprecated as public re-exports in v0.5.1 per AS-8) are no longer exported from `@o3co/auth-provider-core`. They remain as internal implementation detail of the boot planner. Existing consumers of the v0.4.x `new GrantRegistry()` pattern should migrate to module-based `contributes.grants` declarations.
+> **Removed**: the `GrantRegistry` and `GrantRegistryError` classes (deprecated as public re-exports in v0.5.1 per AS-8) are no longer exported from `@o3co/auth-provider-core`. They remain as internal implementation detail of the boot planner. Existing consumers of the v0.4.x `new GrantRegistry()` pattern should migrate to module-based `contributes.grants` declarations. See CHANGELOG for the release that performed this removal.
 
 ### Token Utilities
 

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -8,11 +8,11 @@ http {
 oauth {
   jwt {
     issuer = ${?OAUTH_JWT_ISSUER}
-    # SF-1 / v0.6.0 (Phase G / S2): the central JWT verifier rejects
+    # SF-1 / Phase G / S2: the central JWT verifier rejects
     # tokens whose `typ` header is absent. The previous v0.5.x default
     # accepted typ-less tokens (with a `jwt_verify_legacy_typ` warning)
-    # to keep v0.4.x tokens verifying through the migration window; at
-    # v0.6.0 that window is closed by default. Operators with v0.4.x
+    # to keep v0.4.x tokens verifying through the migration window;
+    # this release closes that window by default. Operators with v0.4.x
     # tokens still in circulation can opt back via
     # `OAUTH_JWT_LEGACY_TYP_ACCEPT=true` for their own bounded migration
     # window, but the safe default is now `false` (reject typ-less tokens
@@ -58,11 +58,11 @@ oauth {
     # tokens are still in circulation).
     unknownFamilyPolicy = "reject"
     unknownFamilyPolicy = ${?OAUTH_REFRESH_TOKEN_UNKNOWN_FAMILY_POLICY}
-    # SF-6 / v0.6.0 (Phase G / M6): refresh tokens lacking jti or
+    # SF-6 / Phase G / M6: refresh tokens lacking jti or
     # family_id claims when family rotation is wired are always rejected.
-    # The `"accept-with-warning"` migration-window value was removed at
-    # v0.6.0 along with the env-var override — there is no longer an
-    # opt-in to bypass replay detection.
+    # The `"accept-with-warning"` migration-window value was removed in
+    # this release along with the env-var override — there is no longer
+    # an opt-in to bypass replay detection.
     legacyRtPolicy = "reject"
   }
   grants {

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -8,11 +8,11 @@ http {
 oauth {
   jwt {
     issuer = ${?OAUTH_JWT_ISSUER}
-    # SF-1 / 1.0 GA (Phase G / S2): the central JWT verifier rejects
+    # SF-1 / v0.6.0 (Phase G / S2): the central JWT verifier rejects
     # tokens whose `typ` header is absent. The previous v0.5.x default
     # accepted typ-less tokens (with a `jwt_verify_legacy_typ` warning)
     # to keep v0.4.x tokens verifying through the migration window; at
-    # 1.0 GA that window is closed by default. Operators with v0.4.x
+    # v0.6.0 that window is closed by default. Operators with v0.4.x
     # tokens still in circulation can opt back via
     # `OAUTH_JWT_LEGACY_TYP_ACCEPT=true` for their own bounded migration
     # window, but the safe default is now `false` (reject typ-less tokens
@@ -58,10 +58,10 @@ oauth {
     # tokens are still in circulation).
     unknownFamilyPolicy = "reject"
     unknownFamilyPolicy = ${?OAUTH_REFRESH_TOKEN_UNKNOWN_FAMILY_POLICY}
-    # SF-6 / 1.0 GA (Phase G / M6): refresh tokens lacking jti or
+    # SF-6 / v0.6.0 (Phase G / M6): refresh tokens lacking jti or
     # family_id claims when family rotation is wired are always rejected.
     # The `"accept-with-warning"` migration-window value was removed at
-    # 1.0 GA along with the env-var override — there is no longer an
+    # v0.6.0 along with the env-var override — there is no longer an
     # opt-in to bypass replay detection.
     legacyRtPolicy = "reject"
   }

--- a/packages/core/src/config/__tests__/refresh-token-schema.test.mts
+++ b/packages/core/src/config/__tests__/refresh-token-schema.test.mts
@@ -60,7 +60,8 @@ describe("oauth.refreshToken schema — removed-field preprocess (Phase G / M4)"
 		expect(result.success).toBe(false);
 		if (result.success) return;
 		const issue = result.error.issues.find((i) => i.message.includes("legacyTokenCompat"));
-		expect(issue?.message).toMatch(/v0\.6\.0/);
+		expect(issue?.message).toMatch(/has been removed/);
+		expect(issue?.message).toMatch(/Phase G \/ M4/);
 		expect(issue?.message).toMatch(/v0\.5\.x or newer/);
 	});
 });
@@ -76,7 +77,7 @@ describe("oauth.refreshToken schema — legacyRtPolicy enum tightening (Phase G 
 		expect(result.success).toBe(true);
 	});
 
-	it("rejects legacyRtPolicy='accept-with-warning' (removed at v0.6.0)", () => {
+	it("rejects legacyRtPolicy='accept-with-warning' (removed)", () => {
 		const result = refreshTokenSchema.safeParse({
 			...validBase,
 			legacyRtPolicy: "accept-with-warning",

--- a/packages/core/src/config/__tests__/refresh-token-schema.test.mts
+++ b/packages/core/src/config/__tests__/refresh-token-schema.test.mts
@@ -60,7 +60,7 @@ describe("oauth.refreshToken schema — removed-field preprocess (Phase G / M4)"
 		expect(result.success).toBe(false);
 		if (result.success) return;
 		const issue = result.error.issues.find((i) => i.message.includes("legacyTokenCompat"));
-		expect(issue?.message).toMatch(/1\.0 GA/);
+		expect(issue?.message).toMatch(/v0\.6\.0/);
 		expect(issue?.message).toMatch(/v0\.5\.x or newer/);
 	});
 });
@@ -76,7 +76,7 @@ describe("oauth.refreshToken schema — legacyRtPolicy enum tightening (Phase G 
 		expect(result.success).toBe(true);
 	});
 
-	it("rejects legacyRtPolicy='accept-with-warning' (removed at 1.0 GA)", () => {
+	it("rejects legacyRtPolicy='accept-with-warning' (removed at v0.6.0)", () => {
 		const result = refreshTokenSchema.safeParse({
 			...validBase,
 			legacyRtPolicy: "accept-with-warning",

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -115,7 +115,7 @@ const LEGACY_JWT_FIELDS = [
 ] as const;
 
 /**
- * Fields removed from `oauth.refreshToken` at 1.0 GA. Detected on the raw
+ * Fields removed from `oauth.refreshToken` at v0.6.0. Detected on the raw
  * input by the preprocess wrapper below so that operators upgrading from
  * v0.5.x get a targeted error instead of having their flag silently
  * stripped by Zod's default `unknown-key strip` behavior.
@@ -127,7 +127,7 @@ const REMOVED_REFRESH_TOKEN_FIELDS: ReadonlyArray<{
 }> = [
 	{
 		name: "legacyTokenCompat",
-		removedIn: "1.0 GA (Phase G / M4)",
+		removedIn: "v0.6.0 (Phase G / M4)",
 		note:
 			"v0.4.x refresh-token shape compat (payload.type, claims.user.id fallback) is no " +
 			"longer accepted. Ensure all in-flight refresh tokens were minted by v0.5.x or newer " +
@@ -180,10 +180,10 @@ const refreshTokenSchemaBase = z.object({
 	// windows. Per the v0.5.1 ADR the literal default lives in
 	// `application.conf`, not here.
 	unknownFamilyPolicy: z.enum(["accept", "reject"]),
-	// SF-6 (v0.5.1) / 1.0 GA (Phase G / M6): policy for refresh tokens
+	// SF-6 (v0.5.1) / v0.6.0 (Phase G / M6): policy for refresh tokens
 	// lacking `jti` or `family_id` claims when family rotation is wired.
 	// The `"accept-with-warning"` migration-window value was removed at
-	// 1.0 GA; only `"reject"` remains. Operators upgrading from v0.5.x
+	// v0.6.0; only `"reject"` remains. Operators upgrading from v0.5.x
 	// who still set `accept-with-warning` get a Zod
 	// `invalid_enum_value` error pointing at this field.
 	legacyRtPolicy: z.enum(["reject"]),

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -115,10 +115,17 @@ const LEGACY_JWT_FIELDS = [
 ] as const;
 
 /**
- * Fields removed from `oauth.refreshToken` at v0.6.0. Detected on the raw
- * input by the preprocess wrapper below so that operators upgrading from
- * v0.5.x get a targeted error instead of having their flag silently
- * stripped by Zod's default `unknown-key strip` behavior.
+ * Fields removed from `oauth.refreshToken`. Detected on the raw input by the
+ * preprocess wrapper below so that operators upgrading from v0.5.x get a
+ * targeted error instead of having their flag silently stripped by Zod's
+ * default `unknown-key strip` behavior.
+ *
+ * The `removedIn` field carries the internal marker (e.g., `Phase G / M4`) so
+ * the error message can point operators at the corresponding CHANGELOG entry.
+ * Per docs/release-policy.md R5, the value MUST NOT pre-stamp a release tag
+ * before that release is cut. At each release cut, R6 step 5 fills the
+ * released tag into this field for entries that landed in the cut release;
+ * before that, the marker alone is sufficient.
  */
 const REMOVED_REFRESH_TOKEN_FIELDS: ReadonlyArray<{
 	name: string;
@@ -127,7 +134,7 @@ const REMOVED_REFRESH_TOKEN_FIELDS: ReadonlyArray<{
 }> = [
 	{
 		name: "legacyTokenCompat",
-		removedIn: "v0.6.0 (Phase G / M4)",
+		removedIn: "Phase G / M4",
 		note:
 			"v0.4.x refresh-token shape compat (payload.type, claims.user.id fallback) is no " +
 			"longer accepted. Ensure all in-flight refresh tokens were minted by v0.5.x or newer " +
@@ -180,10 +187,10 @@ const refreshTokenSchemaBase = z.object({
 	// windows. Per the v0.5.1 ADR the literal default lives in
 	// `application.conf`, not here.
 	unknownFamilyPolicy: z.enum(["accept", "reject"]),
-	// SF-6 (v0.5.1) / v0.6.0 (Phase G / M6): policy for refresh tokens
-	// lacking `jti` or `family_id` claims when family rotation is wired.
-	// The `"accept-with-warning"` migration-window value was removed at
-	// v0.6.0; only `"reject"` remains. Operators upgrading from v0.5.x
+	// SF-6 (v0.5.1) / Phase G / M6: policy for refresh tokens lacking
+	// `jti` or `family_id` claims when family rotation is wired. The
+	// `"accept-with-warning"` migration-window value was removed in this
+	// release; only `"reject"` remains. Operators upgrading from v0.5.x
 	// who still set `accept-with-warning` get a Zod
 	// `invalid_enum_value` error pointing at this field.
 	legacyRtPolicy: z.enum(["reject"]),
@@ -204,7 +211,7 @@ const refreshTokenSchema = z.preprocess((raw, ctx) => {
 				ctx.addIssue({
 					code: z.ZodIssueCode.custom,
 					message:
-						`oauth.refreshToken.${removed.name} was removed in ${removed.removedIn}. ` +
+						`oauth.refreshToken.${removed.name} has been removed (${removed.removedIn}; see CHANGELOG). ` +
 						`${removed.note} Remove this field from your config.`,
 					path: [removed.name],
 				});

--- a/packages/core/src/grants/registry.mts
+++ b/packages/core/src/grants/registry.mts
@@ -65,9 +65,9 @@ export class GrantRegistryError extends Error {
  * declarations. Phase 9 (A2-γ caller migration) internalises the registry
  * and removes it from the public API. Phase 3 establishes the contract.
  *
- * Public-export removal status (AS-8, 1.0 GA): the public re-export of
+ * Public-export removal status (AS-8, v0.6.0): the public re-export of
  * `GrantRegistry` / `GrantRegistryError` from `@o3co/auth-provider-core`
- * was removed at 1.0 GA per A2-γ §3.3. Both classes remain as internal
+ * was removed at v0.6.0 per A2-γ §3.3. Both classes remain as internal
  * implementation detail of the boot planner; external consumers wire
  * grants through module-based `contributes.grants` declarations.
  *

--- a/packages/core/src/grants/registry.mts
+++ b/packages/core/src/grants/registry.mts
@@ -65,9 +65,9 @@ export class GrantRegistryError extends Error {
  * declarations. Phase 9 (A2-γ caller migration) internalises the registry
  * and removes it from the public API. Phase 3 establishes the contract.
  *
- * Public-export removal status (AS-8, v0.6.0): the public re-export of
+ * Public-export removal status (AS-8): the public re-export of
  * `GrantRegistry` / `GrantRegistryError` from `@o3co/auth-provider-core`
- * was removed at v0.6.0 per A2-γ §3.3. Both classes remain as internal
+ * was removed per A2-γ §3.3. Both classes remain as internal
  * implementation detail of the boot planner; external consumers wire
  * grants through module-based `contributes.grants` declarations.
  *

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -116,7 +116,7 @@ export {
 // Grant types and interfaces.
 //
 // `GrantRegistry` and `GrantRegistryError` (deprecated public re-exports
-// in v0.5.1 per AS-8) were removed at 1.0 GA per A2-γ §3.3. The classes
+// in v0.5.1 per AS-8) were removed at v0.6.0 per A2-γ §3.3. The classes
 // remain as internal implementation detail of the boot planner; consumer
 // code wires grants via module-based `contributes.grants` declarations
 // instead.

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -116,7 +116,7 @@ export {
 // Grant types and interfaces.
 //
 // `GrantRegistry` and `GrantRegistryError` (deprecated public re-exports
-// in v0.5.1 per AS-8) were removed at v0.6.0 per A2-γ §3.3. The classes
+// in v0.5.1 per AS-8) were removed per A2-γ §3.3. The classes
 // remain as internal implementation detail of the boot planner; consumer
 // code wires grants via module-based `contributes.grants` declarations
 // instead.

--- a/packages/core/src/jwt/verify.mts
+++ b/packages/core/src/jwt/verify.mts
@@ -127,12 +127,11 @@ export interface JwtVerifyOptions {
 	/**
 	 * SF-1 transition flag for the v0.4.x→v0.5.x typ-header rollout.
 	 *
-	 * The v0.6.0 default is `false`: tokens whose `typ` header is absent
-	 * are rejected. Operators with v0.4.x tokens still in circulation can
-	 * set this to `true` for their own bounded migration window — when
-	 * true, typ-less tokens are accepted and emit a
-	 * `jwt_verify_legacy_typ` warning. The v0.5.x default was `true`;
-	 * v0.6.0 flips it as part of Phase G S2.
+	 * The default is `false`: tokens whose `typ` header is absent are
+	 * rejected. Operators with v0.4.x tokens still in circulation can set
+	 * this to `true` for their own bounded migration window — when true,
+	 * typ-less tokens are accepted and emit a `jwt_verify_legacy_typ`
+	 * warning. The v0.5.x default was `true`; Phase G S2 flips it.
 	 */
 	readonly legacyTypAccept?: boolean;
 }

--- a/packages/core/src/jwt/verify.mts
+++ b/packages/core/src/jwt/verify.mts
@@ -127,12 +127,12 @@ export interface JwtVerifyOptions {
 	/**
 	 * SF-1 transition flag for the v0.4.x→v0.5.x typ-header rollout.
 	 *
-	 * The 1.0 GA default is `false`: tokens whose `typ` header is absent
+	 * The v0.6.0 default is `false`: tokens whose `typ` header is absent
 	 * are rejected. Operators with v0.4.x tokens still in circulation can
 	 * set this to `true` for their own bounded migration window — when
 	 * true, typ-less tokens are accepted and emit a
 	 * `jwt_verify_legacy_typ` warning. The v0.5.x default was `true`;
-	 * 1.0 GA flips it as part of Phase G S2.
+	 * v0.6.0 flips it as part of Phase G S2.
 	 */
 	readonly legacyTypAccept?: boolean;
 }

--- a/packages/core/src/modules/manifest/contributes-map.mts
+++ b/packages/core/src/modules/manifest/contributes-map.mts
@@ -40,7 +40,7 @@ import type { RouteContributionEntry } from "./route-contribution.mjs";
 //   ExchangeTokenValidator      — packages/oauth-token-exchange/src/validator/types.mts (Phase F deferred — circular import)
 //
 // Canonical (no-suffix) interface names are used for the substitution
-// RHS. The v0.5.1-era `*Base` deprecation aliases were removed at v0.6.0
+// RHS. The v0.5.1-era `*Base` deprecation aliases were removed
 // (M2); references on this site are to the interfaces themselves.
 
 /**

--- a/packages/core/src/modules/manifest/contributes-map.mts
+++ b/packages/core/src/modules/manifest/contributes-map.mts
@@ -40,7 +40,7 @@ import type { RouteContributionEntry } from "./route-contribution.mjs";
 //   ExchangeTokenValidator      — packages/oauth-token-exchange/src/validator/types.mts (Phase F deferred — circular import)
 //
 // Canonical (no-suffix) interface names are used for the substitution
-// RHS. The v0.5.1-era `*Base` deprecation aliases were removed at 1.0 GA
+// RHS. The v0.5.1-era `*Base` deprecation aliases were removed at v0.6.0
 // (M2); references on this site are to the interfaces themselves.
 
 /**

--- a/packages/core/src/policy/types.mts
+++ b/packages/core/src/policy/types.mts
@@ -56,7 +56,7 @@ export type GrantPolicyDecision =
  * AS-7 collision resolution renamed that placeholder to
  * `GrantPolicyHookContribution`, freeing this name for the canonical
  * interface; the `*Base` deprecation alias previously exposed alongside
- * was removed at 1.0 GA.
+ * was removed at v0.6.0.
  */
 export interface GrantPolicyHook {
 	readonly kind: string;

--- a/packages/core/src/policy/types.mts
+++ b/packages/core/src/policy/types.mts
@@ -56,7 +56,7 @@ export type GrantPolicyDecision =
  * AS-7 collision resolution renamed that placeholder to
  * `GrantPolicyHookContribution`, freeing this name for the canonical
  * interface; the `*Base` deprecation alias previously exposed alongside
- * was removed at v0.6.0.
+ * was removed.
  */
 export interface GrantPolicyHook {
 	readonly kind: string;

--- a/packages/core/src/repositories/ClientRepository.mts
+++ b/packages/core/src/repositories/ClientRepository.mts
@@ -31,8 +31,10 @@ export interface ClientRepository {
 	 * a public projection without authentication. Single-object stores
 	 * (e.g. `UserSessionStore`) use `get(<id>)` instead. Operation-specific
 	 * names like `consumeByCode` denote atomic single-use semantics; they
-	 * are NOT subject to the `findBy` convention. The convention will be
-	 * enforced at v0.6.0 via a documented contributor guide and lint rule.
+	 * are NOT subject to the `findBy` convention. The convention is
+	 * currently enforced by code review on PRs that add or rename
+	 * repository methods; a lint rule and contributor-guide section may
+	 * follow once the convention has settled across all repositories.
 	 */
 	findById(clientId: string): Promise<PublicClient | null>;
 	/**

--- a/packages/core/src/repositories/ClientRepository.mts
+++ b/packages/core/src/repositories/ClientRepository.mts
@@ -32,7 +32,7 @@ export interface ClientRepository {
 	 * (e.g. `UserSessionStore`) use `get(<id>)` instead. Operation-specific
 	 * names like `consumeByCode` denote atomic single-use semantics; they
 	 * are NOT subject to the `findBy` convention. The convention will be
-	 * enforced at 1.0 GA via a documented contributor guide and lint rule.
+	 * enforced at v0.6.0 via a documented contributor guide and lint rule.
 	 */
 	findById(clientId: string): Promise<PublicClient | null>;
 	/**

--- a/packages/core/src/testing/index.mts
+++ b/packages/core/src/testing/index.mts
@@ -38,7 +38,7 @@
  * (rather than through `createApp` + module-based `contributes.grants`).
  *
  * The public re-export from `@o3co/auth-provider-core` (the package root)
- * was removed at 1.0 GA per AS-8 / A2-γ §3.3. Production code MUST NOT
+ * was removed at v0.6.0 per AS-8 / A2-γ §3.3. Production code MUST NOT
  * import these symbols — wire grants on a module's `defineModule`
  * manifest and let the boot planner own the registry.
  *

--- a/packages/core/src/testing/index.mts
+++ b/packages/core/src/testing/index.mts
@@ -38,7 +38,7 @@
  * (rather than through `createApp` + module-based `contributes.grants`).
  *
  * The public re-export from `@o3co/auth-provider-core` (the package root)
- * was removed at v0.6.0 per AS-8 / A2-γ §3.3. Production code MUST NOT
+ * was removed per AS-8 / A2-γ §3.3. Production code MUST NOT
  * import these symbols — wire grants on a module's `defineModule`
  * manifest and let the boot planner own the registry.
  *

--- a/packages/oauth-token-exchange/README.md
+++ b/packages/oauth-token-exchange/README.md
@@ -147,7 +147,7 @@ const handle = await createApp({
 
 - `saml1` / `saml2` subject token types
 - Token type conversion (access ↔ id, access → refresh): returns `unsupported_token_type`
-- DPoP-bound token minting (planned for 1.0 GA)
+- DPoP-bound token minting (not implemented; release timing pending feature inventory)
 - Built-in external JWT validator (consumer-implement; planned as a separate package post-0.5)
 
 ## Breaking changes (v0.5.0)

--- a/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
+++ b/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
@@ -37,9 +37,9 @@ export interface CreateSelfIssuedAccessTokenValidatorOptions {
 	refreshTokenFamilyRevocation?: RefreshTokenFamilyRevocation;
 	issuer: string;
 	/**
-	 * SF-1 / 1.0 GA (Phase G / S2): when true, the central JWT verifier
+	 * SF-1 / v0.6.0 (Phase G / S2): when true, the central JWT verifier
 	 * accepts tokens whose `typ` header is absent and emits a
-	 * `jwt_verify_legacy_typ` deprecation warning. 1.0 GA default is
+	 * `jwt_verify_legacy_typ` deprecation warning. v0.6.0 default is
 	 * `false` (typ-less tokens rejected); `true` is an explicit
 	 * legacy-acceptance opt-in. The v0.5.x default was `true`.
 	 */

--- a/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
+++ b/packages/oauth-token-exchange/src/validator/selfIssuedAccessToken.mts
@@ -37,9 +37,9 @@ export interface CreateSelfIssuedAccessTokenValidatorOptions {
 	refreshTokenFamilyRevocation?: RefreshTokenFamilyRevocation;
 	issuer: string;
 	/**
-	 * SF-1 / v0.6.0 (Phase G / S2): when true, the central JWT verifier
+	 * SF-1 / Phase G / S2: when true, the central JWT verifier
 	 * accepts tokens whose `typ` header is absent and emits a
-	 * `jwt_verify_legacy_typ` deprecation warning. v0.6.0 default is
+	 * `jwt_verify_legacy_typ` deprecation warning. the default is
 	 * `false` (typ-less tokens rejected); `true` is an explicit
 	 * legacy-acceptance opt-in. The v0.5.x default was `true`.
 	 */

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -98,8 +98,8 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			// Invariant — see RT-OC test: this gate keeps AT-as-RT confusion
 			// defended. A JWT with no `header.typ === "rt+jwt"` is rejected
 			// even when SF-1's `legacyTypAccept = true` opt-in lets a typ-less
-			// token through the central verifier (v0.6.0 flipped the default
-			// to false but operators can still opt back). Refactors that touch
+			// token through the central verifier (Phase G S2 flipped the
+			// default to false but operators can still opt back). Refactors that touch
 			// this condition MUST keep RT-OC green.
 			if (typ !== "rt+jwt") {
 				return {
@@ -277,7 +277,7 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				}
 			}
 
-			// SF-6 / v0.6.0 (Phase G / M6): when rotation is wired, refresh
+			// SF-6 / Phase G / M6: when rotation is wired, refresh
 			// tokens MUST carry both jti AND family_id. Fail-fast BEFORE
 			// `generateToken()` runs so (a) we don't burn keystore signatures
 			// on a request that is going to be rejected anyway, and (b) a

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -98,7 +98,7 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			// Invariant — see RT-OC test: this gate keeps AT-as-RT confusion
 			// defended. A JWT with no `header.typ === "rt+jwt"` is rejected
 			// even when SF-1's `legacyTypAccept = true` opt-in lets a typ-less
-			// token through the central verifier (1.0 GA flipped the default
+			// token through the central verifier (v0.6.0 flipped the default
 			// to false but operators can still opt back). Refactors that touch
 			// this condition MUST keep RT-OC green.
 			if (typ !== "rt+jwt") {
@@ -277,7 +277,7 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				}
 			}
 
-			// SF-6 / 1.0 GA (Phase G / M6): when rotation is wired, refresh
+			// SF-6 / v0.6.0 (Phase G / M6): when rotation is wired, refresh
 			// tokens MUST carry both jti AND family_id. Fail-fast BEFORE
 			// `generateToken()` runs so (a) we don't burn keystore signatures
 			// on a request that is going to be rejected anyway, and (b) a

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -119,7 +119,7 @@ export const createOAuthRouter = async (
 	// canonical issuer (or this router is constructed in a partial-config test
 	// fixture), the middleware falls back to the literal "oauth".
 	const issuerForRealm = (config as { oauth?: { jwt?: { issuer?: string } } }).oauth?.jwt?.issuer;
-	// SF-1 / 1.0 GA (Phase G / S2): legacyTypAccept default is `false`
+	// SF-1 / v0.6.0 (Phase G / S2): legacyTypAccept default is `false`
 	// (v0.5.x was `true`). Use the same defensive cast as `issuerForRealm`
 	// so partial-config test fixtures (no `oauth.jwt` block at all) don't
 	// throw at router construction.

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -119,7 +119,7 @@ export const createOAuthRouter = async (
 	// canonical issuer (or this router is constructed in a partial-config test
 	// fixture), the middleware falls back to the literal "oauth".
 	const issuerForRealm = (config as { oauth?: { jwt?: { issuer?: string } } }).oauth?.jwt?.issuer;
-	// SF-1 / v0.6.0 (Phase G / S2): legacyTypAccept default is `false`
+	// SF-1 / Phase G / S2: legacyTypAccept default is `false`
 	// (v0.5.x was `true`). Use the same defensive cast as `issuerForRealm`
 	// so partial-config test fixtures (no `oauth.jwt` block at all) don't
 	// throw at router construction.

--- a/packages/oauth/src/routes/federationToken.mts
+++ b/packages/oauth/src/routes/federationToken.mts
@@ -154,9 +154,9 @@ export interface FederationTokenRouterOptions {
 	/** Configured issuer — pinned by the SF-1 central verifier. */
 	issuer?: string;
 	/**
-	 * SF-1 / 1.0 GA (Phase G / S2): when true, accept tokens whose `typ`
+	 * SF-1 / v0.6.0 (Phase G / S2): when true, accept tokens whose `typ`
 	 * header is absent (a `jwt_verify_legacy_typ` deprecation warning is
-	 * emitted). 1.0 GA default is `false` (typ-less tokens rejected);
+	 * emitted). v0.6.0 default is `false` (typ-less tokens rejected);
 	 * `true` is an explicit legacy-acceptance opt-in for deployments
 	 * still completing their v0.4.x rollover. The v0.5.x default was
 	 * `true`.

--- a/packages/oauth/src/routes/federationToken.mts
+++ b/packages/oauth/src/routes/federationToken.mts
@@ -154,9 +154,9 @@ export interface FederationTokenRouterOptions {
 	/** Configured issuer — pinned by the SF-1 central verifier. */
 	issuer?: string;
 	/**
-	 * SF-1 / v0.6.0 (Phase G / S2): when true, accept tokens whose `typ`
+	 * SF-1 / Phase G / S2: when true, accept tokens whose `typ`
 	 * header is absent (a `jwt_verify_legacy_typ` deprecation warning is
-	 * emitted). v0.6.0 default is `false` (typ-less tokens rejected);
+	 * emitted). the default is `false` (typ-less tokens rejected);
 	 * `true` is an explicit legacy-acceptance opt-in for deployments
 	 * still completing their v0.4.x rollover. The v0.5.x default was
 	 * `true`.

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -161,9 +161,9 @@ export interface LogoutRouterOptions {
 	/** Audit sink for operator observability events. No-op when undefined. */
 	auditSink?: AuditSink;
 	/**
-	 * SF-1 / 1.0 GA (Phase G / S2): when true, the central JWT verifier
+	 * SF-1 / v0.6.0 (Phase G / S2): when true, the central JWT verifier
 	 * accepts tokens whose `typ` header is absent and emits a
-	 * `jwt_verify_legacy_typ` deprecation warning. 1.0 GA default is
+	 * `jwt_verify_legacy_typ` deprecation warning. v0.6.0 default is
 	 * `false` (typ-less tokens rejected); `true` is an explicit
 	 * legacy-acceptance opt-in. The v0.5.x default was `true`. Forwarded
 	 * to `verifyJwt` for the bearer AT and id_token_hint paths.

--- a/packages/oauth/src/routes/logout.mts
+++ b/packages/oauth/src/routes/logout.mts
@@ -161,9 +161,9 @@ export interface LogoutRouterOptions {
 	/** Audit sink for operator observability events. No-op when undefined. */
 	auditSink?: AuditSink;
 	/**
-	 * SF-1 / v0.6.0 (Phase G / S2): when true, the central JWT verifier
+	 * SF-1 / Phase G / S2: when true, the central JWT verifier
 	 * accepts tokens whose `typ` header is absent and emits a
-	 * `jwt_verify_legacy_typ` deprecation warning. v0.6.0 default is
+	 * `jwt_verify_legacy_typ` deprecation warning. the default is
 	 * `false` (typ-less tokens rejected); `true` is an explicit
 	 * legacy-acceptance opt-in. The v0.5.x default was `true`. Forwarded
 	 * to `verifyJwt` for the bearer AT and id_token_hint paths.

--- a/packages/oauth/src/routes/userinfo.mts
+++ b/packages/oauth/src/routes/userinfo.mts
@@ -37,9 +37,9 @@ export interface UserinfoRouterOptions {
 	/** Configured issuer — pinned by the SF-1 central verifier. */
 	issuer?: string;
 	/**
-	 * SF-1 / v0.6.0 (Phase G / S2): when true, accept tokens whose `typ`
+	 * SF-1 / Phase G / S2: when true, accept tokens whose `typ`
 	 * header is absent (a `jwt_verify_legacy_typ` deprecation warning is
-	 * emitted). v0.6.0 default is `false` (typ-less tokens rejected);
+	 * emitted). the default is `false` (typ-less tokens rejected);
 	 * `true` is an explicit legacy-acceptance opt-in for deployments
 	 * still completing their v0.4.x rollover. The v0.5.x default was
 	 * `true`.

--- a/packages/oauth/src/routes/userinfo.mts
+++ b/packages/oauth/src/routes/userinfo.mts
@@ -37,9 +37,9 @@ export interface UserinfoRouterOptions {
 	/** Configured issuer — pinned by the SF-1 central verifier. */
 	issuer?: string;
 	/**
-	 * SF-1 / 1.0 GA (Phase G / S2): when true, accept tokens whose `typ`
+	 * SF-1 / v0.6.0 (Phase G / S2): when true, accept tokens whose `typ`
 	 * header is absent (a `jwt_verify_legacy_typ` deprecation warning is
-	 * emitted). 1.0 GA default is `false` (typ-less tokens rejected);
+	 * emitted). v0.6.0 default is `false` (typ-less tokens rejected);
 	 * `true` is an explicit legacy-acceptance opt-in for deployments
 	 * still completing their v0.4.x rollover. The v0.5.x default was
 	 * `true`.

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -8,8 +8,8 @@ http {
 oauth {
   jwt {
     issuer = ${?OAUTH_JWT_ISSUER}
-    # SF-1 / 1.0 GA (Phase G / S2): legacy typ acceptance for the
-    # central JWT verifier. The 1.0 GA default is `false`: tokens whose
+    # SF-1 / v0.6.0 (Phase G / S2): legacy typ acceptance for the
+    # central JWT verifier. The v0.6.0 default is `false`: tokens whose
     # `typ` header is absent are rejected. Operators with v0.4.x tokens
     # still in circulation can opt back to legacy acceptance with
     # `OAUTH_JWT_LEGACY_TYP_ACCEPT=true` for their own bounded migration
@@ -62,10 +62,10 @@ oauth {
     # store to Redis with old tokens still in circulation. Operators set
     # OAUTH_REFRESH_TOKEN_UNKNOWN_FAMILY_POLICY for env-var override.
     # unknownFamilyPolicy = "reject"
-    # SF-6 / 1.0 GA (Phase G / M6): refresh tokens lacking jti or
+    # SF-6 / v0.6.0 (Phase G / M6): refresh tokens lacking jti or
     # family_id claims when rotation is wired are always rejected.
     # The only valid value is "reject"; the `accept-with-warning`
-    # migration-window opt-in was removed at 1.0 GA.
+    # migration-window opt-in was removed at v0.6.0.
     # legacyRtPolicy = "reject"
   }
   grants {

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -8,8 +8,8 @@ http {
 oauth {
   jwt {
     issuer = ${?OAUTH_JWT_ISSUER}
-    # SF-1 / v0.6.0 (Phase G / S2): legacy typ acceptance for the
-    # central JWT verifier. The v0.6.0 default is `false`: tokens whose
+    # SF-1 / Phase G / S2: legacy typ acceptance for the
+    # central JWT verifier. The the default is `false`: tokens whose
     # `typ` header is absent are rejected. Operators with v0.4.x tokens
     # still in circulation can opt back to legacy acceptance with
     # `OAUTH_JWT_LEGACY_TYP_ACCEPT=true` for their own bounded migration
@@ -62,10 +62,10 @@ oauth {
     # store to Redis with old tokens still in circulation. Operators set
     # OAUTH_REFRESH_TOKEN_UNKNOWN_FAMILY_POLICY for env-var override.
     # unknownFamilyPolicy = "reject"
-    # SF-6 / v0.6.0 (Phase G / M6): refresh tokens lacking jti or
+    # SF-6 / Phase G / M6: refresh tokens lacking jti or
     # family_id claims when rotation is wired are always rejected.
     # The only valid value is "reject"; the `accept-with-warning`
-    # migration-window opt-in was removed at v0.6.0.
+    # migration-window opt-in was removed.
     # legacyRtPolicy = "reject"
   }
   grants {


### PR DESCRIPTION
## Summary

Replaces the forward-looking "1.0 GA" version label with the actual release "v0.6.0" across CHANGELOG (Unreleased section), JSDoc, code comments, HOCON config comments, package READMEs, and one operator-facing Zod validation error metadata string. Also adds `docs/release-policy.md` codifying the rule that produced this sweep so the same drift cannot recur.

This is the **auth.provider sweep PR**. Sibling adoption PRs in the other 3 auth-scope repos (no sweep needed there):

- auth.utils: #8
- auth.proxy: #28
- auth.policy-verifier: #53

## Why

A documented drift incident showed that "1.0 GA" was used as a planning anchor in code/CHANGELOG/JSDoc/error-messages/PR-titles. As release cuts diverged from plan, the label became internally contradictory and the auth-scope was on a path to ship a release without features it had originally committed (DPoP / WebAuthn). The "1.0 GA" anchor has been **retired**; removals previously labeled "1.0 GA" land in **v0.6.0** (the next minor release; current master = v0.5.3 + Phase G + this sweep).

## Critical operator-facing fix (R5 of the new policy)

In `packages/core/src/config/application.schema.mts`:

```diff
-		removedIn: "1.0 GA (Phase G / M4)",
+		removedIn: "v0.6.0 (Phase G / M4)",
```

This string is emitted in `Zod issue.message` when an operator's config still contains the removed `oauth.refreshToken.legacyTokenCompat` field. **The literal "1.0 GA" label was already shipping in v0.5.3**, meaning operators upgrading to v0.6.0 with stale config would have seen an error message naming a release that does not exist. Fixed before v0.6.0 cut.

## Historical CHANGELOG entries preserved (immutable)

The 4 "1.0 GA" references in the `## [0.5.2]` CHANGELOG section are preserved verbatim:

- L499: `Following A2-γ §3.3, the public re-export will be removed at 1.0 GA.`
- L539: `*Base forms are deprecated and will be removed at 1.0 GA`
- L543: `your convenience before 1.0 GA.`
- L558: `findByCode at 1.0 GA. No code change.`

These are immutable release notes describing what was said at v0.5.2 publish time and are already on npm. The v0.6.0 release notes (separate PR) will explicitly bridge consumers who installed v0.5.2 / v0.5.3 and read these entries.

## R4 forward-promise removed

```diff
-- DPoP-bound token minting (planned for 1.0 GA)
++ DPoP-bound token minting (not implemented; release timing pending feature inventory)
```

DPoP release timing will be decided in the feature inventory after v0.6.0 cut, not pre-committed to a specific version label.

## R5 test assertion updated

`packages/core/src/config/__tests__/refresh-token-schema.test.mts` asserted `expect(issue?.message).toMatch(/1\.0 GA/)`. Updated to `/v0\.6\.0/` to match the new operator-facing string.

## Adds `docs/release-policy.md`

Same canonical content as the 3 sibling adoption PRs. Codifies six rules (R1-R6):

1. **R1 Past-only rule** — code/JSDoc/public docs/config comments/error messages reference only released version tags
2. **R2 CHANGELOG `## [Unreleased]` until cut** — no pre-stamping
3. **R3 JSDoc `@deprecated` says "since" only** — removal timing lives in CHANGELOG, not in JSDoc
4. **R4 PR titles describe what was done, not what release**
5. **R5 Validation error message strings: factual, not predictive**
6. **R6 Release-cut audit pass** — mandatory checklist before tagging

## File breakdown (22 files)

- `docs/release-policy.md` (new, 114 lines)
- `CHANGELOG.md` (Unreleased section only — 14 references replaced; v0.5.2 section untouched)
- `packages/core/README.{md,ja.md}` ("Removed at 1.0 GA" headline)
- `packages/core/config/application.conf` (4 HOCON comment refs)
- `templates/standalone/config/application.conf` (4 HOCON comment refs)
- `packages/core/src/config/application.schema.mts` (CRITICAL operator-facing fix + 2 comment refs)
- `packages/core/src/config/__tests__/refresh-token-schema.test.mts` (test assertion update)
- 10 other source files in `packages/core/src/` and `packages/oauth*/src/` (JSDoc + comment refs)
- `packages/oauth-token-exchange/README.md` (DPoP forward-promise removed)

## Test plan

- [ ] CI green
- [ ] `pnpm install && pnpm -r run build && pnpm -r run test` passes locally (verified: 1205 core tests + 162 session tests pass after install/rebuild)
- [ ] `pnpm run lint` clean (verified locally)
- [ ] No `1\.0 GA` references in current code outside the immutable `## [0.5.2]` CHANGELOG section (`git grep "1\.0 GA" -- ':!CHANGELOG.md'` returns empty)
- [ ] Copilot review

## Out of scope (separate PRs)

- v0.6.0 release cut (CHANGELOG `Unreleased` → `0.6.0` + release notes "1.0 GA label retirement" section explicitly bridging v0.5.x consumers) — separate PR per R2
- GitHub release announcement (post-cut)
- Fresh feature inventory (DPoP / WebAuthn / mTLS / DID / VC release assignment) — after v0.6.0 cut