### PR TITLE
chore: prepare v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-12
+
+### "1.0 GA" planning-label retirement
+
+Pre-v0.6.0, the auth scope used "1.0 GA" as a planning anchor for a
+batch of breaking removals and renames across `auth.provider`. As
+release cuts diverged from plan, the label drifted: the v0.5.2 and
+v0.5.3 CHANGELOG entries below reference "removal at 1.0 GA" for
+changes that, in fact, **land in v0.6.0**. There is no
+separate "1.0 GA" release — v0.6.0 supersedes that framing.
+
+Concretely, the changes promised at "1.0 GA" in v0.5.x CHANGELOG
+entries are realized here:
+
+- `GrantRegistry` / `GrantRegistryError` public re-export removal (Phase G / M1)
+- `*Base` interface aliases removal (Phase G / M2)
+- `oauth.tokenExchange.allowPolicyWidening` flag removal (Phase G / M3)
+- `oauth.refreshToken.legacyTokenCompat` flag removal (Phase G / M4)
+- `oauth.refreshToken.legacyRtPolicy = "accept-with-warning"` enum value removal (Phase G / M6)
+- `CodeRepository.getByCode` → `findByCode` rename (Phase G / M5)
+- `oauth.jwt.legacyTypAccept` default `true → false` (Phase G / S2)
+
+For the reasoning behind the label retirement and the going-forward
+labeling discipline that prevents this from happening again, see
+[`docs/release-policy.md`](docs/release-policy.md).
+
 ### Security (Phase G — S2 `legacyTypAccept` default flipped `true → false`)
 
 - **BREAKING**: `oauth.jwt.legacyTypAccept` default flipped from `true`
@@ -55,7 +81,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Migration: consumers implementing `CodeRepository` (custom storage
   adapters) must rename their `getByCode` method to `findByCode`. The
   in-memory adapter (`InMemoryCodeRepository`) and Redis adapter
-  (`@o3co/auth-provider-redis`) are updated by this release.
+  (`@o3co/auth-provider-redis`) are updated by v0.6.0.
 - Affected APIs: `CodeRepository.getByCode` (removed) →
   `CodeRepository.findByCode` (added). No transitional alias.
 
@@ -99,7 +125,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   and the `OAUTH_REFRESH_TOKEN_LEGACY_TOKEN_COMPAT` env-var override. The
   flag was introduced in v0.5.2 (AS-12) with default `true` to accept
   v0.4.x refresh-token shapes during the migration window. v0.5.x is now
-  out of the bounded window; this release enforces the strict shape
+  out of the bounded window; v0.6.0 enforces the strict shape
   unconditionally.
   - Refresh-grant rejection gate now accepts **only** `header.typ ===
     "rt+jwt"` as the refresh marker. Tokens carrying the legacy
@@ -114,7 +140,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Migration: operators must ensure all in-flight refresh tokens were
     minted by v0.5.x or newer (which emit both `header.typ = "rt+jwt"`
     and a top-level `sub`) before upgrading. v0.5.2 documented this
-    migration plan in its Migration note; this release finalizes the cutover.
+    migration plan in its Migration note; v0.6.0 finalizes the cutover.
   - Affected APIs/config (removed):
     `oauth.refreshToken.legacyTokenCompat`,
     `OAUTH_REFRESH_TOKEN_LEGACY_TOKEN_COMPAT`,
@@ -146,7 +172,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **BREAKING**: Removed the `*Base` suffix from the 5 extension-point
   interfaces (closes AS-7). The canonical names without the suffix were
   added as type aliases in v0.5.1; both names coexisted with `@deprecated`
-  JSDoc on the `*Base` form. In this release the canonical names ARE the
+  JSDoc on the `*Base` form. In v0.6.0 the canonical names ARE the
   interfaces; the `*Base` aliases are removed.
   - `AuditSinkBase` → `AuditSink`
   - `FederationTokenStoreBase` → `FederationTokenStore`

--- a/packages/core/config/application.conf
+++ b/packages/core/config/application.conf
@@ -12,7 +12,7 @@ oauth {
     # tokens whose `typ` header is absent. The previous v0.5.x default
     # accepted typ-less tokens (with a `jwt_verify_legacy_typ` warning)
     # to keep v0.4.x tokens verifying through the migration window;
-    # this release closes that window by default. Operators with v0.4.x
+    # v0.6.0 closes that window by default. Operators with v0.4.x
     # tokens still in circulation can opt back via
     # `OAUTH_JWT_LEGACY_TYP_ACCEPT=true` for their own bounded migration
     # window, but the safe default is now `false` (reject typ-less tokens
@@ -60,8 +60,8 @@ oauth {
     unknownFamilyPolicy = ${?OAUTH_REFRESH_TOKEN_UNKNOWN_FAMILY_POLICY}
     # SF-6 / Phase G / M6: refresh tokens lacking jti or
     # family_id claims when family rotation is wired are always rejected.
-    # The `"accept-with-warning"` migration-window value was removed in
-    # this release along with the env-var override — there is no longer
+    # The `"accept-with-warning"` migration-window value was removed
+    # in v0.6.0 along with the env-var override — there is no longer
     # an opt-in to bypass replay detection.
     legacyRtPolicy = "reject"
   }

--- a/packages/core/src/config/__tests__/refresh-token-schema.test.mts
+++ b/packages/core/src/config/__tests__/refresh-token-schema.test.mts
@@ -60,7 +60,7 @@ describe("oauth.refreshToken schema — removed-field preprocess (Phase G / M4)"
 		expect(result.success).toBe(false);
 		if (result.success) return;
 		const issue = result.error.issues.find((i) => i.message.includes("legacyTokenCompat"));
-		expect(issue?.message).toMatch(/has been removed/);
+		expect(issue?.message).toMatch(/was removed in v0\.6\.0/);
 		expect(issue?.message).toMatch(/Phase G \/ M4/);
 		expect(issue?.message).toMatch(/v0\.5\.x or newer/);
 	});

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -120,12 +120,12 @@ const LEGACY_JWT_FIELDS = [
  * targeted error instead of having their flag silently stripped by Zod's
  * default `unknown-key strip` behavior.
  *
- * The `removedIn` field carries the internal marker (e.g., `Phase G / M4`) so
- * the error message can point operators at the corresponding CHANGELOG entry.
- * Per docs/release-policy.md R5, the value MUST NOT pre-stamp a release tag
- * before that release is cut. At each release cut, R6 step 5 fills the
- * released tag into this field for entries that landed in the cut release;
- * before that, the marker alone is sufficient.
+ * The `removedIn` field carries the released tag plus internal phase marker
+ * (e.g., `v0.6.0 (Phase G / M4)`) so the operator-facing error message names
+ * the release that performed the removal and the CHANGELOG entry that
+ * documents it. Per docs/release-policy.md R5, the released-tag portion is
+ * filled in at release-cut time (R6 step 5) — entries added on HEAD between
+ * cuts use a neutral value like `"Phase G / M4"` until the next cut.
  */
 const REMOVED_REFRESH_TOKEN_FIELDS: ReadonlyArray<{
 	name: string;
@@ -134,7 +134,7 @@ const REMOVED_REFRESH_TOKEN_FIELDS: ReadonlyArray<{
 }> = [
 	{
 		name: "legacyTokenCompat",
-		removedIn: "Phase G / M4",
+		removedIn: "v0.6.0 (Phase G / M4)",
 		note:
 			"v0.4.x refresh-token shape compat (payload.type, claims.user.id fallback) is no " +
 			"longer accepted. Ensure all in-flight refresh tokens were minted by v0.5.x or newer " +
@@ -211,7 +211,7 @@ const refreshTokenSchema = z.preprocess((raw, ctx) => {
 				ctx.addIssue({
 					code: z.ZodIssueCode.custom,
 					message:
-						`oauth.refreshToken.${removed.name} has been removed (${removed.removedIn}; see CHANGELOG). ` +
+						`oauth.refreshToken.${removed.name} was removed in ${removed.removedIn}; see CHANGELOG. ` +
 						`${removed.note} Remove this field from your config.`,
 					path: [removed.name],
 				});


### PR DESCRIPTION
## Summary

- Cuts the v0.6.0 section in CHANGELOG.md (rename \`## [Unreleased]\` → \`## [0.6.0] - 2026-05-12\` + new empty Unreleased placeholder)
- Runs the R6 release-cut audit pass per [docs/release-policy.md](docs/release-policy.md): fills in the actual v0.6.0 tag for items that were neutralized in PR #163 (operator-facing schema metadata, HOCON config comments, CHANGELOG body "this release" mentions)
- Adds a prominent **"1.0 GA planning-label retirement"** section at the top of the v0.6.0 release notes, bridging consumers who installed v0.5.2/v0.5.3 from npm and read entries promising "removal at 1.0 GA"

## R6 release-cut audit checklist

| Step | Action | Status |
| --- | --- | --- |
| R6.1 | grep forward-version references | ✅ none remaining outside historical CHANGELOG sections |
| R6.2 | rename \`## [Unreleased]\` → \`## [0.6.0] - 2026-05-12\` | ✅ |
| R6.3 | body "this release" → "v0.6.0" inside v0.6.0 section | ✅ (4 mentions) |
| R6.4 | JSDoc / code comments / config comments forward-version replacement | ✅ HOCON: 2 mentions in application.conf |
| R6.5 | Schema metadata strings: fill released tag | ✅ \`removedIn: "v0.6.0 (Phase G / M4)"\` + message template restructured + test assertion updated |
| R6.6 | PR title uses "chore: prepare v0.6.0 release" | ✅ (no Phase / GA labels) |
| R6.7 | Release notes include retirement note | ✅ (top of v0.6.0 section) |

## 1.0 GA label retirement note (consumer bridge)

The v0.6.0 release notes explicitly state that removals previously labeled "1.0 GA" in v0.5.2 and v0.5.3 CHANGELOG entries (already shipped on npm) **land in v0.6.0** — there is no separate "1.0 GA" release. Cross-references all 7 Phase G items + S2 default flip and links to \`docs/release-policy.md\` for the full reasoning.

## Operator-facing fix (R5 finalization)

- Before this PR: \`removedIn: "Phase G / M4"\`, error reads "X has been removed (Phase G / M4; see CHANGELOG)"
- After this PR: \`removedIn: "v0.6.0 (Phase G / M4)"\`, error reads "X was removed in v0.6.0 (Phase G / M4); see CHANGELOG"

Operators now see the released tag in the error message. The R5 contract is honored: the version pre-stamp was applied at the moment of release cut, not before.

## Test plan

- [x] \`pnpm install --frozen-lockfile\`: passes (verified locally)
- [x] \`pnpm -r run build\`: green
- [x] \`pnpm --filter @o3co/auth-provider-core run test\`: 1205 / 1205 pass
- [x] \`pnpm run lint\`: clean (423 files, 0 errors)
- [ ] CI confirms above
- [ ] After merge: tag \`v0.6.0\` to trigger release.yml workflow (Trusted Publisher OIDC publishes 9 packages to npm)

## Files changed (4)

- \`CHANGELOG.md\` (rename + retirement section + body "this release" → "v0.6.0")
- \`packages/core/src/config/application.schema.mts\` (R6 step 5: \`removedIn\` value restored + message template + JSDoc)
- \`packages/core/src/config/__tests__/refresh-token-schema.test.mts\` (test assertion: \`/was removed in v0\\.6\\.0/\`)
- \`packages/core/config/application.conf\` (R6 step 4: HOCON comments)

## Out of scope (follow-up PRs)

- Tagging \`v0.6.0\` after this merges (triggers release.yml)
- GitHub release announcement (separate post-tag step, per docs/release-policy.md R6 step 7)