### PR TITLE
docs: drop "one release cycle" forward-promise from deprecated-bit comments (R6 soft sweep)

### DIFF
--- a/packages/redis/src/code-repository.mts
+++ b/packages/redis/src/code-repository.mts
@@ -221,10 +221,10 @@ export const redisCodeRepositoryBuilder: AdapterBuilder<CodeRepository> = (confi
 /**
  * `defineModule` manifest for the Redis CodeRepository (OR-9 / Wave 5d).
  *
- * Static composition path. The legacy `redisCodeRepositoryBuilder` still
- * exists for one release cycle but is deprecated — operators wiring redis
- * codes should switch to this module + provide `codeRepositoryClient` from
- * `makeIoredisClients()`.
+ * Static composition path. `redisCodeRepositoryBuilder` is still exported
+ * but deprecated — operators wiring redis codes should switch to this
+ * module + provide `codeRepositoryClient` from `makeIoredisClients()`.
+ * Removal target is tracked in CHANGELOG.
  *
  * configSchema: top-level key `redisCodeRepository` (module-namespaced per
  * master roadmap §3.5). No `.default()` per ADR — defaults live in

--- a/packages/redis/src/code-repository.mts
+++ b/packages/redis/src/code-repository.mts
@@ -223,8 +223,8 @@ export const redisCodeRepositoryBuilder: AdapterBuilder<CodeRepository> = (confi
  *
  * Static composition path. `redisCodeRepositoryBuilder` is still exported
  * but deprecated — operators wiring redis codes should switch to this
- * module + provide `codeRepositoryClient` from `makeIoredisClients()`.
- * Removal target is tracked in CHANGELOG.
+ * module + provide `codeRepositoryClient` from `makeIoredisClients()` —
+ * see CHANGELOG for the removal version.
  *
  * configSchema: top-level key `redisCodeRepository` (module-namespaced per
  * master roadmap §3.5). No `.default()` per ADR — defaults live in

--- a/packages/redis/src/index.mts
+++ b/packages/redis/src/index.mts
@@ -51,8 +51,8 @@ export type {
 // CodeRepository (Phase 10 Q4 / OR-9 Wave 5d).
 // Relocated from @o3co/auth-provider-foundation. v0.5.1 OR-9 added the module
 // pattern + migrated to ioredis-typed `CodeRepositoryClient`; the legacy
-// builder is retained one release cycle as deprecated and now requires the
-// new `{ client, keyPrefix?, defaultExpiresIn? }` shape.
+// builder is retained as deprecated and now requires the new
+// `{ client, keyPrefix?, defaultExpiresIn? }` shape.
 // ---------------------------------------------------------------------------
 export {
 	RedisCodeRepository,

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -52,7 +52,7 @@ oauth {
   # (`standaloneRedisClientsModule`). Memory-only deployments lose codes on
   # restart and across replicas — multi-replica production MUST use "redis".
   # Supersedes the legacy `repositories.code.type` switch (kept below as
-  # deprecated for backward compat).
+  # deprecated for backward compat — see CHANGELOG for the removal version).
   code {
     adapter = "redis"
     adapter = ${?OAUTH_CODE_ADAPTER}

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -51,8 +51,8 @@ oauth {
   # `redisCodeRepositoryModule` against the shared ioredis socket
   # (`standaloneRedisClientsModule`). Memory-only deployments lose codes on
   # restart and across replicas — multi-replica production MUST use "redis".
-  # Supersedes the legacy `repositories.code.type` switch (kept below for
-  # one release cycle for backward compat).
+  # Supersedes the legacy `repositories.code.type` switch (kept below as
+  # deprecated for backward compat).
   code {
     adapter = "redis"
     adapter = ${?OAUTH_CODE_ADAPTER}


### PR DESCRIPTION
## Summary

- Soft "forward-promise sweep" follow-up to PR #177 — removes the 3 remaining `one release cycle` time-based promises in deprecated-bit comments that did not match the R3 literal pattern.
- Aligns all 3 sites with the canonical `see CHANGELOG for the removal version` / `tracked in CHANGELOG` phrasing already used in adjacent runtime warn strings (`packages/redis/src/code-repository.mts:213`, `templates/standalone/src/buildModules.mts:111`) per `docs/release-policy.md` R1.
- **Docs-only, no functional change.** The deprecated `redisCodeRepositoryBuilder` export and the `repositories.code.type` legacy switch remain wired and continue to emit deprecation warnings on use.

## Files

- `packages/redis/src/code-repository.mts` — JSDoc on `redisCodeRepositoryModule`
- `packages/redis/src/index.mts` — file-level comment on the CodeRepository block
- `templates/standalone/config/application.conf` — HOCON comment above `oauth.code`

## Multi-agent review (run before push)

- 🔵 Claude (design & logic): PASS — 1 Minor (cross-file phrasing inconsistency) → addressed in `a2eea0a9`.
- 🟠 Codex (security & performance): PASS — no findings; "comments only, no runtime / API / test impact".

## Test plan

- [x] `pnpm lint` clean (biome check, 480 files, no fixes applied)
- [x] No test file edits required — smoke tests at `templates/standalone/src/__tests__/smoke.test.mts` continue to exercise the legacy `repositories.code.type = "redis"` fallback path
- [x] No public API or schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)