### PR TITLE
feat: RFC 8707 Resource Indicator opt-in plumbing (Wave 1 PR 3/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **RFC 8707 Resource Indicator opt-in plumbing (`oauth.resourceIndicator.enabled`, default `false`)** (Wave 1 §5 — Stage 1).
+  When opted in, `body.resource` (string or array of strings) is forwarded to the
+  `GrantPolicyHook.evaluate(...)` request for `client_credentials` and `refresh_token`
+  grants. The policy hook may use the parameter to narrow `grantedScope` or
+  `grantedAudience`; both grants now also fail-closed on policy-returned scope or
+  audience that is not a subset of the request / `client.allowedAudiences`
+  respectively. The library does NOT itself enforce RFC 8707 §2 resource-to-audience
+  binding at this stage — that is **Stage 2 (Wave 2)** scope (per spec §5.6). When
+  `oauth.resourceIndicator.enabled` is absent or `false`, the entire path is a no-op
+  and consumer behavior is byte-equivalent to v0.6.0.
+  - **`authorization_code` deferred to Wave 2**: at the token endpoint, scope is
+    already locked by the authorization-endpoint policy (C-2 / D-1 evaluate-once-at-`/authorize`).
+    Plumbing resource into the auth_code grant requires a Wave 2 design that
+    respects this invariant; for Wave 1 the auth_code token endpoint silently
+    ignores `body.resource`. Token-exchange retains its independent RFC 8693 + 8707
+    enforcement (§5.2 non-goal, unchanged).
+
 ### Changed
 
 - **`@o3co/auth-provider-core` now ships `reference.conf` as a declarative defaults layer.**

--- a/packages/core/config/reference.conf
+++ b/packages/core/config/reference.conf
@@ -112,6 +112,17 @@ oauth {
     maxActorChainDepth = 3
     maxActorChainDepth = ${?OAUTH_TOKEN_EXCHANGE_MAX_ACTOR_CHAIN_DEPTH}
   }
+  # Wave 1 §5.3 / RFC 8707: opt-in gate for Resource Indicator enforcement.
+  # Secure-by-default: off at the library layer. Operators enable via
+  # `OAUTH_RESOURCE_INDICATOR_ENABLED=true` or by overriding `enabled = true`
+  # in their own application.conf layer.
+  # Pattern: literal false + env-override line (PR #171 / feedback_secure_default_opt_in):
+  # the literal provides the anchor so HOCON env-substitution has a binding
+  # point; without it ${?VAR} is silently dropped when the env var is unset.
+  resourceIndicator {
+    enabled = false
+    enabled = ${?OAUTH_RESOURCE_INDICATOR_ENABLED}
+  }
 }
 
 session {

--- a/packages/core/src/config/__tests__/resourceIndicator.test.mts
+++ b/packages/core/src/config/__tests__/resourceIndicator.test.mts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import { CoreConfigSchema } from "../application.schema.mjs";
+
+/**
+ * Access the resourceIndicator sub-schema directly so we can test the
+ * boolean-from-HOCON coercion without standing up a full AppConfig fixture.
+ *
+ * The field is `.optional()` in the schema — default `false` lives in
+ * `packages/core/config/reference.conf` per ADR 2026-04-30.
+ */
+const resourceIndicatorSchema = CoreConfigSchema.shape.oauth.shape.resourceIndicator;
+
+describe("oauth.resourceIndicator schema — Wave 1 §5.3 / RFC 8707 opt-in foundation", () => {
+	it("is absent when omitted (optional field — default lives in reference.conf)", () => {
+		// The full oauth block still needs its required fields; we test
+		// resourceIndicator in isolation via the sub-schema.
+		const result = resourceIndicatorSchema.safeParse(undefined);
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data).toBeUndefined();
+	});
+
+	it("accepts enabled=true (boolean)", () => {
+		const result = resourceIndicatorSchema.safeParse({ enabled: true });
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data?.enabled).toBe(true);
+	});
+
+	it("accepts enabled=false (boolean)", () => {
+		const result = resourceIndicatorSchema.safeParse({ enabled: false });
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data?.enabled).toBe(false);
+	});
+
+	it('accepts enabled="true" (HOCON env-substitution returns string) and coerces to boolean true', () => {
+		const result = resourceIndicatorSchema.safeParse({ enabled: "true" });
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data?.enabled).toBe(true);
+	});
+
+	it('accepts enabled="false" (HOCON env-substitution returns string) and coerces to boolean false', () => {
+		const result = resourceIndicatorSchema.safeParse({ enabled: "false" });
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data?.enabled).toBe(false);
+	});
+
+	it('rejects enabled="yes" (not a recognized boolean string)', () => {
+		const result = resourceIndicatorSchema.safeParse({ enabled: "yes" });
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects enabled=42 (non-string non-boolean)", () => {
+		const result = resourceIndicatorSchema.safeParse({ enabled: 42 });
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -222,6 +222,33 @@ const refreshTokenSchema = z.preprocess((raw, ctx) => {
 }, refreshTokenSchemaBase);
 
 /**
+ * Env-var-safe boolean coercion for `enabled` fields.
+ *
+ * z.coerce.boolean() calls JavaScript's Boolean(value), so any non-empty string
+ * (including "false", "no", "0") coerces to true. This is unsafe for env-var
+ * overrides where operators set e.g. OAUTH_RESOURCE_INDICATOR_ENABLED=false.
+ *
+ * This preprocess explicitly maps the common string representations:
+ *   "true" | "1"        → true
+ *   "false" | "0" | ""  → false
+ *   boolean             → pass-through unchanged
+ *   other values        → forwarded to z.boolean() which rejects with a type error
+ *
+ * Used by:
+ *  - federation `enabled` fields (fullSectionsSchema)
+ *  - oauth.resourceIndicator.enabled (Wave 1 §5.3 / RFC 8707)
+ */
+const coerceBooleanFromEnv = z.preprocess((val) => {
+	if (typeof val === "boolean") return val;
+	if (typeof val === "string") {
+		const normalized = val.trim().toLowerCase();
+		if (normalized === "true" || normalized === "1") return true;
+		if (normalized === "false" || normalized === "0" || normalized === "") return false;
+	}
+	return val; // zod rejects with a type error for other values
+}, z.boolean());
+
+/**
  * Minimal always-required config for the auth provider core.
  * Token-only deployments (no session, no federation) only need these sections.
  */
@@ -275,6 +302,18 @@ export const CoreConfigSchema = z.object({
 				maxActorChainDepth: z.coerce.number().int().positive(),
 			})
 			.optional(),
+		// Wave 1 §5.3 (v0.6.x): opt-in gate for RFC 8707 Resource Indicator
+		// enforcement. `enabled = false` in reference.conf ensures the feature
+		// is off by default; operators set `enabled = true` (or
+		// `OAUTH_RESOURCE_INDICATOR_ENABLED=true`) to activate. Shape-only per
+		// ADR 2026-04-30 — no `.default()` here; default lives in reference.conf
+		// (added in Task 18). `coerceBooleanFromEnv` handles the HOCON
+		// env-substitution string → boolean coercion established by PR #171.
+		resourceIndicator: z
+			.object({
+				enabled: coerceBooleanFromEnv,
+			})
+			.optional(),
 	}),
 });
 
@@ -292,29 +331,6 @@ export function composeConfigSchema(moduleSchemas: z.ZodObject<z.ZodRawShape>[])
 	}
 	return schema;
 }
-
-/**
- * Env-var-safe boolean coercion for federation `enabled` fields.
- *
- * z.coerce.boolean() calls JavaScript's Boolean(value), so any non-empty string
- * (including "false", "no", "0") coerces to true. This is unsafe for env-var
- * overrides where operators set FEDERATIONS_*_ENABLED=false to disable a federation.
- *
- * This preprocess explicitly maps the common string representations:
- *   "true" | "1"        → true
- *   "false" | "0" | ""  → false
- *   boolean             → pass-through unchanged
- *   other values        → forwarded to z.boolean() which rejects with a type error
- */
-const coerceBooleanFromEnv = z.preprocess((val) => {
-	if (typeof val === "boolean") return val;
-	if (typeof val === "string") {
-		const normalized = val.trim().toLowerCase();
-		if (normalized === "true" || normalized === "1") return true;
-		if (normalized === "false" || normalized === "0" || normalized === "") return false;
-	}
-	return val; // zod rejects with a type error for other values
-}, z.boolean());
 
 const federationEntrySchema = z
 	.object({

--- a/packages/oauth/src/__tests__/clientCredentials.test.mts
+++ b/packages/oauth/src/__tests__/clientCredentials.test.mts
@@ -231,3 +231,137 @@ describe("createClientCredentialsGrant — token issuance", () => {
 		expect(payload.aud).toBeUndefined();
 	});
 });
+
+describe("createClientCredentialsGrant — grantPolicy scope validation (CP-18 fail-closed)", () => {
+	const depsWithPolicy = (
+		evaluate: (input: Record<string, unknown>) => Promise<{
+			outcome: "allow" | "deny";
+			grantedScope?: string[];
+			grantedAudience?: string[];
+			error?: string;
+			errorDescription?: string;
+		}>,
+	): GrantDependencies => ({
+		...baseDeps,
+		config: {
+			oauth: {
+				...baseDeps.config.oauth,
+				resourceIndicator: { enabled: true },
+			},
+		} as unknown as GrantDependencies["config"],
+		grantPolicy: {
+			evaluate: evaluate as unknown as GrantDependencies["grantPolicy"],
+		} as unknown as GrantDependencies["grantPolicy"],
+	});
+
+	it("accepts policy grantedScope that is a subset of allowedScopes and mints with narrowed scope", async () => {
+		// Policy narrows read:foo + write:foo → read:foo only. Handler must accept.
+		const client = makeClient({ allowedScopes: ["read:foo", "write:foo"] });
+		const handler = createClientCredentialsGrant(
+			depsWithPolicy(async () => ({ outcome: "allow", grantedScope: ["read:foo"] })),
+		);
+
+		const { result } = await handler.handle(makeCtx(client));
+
+		expect(result.status).toBe(200);
+		if (!("tokens" in result)) throw new Error("expected tokens in result");
+		const payload = decodeJwt(result.tokens.access_token) as Record<string, unknown>;
+		expect(payload.scope).toBe("read:foo");
+	});
+
+	it("rejects policy grantedScope that exceeds allowedScopes with 400 invalid_scope (CP-18)", async () => {
+		// Policy returns 'admin' which is NOT in client.allowedScopes → fail-closed.
+		const client = makeClient({ allowedScopes: ["read:foo"] });
+		const handler = createClientCredentialsGrant(
+			depsWithPolicy(async () => ({
+				outcome: "allow",
+				grantedScope: ["read:foo", "admin"],
+			})),
+		);
+
+		const { result } = await handler.handle(makeCtx(client));
+
+		expect(result.status).toBe(400);
+		expect("error" in result && result.error).toBe("invalid_scope");
+		expect("errorDescription" in result && result.errorDescription).toContain("admin");
+	});
+});
+
+describe("createClientCredentialsGrant — grantPolicy audience validation (Codex P2-3)", () => {
+	const depsWithAudiencePolicy = (
+		evaluate: (input: Record<string, unknown>) => Promise<{
+			outcome: "allow" | "deny";
+			grantedScope?: string[];
+			grantedAudience?: string[];
+			error?: string;
+			errorDescription?: string;
+		}>,
+	): GrantDependencies => ({
+		...baseDeps,
+		config: {
+			oauth: {
+				...baseDeps.config.oauth,
+				resourceIndicator: { enabled: true },
+			},
+		} as unknown as GrantDependencies["config"],
+		grantPolicy: {
+			evaluate: evaluate as unknown as GrantDependencies["grantPolicy"],
+		} as unknown as GrantDependencies["grantPolicy"],
+	});
+
+	it("uses policy grantedAudience when it is within allowedAudiences (subset check)", async () => {
+		// Client allows ["https://rs1", "https://rs2"]; policy narrows to
+		// ["https://rs2"]. Token aud must be https://rs2 (not allowedAudiences[0]).
+		const client = makeClient({
+			allowedAudiences: ["https://rs1", "https://rs2"],
+		});
+		const handler = createClientCredentialsGrant(
+			depsWithAudiencePolicy(async () => ({
+				outcome: "allow",
+				grantedAudience: ["https://rs2"],
+			})),
+		);
+
+		const { result } = await handler.handle(makeCtx(client));
+
+		expect(result.status).toBe(200);
+		if (!("tokens" in result)) throw new Error("expected tokens in result");
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.aud).toBe("https://rs2");
+	});
+
+	it("rejects policy grantedAudience outside allowedAudiences with 400 invalid_request", async () => {
+		// Policy returns an audience not in client.allowedAudiences → fail-closed.
+		const client = makeClient({ allowedAudiences: ["https://rs1"] });
+		const handler = createClientCredentialsGrant(
+			depsWithAudiencePolicy(async () => ({
+				outcome: "allow",
+				grantedAudience: ["https://other.example"],
+			})),
+		);
+
+		const { result } = await handler.handle(makeCtx(client));
+
+		expect(result.status).toBe(400);
+		expect("error" in result && result.error).toBe("invalid_request");
+		expect("errorDescription" in result && result.errorDescription).toContain(
+			"https://other.example",
+		);
+	});
+
+	it("falls back to allowedAudiences[0] when policy returns no grantedAudience", async () => {
+		// Policy omits grantedAudience (outcome: allow, no audience field).
+		// Existing fallback behavior (allowedAudiences[0]) must be preserved.
+		const client = makeClient({ allowedAudiences: ["https://api.example"] });
+		const handler = createClientCredentialsGrant(
+			depsWithAudiencePolicy(async () => ({ outcome: "allow" })),
+		);
+
+		const { result } = await handler.handle(makeCtx(client));
+
+		expect(result.status).toBe(200);
+		if (!("tokens" in result)) throw new Error("expected tokens in result");
+		const payload = decodeJwt(result.tokens.access_token);
+		expect(payload.aud).toBe("https://api.example");
+	});
+});

--- a/packages/oauth/src/__tests__/clientCredentials.test.mts
+++ b/packages/oauth/src/__tests__/clientCredentials.test.mts
@@ -365,3 +365,73 @@ describe("createClientCredentialsGrant — grantPolicy audience validation (Code
 		expect(payload.aud).toBe("https://api.example");
 	});
 });
+
+describe("createClientCredentialsGrant — grantPolicy scope ceiling (Codex Round 2 P1)", () => {
+	const depsWithPolicy = (
+		evaluate: (input: Record<string, unknown>) => Promise<{
+			outcome: "allow" | "deny";
+			grantedScope?: string[];
+			grantedAudience?: string[] | undefined;
+			error?: string;
+			errorDescription?: string;
+		}>,
+	): GrantDependencies => ({
+		...baseDeps,
+		config: {
+			oauth: {
+				...baseDeps.config.oauth,
+				resourceIndicator: { enabled: true },
+			},
+		} as unknown as GrantDependencies["config"],
+		grantPolicy: {
+			evaluate: evaluate as unknown as GrantDependencies["grantPolicy"],
+		} as unknown as GrantDependencies["grantPolicy"],
+	});
+
+	it("returns 400 when policy grantedScope is outside the requested (effectiveScopes) set even if within allowedScopes (Codex Round 2 P1-1)", async () => {
+		// Client allowedScopes: ["read", "write"]. Request narrows to scope=read.
+		// effectiveScopes becomes ["read"]. Policy returns grantedScope: ["write"].
+		// write ∈ allowedScopes but NOT ∈ effectiveScopes (the requested set).
+		// Ceiling must be effectiveScopes, not client.allowedScopes.
+		const client = makeClient({ allowedScopes: ["read", "write"] });
+		const handler = createClientCredentialsGrant(
+			depsWithPolicy(async () => ({
+				outcome: "allow",
+				grantedScope: ["write"],
+				grantedAudience: undefined,
+			})),
+		);
+
+		const { result } = await handler.handle(
+			makeCtx(client, { grant_type: "client_credentials", scope: "read", resource: "https://rs1" }),
+		);
+
+		expect(result.status).toBe(400);
+		expect("error" in result && result.error).toBe("invalid_scope");
+		expect("errorDescription" in result && result.errorDescription).toContain("write");
+	});
+
+	it("honors empty grantedScope: [] from policy as 'strip all scopes' (Codex Round 2 P1-2)", async () => {
+		// Policy explicitly returns grantedScope: [] — intent is "allow the grant
+		// but issue no scopes". The empty array must be applied (effectiveScopes = [])
+		// so the token has no scope claim, not the pre-policy effectiveScopes.
+		const client = makeClient({ allowedScopes: ["read"] });
+		const handler = createClientCredentialsGrant(
+			depsWithPolicy(async () => ({
+				outcome: "allow",
+				grantedScope: [],
+				grantedAudience: undefined,
+			})),
+		);
+
+		const { result } = await handler.handle(
+			makeCtx(client, { grant_type: "client_credentials", scope: "read", resource: "https://rs1" }),
+		);
+
+		expect(result.status).toBe(200);
+		if (!("tokens" in result)) throw new Error("expected tokens in result");
+		const payload = decodeJwt(result.tokens.access_token) as Record<string, unknown>;
+		// After policy strip, scope claim should be absent or empty string.
+		expect(payload.scope ?? "").toBe("");
+	});
+});

--- a/packages/oauth/src/__tests__/refreshToken.test.mts
+++ b/packages/oauth/src/__tests__/refreshToken.test.mts
@@ -1232,6 +1232,81 @@ describe("createRefreshTokenGrant", () => {
 		});
 	});
 
+	describe("refresh_token grant — grantPolicy audience validation (Codex Round 4 P2)", () => {
+		function createStubPolicy(evaluate: GrantPolicyHook["evaluate"]): GrantPolicyHook {
+			return { kind: "stub", evaluate };
+		}
+
+		function depsWithAudiencePolicy(evaluate: GrantPolicyHook["evaluate"]): GrantDependencies {
+			return {
+				...mockDeps,
+				config: {
+					oauth: {
+						...mockDeps.config.oauth,
+						resourceIndicator: { enabled: true },
+					},
+				} as unknown as GrantDependencies["config"],
+				grantPolicy: createStubPolicy(evaluate),
+				// allowedAudiences lives on the authenticatedClient in the ctx — set per-test.
+			};
+		}
+
+		it("rejects policy grantedAudience outside client.allowedAudiences with 400 invalid_request (Test A)", async () => {
+			// Policy returns an audience not in client.allowedAudiences → fail-closed.
+			const token = await makeRefreshToken({ scope: "read" });
+			const deps = depsWithAudiencePolicy(async () => ({
+				outcome: "allow",
+				grantedAudience: ["https://other.example"],
+			}));
+			const handler = createRefreshTokenGrant(deps);
+
+			const { result } = await handler.handle({
+				body: { refresh_token: token },
+				session: {},
+				issuer: "localhost",
+				metadata: {},
+				authenticatedClient: {
+					...DEFAULT_AUTH_CLIENT,
+					allowedAudiences: ["https://api.example"],
+				},
+			});
+
+			expect(result.status).toBe(400);
+			if (!("error" in result)) expect.fail("Expected error in result");
+			expect(result.error).toBe("invalid_request");
+			expect(result.errorDescription).toContain("https://other.example");
+		});
+
+		it("uses policy grantedAudience when within client.allowedAudiences (Test B)", async () => {
+			// Policy narrows to ["https://api.example"] ∈ allowedAudiences → 200, token aud is https://api.example.
+			const token = await makeRefreshToken({ scope: "read" });
+			const deps = depsWithAudiencePolicy(async () => ({
+				outcome: "allow",
+				grantedAudience: ["https://api.example"],
+			}));
+			const handler = createRefreshTokenGrant(deps);
+
+			const { result } = await handler.handle({
+				body: { refresh_token: token },
+				session: {},
+				issuer: "localhost",
+				metadata: {},
+				authenticatedClient: {
+					...DEFAULT_AUTH_CLIENT,
+					allowedAudiences: ["https://api.example", "https://other.example"],
+				},
+			});
+
+			expect(result.status).toBe(200);
+			if (!("tokens" in result)) expect.fail("Expected tokens in result");
+			const parts = result.tokens.access_token.split(".");
+			const payload = JSON.parse(
+				Buffer.from(parts[1] ?? "", "base64url").toString("utf-8"),
+			) as Record<string, unknown>;
+			expect(payload.aud).toBe("https://api.example");
+		});
+	});
+
 	describe("sid claim propagation and userSessionStore integration (TODO-F-3 task 4)", () => {
 		function decodeTokenPayload(token: string): Record<string, unknown> {
 			const parts = token.split(".");

--- a/packages/oauth/src/__tests__/resourceIndicator.flag.test.mts
+++ b/packages/oauth/src/__tests__/resourceIndicator.flag.test.mts
@@ -220,35 +220,33 @@ describe("RFC 8707 resource indicator — flag off (default, resourceIndicator a
 			authenticatedClient: DEFAULT_AUTH_CLIENT,
 		});
 
+		// refresh_token has a pre-existing grantPolicy.evaluate call — it still
+		// runs flag-off, but resource is NOT forwarded (undefined).
 		expect(capturedResource).toBeUndefined();
 	});
 
-	it("authorization_code: grantPolicy.evaluate sees resource: undefined when body.resource present", async () => {
-		let capturedResource: unknown = "NOT_CALLED";
-		const policy = makeStubPolicy(async (req) => {
-			capturedResource = req.resource;
-			return { outcome: "allow" };
-		});
+	it("authorization_code: grantPolicy.evaluate is NOT called when flag is off", async () => {
+		const seenPolicy = vi.fn().mockResolvedValue({ outcome: "allow" });
+		const policy = makeStubPolicy(seenPolicy);
 		const deps = makeAuthzDeps({ grantPolicy: policy });
 		const handler = createAuthorizationGrant(deps);
 
 		await handler.handle(makeAuthzCtx({ resource: "https://rs1" }));
 
-		expect(capturedResource).toBeUndefined();
+		// Flag-off must NOT introduce a new policy invocation for authorization_code.
+		expect(seenPolicy).not.toHaveBeenCalled();
 	});
 
-	it("client_credentials: grantPolicy.evaluate sees resource: undefined when body.resource present", async () => {
-		let capturedResource: unknown = "NOT_CALLED";
-		const policy = makeStubPolicy(async (req) => {
-			capturedResource = req.resource;
-			return { outcome: "allow" };
-		});
+	it("client_credentials: grantPolicy.evaluate is NOT called when flag is off", async () => {
+		const seenPolicy = vi.fn().mockResolvedValue({ outcome: "allow" });
+		const policy = makeStubPolicy(seenPolicy);
 		const deps = makeCCDeps({ grantPolicy: policy });
 		const handler = createClientCredentialsGrant(deps);
 
 		await handler.handle(makeCCCtx({ resource: "https://rs1" }));
 
-		expect(capturedResource).toBeUndefined();
+		// Flag-off must NOT introduce a new policy invocation for client_credentials.
+		expect(seenPolicy).not.toHaveBeenCalled();
 	});
 });
 
@@ -275,35 +273,32 @@ describe("RFC 8707 resource indicator — flag off (explicit false)", () => {
 			authenticatedClient: DEFAULT_AUTH_CLIENT,
 		});
 
+		// refresh_token: pre-existing call still runs, resource NOT forwarded.
 		expect(capturedResource).toBeUndefined();
 	});
 
-	it("authorization_code: grantPolicy.evaluate sees resource: undefined when body.resource present", async () => {
-		let capturedResource: unknown = "NOT_CALLED";
-		const policy = makeStubPolicy(async (req) => {
-			capturedResource = req.resource;
-			return { outcome: "allow" };
-		});
+	it("authorization_code: grantPolicy.evaluate is NOT called when explicit false", async () => {
+		const seenPolicy = vi.fn().mockResolvedValue({ outcome: "allow" });
+		const policy = makeStubPolicy(seenPolicy);
 		const deps = makeAuthzDeps({ grantPolicy: policy }, false);
 		const handler = createAuthorizationGrant(deps);
 
 		await handler.handle(makeAuthzCtx({ resource: "https://rs1" }));
 
-		expect(capturedResource).toBeUndefined();
+		// Explicit false must preserve pre-existing semantics (no new invocation).
+		expect(seenPolicy).not.toHaveBeenCalled();
 	});
 
-	it("client_credentials: grantPolicy.evaluate sees resource: undefined when body.resource present", async () => {
-		let capturedResource: unknown = "NOT_CALLED";
-		const policy = makeStubPolicy(async (req) => {
-			capturedResource = req.resource;
-			return { outcome: "allow" };
-		});
+	it("client_credentials: grantPolicy.evaluate is NOT called when explicit false", async () => {
+		const seenPolicy = vi.fn().mockResolvedValue({ outcome: "allow" });
+		const policy = makeStubPolicy(seenPolicy);
 		const deps = makeCCDeps({ grantPolicy: policy }, false);
 		const handler = createClientCredentialsGrant(deps);
 
 		await handler.handle(makeCCCtx({ resource: "https://rs1" }));
 
-		expect(capturedResource).toBeUndefined();
+		// Explicit false must preserve pre-existing semantics (no new invocation).
+		expect(seenPolicy).not.toHaveBeenCalled();
 	});
 });
 
@@ -408,5 +403,33 @@ describe("RFC 8707 resource indicator — flag on", () => {
 		await handler.handle(makeCCCtx({ resource: ["https://r1", "https://r2"] }));
 
 		expect(capturedResource).toEqual(["https://r1", "https://r2"]);
+	});
+
+	it("authorization_code: grantPolicy.evaluate IS called with resource: undefined when flag is on but body has no resource", async () => {
+		// Operator opted in → policy gate runs even without a resource param.
+		// This locks in the "feature on, client omitted resource" case so a future
+		// refactor cannot accidentally treat it as flag-off.
+		const seenPolicy = vi.fn().mockResolvedValue({ outcome: "allow" });
+		const policy = makeStubPolicy(seenPolicy);
+		const deps = makeAuthzDeps({ grantPolicy: policy }, true);
+		const handler = createAuthorizationGrant(deps);
+
+		await handler.handle(makeAuthzCtx({})); // no body.resource
+
+		expect(seenPolicy).toHaveBeenCalledOnce();
+		expect(seenPolicy.mock.calls[0][0].resource).toBeUndefined();
+	});
+
+	it("client_credentials: grantPolicy.evaluate IS called with resource: undefined when flag is on but body has no resource", async () => {
+		// Operator opted in → policy gate runs even without a resource param.
+		const seenPolicy = vi.fn().mockResolvedValue({ outcome: "allow" });
+		const policy = makeStubPolicy(seenPolicy);
+		const deps = makeCCDeps({ grantPolicy: policy }, true);
+		const handler = createClientCredentialsGrant(deps);
+
+		await handler.handle(makeCCCtx({})); // no body.resource
+
+		expect(seenPolicy).toHaveBeenCalledOnce();
+		expect(seenPolicy.mock.calls[0][0].resource).toBeUndefined();
 	});
 });

--- a/packages/oauth/src/__tests__/resourceIndicator.flag.test.mts
+++ b/packages/oauth/src/__tests__/resourceIndicator.flag.test.mts
@@ -15,12 +15,21 @@
  */
 
 /**
- * RFC 8707 opt-in plumbing — flag-off / flag-on tests for the 3 grant handlers
+ * RFC 8707 opt-in plumbing — flag-off / flag-on tests for the grant handlers
  * that carry `extractResourceParam` wiring (T18). Token-exchange is excluded
  * per spec §5.2.
  *
- * Each describe block has 3 grants × 3 tests = 9 tests, plus a regression note
- * confirming token-exchange is untouched.
+ * Wave 1 partial coverage:
+ * - refresh_token: resource indicator plumbed (flag-on forwards body.resource)
+ * - client_credentials: resource indicator plumbed (flag-on forwards body.resource)
+ * - authorization_code: intentionally DEFERRED to Wave 2.
+ *   At the token endpoint, scope is already locked by the authorization-endpoint
+ *   policy (C-2 / D-1 evaluate-once-at-authorize). Applying resource-aware
+ *   narrowing at the token endpoint would require a Wave 2 design that respects
+ *   that invariant. body.resource is currently ignored for authorization_code.
+ *   Tests below lock in this "never invokes policy at auth_code token endpoint"
+ *   invariant explicitly so a future refactor cannot accidentally reintroduce
+ *   the T18 partial that Codex Round 3 flagged as P1 (over-scoped tokens).
  */
 
 import { createSecretKey } from "node:crypto";
@@ -349,32 +358,31 @@ describe("RFC 8707 resource indicator — flag on", () => {
 		expect(capturedResource).toEqual(["https://r1", "https://r2"]);
 	});
 
-	it("authorization_code: grantPolicy.evaluate sees resource: [string] when body.resource is string", async () => {
-		let capturedResource: unknown = "NOT_CALLED";
-		const policy = makeStubPolicy(async (req) => {
-			capturedResource = req.resource;
-			return { outcome: "allow" };
-		});
+	it("authorization_code: grantPolicy.evaluate is NOT called even when flag is on and body.resource is string (Wave 2 deferred)", async () => {
+		// body.resource is intentionally ignored for authorization_code at the
+		// token endpoint. Scope is already locked at /authorize (C-2 / D-1).
+		// Applying resource-aware narrowing here would violate evaluate-once-at-authorize.
+		// This test locks in the deferral: a future refactor must not silently
+		// reintroduce the T18 invocation without a Wave 2 redesign review.
+		const seenPolicy = vi.fn().mockResolvedValue({ outcome: "allow" });
+		const policy = makeStubPolicy(seenPolicy);
 		const deps = makeAuthzDeps({ grantPolicy: policy }, true);
 		const handler = createAuthorizationGrant(deps);
 
 		await handler.handle(makeAuthzCtx({ resource: "https://rs1" }));
 
-		expect(capturedResource).toEqual(["https://rs1"]);
+		expect(seenPolicy).not.toHaveBeenCalled();
 	});
 
-	it("authorization_code: grantPolicy.evaluate sees resource: array when body.resource is array", async () => {
-		let capturedResource: unknown = "NOT_CALLED";
-		const policy = makeStubPolicy(async (req) => {
-			capturedResource = req.resource;
-			return { outcome: "allow" };
-		});
+	it("authorization_code: grantPolicy.evaluate is NOT called even when flag is on and body.resource is array (Wave 2 deferred)", async () => {
+		const seenPolicy = vi.fn().mockResolvedValue({ outcome: "allow" });
+		const policy = makeStubPolicy(seenPolicy);
 		const deps = makeAuthzDeps({ grantPolicy: policy }, true);
 		const handler = createAuthorizationGrant(deps);
 
 		await handler.handle(makeAuthzCtx({ resource: ["https://r1", "https://r2"] }));
 
-		expect(capturedResource).toEqual(["https://r1", "https://r2"]);
+		expect(seenPolicy).not.toHaveBeenCalled();
 	});
 
 	it("client_credentials: grantPolicy.evaluate sees resource: [string] when body.resource is string", async () => {
@@ -405,10 +413,10 @@ describe("RFC 8707 resource indicator — flag on", () => {
 		expect(capturedResource).toEqual(["https://r1", "https://r2"]);
 	});
 
-	it("authorization_code: grantPolicy.evaluate IS called with resource: undefined when flag is on but body has no resource", async () => {
-		// Operator opted in → policy gate runs even without a resource param.
-		// This locks in the "feature on, client omitted resource" case so a future
-		// refactor cannot accidentally treat it as flag-off.
+	it("authorization_code: grantPolicy.evaluate is NOT called even when flag is on and body has no resource (Wave 2 deferred)", async () => {
+		// Invariant: authorization_code NEVER invokes grantPolicy.evaluate at the
+		// token endpoint regardless of flag state or body.resource presence.
+		// body.resource is silently ignored. This is the Wave 2 deferral invariant.
 		const seenPolicy = vi.fn().mockResolvedValue({ outcome: "allow" });
 		const policy = makeStubPolicy(seenPolicy);
 		const deps = makeAuthzDeps({ grantPolicy: policy }, true);
@@ -416,8 +424,7 @@ describe("RFC 8707 resource indicator — flag on", () => {
 
 		await handler.handle(makeAuthzCtx({})); // no body.resource
 
-		expect(seenPolicy).toHaveBeenCalledOnce();
-		expect(seenPolicy.mock.calls[0][0].resource).toBeUndefined();
+		expect(seenPolicy).not.toHaveBeenCalled();
 	});
 
 	it("client_credentials: grantPolicy.evaluate IS called with resource: undefined when flag is on but body has no resource", async () => {
@@ -432,4 +439,46 @@ describe("RFC 8707 resource indicator — flag on", () => {
 		expect(seenPolicy).toHaveBeenCalledOnce();
 		expect(seenPolicy.mock.calls[0][0].resource).toBeUndefined();
 	});
+});
+
+// ---------------------------------------------------------------------------
+// Invariant: authorization_code NEVER invokes grantPolicy at token endpoint
+// ---------------------------------------------------------------------------
+// Wave 2 deferral lock. This describe block exists as a single explicit
+// statement of the invariant so that any future PR touching authorization.mts
+// must consciously delete or modify this test — making the deferral decision
+// visible in code review, not just in comments.
+// ---------------------------------------------------------------------------
+
+describe("RFC 8707 authorization_code — token-endpoint policy invariant (Wave 2 deferred)", () => {
+	const flagStates: Array<{ label: string; enabled: boolean | undefined }> = [
+		{ label: "flag absent", enabled: undefined },
+		{ label: "flag explicit false", enabled: false },
+		{ label: "flag explicit true", enabled: true },
+	];
+
+	const resourceStates: Array<{ label: string; resource?: string | string[] }> = [
+		{ label: "no body.resource" },
+		{ label: "body.resource string", resource: "https://rs1.example" },
+		{ label: "body.resource array", resource: ["https://r1.example", "https://r2.example"] },
+	];
+
+	for (const flagState of flagStates) {
+		for (const resourceState of resourceStates) {
+			it(`grantPolicy.evaluate is NOT called: ${flagState.label}, ${resourceState.label}`, async () => {
+				const seenPolicy = vi.fn().mockResolvedValue({ outcome: "allow" });
+				const policy = makeStubPolicy(seenPolicy);
+				const deps = makeAuthzDeps({ grantPolicy: policy }, flagState.enabled);
+				const handler = createAuthorizationGrant(deps);
+
+				const bodyOverrides: Record<string, unknown> = {};
+				if (resourceState.resource !== undefined) {
+					bodyOverrides.resource = resourceState.resource;
+				}
+				await handler.handle(makeAuthzCtx(bodyOverrides));
+
+				expect(seenPolicy).not.toHaveBeenCalled();
+			});
+		}
+	}
 });

--- a/packages/oauth/src/__tests__/resourceIndicator.flag.test.mts
+++ b/packages/oauth/src/__tests__/resourceIndicator.flag.test.mts
@@ -1,0 +1,412 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * RFC 8707 opt-in plumbing — flag-off / flag-on tests for the 3 grant handlers
+ * that carry `extractResourceParam` wiring (T18). Token-exchange is excluded
+ * per spec §5.2.
+ *
+ * Each describe block has 3 grants × 3 tests = 9 tests, plus a regression note
+ * confirming token-exchange is untouched.
+ */
+
+import { createSecretKey } from "node:crypto";
+import {
+	type AuthenticatedClient,
+	type ClientRepository,
+	type CodeRepository,
+	createSymmetricKeyStore,
+	type GrantContext,
+	type GrantDependencies,
+	type GrantPolicyHook,
+} from "@o3co/auth-provider-core";
+import { SignJWT } from "jose";
+import { describe, expect, it, vi } from "vitest";
+import { createAuthorizationGrant } from "#/grants/authorization.mjs";
+import { createClientCredentialsGrant } from "#/grants/clientCredentials.mjs";
+import { createRefreshTokenGrant } from "#/grants/refreshToken.mjs";
+
+// ---------------------------------------------------------------------------
+// Shared test setup
+// ---------------------------------------------------------------------------
+
+const SECRET = "test-secret-at-least-32-chars!!";
+const keyStore = createSymmetricKeyStore(SECRET);
+const secretKey = createSecretKey(Buffer.from(SECRET));
+
+const RP_URI = "https://rp.example/cb";
+const CLIENT_ID = "client1";
+
+const DEFAULT_AUTH_CLIENT: AuthenticatedClient = {
+	clientId: CLIENT_ID,
+	tokenEndpointAuthMethod: "client_secret_basic",
+	allowedGrantTypes: ["client_credentials"],
+	allowedScopes: ["read:res"],
+};
+
+function makeStubPolicy(
+	evaluate: GrantPolicyHook["evaluate"] = async () => ({ outcome: "allow" }),
+): GrantPolicyHook {
+	return { kind: "stub", evaluate };
+}
+
+// ---------------------------------------------------------------------------
+// refresh_token setup helpers
+// ---------------------------------------------------------------------------
+
+async function makeRefreshToken(overrides: Record<string, unknown> = {}): Promise<string> {
+	return new SignJWT({ sub: "u1", scope: "read write", ...overrides })
+		.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+		.setIssuer("localhost")
+		.setAudience(CLIENT_ID)
+		.setExpirationTime("24h")
+		.sign(secretKey);
+}
+
+function makeRefreshDeps(
+	extra: Partial<GrantDependencies> = {},
+	enableResourceIndicator?: boolean,
+): GrantDependencies {
+	const base = {
+		oauth: {
+			jwt: { secret: SECRET },
+			accessToken: { expiresIn: 3600 },
+			refreshToken: { expiresIn: 86400, unknownFamilyPolicy: "reject" },
+			grants: {
+				authorization_code: { enabled: true },
+				refresh_token: { enabled: true },
+			},
+		},
+	};
+	if (enableResourceIndicator !== undefined) {
+		(base.oauth as Record<string, unknown>).resourceIndicator = {
+			enabled: enableResourceIndicator,
+		};
+	}
+	return {
+		config: base as unknown as GrantDependencies["config"],
+		keyStore,
+		...extra,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// authorization_code setup helpers
+// ---------------------------------------------------------------------------
+
+const mockClientRepository: ClientRepository = {
+	findById: vi.fn().mockResolvedValue(null),
+	authenticate: vi.fn().mockResolvedValue(null),
+};
+
+function makeAuthzDeps(
+	extra: Partial<GrantDependencies> = {},
+	enableResourceIndicator?: boolean,
+): GrantDependencies & { codeRepository: CodeRepository; clientRepository: ClientRepository } {
+	const base = {
+		oauth: {
+			jwt: { secret: "test-secret" },
+			accessToken: { expiresIn: 3600 },
+			refreshToken: { expiresIn: 86400 },
+			grants: {
+				authorization_code: { enabled: true },
+				refresh_token: { enabled: true },
+			},
+		},
+	};
+	if (enableResourceIndicator !== undefined) {
+		(base.oauth as Record<string, unknown>).resourceIndicator = {
+			enabled: enableResourceIndicator,
+		};
+	}
+	return {
+		config: base as unknown as GrantDependencies["config"],
+		keyStore: createSymmetricKeyStore("test-secret"),
+		codeRepository: {
+			consumeByCode: vi.fn().mockResolvedValue({ client_id: CLIENT_ID, redirect_uri: RP_URI }),
+			createCode: vi.fn(),
+			findByCode: vi.fn(),
+			removeByCode: vi.fn(),
+		} as unknown as CodeRepository,
+		clientRepository: mockClientRepository,
+		...extra,
+	};
+}
+
+function makeAuthzCtx(bodyOverrides: Record<string, unknown> = {}): GrantContext {
+	return {
+		body: {
+			code: "abc",
+			redirect_uri: RP_URI,
+			...bodyOverrides,
+		},
+		session: { user: { id: "u1" } },
+		issuer: "localhost",
+		metadata: { ip: "127.0.0.1" },
+		authenticatedClient: DEFAULT_AUTH_CLIENT,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// client_credentials setup helpers
+// ---------------------------------------------------------------------------
+
+function makeCCDeps(
+	extra: Partial<GrantDependencies> = {},
+	enableResourceIndicator?: boolean,
+): GrantDependencies {
+	const base = {
+		oauth: {
+			jwt: { issuer: "https://test.example" },
+			accessToken: { expiresIn: 3600 },
+			refreshToken: { expiresIn: 86400 },
+		},
+	};
+	if (enableResourceIndicator !== undefined) {
+		(base.oauth as Record<string, unknown>).resourceIndicator = {
+			enabled: enableResourceIndicator,
+		};
+	}
+	return {
+		config: base as unknown as GrantDependencies["config"],
+		keyStore,
+		...extra,
+	};
+}
+
+function makeCCCtx(bodyOverrides: Record<string, unknown> = {}): GrantContext {
+	return {
+		body: { grant_type: "client_credentials", ...bodyOverrides },
+		session: {},
+		issuer: "https://test.example",
+		metadata: {},
+		authenticatedClient: DEFAULT_AUTH_CLIENT,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests: flag off (resourceIndicator absent from config)
+// ---------------------------------------------------------------------------
+
+describe("RFC 8707 resource indicator — flag off (default, resourceIndicator absent)", () => {
+	it("refresh_token: grantPolicy.evaluate sees resource: undefined when body.resource present", async () => {
+		const token = await makeRefreshToken();
+		let capturedResource: unknown = "NOT_CALLED";
+		const policy = makeStubPolicy(async (req) => {
+			capturedResource = req.resource;
+			return { outcome: "allow" };
+		});
+		const deps = makeRefreshDeps({ grantPolicy: policy });
+		const handler = createRefreshTokenGrant(deps);
+
+		await handler.handle({
+			body: { refresh_token: token, resource: "https://rs1" },
+			session: {},
+			issuer: "localhost",
+			metadata: {},
+			authenticatedClient: DEFAULT_AUTH_CLIENT,
+		});
+
+		expect(capturedResource).toBeUndefined();
+	});
+
+	it("authorization_code: grantPolicy.evaluate sees resource: undefined when body.resource present", async () => {
+		let capturedResource: unknown = "NOT_CALLED";
+		const policy = makeStubPolicy(async (req) => {
+			capturedResource = req.resource;
+			return { outcome: "allow" };
+		});
+		const deps = makeAuthzDeps({ grantPolicy: policy });
+		const handler = createAuthorizationGrant(deps);
+
+		await handler.handle(makeAuthzCtx({ resource: "https://rs1" }));
+
+		expect(capturedResource).toBeUndefined();
+	});
+
+	it("client_credentials: grantPolicy.evaluate sees resource: undefined when body.resource present", async () => {
+		let capturedResource: unknown = "NOT_CALLED";
+		const policy = makeStubPolicy(async (req) => {
+			capturedResource = req.resource;
+			return { outcome: "allow" };
+		});
+		const deps = makeCCDeps({ grantPolicy: policy });
+		const handler = createClientCredentialsGrant(deps);
+
+		await handler.handle(makeCCCtx({ resource: "https://rs1" }));
+
+		expect(capturedResource).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: flag off (resourceIndicator.enabled === false, explicit)
+// ---------------------------------------------------------------------------
+
+describe("RFC 8707 resource indicator — flag off (explicit false)", () => {
+	it("refresh_token: grantPolicy.evaluate sees resource: undefined when body.resource present", async () => {
+		const token = await makeRefreshToken();
+		let capturedResource: unknown = "NOT_CALLED";
+		const policy = makeStubPolicy(async (req) => {
+			capturedResource = req.resource;
+			return { outcome: "allow" };
+		});
+		const deps = makeRefreshDeps({ grantPolicy: policy }, false);
+		const handler = createRefreshTokenGrant(deps);
+
+		await handler.handle({
+			body: { refresh_token: token, resource: "https://rs1" },
+			session: {},
+			issuer: "localhost",
+			metadata: {},
+			authenticatedClient: DEFAULT_AUTH_CLIENT,
+		});
+
+		expect(capturedResource).toBeUndefined();
+	});
+
+	it("authorization_code: grantPolicy.evaluate sees resource: undefined when body.resource present", async () => {
+		let capturedResource: unknown = "NOT_CALLED";
+		const policy = makeStubPolicy(async (req) => {
+			capturedResource = req.resource;
+			return { outcome: "allow" };
+		});
+		const deps = makeAuthzDeps({ grantPolicy: policy }, false);
+		const handler = createAuthorizationGrant(deps);
+
+		await handler.handle(makeAuthzCtx({ resource: "https://rs1" }));
+
+		expect(capturedResource).toBeUndefined();
+	});
+
+	it("client_credentials: grantPolicy.evaluate sees resource: undefined when body.resource present", async () => {
+		let capturedResource: unknown = "NOT_CALLED";
+		const policy = makeStubPolicy(async (req) => {
+			capturedResource = req.resource;
+			return { outcome: "allow" };
+		});
+		const deps = makeCCDeps({ grantPolicy: policy }, false);
+		const handler = createClientCredentialsGrant(deps);
+
+		await handler.handle(makeCCCtx({ resource: "https://rs1" }));
+
+		expect(capturedResource).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: flag on (resourceIndicator.enabled === true)
+// ---------------------------------------------------------------------------
+
+describe("RFC 8707 resource indicator — flag on", () => {
+	it("refresh_token: grantPolicy.evaluate sees resource: [string] when body.resource is string", async () => {
+		const token = await makeRefreshToken();
+		let capturedResource: unknown = "NOT_CALLED";
+		const policy = makeStubPolicy(async (req) => {
+			capturedResource = req.resource;
+			return { outcome: "allow" };
+		});
+		const deps = makeRefreshDeps({ grantPolicy: policy }, true);
+		const handler = createRefreshTokenGrant(deps);
+
+		await handler.handle({
+			body: { refresh_token: token, resource: "https://rs1" },
+			session: {},
+			issuer: "localhost",
+			metadata: {},
+			authenticatedClient: DEFAULT_AUTH_CLIENT,
+		});
+
+		expect(capturedResource).toEqual(["https://rs1"]);
+	});
+
+	it("refresh_token: grantPolicy.evaluate sees resource: array when body.resource is array", async () => {
+		const token = await makeRefreshToken();
+		let capturedResource: unknown = "NOT_CALLED";
+		const policy = makeStubPolicy(async (req) => {
+			capturedResource = req.resource;
+			return { outcome: "allow" };
+		});
+		const deps = makeRefreshDeps({ grantPolicy: policy }, true);
+		const handler = createRefreshTokenGrant(deps);
+
+		await handler.handle({
+			body: { refresh_token: token, resource: ["https://r1", "https://r2"] },
+			session: {},
+			issuer: "localhost",
+			metadata: {},
+			authenticatedClient: DEFAULT_AUTH_CLIENT,
+		});
+
+		expect(capturedResource).toEqual(["https://r1", "https://r2"]);
+	});
+
+	it("authorization_code: grantPolicy.evaluate sees resource: [string] when body.resource is string", async () => {
+		let capturedResource: unknown = "NOT_CALLED";
+		const policy = makeStubPolicy(async (req) => {
+			capturedResource = req.resource;
+			return { outcome: "allow" };
+		});
+		const deps = makeAuthzDeps({ grantPolicy: policy }, true);
+		const handler = createAuthorizationGrant(deps);
+
+		await handler.handle(makeAuthzCtx({ resource: "https://rs1" }));
+
+		expect(capturedResource).toEqual(["https://rs1"]);
+	});
+
+	it("authorization_code: grantPolicy.evaluate sees resource: array when body.resource is array", async () => {
+		let capturedResource: unknown = "NOT_CALLED";
+		const policy = makeStubPolicy(async (req) => {
+			capturedResource = req.resource;
+			return { outcome: "allow" };
+		});
+		const deps = makeAuthzDeps({ grantPolicy: policy }, true);
+		const handler = createAuthorizationGrant(deps);
+
+		await handler.handle(makeAuthzCtx({ resource: ["https://r1", "https://r2"] }));
+
+		expect(capturedResource).toEqual(["https://r1", "https://r2"]);
+	});
+
+	it("client_credentials: grantPolicy.evaluate sees resource: [string] when body.resource is string", async () => {
+		let capturedResource: unknown = "NOT_CALLED";
+		const policy = makeStubPolicy(async (req) => {
+			capturedResource = req.resource;
+			return { outcome: "allow" };
+		});
+		const deps = makeCCDeps({ grantPolicy: policy }, true);
+		const handler = createClientCredentialsGrant(deps);
+
+		await handler.handle(makeCCCtx({ resource: "https://rs1" }));
+
+		expect(capturedResource).toEqual(["https://rs1"]);
+	});
+
+	it("client_credentials: grantPolicy.evaluate sees resource: array when body.resource is array", async () => {
+		let capturedResource: unknown = "NOT_CALLED";
+		const policy = makeStubPolicy(async (req) => {
+			capturedResource = req.resource;
+			return { outcome: "allow" };
+		});
+		const deps = makeCCDeps({ grantPolicy: policy }, true);
+		const handler = createClientCredentialsGrant(deps);
+
+		await handler.handle(makeCCCtx({ resource: ["https://r1", "https://r2"] }));
+
+		expect(capturedResource).toEqual(["https://r1", "https://r2"]);
+	});
+});

--- a/packages/oauth/src/grants/__tests__/_resourceIndicator.test.mts
+++ b/packages/oauth/src/grants/__tests__/_resourceIndicator.test.mts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { extractResourceParam } from "#/grants/_resourceIndicator.mjs";
+
+describe("extractResourceParam", () => {
+	it("returns null when resource is absent", () => {
+		expect(extractResourceParam({})).toBeNull();
+	});
+
+	it("returns null when resource is empty string", () => {
+		expect(extractResourceParam({ resource: "" })).toBeNull();
+	});
+
+	it("wraps a single string value in an array", () => {
+		expect(extractResourceParam({ resource: "https://rs1.example" })).toEqual([
+			"https://rs1.example",
+		]);
+	});
+
+	it("does NOT split on commas — URIs may contain commas (RFC 8707 §5.4)", () => {
+		expect(extractResourceParam({ resource: "https://a,b.example" })).toEqual([
+			"https://a,b.example",
+		]);
+	});
+
+	it("returns the array as-is when resource is an array of strings", () => {
+		expect(extractResourceParam({ resource: ["https://r1", "https://r2"] })).toEqual([
+			"https://r1",
+			"https://r2",
+		]);
+	});
+
+	it("returns null for a non-string, non-array value (defensive)", () => {
+		expect(extractResourceParam({ resource: 42 as unknown })).toBeNull();
+	});
+
+	it("returns null when the array contains a non-string element (defensive against mixed-type arrays)", () => {
+		expect(extractResourceParam({ resource: ["https://r1", 42] as unknown })).toBeNull();
+	});
+});

--- a/packages/oauth/src/grants/_resourceIndicator.mts
+++ b/packages/oauth/src/grants/_resourceIndicator.mts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * File-internal helper for extracting the RFC 8707 `resource` parameter from
+ * a request body. Internal to grants/ — NOT exported from the package barrel.
+ * The leading underscore signals file-internal status to sibling modules.
+ *
+ * No comma-splitting is performed: RFC 8707 §5.4 treats each `resource`
+ * value as a URI and URIs may legally contain commas, so splitting would
+ * silently corrupt valid resource indicators.
+ */
+
+/**
+ * Extracts the `resource` parameter from a token request body per RFC 8707.
+ *
+ * Returns `null` when the parameter is absent, null, or an empty string.
+ * A single string is normalised to a one-element array. An array is returned
+ * as-is only when every element is a string; otherwise returns `null`
+ * (defensive against malformed / injected input).
+ */
+export function extractResourceParam(body: Record<string, unknown>): readonly string[] | null {
+	const v = body.resource;
+	if (v === undefined || v === null || v === "") return null;
+	if (typeof v === "string") return [v];
+	if (Array.isArray(v) && v.every((x) => typeof x === "string")) return v as readonly string[];
+	return null;
+}

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -30,6 +30,7 @@ import {
 	type UserSession,
 } from "@o3co/auth-provider-core";
 import { decodeJwtPayload } from "./_jwtPayload.mjs";
+import { extractResourceParam } from "./_resourceIndicator.mjs";
 import { resolvePkceSupportedMethods } from "./pkce.mjs";
 
 export const createAuthorizationGrant = (
@@ -338,6 +339,52 @@ export const createAuthorizationGrant = (
 
 			const rawUserId = (session.user as Record<string, unknown> | undefined)?.id;
 			const userId = typeof rawUserId === "string" ? rawUserId : undefined;
+
+			// RFC 8707: supplementary resource-indicator policy check at the token
+			// endpoint (separate from the scope-narrowing policy evaluated once at
+			// /authorize per C-2 / D-1 design). Only runs when grantPolicy is wired
+			// AND the resource indicator feature is opted in. Flag-off (default)
+			// leaves resource: undefined so the policy sees no resource constraint —
+			// preserving pre-existing behaviour for all existing deployments.
+			if (deps.grantPolicy) {
+				const resourceIndicatorEnabled = deps.config.oauth.resourceIndicator?.enabled === true;
+				const resource = resourceIndicatorEnabled
+					? extractResourceParam(body as Record<string, unknown>)
+					: null;
+				let decision: Awaited<ReturnType<typeof deps.grantPolicy.evaluate>>;
+				try {
+					decision = await deps.grantPolicy.evaluate(
+						{
+							grantType: "authorization_code",
+							clientId: authenticatedClientId,
+							subject: userId,
+							requestedScope:
+								grantedScopes && grantedScopes.length > 0 ? [...grantedScopes] : undefined,
+							// RFC 8707: populated only when oauth.resourceIndicator.enabled
+							// is true; undefined otherwise.
+							resource: resource ?? undefined,
+						},
+						{ ip: ctx.ip, userAgent: ctx.userAgent, issuer: issuer ?? "" },
+					);
+				} catch {
+					return {
+						result: {
+							status: 503,
+							error: "temporarily_unavailable",
+							errorDescription: "policy evaluation unavailable",
+						},
+					};
+				}
+				if (decision.outcome === "deny") {
+					return {
+						result: {
+							status: 400,
+							error: decision.error,
+							errorDescription: decision.errorDescription,
+						},
+					};
+				}
+			}
 
 			// Initial rt+jwt opens a new refresh-token family for replay detection
 			// per RFC 6819 §5.2.2.3. All subsequent rotations carry the same

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -30,7 +30,6 @@ import {
 	type UserSession,
 } from "@o3co/auth-provider-core";
 import { decodeJwtPayload } from "./_jwtPayload.mjs";
-import { extractResourceParam } from "./_resourceIndicator.mjs";
 import { resolvePkceSupportedMethods } from "./pkce.mjs";
 
 export const createAuthorizationGrant = (
@@ -339,51 +338,6 @@ export const createAuthorizationGrant = (
 
 			const rawUserId = (session.user as Record<string, unknown> | undefined)?.id;
 			const userId = typeof rawUserId === "string" ? rawUserId : undefined;
-
-			// RFC 8707: supplementary resource-indicator policy check at the token
-			// endpoint (separate from the scope-narrowing policy evaluated once at
-			// /authorize per C-2 / D-1 design). Only runs when grantPolicy is wired
-			// AND the resource indicator feature is explicitly opted in
-			// (oauth.resourceIndicator.enabled === true). Flag-off (the default)
-			// skips this block entirely — preserving pre-existing semantics for all
-			// deployments that wire grantPolicy without enabling RFC 8707.
-			const resourceIndicatorEnabled = deps.config.oauth.resourceIndicator?.enabled === true;
-			if (deps.grantPolicy && resourceIndicatorEnabled) {
-				const resource = extractResourceParam(body as Record<string, unknown>);
-				let decision: Awaited<ReturnType<typeof deps.grantPolicy.evaluate>>;
-				try {
-					decision = await deps.grantPolicy.evaluate(
-						{
-							grantType: "authorization_code",
-							clientId: authenticatedClientId,
-							subject: userId,
-							requestedScope:
-								grantedScopes && grantedScopes.length > 0 ? [...grantedScopes] : undefined,
-							// RFC 8707: resource is null when body has no `resource` param;
-							// undefined passed to policy signals "no resource requested".
-							resource: resource ?? undefined,
-						},
-						{ ip: ctx.ip, userAgent: ctx.userAgent, issuer: issuer ?? "" },
-					);
-				} catch {
-					return {
-						result: {
-							status: 503,
-							error: "temporarily_unavailable",
-							errorDescription: "policy evaluation unavailable",
-						},
-					};
-				}
-				if (decision.outcome === "deny") {
-					return {
-						result: {
-							status: 400,
-							error: decision.error,
-							errorDescription: decision.errorDescription,
-						},
-					};
-				}
-			}
 
 			// Initial rt+jwt opens a new refresh-token family for replay detection
 			// per RFC 6819 §5.2.2.3. All subsequent rotations carry the same

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -343,14 +343,13 @@ export const createAuthorizationGrant = (
 			// RFC 8707: supplementary resource-indicator policy check at the token
 			// endpoint (separate from the scope-narrowing policy evaluated once at
 			// /authorize per C-2 / D-1 design). Only runs when grantPolicy is wired
-			// AND the resource indicator feature is opted in. Flag-off (default)
-			// leaves resource: undefined so the policy sees no resource constraint —
-			// preserving pre-existing behaviour for all existing deployments.
-			if (deps.grantPolicy) {
-				const resourceIndicatorEnabled = deps.config.oauth.resourceIndicator?.enabled === true;
-				const resource = resourceIndicatorEnabled
-					? extractResourceParam(body as Record<string, unknown>)
-					: null;
+			// AND the resource indicator feature is explicitly opted in
+			// (oauth.resourceIndicator.enabled === true). Flag-off (the default)
+			// skips this block entirely — preserving pre-existing semantics for all
+			// deployments that wire grantPolicy without enabling RFC 8707.
+			const resourceIndicatorEnabled = deps.config.oauth.resourceIndicator?.enabled === true;
+			if (deps.grantPolicy && resourceIndicatorEnabled) {
+				const resource = extractResourceParam(body as Record<string, unknown>);
 				let decision: Awaited<ReturnType<typeof deps.grantPolicy.evaluate>>;
 				try {
 					decision = await deps.grantPolicy.evaluate(
@@ -360,8 +359,8 @@ export const createAuthorizationGrant = (
 							subject: userId,
 							requestedScope:
 								grantedScopes && grantedScopes.length > 0 ? [...grantedScopes] : undefined,
-							// RFC 8707: populated only when oauth.resourceIndicator.enabled
-							// is true; undefined otherwise.
+							// RFC 8707: resource is null when body has no `resource` param;
+							// undefined passed to policy signals "no resource requested".
 							resource: resource ?? undefined,
 						},
 						{ ip: ctx.ip, userAgent: ctx.userAgent, issuer: issuer ?? "" },

--- a/packages/oauth/src/grants/clientCredentials.mts
+++ b/packages/oauth/src/grants/clientCredentials.mts
@@ -23,6 +23,7 @@ import {
 	generateToken,
 	generateTokenResponse,
 } from "@o3co/auth-provider-core";
+import { extractResourceParam } from "./_resourceIndicator.mjs";
 
 const GRANT_TYPE = "client_credentials";
 
@@ -77,13 +78,64 @@ export const createClientCredentialsGrant = (deps: GrantDependencies): GrantHand
 			if ("error" in scopeOutcome) {
 				return { result: scopeOutcome };
 			}
-			const effectiveScopes = scopeOutcome.scopes;
+			let effectiveScopes = scopeOutcome.scopes;
 
 			// Pass `ctx.issuer` through untouched: `generateToken` omits the
 			// `iss` claim when it is null/undefined, matching the sibling
 			// authorization_code / refresh_token grants. Coercing undefined to
 			// `""` would emit a malformed `iss: ""` JWT.
 			const issuer = ctx.issuer;
+
+			if (deps.grantPolicy) {
+				// RFC 8707: resolve resource indicator (opt-in, default off).
+				const resourceIndicatorEnabled = deps.config.oauth.resourceIndicator?.enabled === true;
+				const resource = resourceIndicatorEnabled
+					? extractResourceParam(ctx.body as Record<string, unknown>)
+					: null;
+				// CP-18 pattern: fail-closed on policy throw — same rationale
+				// as the refresh_token path. Policy is a security boundary;
+				// failing open would effectively grant the pre-policy scope
+				// ceiling.
+				let decision: Awaited<ReturnType<typeof deps.grantPolicy.evaluate>>;
+				try {
+					decision = await deps.grantPolicy.evaluate(
+						{
+							grantType: GRANT_TYPE,
+							clientId: client.clientId,
+							// RFC 6749 §4.4: client_credentials has no end-user;
+							// subject is the client itself.
+							subject: client.clientId,
+							requestedScope: effectiveScopes.length > 0 ? [...effectiveScopes] : undefined,
+							// RFC 8707: populated only when oauth.resourceIndicator.enabled
+							// is true; undefined otherwise (flag-off preserves pre-existing
+							// semantics).
+							resource: resource ?? undefined,
+						},
+						{ ip: ctx.ip, userAgent: ctx.userAgent, issuer: issuer ?? "" },
+					);
+				} catch {
+					return {
+						result: {
+							status: 503,
+							error: "temporarily_unavailable",
+							errorDescription: "policy evaluation unavailable",
+						},
+					};
+				}
+				if (decision.outcome === "deny") {
+					return {
+						result: {
+							status: 400,
+							error: decision.error,
+							errorDescription: decision.errorDescription,
+						},
+					};
+				}
+				if (decision.grantedScope) {
+					effectiveScopes = decision.grantedScope;
+				}
+			}
+
 			const audience = client.allowedAudiences?.[0] ?? issuer ?? null;
 			const scopeClaim = effectiveScopes.length > 0 ? effectiveScopes.join(" ") : null;
 

--- a/packages/oauth/src/grants/clientCredentials.mts
+++ b/packages/oauth/src/grants/clientCredentials.mts
@@ -86,16 +86,17 @@ export const createClientCredentialsGrant = (deps: GrantDependencies): GrantHand
 			// `""` would emit a malformed `iss: ""` JWT.
 			const issuer = ctx.issuer;
 
-			if (deps.grantPolicy) {
-				// RFC 8707: resolve resource indicator (opt-in, default off).
-				const resourceIndicatorEnabled = deps.config.oauth.resourceIndicator?.enabled === true;
-				const resource = resourceIndicatorEnabled
-					? extractResourceParam(ctx.body as Record<string, unknown>)
-					: null;
+			// RFC 8707: resource-indicator policy check. Only runs when grantPolicy
+			// is wired AND oauth.resourceIndicator.enabled === true. Flag-off
+			// (the default) skips this block entirely — preserving pre-existing
+			// semantics for deployments that wire grantPolicy without RFC 8707.
+			const resourceIndicatorEnabled = deps.config.oauth.resourceIndicator?.enabled === true;
+			if (deps.grantPolicy && resourceIndicatorEnabled) {
 				// CP-18 pattern: fail-closed on policy throw — same rationale
 				// as the refresh_token path. Policy is a security boundary;
 				// failing open would effectively grant the pre-policy scope
 				// ceiling.
+				const resource = extractResourceParam(ctx.body as Record<string, unknown>);
 				let decision: Awaited<ReturnType<typeof deps.grantPolicy.evaluate>>;
 				try {
 					decision = await deps.grantPolicy.evaluate(
@@ -106,9 +107,8 @@ export const createClientCredentialsGrant = (deps: GrantDependencies): GrantHand
 							// subject is the client itself.
 							subject: client.clientId,
 							requestedScope: effectiveScopes.length > 0 ? [...effectiveScopes] : undefined,
-							// RFC 8707: populated only when oauth.resourceIndicator.enabled
-							// is true; undefined otherwise (flag-off preserves pre-existing
-							// semantics).
+							// RFC 8707: resource is null when body has no `resource` param;
+							// undefined passed to policy signals "no resource requested".
 							resource: resource ?? undefined,
 						},
 						{ ip: ctx.ip, userAgent: ctx.userAgent, issuer: issuer ?? "" },

--- a/packages/oauth/src/grants/clientCredentials.mts
+++ b/packages/oauth/src/grants/clientCredentials.mts
@@ -86,6 +86,11 @@ export const createClientCredentialsGrant = (deps: GrantDependencies): GrantHand
 			// `""` would emit a malformed `iss: ""` JWT.
 			const issuer = ctx.issuer;
 
+			// Audience from policy evaluation (Fix #3): set inside the
+			// grantPolicy block when decision.grantedAudience is valid.
+			// null means "no policy override — use the existing fallback".
+			let policyGrantedAudience: string | null = null;
+
 			// RFC 8707: resource-indicator policy check. Only runs when grantPolicy
 			// is wired AND oauth.resourceIndicator.enabled === true. Flag-off
 			// (the default) skips this block entirely — preserving pre-existing
@@ -132,11 +137,52 @@ export const createClientCredentialsGrant = (deps: GrantDependencies): GrantHand
 					};
 				}
 				if (decision.grantedScope) {
-					effectiveScopes = decision.grantedScope;
+					// CP-18: fail-closed. Re-validate the policy's returned scopes
+					// against client.allowedScopes — a buggy or compromised policy
+					// could return expanded scopes (e.g. 'admin' for a client
+					// allowed only 'read'). Mirrors the pattern in refreshToken.mts
+					// (CP-15) where grantedScope is checked against the original
+					// token's scope set.
+					const allowedSet = client.allowedScopes ?? [];
+					const exceeded = decision.grantedScope.filter((s) => !allowedSet.includes(s));
+					if (exceeded.length > 0) {
+						return {
+							result: {
+								status: 400,
+								error: "invalid_scope",
+								errorDescription: `policy returned scopes exceeding client allowedScopes: ${exceeded.join(" ")}`,
+							},
+						};
+					}
+					// CP-15 mirror: empty array → keep effectiveScopes unchanged
+					// (no narrowing signal) rather than wiping to empty.
+					if (decision.grantedScope.length > 0) {
+						effectiveScopes = decision.grantedScope;
+					}
+				}
+				if (decision.grantedAudience && decision.grantedAudience.length > 0) {
+					// Fail-closed audience validation: policy may only narrow to
+					// audiences already in client.allowedAudiences. An out-of-bounds
+					// audience from a buggy/compromised policy would mint a token
+					// accepted by a resource server the client is not authorized for.
+					const allowedAudSet = new Set(client.allowedAudiences ?? []);
+					const exceeded = decision.grantedAudience.filter((a) => !allowedAudSet.has(a));
+					if (exceeded.length > 0) {
+						return {
+							result: {
+								status: 400,
+								error: "invalid_request",
+								errorDescription: `policy returned audiences outside client allowedAudiences: ${exceeded.join(" ")}`,
+							},
+						};
+					}
+					// Use the policy-narrowed audience (flatten to first, matching
+					// the refresh_token and authorization_code grant patterns).
+					policyGrantedAudience = decision.grantedAudience[0];
 				}
 			}
 
-			const audience = client.allowedAudiences?.[0] ?? issuer ?? null;
+			const audience = policyGrantedAudience ?? client.allowedAudiences?.[0] ?? issuer ?? null;
 			const scopeClaim = effectiveScopes.length > 0 ? effectiveScopes.join(" ") : null;
 
 			const accessToken = await generateToken(

--- a/packages/oauth/src/grants/clientCredentials.mts
+++ b/packages/oauth/src/grants/clientCredentials.mts
@@ -136,29 +136,32 @@ export const createClientCredentialsGrant = (deps: GrantDependencies): GrantHand
 						},
 					};
 				}
-				if (decision.grantedScope) {
+				if (decision.grantedScope !== undefined) {
 					// CP-18: fail-closed. Re-validate the policy's returned scopes
-					// against client.allowedScopes — a buggy or compromised policy
-					// could return expanded scopes (e.g. 'admin' for a client
-					// allowed only 'read'). Mirrors the pattern in refreshToken.mts
-					// (CP-15) where grantedScope is checked against the original
-					// token's scope set.
-					const allowedSet = client.allowedScopes ?? [];
-					const exceeded = decision.grantedScope.filter((s) => !allowedSet.includes(s));
+					// against effectiveScopes (the already-narrowed request set, after
+					// client allowlist has been applied) — not against client.allowedScopes.
+					// A buggy/compromised policy returning a scope that was not in the
+					// request (e.g. 'write' for a request narrowed to 'read') is scope
+					// expansion and must be rejected, even if that scope is in
+					// client.allowedScopes. Mirrors refreshToken.mts CP-15 exactly:
+					// ceiling is the post-narrowing effective scope, not the full ceiling.
+					const requestedSet = new Set(effectiveScopes);
+					const exceeded = decision.grantedScope.filter((s) => !requestedSet.has(s));
 					if (exceeded.length > 0) {
 						return {
 							result: {
 								status: 400,
 								error: "invalid_scope",
-								errorDescription: `policy returned scopes exceeding client allowedScopes: ${exceeded.join(" ")}`,
+								errorDescription: `policy returned scopes exceeding requested scope: ${exceeded.join(" ")}`,
 							},
 						};
 					}
-					// CP-15 mirror: empty array → keep effectiveScopes unchanged
-					// (no narrowing signal) rather than wiping to empty.
-					if (decision.grantedScope.length > 0) {
-						effectiveScopes = decision.grantedScope;
-					}
+					// CP-15 mirror: assign unconditionally when policy returned the
+					// field — including empty array (policy intent: strip all scopes).
+					// Matches refreshToken.mts behavior: presence (even []) overrides
+					// effectiveScopes; the scope claim emission at line ~186 handles
+					// empty → null naturally (effectiveScopes.length > 0 check).
+					effectiveScopes = decision.grantedScope;
 				}
 				if (decision.grantedAudience && decision.grantedAudience.length > 0) {
 					// Fail-closed audience validation: policy may only narrow to

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -244,9 +244,27 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 					finalScope = decision.grantedScope.length > 0 ? decision.grantedScope.join(" ") : null;
 				}
 				if (decision.grantedAudience && decision.grantedAudience.length > 0) {
-					// generateToken carries a single `aud` claim; policy may narrow
-					// to multiple audiences, but we flatten to the first one here.
-					// Multi-audience tokens are out of scope for this grant path.
+					// Fail-closed audience validation: policy may only narrow to
+					// audiences already in client.allowedAudiences. An out-of-bounds
+					// audience from a buggy/compromised policy would mint a token
+					// accepted by a resource server the client is not authorized for.
+					// Mirrors clientCredentials.mts exactly (same ceiling, error code,
+					// message phrasing). Activated by T18 wiring resource into this
+					// path; pre-T18 grantPolicy paths that returned no grantedAudience
+					// are byte-equivalent (this block only runs on non-empty arrays).
+					const allowedAudSet = new Set(ctx.authenticatedClient.allowedAudiences ?? []);
+					const exceeded = decision.grantedAudience.filter((a) => !allowedAudSet.has(a));
+					if (exceeded.length > 0) {
+						return {
+							result: {
+								status: 400,
+								error: "invalid_request",
+								errorDescription: `policy returned audiences outside client allowedAudiences: ${exceeded.join(" ")}`,
+							},
+						};
+					}
+					// Flatten to first entry (multi-audience tokens are out of scope
+					// for this grant path — matches cc and authorization_code patterns).
 					finalAudience = decision.grantedAudience[0];
 				}
 			}

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -26,6 +26,7 @@ import {
 } from "@o3co/auth-provider-core";
 import type { JWTPayload } from "jose";
 import { decodeJwtPayload } from "./_jwtPayload.mjs";
+import { extractResourceParam } from "./_resourceIndicator.mjs";
 
 export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler => {
 	const { config, keyStore, logger } = deps;
@@ -181,6 +182,10 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				// the narrowed decision would have been. Failing open would
 				// effectively grant the pre-policy scope ceiling, which is
 				// exactly what policy exists to prevent.
+				const resourceIndicatorEnabled = deps.config.oauth.resourceIndicator?.enabled === true;
+				const resource = resourceIndicatorEnabled
+					? extractResourceParam(body as Record<string, unknown>)
+					: null;
 				let decision: Awaited<ReturnType<typeof deps.grantPolicy.evaluate>>;
 				try {
 					decision = await deps.grantPolicy.evaluate(
@@ -194,6 +199,10 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 								? [...new Set(requestedScope.split(" ").filter(Boolean))]
 								: undefined,
 							originalScope: scopeStr ? scopeStr.split(" ") : undefined,
+							// RFC 8707: populated only when oauth.resourceIndicator.enabled
+							// is true; undefined otherwise (flag-off preserves pre-existing
+							// semantics and token-exchange's independent resource contract).
+							resource: resource ?? undefined,
 						},
 						{ ip: ctx.ip, userAgent: ctx.userAgent, issuer: issuer ?? "" },
 					);

--- a/templates/standalone/src/__tests__/three-tier-resolution.test.mts
+++ b/templates/standalone/src/__tests__/three-tier-resolution.test.mts
@@ -95,4 +95,23 @@ describe("three-tier HOCON resolution (env → application.conf → reference.co
 		const config = buildResolvedConfig("development");
 		expect(grants(config).client_credentials?.enabled).toBe(false);
 	});
+
+	it("reference.conf default for oauth.resourceIndicator.enabled is false", () => {
+		// reference.conf must ship the literal `false` anchor so that the
+		// schema coercion (coerceBooleanFromEnv) can produce a boolean value.
+		// Without the HOCON block the field resolves to undefined.
+		const config = buildResolvedConfig("development");
+		expect(config.oauth.resourceIndicator?.enabled).toBe(false);
+	});
+
+	it("env var OAUTH_RESOURCE_INDICATOR_ENABLED=true reaches resolved config and coerces to boolean true", () => {
+		// HOCON env-substitution returns a string. The reference.conf anchor
+		// (`enabled = ${?OAUTH_RESOURCE_INDICATOR_ENABLED}`) lets the env var
+		// reach the resolved layer; the schema's coerceBooleanFromEnv turns
+		// "true" → true so `=== true` guards in grant handlers work correctly.
+		const config = buildResolvedConfig("development", {
+			OAUTH_RESOURCE_INDICATOR_ENABLED: "true",
+		});
+		expect(config.oauth.resourceIndicator?.enabled).toBe(true);
+	});
 });


### PR DESCRIPTION
## Summary

Implements **RFC 8707 Resource Indicator opt-in plumbing** per Wave 1 §5 Stage 1.

- New config flag `oauth.resourceIndicator.enabled` (default `false` via reference.conf per PR #171 discipline; consumer enables explicitly).
- File-internal helper `extractResourceParam` at `packages/oauth/src/grants/_resourceIndicator.mts` (no barrel export).
- Plumbed into `client_credentials` and `refresh_token` grants. Token-exchange unchanged (§5.2 non-goal).
- `authorization_code` token endpoint **intentionally deferred to Wave 2** (see "Stage boundary" below).
- `client_credentials` + `refresh_token` now fail-closed on policy-returned scope / audience expansion (cc) and audience expansion (refresh_token), mirroring CP-15 / CP-18 patterns.

Spec: `.claude/superpowers/specs/2026-05-12-wave-1-spec.md` §5
Plan: `.claude/superpowers/plans/2026-05-12-wave-1-plan.md` Phase 3 (Tasks 16–19)

## Commits

1. `baa14a68` T16 — schema field with `coerceBooleanFromEnv` z.preprocess (no `.default()`, per ADR 2026-04-30)
2. `21578b47` T17 — file-internal `extractResourceParam` helper
3. `5f7cc3f8` T18 — wire helper into 3 grants
4. `faa731b8` T18 follow-up — gate new policy invocations on flag-on (no behavior change when flag off)
5. `e750b6b0` Review fix #1 — add `oauth.resourceIndicator` block to reference.conf (convergence: Claude + Codex)
6. `01b82b6a` Review fix #2 + #3 — cc fail-closed scope validation + audience validation (CP-18 / Codex P2)
7. `d59c15df` Review fix Round 2 — cc ceiling = effectiveScopes + honor empty `grantedScope: []` (Codex Round 2 P1)
8. `3cadcf16` Review fix Round 3 — defer auth_code resource invocation to Wave 2 (revert T18 partial)
9. `c2e35ed6` Review fix Round 4 — refresh_token audience validation mirrors cc (Codex Round 4 P2)
10. `9d77afa9` CHANGELOG: Stage 1 entry + Stage 2 boundary disclosure

## Stage boundary (Wave 1 §5.6 staging)

Per spec §5.6, the 3-stage RFC 8707 migration is:

- **Stage 1 (this PR, Wave 1)**: opt-in plumbing — forward `body.resource` to the `GrantPolicyHook`. The policy may return narrowed scope / audience; both are now validated against the request set / client.allowedAudiences (fail-closed on expansion). The library does NOT itself enforce RFC 8707 §2 resource-to-audience binding.
- **Stage 2 (Wave 2)**: audience-restrict — library-level enforcement that issued `aud` represents the requested resource (matching token-exchange's existing IH-8 enforcement).
- **Stage 3 (Wave 3)**: require — `resource` MUST be present, missing parameter = `invalid_target`.

## Disclosure — dismissed Codex Round 5 findings (Stage 1 boundary)

Codex Round 5 (run after Round 4 fix) flagged 2 P2 issues:
- cc + refresh_token: policy may allow without `grantedAudience` (or return multiple) → resulting token `aud` may not represent the requested resource.

**Dismissed as Stage 2 (Wave 2) scope** per spec §5.6 staging. Stage 1's contract is "policy gets resource; library enforces subset-of-client-ceiling only". Stage 2 introduces the resource-to-audience binding enforcement. Token-exchange's existing IH-8 path is the reference implementation that Stage 2 will generalize to `client_credentials` / `refresh_token`.

**Overturn condition**: if the project decides to collapse Stage 1+2 into a single Wave 1 deliverable. Currently the staging is explicit in the spec, with stakeholder rationale documented in the inventory (`project_post_v060_inventory.md`).

A follow-up issue will be filed post-merge for Stage 2 audience-restrict enforcement.

## Auth-code deferral rationale

T18a (5f7cc3f8) initially added a new `grantPolicy.evaluate(...)` invocation at the auth_code token endpoint. Three review rounds surfaced increasingly serious issues with this site:

- Round 1 Claude (Minor): "asymmetric — discards `grantedScope`"
- Round 3 Codex (P1): "honors deny but ignores `grantedScope`/`grantedAudience` narrowing → over-scoped tokens"

The root cause: auth_code's scope is narrowed once at `/authorize` per C-2 / D-1 evaluate-once-at-authorize design. Adding a 2nd policy invocation at the token endpoint either (a) breaks the C-2 / D-1 invariant or (b) leaves the policy decision unused. Wave 1 §5 is "plumb resource into 3 grants", not "introduce new policy invocation lifecycle".

Commit `3cadcf16` reverts the auth_code addition; `authorization.mts` is now byte-equivalent to develop. `body.resource` at the auth_code token endpoint is silently ignored pending a Wave 2 design.

## Test plan

- [x] Config schema accepts boolean true/false + HOCON-env-substituted string `"true"`/`"false"`; rejects other strings / non-booleans (7 tests)
- [x] reference.conf 3-tier resolution: default false; env-var `OAUTH_RESOURCE_INDICATOR_ENABLED=true` reaches resolved config as boolean true (2 tests in three-tier-resolution.test.mts)
- [x] `extractResourceParam` helper: 7 test cases incl. RFC 8707 non-comma-split + mixed-type-array defensive rejection
- [x] Each grant respects flag-off: `client_credentials` + `refresh_token` see `resource: undefined` in policy request; `authorization_code` does NOT invoke policy at token endpoint regardless of flag state (9 parametrized invariant tests + 4 per-grant tests)
- [x] Each grant respects flag-on: `client_credentials` + `refresh_token` pass body.resource via policy; `authorization_code` still ignores per Wave 2 deferral
- [x] `client_credentials` fail-closed: policy expanding scope beyond effectiveScopes → 400 invalid_scope; empty `grantedScope: []` honored as strip-all
- [x] `client_credentials` audience: policy `grantedAudience` outside `client.allowedAudiences` → 400 invalid_request; subset → applied; absent → fallback to `client.allowedAudiences[0]` / issuer
- [x] `refresh_token` audience: mirrors cc's subset validation (Codex Round 4 P2 fix)
- [x] Token-exchange untouched: no test file modified
- [x] Full repo `pnpm test` green
- [x] `pnpm run lint` clean
- [x] `pnpm run build` (tsc --strict) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)