### PR TITLE
fix(webauthn): Wave 1 post-merge security audit — H-1/H-2 + M-1..M-4

### DIFF
--- a/packages/webauthn/README.md
+++ b/packages/webauthn/README.md
@@ -86,7 +86,7 @@ The webauthn grant has **no library-side `allowedScopes` ceiling**. Client crede
 
 `grantPolicy` is the **only scope-bounding gate** for this grant. Policy invocation is unconditional whenever `grantPolicy` is wired — it is NOT gated on `oauth.resourceIndicator.enabled` (that flag controls only whether `body.resource` is forwarded to the policy, per Stage 1 RFC 8707 plumbing). This mirrors the `refresh_token` grant pattern.
 
-**`grantPolicy` is REQUIRED at boot.** As of the Wave 1 post-merge security fix, wiring `webauthnModule` without a `grantPolicy` slot fails fast at `createApp(...)` with a clear error. There is no silent-allow-all path. Deployments that intentionally accept unbounded scope (NOT recommended for production) must wire an explicit no-op policy returning `{ outcome: "permit" }` — making the choice visible in the composition root.
+**`grantPolicy` is REQUIRED at boot.** As of the Wave 1 post-merge security fix, wiring `webauthnModule` without a `grantPolicy` slot fails fast at `createApp(...)` with a clear error. There is no silent-allow-all path. Deployments that intentionally accept unbounded scope (NOT recommended for production) must wire an explicit no-op policy returning `{ outcome: "allow" }` — making the choice visible in the composition root.
 
 ## SECURITY — token revocation limitations
 

--- a/packages/webauthn/README.md
+++ b/packages/webauthn/README.md
@@ -78,15 +78,19 @@ await store.registerCredential({ userId: opaqueUserId, /* ... */ });
 
 The bootstrap module's `webauthnSubject` should therefore expose the opaque handle as `userId`, not the email or username.
 
+The registration endpoints enforce a 1..64-byte length on `webauthnSubject.userId` (WebAuthn §5.4.3 user-handle constraint). Requests with a userId outside this range fail with 500 `server_error` — this is a consumer-misconfiguration check, not a runtime user error.
+
 ## SECURITY — scope authorization
 
 The webauthn grant has **no library-side `allowedScopes` ceiling**. Client credentials and authorization code grants bind issued scope to `client.allowedScopes` at the handler level; webauthn cannot, because the passkey is the authentication event, not a scope authorization token.
 
 `grantPolicy` is the **only scope-bounding gate** for this grant. Policy invocation is unconditional whenever `grantPolicy` is wired — it is NOT gated on `oauth.resourceIndicator.enabled` (that flag controls only whether `body.resource` is forwarded to the policy, per Stage 1 RFC 8707 plumbing). This mirrors the `refresh_token` grant pattern.
 
-Deployments wanting scope authorization **MUST wire `grantPolicy`**. Without it, the grant issues whatever scope the caller requests.
+**`grantPolicy` is REQUIRED at boot.** As of the Wave 1 post-merge security fix, wiring `webauthnModule` without a `grantPolicy` slot fails fast at `createApp(...)` with a clear error. There is no silent-allow-all path. Deployments that intentionally accept unbounded scope (NOT recommended for production) must wire an explicit no-op policy returning `{ outcome: "permit" }` — making the choice visible in the composition root.
 
-When `grantPolicy` is not wired and scope is requested, the token is issued as-is. This is intentional Wave 1 behavior and is documented here; a future Wave may introduce a configurable deny-by-default for unwired scope.
+## SECURITY — token revocation limitations
+
+Webauthn access tokens are revocable via `POST /oauth/revoke` ONLY when the grant was invoked with an authenticated client. Without client auth, the AT carries no `client_id` / `azp` claim — the revoke endpoint's ownership check (`client_id ?? azp ?? aud` must match the revoking client) cannot match, and the request returns 200 with no denylist insertion (RFC 7009 fail-closed). Operators relying on AT revocation MUST require client auth on the webauthn grant path (e.g. wire `clientAuthMw` before the grant handler).
 
 ## SECURITY — registration authorization strength
 

--- a/packages/webauthn/src/__tests__/config.test.mts
+++ b/packages/webauthn/src/__tests__/config.test.mts
@@ -76,4 +76,49 @@ describe("webauthnConfigSchema (spec §2.4.1)", () => {
 			}).success,
 		).toBe(false);
 	});
+
+	// Wave 1 post-merge audit M-1 + follow-up review I2:
+	// URL-parse-based origin gate must reject textual-prefix bypasses.
+	describe("origin secure-context gate (M-1 / I2)", () => {
+		const okBase = {
+			rpId: "x",
+			rpName: "x",
+			attestationPreference: "none" as const,
+			userVerification: "preferred" as const,
+			challengeTtlMs: 120_000,
+		};
+		const accepts = [
+			"https://example.com",
+			"https://app.example.com:8443",
+			"http://localhost",
+			"http://localhost:3000",
+			"http://127.0.0.1",
+			"http://127.0.0.1:8080",
+			"http://[::1]",
+			"http://[::1]:9000",
+		];
+		const rejects = [
+			"http://example.com", // non-loopback http
+			"file:///etc/passwd",
+			"javascript:alert(1)",
+			"https://*.example.com", // wildcard
+			"http://127.0.0.1.evil.com", // hostname-prefix bypass
+			"http://127.0.0.1@evil.com", // userinfo bypass (loopback in user)
+			"http://[::1]@evil.com", // userinfo bypass (ipv6 in user)
+			"https://user:pass@example.com", // userinfo present
+			"http://localhost@evil.com", // userinfo bypass (loopback hostname in user)
+		];
+
+		for (const origin of accepts) {
+			it(`accepts ${origin}`, () => {
+				expect(webauthnConfigSchema.safeParse({ ...okBase, origin: [origin] }).success).toBe(true);
+			});
+		}
+
+		for (const origin of rejects) {
+			it(`rejects ${origin}`, () => {
+				expect(webauthnConfigSchema.safeParse({ ...okBase, origin: [origin] }).success).toBe(false);
+			});
+		}
+	});
 });

--- a/packages/webauthn/src/__tests__/grant.test.mts
+++ b/packages/webauthn/src/__tests__/grant.test.mts
@@ -396,6 +396,49 @@ describe("createWebAuthnGrant — success (Wave 1 first slice)", () => {
 		expect(payload.sub).toBe(USER_ID);
 	});
 
+	// Post-merge audit H-1: when client authenticated, the AT carries client_id +
+	// azp so /oauth/revoke can resolve ownership (otherwise revoke silently no-ops
+	// per PR #165 fail-closed ownership check).
+	it("H-1 regression: when ctx.authenticatedClient is set, AT carries client_id + azp claims (revocable)", async () => {
+		const store = createMemoryWebAuthnCredentialStore();
+		await store.registerCredential(makeCredential());
+		mockVerifyAssertion.mockResolvedValue({ ok: true, newSignCount: 6 });
+
+		const deps = makeBaseDeps(store);
+		const handler = createWebAuthnGrant(deps);
+		const client = {
+			clientId: "test-client-id",
+			allowedGrantTypes: [WEBAUTHN_GRANT_TYPE],
+			allowedScopes: [],
+			allowedAudiences: [],
+		} as unknown as NonNullable<GrantContext["authenticatedClient"]>;
+
+		const ctx = makeCtx({ assertion: makeAssertionResponse() }, client);
+		const { result } = await handler.handle(ctx);
+
+		expect(result.status).toBe(200);
+		if (!("tokens" in result)) throw new Error("expected tokens");
+		const payload = decodeJwtPayload(result.tokens.access_token) as Record<string, unknown>;
+		expect(payload.client_id).toBe("test-client-id");
+		expect(payload.azp).toBe("test-client-id");
+	});
+
+	it("H-1 regression: when ctx.authenticatedClient is null, AT has NO client_id / azp (documented unrevocable mode)", async () => {
+		const store = createMemoryWebAuthnCredentialStore();
+		await store.registerCredential(makeCredential());
+		mockVerifyAssertion.mockResolvedValue({ ok: true, newSignCount: 6 });
+
+		const deps = makeBaseDeps(store);
+		const handler = createWebAuthnGrant(deps);
+		const { result } = await handler.handle(makeCtx({ assertion: makeAssertionResponse() }));
+
+		expect(result.status).toBe(200);
+		if (!("tokens" in result)) throw new Error("expected tokens");
+		const payload = decodeJwtPayload(result.tokens.access_token) as Record<string, unknown>;
+		expect(payload.client_id).toBeUndefined();
+		expect(payload.azp).toBeUndefined();
+	});
+
 	it("updates the stored signCount after successful verification", async () => {
 		const store = createMemoryWebAuthnCredentialStore();
 		await store.registerCredential(makeCredential({ signCount: 5 }));

--- a/packages/webauthn/src/__tests__/module.boot.test.mts
+++ b/packages/webauthn/src/__tests__/module.boot.test.mts
@@ -61,7 +61,15 @@ import { webauthnModule } from "../module.mjs";
 // Shared boot components
 // ---------------------------------------------------------------------------
 
-const coreConfig = makeValidCoreConfig();
+const coreConfig = {
+	...makeValidCoreConfig(),
+	oauth: {
+		...makeValidCoreConfig().oauth,
+		// CP-20 invariant: a non-empty issuer is required when grantPolicy is wired.
+		// makeValidCoreConfig() omits it; we set it here for the H-2-mandated policy wiring.
+		jwt: { ...makeValidCoreConfig().oauth.jwt, issuer: "https://test.example" },
+	},
+};
 
 /** Minimal bootstrap: config + pathResolver + keyStore. */
 const minBoot = {
@@ -91,6 +99,19 @@ const webauthnConfigModule = defineModule({
 	name: "test:webauthn-config-bootstrap",
 	provides: {
 		webauthnConfig: () => stubWebAuthnConfig,
+	},
+});
+
+/** Bootstrap module: provides a permit-all GrantPolicy. Required by webauthnModule's
+ * H-2 fail-fast invariant. Test fixtures wire this; production deployments wire a
+ * real GrantPolicyHook from @o3co/auth-provider-policy. */
+const noopGrantPolicyModule = defineModule({
+	name: "test:webauthn-noop-grant-policy",
+	provides: {
+		grantPolicy: (): GrantPolicyHook => ({
+			kind: "test-noop",
+			evaluate: async () => ({ outcome: "allow" }) as const,
+		}),
 	},
 });
 
@@ -126,6 +147,7 @@ const happyPathModules = [
 	memoryReplaySeenSetModule,
 	defaultChallengeCeremonyModule,
 	memoryWebAuthnCredentialStoreModule,
+	noopGrantPolicyModule,
 	activatorModule,
 ];
 
@@ -203,6 +225,38 @@ describe("webauthnModule boot integration (Wave 1 T31)", () => {
 			reason: "missing-required-component",
 			details: { missingKey: "webauthnConfig" },
 		} satisfies Partial<InstanceType<typeof BootError>>);
+	});
+
+	/**
+	 * H-2 regression — webauthn grant requires grantPolicy at boot.
+	 *
+	 * Wave 1 post-merge security audit found that the webauthn grant has no
+	 * library-side scope ceiling (unlike client_credentials which falls back to
+	 * `client.allowedScopes`). Without grantPolicy wired, the grant issues
+	 * whatever scope the caller requests. README documents "MUST wire grantPolicy"
+	 * but nothing enforced it; this test asserts the new fail-fast at boot.
+	 *
+	 * Cross-refs: post-merge security audit H-2 / [[feedback_pre_merge_final_audit_gate]]
+	 */
+	it("H-2 fail-fast: boot throws when webauthnModule wired without grantPolicy", async () => {
+		// All deps present EXCEPT grantPolicy.
+		const modulesWithoutPolicy = [
+			webauthnModule,
+			webauthnConfigModule,
+			keyStoreModule,
+			memoryChallengeStoreModule,
+			memoryReplaySeenSetModule,
+			defaultChallengeCeremonyModule,
+			memoryWebAuthnCredentialStoreModule,
+			activatorModule,
+		];
+
+		await expect(
+			createApp({
+				modules: modulesWithoutPolicy,
+				bootstrapComponents: minBoot,
+			}),
+		).rejects.toThrow(/webauthn grant requires `grantPolicy`/);
 	});
 
 	/**

--- a/packages/webauthn/src/config.mts
+++ b/packages/webauthn/src/config.mts
@@ -55,6 +55,8 @@ export const webauthnConfigSchema = z.object({
 	 *
 	 * Each origin MUST be a literal origin (scheme + host + optional port) —
 	 * `https://example.com`, `https://app.example.com`, `http://localhost:3000`.
+	 * MUST NOT include a trailing slash (`https://example.com/` will never match
+	 * the browser-sent clientDataJSON origin, which is the literal-origin form).
 	 * Wildcards are NOT allowed: SimpleWebAuthn does exact-string-match against
 	 * the authenticator's clientDataJSON, so `https://*.example.com` accepts at
 	 * parse time but breaks every ceremony at runtime. Non-https schemes other
@@ -72,15 +74,35 @@ export const webauthnConfigSchema = z.object({
 					message: "origin must not contain wildcards — SimpleWebAuthn does exact-match only",
 				})
 				.refine(
-					(u) =>
-						u.startsWith("https://") ||
-						u === "http://localhost" ||
-						u.startsWith("http://localhost:") ||
-						u.startsWith("http://127.0.0.1") ||
-						u.startsWith("http://[::1]"),
+					(u) => {
+						// URL-parse-based check (not string-prefix) so attacker-prefix
+						// bypasses like `http://127.0.0.1.evil.com`, `http://127.0.0.1@evil.com`,
+						// `http://[::1]@evil.com` are rejected. The .url() validator above
+						// guarantees parseability.
+						let parsed: URL;
+						try {
+							parsed = new URL(u);
+						} catch {
+							return false;
+						}
+						// Reject userinfo (`user@host`) regardless of scheme — origins must
+						// not carry credentials.
+						if (parsed.username !== "" || parsed.password !== "") return false;
+						if (parsed.protocol === "https:") return true;
+						if (parsed.protocol === "http:") {
+							// W3C WebAuthn / browser secure-context policy allows http only
+							// for loopback. Hostname comparison is exact-match.
+							return (
+								parsed.hostname === "localhost" ||
+								parsed.hostname === "127.0.0.1" ||
+								parsed.hostname === "[::1]"
+							);
+						}
+						return false;
+					},
 					{
 						message:
-							"origin must be https:// or http://localhost / http://127.0.0.1 / http://[::1] (W3C WebAuthn secure-origin policy)",
+							"origin must be https:// or http:// loopback (localhost / 127.0.0.1 / [::1]) with no userinfo (W3C WebAuthn secure-origin policy)",
 					},
 				),
 		)

--- a/packages/webauthn/src/config.mts
+++ b/packages/webauthn/src/config.mts
@@ -52,8 +52,39 @@ export const webauthnConfigSchema = z.object({
 	 * Allowed HTTPS origin(s) for registration / authentication ceremonies.
 	 * At least one entry required. Multiple entries support sub-domain or
 	 * multi-app deployments sharing a single RP ID.
+	 *
+	 * Each origin MUST be a literal origin (scheme + host + optional port) —
+	 * `https://example.com`, `https://app.example.com`, `http://localhost:3000`.
+	 * Wildcards are NOT allowed: SimpleWebAuthn does exact-string-match against
+	 * the authenticator's clientDataJSON, so `https://*.example.com` accepts at
+	 * parse time but breaks every ceremony at runtime. Non-https schemes other
+	 * than `http://localhost` are rejected because passkeys are not transmittable
+	 * over insecure schemes (W3C WebAuthn §5.1.3 + browser policy).
+	 *
+	 * Cross-refs: Wave 1 post-merge audit M-1.
 	 */
-	origin: z.array(z.string().url()).min(1),
+	origin: z
+		.array(
+			z
+				.string()
+				.url()
+				.refine((u) => !u.includes("*"), {
+					message: "origin must not contain wildcards — SimpleWebAuthn does exact-match only",
+				})
+				.refine(
+					(u) =>
+						u.startsWith("https://") ||
+						u === "http://localhost" ||
+						u.startsWith("http://localhost:") ||
+						u.startsWith("http://127.0.0.1") ||
+						u.startsWith("http://[::1]"),
+					{
+						message:
+							"origin must be https:// or http://localhost / http://127.0.0.1 / http://[::1] (W3C WebAuthn secure-origin policy)",
+					},
+				),
+		)
+		.min(1),
 	/**
 	 * Challenge time-to-live in milliseconds.
 	 * Reference default (S11): 120_000 ms — mobile-network safe baseline.

--- a/packages/webauthn/src/grant.mts
+++ b/packages/webauthn/src/grant.mts
@@ -271,9 +271,11 @@ export const createWebAuthnGrant = (deps: WebAuthnGrantDeps): GrantHandler => {
 			// resourceIndicator flag gates only the resource field.
 			// CP-18 fail-closed — same rationale as clientCredentials.mts.
 			//
-			// Documented gap (intended Wave 1 behavior): when grantPolicy is NOT wired
-			// AND the caller requests scope, the scope is issued as-is (no library-side
-			// ceiling). Deployments wanting scope authorization MUST wire grantPolicy.
+			// H-2 invariant: webauthnModule's grant factory throws at boot when
+			// grantPolicy is unwired, so the `deps.grantPolicy` check below is
+			// effectively always true under the module wiring. Tests that drive
+			// createWebAuthnGrant directly may still pass deps without grantPolicy;
+			// the check keeps the unit-test surface usable.
 			// ------------------------------------------------------------------
 			const resourceIndicatorEnabled = config.oauth.resourceIndicator?.enabled === true;
 

--- a/packages/webauthn/src/grant.mts
+++ b/packages/webauthn/src/grant.mts
@@ -349,6 +349,14 @@ export const createWebAuthnGrant = (deps: WebAuthnGrantDeps): GrantHandler => {
 					// Fail-closed audience validation: when a client is present, policy may
 					// only narrow to audiences already in client.allowedAudiences. When no
 					// client is authenticated there is no allowedAudiences ceiling — skip.
+					//
+					// TRUST ASYMMETRY (Wave 1 post-merge audit M-4): in client-less mode,
+					// `grantPolicy` is the SOLE audience authority — policy can mint a token
+					// for ANY audience it returns, with no library-side ceiling. This is
+					// acceptable per spec §5.6 Stage 1 staging (Stage 2 will add library-layer
+					// audience-binding enforcement per RFC 8707 — issue #173). Operators wiring
+					// webauthn without client-auth MUST therefore trust `grantPolicy` end-to-end
+					// for audience authorization.
 					const client = ctx.authenticatedClient;
 					if (client) {
 						const allowedAudSet = new Set(client.allowedAudiences ?? []);
@@ -380,18 +388,23 @@ export const createWebAuthnGrant = (deps: WebAuthnGrantDeps): GrantHandler => {
 
 			const scopeClaim = effectiveScopes.length > 0 ? effectiveScopes.join(" ") : null;
 
-			const accessToken = await generateToken(
-				{},
-				{
-					expiresIn: config.oauth.accessToken.expiresIn,
-					keyStore,
-					issuer,
-					audience,
-					subject: credential.userId,
-					scope: scopeClaim,
-					tokenType: "at+jwt",
-				},
-			);
+			// Mint client_id + authorizedParty when client authenticated so the AT is
+			// revocable via /oauth/revoke (Wave 1 post-merge security audit H-1: the
+			// revoke endpoint resolves the token's client via `client_id ?? azp ?? aud`
+			// and requires it match the revoking client. Empty data + non-clientId aud
+			// silently caused revoke 200 + no denylist insertion).
+			// Unauthenticated client mode (passkey IS the auth event) remains unrevocable
+			// by /oauth/revoke per RFC 7009 — documented as a known limitation.
+			const accessToken = await generateToken(client ? { client_id: client.clientId } : {}, {
+				expiresIn: config.oauth.accessToken.expiresIn,
+				keyStore,
+				issuer,
+				audience,
+				subject: credential.userId,
+				...(client ? { authorizedParty: client.clientId } : {}),
+				scope: scopeClaim,
+				tokenType: "at+jwt",
+			});
 
 			return {
 				result: {

--- a/packages/webauthn/src/module.mts
+++ b/packages/webauthn/src/module.mts
@@ -104,7 +104,11 @@ export const webauthnModule = defineModule<
 		"keyStore",
 	],
 	optional: [
-		"grantPolicy", // CP-18: gates the webauthn grant when resourceIndicator.enabled; absent = allow-all
+		// grantPolicy is REQUIRED by the webauthn grant (H-2 fail-fast in the
+		// factory below). Declared `optional` here only so the manifest is
+		// composable with non-webauthn modules that don't need policy — the
+		// factory throws at boot when this slot is unwired.
+		"grantPolicy",
 	],
 	contributes: {
 		grants: {
@@ -122,7 +126,7 @@ export const webauthnModule = defineModule<
 							"issues whatever scope the caller requests. Wire a GrantPolicyHook " +
 							"via @o3co/auth-provider-policy or your own implementation. If you " +
 							"intentionally accept unbounded scope (NOT recommended for " +
-							"production), wire a no-op policy returning { outcome: 'permit' }. " +
+							"production), wire a no-op policy returning { outcome: 'allow' }. " +
 							"See packages/webauthn/README.md SECURITY — scope authorization.",
 					);
 				}

--- a/packages/webauthn/src/module.mts
+++ b/packages/webauthn/src/module.mts
@@ -39,17 +39,23 @@
  *   - `keyStore`               — JWT signing; consumed by generateToken inside
  *                                the grant handler.
  *
- * `grantPolicy` is declared as OPTIONAL in this module (same as oauthModule /
- * oauthAuthorizationModule). When wired by the consumer, the boot planner
- * injects it into `deps`; when absent, `deps.grantPolicy` is `undefined`.
- * The grant invokes `grantPolicy.evaluate` UNCONDITIONALLY whenever it is
- * wired (rt-style), mirroring `refresh_token`. `oauth.resourceIndicator.enabled`
- * gates ONLY whether `body.resource` is forwarded to the policy; it does NOT
- * gate whether the policy runs. Without `grantPolicy` wired, the grant issues
- * whatever scope the caller requests — operators MUST wire `grantPolicy` to
- * bound scope (CP-18 fail-closed once wired).
+ * `grantPolicy` is declared as OPTIONAL **in the dependency type signature** so
+ * the manifest can be wired into compositions where other (non-webauthn) modules
+ * may run without policy. But the **grant factory enforces it at boot time**:
+ * if `webauthnModule` is wired without a `grantPolicy` slot, the factory throws
+ * a clear error (Wave 1 post-merge audit H-2 fail-fast). Unlike `client_credentials`
+ * (which falls back to `client.allowedScopes`) and `authorization_code` (narrowed
+ * at /authorize), the webauthn grant has NO library-side scope ceiling — the
+ * passkey is the authentication event, not a scope authorization. Without
+ * `grantPolicy`, an attacker can request any scope and receive it verbatim.
  *
- * Cross-refs: Plan T31 / spec §2.4.1 / PR #172 C1 security fix / Codex Round 3 P1
+ * When wired, the grant invokes `grantPolicy.evaluate` UNCONDITIONALLY (rt-style),
+ * mirroring `refresh_token`. `oauth.resourceIndicator.enabled` gates ONLY whether
+ * `body.resource` is forwarded to the policy; it does NOT gate whether the policy
+ * runs.
+ *
+ * Cross-refs: Plan T31 / spec §2.4.1 / PR #172 C1 security fix / Codex Round 3 P1 /
+ *             Wave 1 post-merge audit H-2
  */
 
 import { defineModule } from "@o3co/auth-provider-core";
@@ -102,8 +108,25 @@ export const webauthnModule = defineModule<
 	],
 	contributes: {
 		grants: {
-			[WEBAUTHN_GRANT_TYPE]: (deps) =>
-				createWebAuthnGrant({
+			[WEBAUTHN_GRANT_TYPE]: (deps) => {
+				// Wave 1 post-merge audit H-2: fail-fast at boot if grantPolicy is
+				// not wired. The webauthn grant has no library-side scope ceiling
+				// (no client → no client.allowedScopes); grantPolicy is the sole
+				// scope gate. Booting without it silently accepts unbounded scope.
+				if (!deps.grantPolicy) {
+					throw new Error(
+						"webauthn grant requires `grantPolicy` to be wired. " +
+							"Unlike client_credentials (client.allowedScopes ceiling) and " +
+							"authorization_code (narrowed at /authorize), the webauthn grant " +
+							"has no library-side scope ceiling — without grantPolicy the grant " +
+							"issues whatever scope the caller requests. Wire a GrantPolicyHook " +
+							"via @o3co/auth-provider-policy or your own implementation. If you " +
+							"intentionally accept unbounded scope (NOT recommended for " +
+							"production), wire a no-op policy returning { outcome: 'permit' }. " +
+							"See packages/webauthn/README.md SECURITY — scope authorization.",
+					);
+				}
+				return createWebAuthnGrant({
 					config: deps.config,
 					keyStore: deps.keyStore,
 					webauthnCredentialStore: deps.webauthnCredentialStore,
@@ -116,7 +139,8 @@ export const webauthnModule = defineModule<
 						// Cross-refs: Codex Round 2 P1-1
 						userVerification: deps.webauthnConfig.userVerification,
 					},
-				}),
+				});
+			},
 		},
 		routes: [
 			// POST /oauth/webauthn/registration/options

--- a/packages/webauthn/src/routes/registrationOptions.mts
+++ b/packages/webauthn/src/routes/registrationOptions.mts
@@ -80,6 +80,23 @@ export function createRegistrationOptionsHandler(deps: RegistrationOptionsDeps):
 		// userId is always taken from the authenticated session — request body cannot
 		// override (prevents victim-targeted enrollment per spec §2.4).
 		const { userId } = subject;
+
+		// Wave 1 post-merge audit M-2: enforce WebAuthn §5.4.3 user-handle constraints
+		// at the boundary. WebAuthn mandates a 1..64-byte opaque user-handle; longer
+		// values are rejected by authenticators at runtime, and consumer misuse
+		// (e.g. passing `req.user.email` here) syncs PII to the authenticator. The
+		// interface JSDoc already documents this MUST, but the library now enforces
+		// it so misconfigurations fail loudly with a 500 (consumer bug, not a 400).
+		const userIdByteLength = new TextEncoder().encode(userId).length;
+		if (userIdByteLength < 1 || userIdByteLength > 64) {
+			res.status(500).json({
+				error: "server_error",
+				error_description:
+					"webauthnSubject.userId must be 1-64 bytes per WebAuthn §5.4.3 (opaque user-handle)",
+			});
+			return;
+		}
+
 		const userName = subject.userName ?? userId;
 		const userDisplayName = subject.userDisplayName ?? userName;
 

--- a/packages/webauthn/src/routes/registrationVerify.mts
+++ b/packages/webauthn/src/routes/registrationVerify.mts
@@ -125,9 +125,9 @@ export function createRegistrationVerifyHandler(deps: RegistrationVerifyDeps): R
 		const { userId } = subject;
 
 		// Wave 1 post-merge audit M-2: enforce WebAuthn §5.4.3 user-handle constraints
-		// (1..64 bytes opaque). Defense-in-depth: registrationOptions enforces the same
-		// invariant, but if a consumer skips that step (custom verify flow), this gate
-		// still catches the misconfig.
+		// (1..64 bytes opaque). Mirrors the registrationOptions gate so the verify
+		// endpoint is independently safe — both endpoints share the same
+		// req.webauthnSubject invariant under normal middleware composition.
 		const userIdByteLength = new TextEncoder().encode(userId).length;
 		if (userIdByteLength < 1 || userIdByteLength > 64) {
 			res.status(500).json({

--- a/packages/webauthn/src/routes/registrationVerify.mts
+++ b/packages/webauthn/src/routes/registrationVerify.mts
@@ -124,6 +124,20 @@ export function createRegistrationVerifyHandler(deps: RegistrationVerifyDeps): R
 		// override (prevents victim-targeted enrollment per spec §2.4).
 		const { userId } = subject;
 
+		// Wave 1 post-merge audit M-2: enforce WebAuthn §5.4.3 user-handle constraints
+		// (1..64 bytes opaque). Defense-in-depth: registrationOptions enforces the same
+		// invariant, but if a consumer skips that step (custom verify flow), this gate
+		// still catches the misconfig.
+		const userIdByteLength = new TextEncoder().encode(userId).length;
+		if (userIdByteLength < 1 || userIdByteLength > 64) {
+			res.status(500).json({
+				error: "server_error",
+				error_description:
+					"webauthnSubject.userId must be 1-64 bytes per WebAuthn §5.4.3 (opaque user-handle)",
+			});
+			return;
+		}
+
 		// Validate request body (nickname + response shape; userId in body is ignored).
 		const parsed = bodySchema.safeParse(req.body);
 		if (!parsed.success) {


### PR DESCRIPTION
## Summary

Post-merge 3-axis audit on Wave 1 final state (develop @ `9df29cb`) — regression / extensibility / security — surfaced 2 High + 4 Medium combined-attack-surface findings that per-round multi-agent-review (6 rounds on #174) could not catch because they emerge from interaction across Wave 1 PRs.

**H-1**: WebAuthn-issued access tokens were silently un-revocable via `/oauth/revoke`. Empty `generateToken({}, ...)` data → no `client_id` / `azp` → revoke ownership check (`client_id ?? azp ?? aud`) never matches → silent 200 with NO denylist insertion. Combined-surface gap between PR #165 (denylist) and PR #174 (webauthn grant). Fix mirrors `clientCredentials.mts` parity.

**H-2**: Cross-grant policy bypass when `grantPolicy` unwired. The webauthn grant has no library-side scope ceiling (unlike CC's `client.allowedScopes`); without policy, caller-requested scope flows verbatim. README documented "MUST wire grantPolicy" but nothing enforced. Fix: throw at module grant-factory if `deps.grantPolicy === undefined` — SF-6-style fail-fast at boot.

**M-1**: `webauthnConfigSchema.origin` accepted wildcards + non-secure schemes + textual-prefix bypasses (`127.0.0.1.evil.com`, `127.0.0.1@evil.com`). Fix: `new URL()`-based parse with exact hostname match + userinfo rejection. 17 new schema tests pin accept/reject matrix.

**M-2**: `WebAuthnSubject.userId` opacity documented but not enforced. Consumer misconfig could leak PII via WebAuthn user-handle (synced to authenticator). Fix: byte-length validation (1..64 per §5.4.3) at both registration boundaries.

**M-3 + M-4**: README sections for token revocation limitations + scope authorization enforcement; code comment cross-ref for client-less audience trust asymmetry (spec §5.6 / issue #173).

## New discipline

This audit validates a new `feedback_pre_merge_final_audit_gate` discipline (saved to memory): Wave / large-feature / new public API surface PRs MUST run a 3-axis final audit (regression / extensibility / security) before merge, in addition to per-round multi-agent-review. The audit caught real gaps invisible to per-round review.

## Review history

- Round 1 review (Claude opus, on `d1da8f5f`): NEEDS_WORK — found `"permit"` → `"allow"` typo in escape-hatch + 3 origin schema textual-prefix bypasses. Both Important fixed in `5ae4b2ee` with 17 added schema tests.
- Codex review attempted twice; verbose-trace style truncated before producing structured verdict (consistent with Round 6 pattern).
- Critical = 0 across all rounds → no additional review round per CLAUDE.md discipline.

## Test plan

- [x] `pnpm -F @o3co/auth-provider-core test` — 1254 passing
- [x] `pnpm -F @o3co/auth-provider-webauthn test` — 121 passing (added: H-1 client-id/azp regression × 2, H-2 boot fail-fast regression, M-1 origin matrix × 17)
- [x] `pnpm run lint` — clean
- [x] `pnpm -F @o3co/auth-provider-core build && pnpm -F @o3co/auth-provider-webauthn build` — clean
- [ ] CI `build-and-test` on PR
- [ ] CI `publish-readiness` on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)