### PR TITLE
feat(core,oauth): Wave 2 Token-binding Cluster Phase 1a — type surface + IntrospectResponse refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added (Wave 2 Token-binding Cluster — Phase 1a)
+
+- **`TokenBinding` base interface + `Confirmation` union in `@o3co/auth-provider-core`.** Cross-cutting types for the Wave 2 Token-binding Cluster (DPoP + mTLS in Phases 2/3). `TokenBinding` is an extensible base shape (`{ kind: string; confirmation: Confirmation }`) — mechanism packages and downstream users extend it with their own evidence fields. `Confirmation` is a narrow readonly union (`{ jkt } | { "x5t#S256" }`) covering the RFC 7800 / IANA-registry-domain claim variants this library ships in Stage 1; adding a new variant is a core semver-minor change.
+- **`GrantContext.tokenBinding?: TokenBinding`** optional readonly field. Populated by `tokenBindingMw` (Phase 1b) before grant dispatch; `undefined` when no binding mechanism is enabled.
+- **`GenerateTokenOptions.confirmation`** drives the JWT `cnf` claim. When set, `generateToken` emits `cnf` matching the provided `Confirmation`; when absent, claims are byte-identical to v0.7.x. `Token.confirmation` echoes the value back to callers for audit purposes.
+- **`generateTokenResponse(tokens, { tokenType?: "Bearer" | "DPoP" })`** — second optional parameter for the wire-level `token_type`. Defaults to `"Bearer"`, matching existing behavior. The function body was refactored to spread construction so the new `readonly Token.confirmation` field can be set at construction without a cast.
+- **`IntrospectResponse` interface + `extractConfirmation` helper in `@o3co/auth-provider-oauth`.** The introspect endpoint's inline JSON shape is now typed and re-exported from the package barrel for consumers (e.g. `auth.proxy` validation layer). The endpoint also reports `token_type: "DPoP"` when the introspected token carries a `cnf.jkt` claim per RFC 9449 §5 (mTLS bindings keep `"Bearer"` per RFC 8705 §3) and mirrors any valid `cnf` claim per RFC 7662 §2.2. `extractConfirmation(unknown): Confirmation | undefined` validates that cnf member values are non-empty strings (rejects malformed `{ jkt: 123 }`, `{ jkt: "" }`, etc.) before they reach the wire response.
+
+Zero behavior change for any v0.7.x consumer that does not opt into the Wave 2 cluster (every existing consumer): `tokenBinding` stays `undefined`, no `cnf` claim is emitted, and the introspect endpoint produces byte-identical responses for tokens that lack `cnf`. See [the Wave 2 Token-binding Cluster spec](./.claude/superpowers/specs/2026-05-18-wave-2-token-binding-cluster-spec.md) for the full design (note: spec is internal — link kept for the in-repo reader).
+
 ## [0.7.0] - 2026-05-15
 
 v0.7.0 ships **Wave 1** of the auth-provider passkey-native auth toolkit roadmap: a new `@o3co/auth-provider-webauthn` package, the `client_credentials` grant, RFC 7009 Token Revocation, RFC 8707 Stage 1 resource-indicator plumbing, and the library `reference.conf` shipping pattern.

--- a/packages/core/src/grants/__tests__/confirmation.test.mts
+++ b/packages/core/src/grants/__tests__/confirmation.test.mts
@@ -22,6 +22,16 @@ describe("Confirmation union", () => {
 		const c: Confirmation = { "x5t#S256": "def456" };
 		expect("x5t#S256" in c).toBe(true);
 	});
+
+	it("rejects unknown confirmation keys at compile time (Confirmation is closed)", () => {
+		// Compile-time guard: if someone widens Confirmation to a permissive
+		// index signature, the @ts-expect-error becomes unused and this test
+		// will fail to compile. Stage 1 confirmation kinds are core-owned per
+		// spec §4.2 (RFC 7800 / IANA registry domain).
+		// @ts-expect-error — `foo` is not a valid Confirmation variant
+		const _bad: Confirmation = { foo: "bar" };
+		void _bad;
+	});
 });
 
 describe("TokenBinding base interface", () => {

--- a/packages/core/src/grants/__tests__/confirmation.test.mts
+++ b/packages/core/src/grants/__tests__/confirmation.test.mts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Confirmation } from "#/grants/confirmation.mjs";
+import type { TokenBinding } from "#/grants/tokenBinding.mjs";
+
+describe("Confirmation union", () => {
+	it("accepts jkt variant", () => {
+		const c: Confirmation = { jkt: "abc123" };
+		expect("jkt" in c).toBe(true);
+	});
+
+	it("accepts x5t#S256 variant", () => {
+		const c: Confirmation = { "x5t#S256": "def456" };
+		expect("x5t#S256" in c).toBe(true);
+	});
+});
+
+describe("TokenBinding base interface", () => {
+	it("requires kind + confirmation", () => {
+		const tb: TokenBinding = {
+			kind: "test",
+			confirmation: { jkt: "abc" },
+		};
+		expect(tb.kind).toBe("test");
+		expect(tb.confirmation).toEqual({ jkt: "abc" });
+	});
+
+	it("supports downstream extension (extends with new kind + fields)", () => {
+		interface FakeTokenBinding extends TokenBinding {
+			readonly kind: "fake";
+			readonly extra: string;
+		}
+		const tb: FakeTokenBinding = {
+			kind: "fake",
+			confirmation: { jkt: "xyz" },
+			extra: "downstream-data",
+		};
+		expect(tb.kind).toBe("fake");
+		expect(tb.extra).toBe("downstream-data");
+	});
+});

--- a/packages/core/src/grants/__tests__/grantContext.test.mts
+++ b/packages/core/src/grants/__tests__/grantContext.test.mts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import type { GrantContext } from "#/grants/types.mjs";
+
+describe("GrantContext.tokenBinding", () => {
+	it("is undefined when not populated by middleware", () => {
+		const ctx: GrantContext = {
+			body: {},
+			session: {},
+			metadata: {},
+			authenticatedClient: null,
+		};
+		expect(ctx.tokenBinding).toBeUndefined();
+	});
+
+	it("accepts a TokenBinding value when populated", () => {
+		const ctx: GrantContext = {
+			body: {},
+			session: {},
+			metadata: {},
+			authenticatedClient: null,
+			tokenBinding: { kind: "test", confirmation: { jkt: "abc" } },
+		};
+		expect(ctx.tokenBinding?.kind).toBe("test");
+	});
+});

--- a/packages/core/src/grants/__tests__/token.test.mts
+++ b/packages/core/src/grants/__tests__/token.test.mts
@@ -306,4 +306,34 @@ describe("generateTokenResponse tokenType option", () => {
 		const response = generateTokenResponse({ accessToken }, { tokenType: "Bearer" });
 		expect(response.token_type).toBe("Bearer");
 	});
+
+	it("DPoP tokenType coexists with refreshToken in response", async () => {
+		const keyStore = createSymmetricKeyStore("x".repeat(32));
+		const accessToken = await generateToken({}, { keyStore, confirmation: { jkt: "abc" } });
+		const refreshToken = await generateToken({}, { keyStore });
+		const response = generateTokenResponse({ accessToken, refreshToken }, { tokenType: "DPoP" });
+		expect(response.token_type).toBe("DPoP");
+		expect(response.refresh_token).toBe(refreshToken.token);
+	});
+});
+
+describe("generateToken cnf coexists with other claims", () => {
+	it("emits cnf alongside sub, scope, exp without interference", async () => {
+		const keyStore = createSymmetricKeyStore("x".repeat(32));
+		const token = await generateToken(
+			{},
+			{
+				keyStore,
+				subject: "u1",
+				scope: "read",
+				expiresIn: 600,
+				confirmation: { jkt: "abc123" },
+			},
+		);
+		const payload = decodeJwt(token.token);
+		expect(payload.sub).toBe("u1");
+		expect(payload.scope).toBe("read");
+		expect(payload.exp).toBeDefined();
+		expect(payload.cnf).toEqual({ jkt: "abc123" });
+	});
 });

--- a/packages/core/src/grants/__tests__/token.test.mts
+++ b/packages/core/src/grants/__tests__/token.test.mts
@@ -16,6 +16,7 @@
 
 import { decodeJwt, decodeProtectedHeader } from "jose";
 import { describe, expect, it } from "vitest";
+import type { Confirmation } from "#/grants/confirmation.mjs";
 import { generateToken, generateTokenResponse } from "#/grants/token.mjs";
 import { createSymmetricKeyStore } from "#/keys/KeyStore.mjs";
 
@@ -249,5 +250,60 @@ describe("generateTokenResponse with id_token", () => {
 	it("omits id_token when not provided (backward compat)", () => {
 		const resp = generateTokenResponse({ accessToken: { token: "at", expiresIn: 3600 } });
 		expect(resp.id_token).toBeUndefined();
+	});
+});
+
+describe("generateToken cnf claim emission", () => {
+	it("does NOT emit cnf when confirmation is absent", async () => {
+		const keyStore = createSymmetricKeyStore("x".repeat(32));
+		const token = await generateToken({}, { keyStore });
+		const payload = decodeJwt(token.token);
+		expect(payload).not.toHaveProperty("cnf");
+	});
+
+	it("emits cnf matching confirmation when present (jkt variant)", async () => {
+		const keyStore = createSymmetricKeyStore("x".repeat(32));
+		const confirmation: Confirmation = { jkt: "abc123" };
+		const token = await generateToken({}, { keyStore, confirmation });
+		const payload = decodeJwt(token.token);
+		expect(payload.cnf).toEqual({ jkt: "abc123" });
+	});
+
+	it("emits cnf matching confirmation when present (x5t#S256 variant)", async () => {
+		const keyStore = createSymmetricKeyStore("x".repeat(32));
+		const confirmation: Confirmation = { "x5t#S256": "def456" };
+		const token = await generateToken({}, { keyStore, confirmation });
+		const payload = decodeJwt(token.token);
+		expect(payload.cnf).toEqual({ "x5t#S256": "def456" });
+	});
+
+	it("echoes confirmation on the returned Token", async () => {
+		const keyStore = createSymmetricKeyStore("x".repeat(32));
+		const confirmation: Confirmation = { jkt: "abc123" };
+		const token = await generateToken({}, { keyStore, confirmation });
+		expect(token.confirmation).toEqual({ jkt: "abc123" });
+	});
+});
+
+describe("generateTokenResponse tokenType option", () => {
+	it("returns Bearer by default", async () => {
+		const keyStore = createSymmetricKeyStore("x".repeat(32));
+		const accessToken = await generateToken({}, { keyStore });
+		const response = generateTokenResponse({ accessToken });
+		expect(response.token_type).toBe("Bearer");
+	});
+
+	it("returns DPoP when tokenType option is DPoP", async () => {
+		const keyStore = createSymmetricKeyStore("x".repeat(32));
+		const accessToken = await generateToken({}, { keyStore, confirmation: { jkt: "abc" } });
+		const response = generateTokenResponse({ accessToken }, { tokenType: "DPoP" });
+		expect(response.token_type).toBe("DPoP");
+	});
+
+	it("returns Bearer when tokenType option is explicitly Bearer", async () => {
+		const keyStore = createSymmetricKeyStore("x".repeat(32));
+		const accessToken = await generateToken({}, { keyStore });
+		const response = generateTokenResponse({ accessToken }, { tokenType: "Bearer" });
+		expect(response.token_type).toBe("Bearer");
 	});
 });

--- a/packages/core/src/grants/confirmation.mts
+++ b/packages/core/src/grants/confirmation.mts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+/**
+ * RFC 7800 confirmation claim, narrowed to the binding methods this
+ * library ships in Stage 1. Adding a future variant (e.g. RFC 9421
+ * `jwk`) is a core semver-minor extension of this union — see Wave 2
+ * Token-binding Cluster spec §4.3.
+ */
+export type Confirmation = { readonly jkt: string } | { readonly "x5t#S256": string };

--- a/packages/core/src/grants/token.mts
+++ b/packages/core/src/grants/token.mts
@@ -35,7 +35,8 @@ export interface Token {
 	 * Echo of `GenerateTokenOptions.confirmation` when set. Read-only
 	 * informational field for callers (e.g. audit log); does NOT drive
 	 * claim emission — that is `GenerateTokenOptions.confirmation`'s job.
-	 * See Wave 2 Token-binding Cluster spec §4.4.
+	 * See RFC 7800 §3 for the `cnf` claim structure and Wave 2
+	 * Token-binding Cluster spec §4.4 for the field's role here.
 	 */
 	readonly confirmation?: Confirmation;
 }
@@ -130,16 +131,19 @@ export const generateToken = async (
 		...(tokenType ? { header: { typ: tokenType } } : {}),
 	});
 
-	const result: Token = { token };
-
-	if (expiresIn !== undefined) result.expiresIn = expiresIn;
-	if (audience !== null && audience !== undefined) result.audience = audience;
-	if (issuer !== null && issuer !== undefined) result.issuer = issuer;
-	if (subject !== null && subject !== undefined) result.subject = subject;
-	if (scope !== null && scope !== undefined) result.scope = scope;
-	if (tokenType !== undefined) result.tokenType = tokenType;
-	if (confirmation !== undefined)
-		(result as { confirmation?: Confirmation }).confirmation = confirmation;
-
-	return result;
+	// Construct Token via spread so `readonly` fields (currently
+	// `confirmation`) can be assigned at construction without a cast.
+	// Spec §4.4 marks `Token.confirmation` readonly for caller-side
+	// immutability; building the record in one expression honors that
+	// contract without diverging from the existing per-field guards.
+	return {
+		token,
+		...(expiresIn !== undefined ? { expiresIn } : {}),
+		...(audience !== null && audience !== undefined ? { audience } : {}),
+		...(issuer !== null && issuer !== undefined ? { issuer } : {}),
+		...(subject !== null && subject !== undefined ? { subject } : {}),
+		...(scope !== null && scope !== undefined ? { scope } : {}),
+		...(tokenType !== undefined ? { tokenType } : {}),
+		...(confirmation !== undefined ? { confirmation } : {}),
+	};
 };

--- a/packages/core/src/grants/token.mts
+++ b/packages/core/src/grants/token.mts
@@ -15,6 +15,7 @@
  */
 import { randomUUID } from "node:crypto";
 import type { JWTPayload, KeyStore } from "../keys/KeyStore.mjs";
+import type { Confirmation } from "./confirmation.mjs";
 
 export const formatObject = <T extends object>(data: T): Partial<T> => {
 	return Object.fromEntries(
@@ -30,6 +31,13 @@ export interface Token {
 	tokenType?: "at+jwt" | "rt+jwt";
 	audience?: string;
 	issuer?: string;
+	/**
+	 * Echo of `GenerateTokenOptions.confirmation` when set. Read-only
+	 * informational field for callers (e.g. audit log); does NOT drive
+	 * claim emission — that is `GenerateTokenOptions.confirmation`'s job.
+	 * See Wave 2 Token-binding Cluster spec §4.4.
+	 */
+	readonly confirmation?: Confirmation;
 }
 
 export interface IntermediateToken {
@@ -47,14 +55,22 @@ export interface TokenResponse {
 	id_token?: string;
 }
 
-export const generateTokenResponse = ({
-	accessToken,
-	refreshToken = undefined,
-	idToken = undefined,
-}: IntermediateToken): TokenResponse => {
+export interface GenerateTokenResponseOptions {
+	/**
+	 * Wire-level token_type for the response envelope. Defaults to "Bearer".
+	 * Set to "DPoP" when the issued access token has a DPoP confirmation
+	 * (RFC 9449 §5). mTLS-bound tokens keep "Bearer" per RFC 8705 §3.
+	 */
+	readonly tokenType?: "Bearer" | "DPoP";
+}
+
+export const generateTokenResponse = (
+	{ accessToken, refreshToken = undefined, idToken = undefined }: IntermediateToken,
+	options?: GenerateTokenResponseOptions,
+): TokenResponse => {
 	return {
 		access_token: accessToken.token,
-		token_type: "Bearer",
+		token_type: options?.tokenType ?? "Bearer",
 		...formatObject({
 			scope: accessToken.scope,
 			refresh_token: refreshToken ? refreshToken.token : null,
@@ -73,6 +89,12 @@ export interface GenerateTokenOptions {
 	authorizedParty?: string | null;
 	scope?: string | null;
 	tokenType?: "at+jwt" | "rt+jwt";
+	/**
+	 * RFC 7800 confirmation claim to emit as the `cnf` JWT claim. When
+	 * absent, no `cnf` claim is emitted — the issued token is unbound
+	 * (Bearer semantics).
+	 */
+	confirmation?: Confirmation;
 }
 
 export const generateToken = async (
@@ -86,6 +108,7 @@ export const generateToken = async (
 		authorizedParty = null,
 		scope = null,
 		tokenType = undefined,
+		confirmation = undefined,
 	}: GenerateTokenOptions,
 ): Promise<Token> => {
 	const now = Math.floor(Date.now() / 1000);
@@ -99,6 +122,7 @@ export const generateToken = async (
 		...(issuer != null ? { iss: issuer } : {}),
 		...(audience != null ? { aud: audience } : {}),
 		...(subject != null ? { sub: subject } : {}),
+		...(confirmation ? { cnf: confirmation } : {}),
 	};
 
 	const token = await keyStore.sign({
@@ -114,6 +138,8 @@ export const generateToken = async (
 	if (subject !== null && subject !== undefined) result.subject = subject;
 	if (scope !== null && scope !== undefined) result.scope = scope;
 	if (tokenType !== undefined) result.tokenType = tokenType;
+	if (confirmation !== undefined)
+		(result as { confirmation?: Confirmation }).confirmation = confirmation;
 
 	return result;
 };

--- a/packages/core/src/grants/tokenBinding.mts
+++ b/packages/core/src/grants/tokenBinding.mts
@@ -22,7 +22,9 @@ import type { Confirmation } from "./confirmation.mjs";
  * Extension boundary: downstream MAY add a new `kind` and evidence
  * fields by extending this interface; the `confirmation` claim itself
  * MUST be one of the variants in `Confirmation` (RFC 7800 / IANA
- * registry domain).
+ * registry domain). Adding a new confirmation variant (e.g. RFC 9421
+ * `jwk` confirmation) is a core semver-minor change, not a
+ * downstream-only extension.
  */
 export interface TokenBinding {
 	readonly kind: string;

--- a/packages/core/src/grants/tokenBinding.mts
+++ b/packages/core/src/grants/tokenBinding.mts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+import type { Confirmation } from "./confirmation.mjs";
+
+/**
+ * Sender-constrained binding established by a transport-layer mechanism.
+ * Core owns only the cross-cutting shape (discriminator + `cnf` claim);
+ * mechanism packages extend with their own evidence fields. See Wave 2
+ * Token-binding Cluster spec §4.2.
+ *
+ * Extension boundary: downstream MAY add a new `kind` and evidence
+ * fields by extending this interface; the `confirmation` claim itself
+ * MUST be one of the variants in `Confirmation` (RFC 7800 / IANA
+ * registry domain).
+ */
+export interface TokenBinding {
+	readonly kind: string;
+	readonly confirmation: Confirmation;
+}

--- a/packages/core/src/grants/types.mts
+++ b/packages/core/src/grants/types.mts
@@ -30,6 +30,7 @@ import type {
 	SessionRPRegistry,
 	UserSessionStore,
 } from "../user-sessions/types.mjs";
+import type { TokenBinding } from "./tokenBinding.mjs";
 
 /**
  * The client identity established by RFC 6749 §2.3 token-endpoint
@@ -113,6 +114,16 @@ export interface GrantContext {
 	 * client identity SHOULD reject `null` with `invalid_client` 401.
 	 */
 	readonly authenticatedClient: AuthenticatedClient | null;
+	/**
+	 * Sender-binding established by `tokenBindingMw` before grant dispatch.
+	 * `undefined` when no binding mechanism is enabled, when the request
+	 * did not carry the required proof / cert, or when the grant is
+	 * invoked outside the standard `/token` route. Grant handlers that
+	 * issue tokens propagate `tokenBinding.confirmation` into
+	 * `GenerateTokenOptions.confirmation`. See Wave 2 Token-binding Cluster
+	 * spec §4.1.
+	 */
+	readonly tokenBinding?: TokenBinding;
 }
 
 export interface GrantSuccess {

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -102,6 +102,7 @@ export type {
 } from "./federation-tokens/types.mjs";
 export { supportsLock } from "./federation-tokens/types.mjs";
 export { filterClaimsByScope } from "./grants/claimFilter.mjs";
+export type { Confirmation } from "./grants/confirmation.mjs";
 // id_token generation (OIDC Core §2)
 export {
 	type GenerateIdTokenOptions,
@@ -129,6 +130,7 @@ export {
 	type Token,
 	type TokenResponse,
 } from "./grants/token.mjs";
+export type { TokenBinding } from "./grants/tokenBinding.mjs";
 export type {
 	AuthenticatedClient,
 	GrantContext,

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -125,6 +125,7 @@ export {
 export {
 	formatObject,
 	type GenerateTokenOptions,
+	type GenerateTokenResponseOptions,
 	generateToken,
 	generateTokenResponse,
 	type Token,

--- a/packages/oauth/src/__tests__/introspect.types.test.mts
+++ b/packages/oauth/src/__tests__/introspect.types.test.mts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import type { IntrospectResponse } from "../types/introspect.mjs";
+import { extractConfirmation, type IntrospectResponse } from "../types/introspect.mjs";
 
 describe("IntrospectResponse typed shape", () => {
 	it("active response with no cnf", () => {
@@ -56,5 +56,56 @@ describe("IntrospectResponse typed shape", () => {
 		expect(r.active).toBe(false);
 		expect(r.cnf).toBeUndefined();
 		expect(r.token_type).toBeUndefined();
+	});
+});
+
+describe("extractConfirmation", () => {
+	it("returns jkt variant for a string jkt", () => {
+		expect(extractConfirmation({ jkt: "abc" })).toEqual({ jkt: "abc" });
+	});
+
+	it("returns x5t#S256 variant for a string x5t#S256", () => {
+		expect(extractConfirmation({ "x5t#S256": "def" })).toEqual({ "x5t#S256": "def" });
+	});
+
+	it("returns undefined for null / undefined / non-object", () => {
+		expect(extractConfirmation(undefined)).toBeUndefined();
+		expect(extractConfirmation(null)).toBeUndefined();
+		expect(extractConfirmation("string")).toBeUndefined();
+		expect(extractConfirmation(42)).toBeUndefined();
+		expect(extractConfirmation(true)).toBeUndefined();
+	});
+
+	it("returns undefined for arrays", () => {
+		expect(extractConfirmation([])).toBeUndefined();
+		expect(extractConfirmation([{ jkt: "abc" }])).toBeUndefined();
+	});
+
+	it("returns undefined for an object missing both jkt and x5t#S256", () => {
+		expect(extractConfirmation({})).toBeUndefined();
+		expect(extractConfirmation({ other: "value" })).toBeUndefined();
+	});
+
+	it("rejects empty-string jkt (RFC 9449 §6 requires non-empty thumbprint)", () => {
+		expect(extractConfirmation({ jkt: "" })).toBeUndefined();
+	});
+
+	it("rejects empty-string x5t#S256 (RFC 8705 §3 requires non-empty thumbprint)", () => {
+		expect(extractConfirmation({ "x5t#S256": "" })).toBeUndefined();
+	});
+
+	it("rejects numeric jkt (malformed cnf — does not leak to RS)", () => {
+		expect(extractConfirmation({ jkt: 123 })).toBeUndefined();
+	});
+
+	it("rejects numeric x5t#S256", () => {
+		expect(extractConfirmation({ "x5t#S256": 456 })).toBeUndefined();
+	});
+
+	it("compound binding (both jkt and x5t#S256 valid) returns jkt — intent-explicit policy", () => {
+		// Spec §1 declares compound binding out of scope for Stage 1.
+		// If both are present (malformed / forged / future), jkt wins,
+		// matching the intent-explicit dispatch policy (spec §3.5).
+		expect(extractConfirmation({ jkt: "abc", "x5t#S256": "def" })).toEqual({ jkt: "abc" });
 	});
 });

--- a/packages/oauth/src/__tests__/introspect.types.test.mts
+++ b/packages/oauth/src/__tests__/introspect.types.test.mts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import type { IntrospectResponse } from "../types/introspect.mjs";
+
+describe("IntrospectResponse typed shape", () => {
+	it("active response with no cnf", () => {
+		const r: IntrospectResponse = {
+			active: true,
+			exp: 1700000000,
+			iat: 1699999000,
+			iss: "https://issuer.example",
+			sub: "user-1",
+			scope: "read",
+			token_type: "Bearer",
+		};
+		expect(r.active).toBe(true);
+		expect(r.cnf).toBeUndefined();
+	});
+
+	it("active response with DPoP cnf returns token_type=DPoP", () => {
+		const r: IntrospectResponse = {
+			active: true,
+			exp: 1700000000,
+			iat: 1699999000,
+			iss: "https://issuer.example",
+			sub: "user-1",
+			scope: "read",
+			token_type: "DPoP",
+			cnf: { jkt: "abc123" },
+		};
+		expect(r.cnf).toEqual({ jkt: "abc123" });
+		expect(r.token_type).toBe("DPoP");
+	});
+
+	it("active response with mTLS cnf keeps token_type=Bearer", () => {
+		const r: IntrospectResponse = {
+			active: true,
+			cnf: { "x5t#S256": "def456" },
+			token_type: "Bearer",
+		};
+		expect(r.cnf).toEqual({ "x5t#S256": "def456" });
+		expect(r.token_type).toBe("Bearer");
+	});
+
+	it("inactive response omits everything except active=false", () => {
+		const r: IntrospectResponse = { active: false };
+		expect(r.active).toBe(false);
+		expect(r.cnf).toBeUndefined();
+		expect(r.token_type).toBeUndefined();
+	});
+});

--- a/packages/oauth/src/__tests__/introspect.types.test.mts
+++ b/packages/oauth/src/__tests__/introspect.types.test.mts
@@ -108,4 +108,19 @@ describe("extractConfirmation", () => {
 		// matching the intent-explicit dispatch policy (spec §3.5).
 		expect(extractConfirmation({ jkt: "abc", "x5t#S256": "def" })).toEqual({ jkt: "abc" });
 	});
+
+	it("falls through to x5t#S256 when jkt is empty-string", () => {
+		// jkt fails its non-empty guard, so the function continues to
+		// the x5t check rather than returning undefined immediately.
+		// Pins the documented fall-through behavior.
+		expect(extractConfirmation({ jkt: "", "x5t#S256": "def" })).toEqual({
+			"x5t#S256": "def",
+		});
+	});
+
+	it("falls through to x5t#S256 when jkt is non-string", () => {
+		expect(extractConfirmation({ jkt: 123, "x5t#S256": "def" })).toEqual({
+			"x5t#S256": "def",
+		});
+	});
 });

--- a/packages/oauth/src/index.mts
+++ b/packages/oauth/src/index.mts
@@ -34,3 +34,4 @@ export { oauthModule } from "./module.mjs";
 export { oauthAuthorizationModule } from "./oauthAuthorization.mjs";
 export { oauthSessionModule } from "./oauthSession.mjs";
 export { createOAuthRouter } from "./routes.mjs";
+export { extractConfirmation, type IntrospectResponse } from "./types/introspect.mjs";

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -20,7 +20,6 @@ import {
 	type AuditSink,
 	type ClientRepository,
 	type CodeRepository,
-	type Confirmation,
 	consoleLogger,
 	emitAuditEvent,
 	errorEnvelope,
@@ -48,7 +47,7 @@ import * as federationTokenRoute from "./routes/federationToken.mjs";
 import * as logoutRoute from "./routes/logout.mjs";
 import { createRevokeRouter } from "./routes/revoke.mjs";
 import * as userinfo from "./routes/userinfo.mjs";
-import type { IntrospectResponse } from "./types/introspect.mjs";
+import { extractConfirmation, type IntrospectResponse } from "./types/introspect.mjs";
 
 // Session data type augmentation
 //
@@ -450,14 +449,11 @@ export const createOAuthRouter = async (
 					// DPoP-bound tokens (cnf.jkt present) return "DPoP" per RFC 9449 §5;
 					// mTLS-bound tokens keep "Bearer" per RFC 8705 §3 (cnf.x5t#S256 does
 					// not change the wire-level token type). Bearer tokens have no cnf
-					// and return "Bearer".
-					const cnfRaw = claims.cnf;
-					const cnf =
-						cnfRaw && typeof cnfRaw === "object" && !Array.isArray(cnfRaw)
-							? (cnfRaw as Confirmation)
-							: undefined;
-					const tokenType: "Bearer" | "DPoP" =
-						cnf && "jkt" in cnf && typeof cnf.jkt === "string" ? "DPoP" : "Bearer";
+					// and return "Bearer". `extractConfirmation` validates member types
+					// (rejects empty-string thumbprints, non-string variants); see
+					// types/introspect.mts.
+					const cnf = extractConfirmation(claims.cnf);
+					const tokenType: "Bearer" | "DPoP" = cnf && "jkt" in cnf ? "DPoP" : "Bearer";
 					const response: IntrospectResponse = {
 						active: true,
 						exp,

--- a/packages/oauth/src/routes.mts
+++ b/packages/oauth/src/routes.mts
@@ -20,6 +20,7 @@ import {
 	type AuditSink,
 	type ClientRepository,
 	type CodeRepository,
+	type Confirmation,
 	consoleLogger,
 	emitAuditEvent,
 	errorEnvelope,
@@ -47,6 +48,7 @@ import * as federationTokenRoute from "./routes/federationToken.mjs";
 import * as logoutRoute from "./routes/logout.mjs";
 import { createRevokeRouter } from "./routes/revoke.mjs";
 import * as userinfo from "./routes/userinfo.mjs";
+import type { IntrospectResponse } from "./types/introspect.mjs";
 
 // Session data type augmentation
 //
@@ -444,27 +446,33 @@ export const createOAuthRouter = async (
 					const rawClientId = claims.client_id;
 					const clientId = typeof rawClientId === "string" ? rawClientId : azp;
 					const scope = typeof claims.scope === "string" ? claims.scope : undefined;
-					// SF-8 (RFC 7662 §2.2): `token_type` is the OAuth 2.0 token-type
-					// identifier registry value (`Bearer` per RFC 6750 §6.1.1), NOT
-					// the JOSE `typ` header value (`at+jwt`). Hardcode the literal —
-					// the SF-1 verifier with `type: "access_token"` already enforces
-					// `typ: "at+jwt"` upstream, so any token reaching this point
-					// has been confirmed as a Bearer access token.
-					return res.status(200).json(
-						formatObject({
-							active: true,
-							exp,
-							iat,
-							iss,
-							aud,
-							sub,
-							azp,
-							client_id: clientId,
-							scope,
-							token_type: "Bearer",
-							jti: typeof jti === "string" ? jti : undefined,
-						}),
-					);
+					// SF-8 + Wave 2: token_type follows the bound-token's confirmation.
+					// DPoP-bound tokens (cnf.jkt present) return "DPoP" per RFC 9449 §5;
+					// mTLS-bound tokens keep "Bearer" per RFC 8705 §3 (cnf.x5t#S256 does
+					// not change the wire-level token type). Bearer tokens have no cnf
+					// and return "Bearer".
+					const cnfRaw = claims.cnf;
+					const cnf =
+						cnfRaw && typeof cnfRaw === "object" && !Array.isArray(cnfRaw)
+							? (cnfRaw as Confirmation)
+							: undefined;
+					const tokenType: "Bearer" | "DPoP" =
+						cnf && "jkt" in cnf && typeof cnf.jkt === "string" ? "DPoP" : "Bearer";
+					const response: IntrospectResponse = {
+						active: true,
+						exp,
+						iat,
+						iss,
+						aud,
+						sub,
+						azp,
+						client_id: clientId,
+						scope,
+						token_type: tokenType,
+						jti: typeof jti === "string" ? jti : undefined,
+						cnf,
+					};
+					return res.status(200).json(formatObject(response));
 				} catch (cause) {
 					// SF-8: same non-access-token signal as the bearer path above.
 					// `active: false` is required by RFC 7662 §2.2 regardless of

--- a/packages/oauth/src/types/introspect.mts
+++ b/packages/oauth/src/types/introspect.mts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+import type { Confirmation } from "@o3co/auth-provider-core";
+
+/**
+ * RFC 7662 §2.2 token introspection response. Pulled into a typed
+ * interface (was inline JSON) so consumers can `import type` it and
+ * so the `cnf` claim has a documented home. See Wave 2 Token-binding
+ * Cluster spec §4.6.
+ */
+export interface IntrospectResponse {
+	readonly active: boolean;
+	readonly exp?: number;
+	readonly iat?: number;
+	readonly iss?: string;
+	readonly aud?: string | readonly string[];
+	readonly sub?: string;
+	readonly azp?: string;
+	readonly client_id?: string;
+	readonly scope?: string;
+	/**
+	 * Wire-level token type. `"DPoP"` when the introspected token carries
+	 * a `cnf.jkt` claim (per RFC 9449 §5 + RFC 7662 §2.2 consistency).
+	 * `"Bearer"` otherwise — including mTLS-bound tokens, because RFC 8705
+	 * does not redefine the wire-level token type.
+	 */
+	readonly token_type?: "Bearer" | "DPoP";
+	readonly jti?: string;
+	/**
+	 * RFC 7662 §2.2 confirmation claim mirror. Present when the introspected
+	 * token carries a `cnf` claim; absent otherwise.
+	 */
+	readonly cnf?: Confirmation;
+}

--- a/packages/oauth/src/types/introspect.mts
+++ b/packages/oauth/src/types/introspect.mts
@@ -15,9 +15,16 @@ import type { Confirmation } from "@o3co/auth-provider-core";
 
 /**
  * RFC 7662 §2.2 token introspection response. Pulled into a typed
- * interface (was inline JSON) so consumers can `import type` it and
- * so the `cnf` claim has a documented home. See Wave 2 Token-binding
- * Cluster spec §4.6.
+ * interface (was inline JSON) so consumers (e.g. auth.proxy validation
+ * layer) can `import type { IntrospectResponse } from "@o3co/auth-
+ * provider-oauth"` and so the `cnf` claim has a documented home. See
+ * Wave 2 Token-binding Cluster spec §4.6.
+ *
+ * RFC 7662 §2.2 optional members `username` and `nbf` are intentionally
+ * omitted: this AS issues `at+jwt` tokens without `nbf` and does not
+ * persist a human-readable `username` (auth.provider's scope excludes
+ * profile storage — see project scope memory). Add them when a
+ * consumer needs them.
  */
 export interface IntrospectResponse {
 	readonly active: boolean;
@@ -33,7 +40,11 @@ export interface IntrospectResponse {
 	 * Wire-level token type. `"DPoP"` when the introspected token carries
 	 * a `cnf.jkt` claim (per RFC 9449 §5 + RFC 7662 §2.2 consistency).
 	 * `"Bearer"` otherwise — including mTLS-bound tokens, because RFC 8705
-	 * does not redefine the wire-level token type.
+	 * does not redefine the wire-level token type. Adding a new
+	 * `token_type` variant (e.g. for a future sender-constrained scheme
+	 * with its own IANA token-type registration) is a core semver-minor
+	 * change, mirroring the `Confirmation` extension boundary in spec
+	 * §4.3.
 	 */
 	readonly token_type?: "Bearer" | "DPoP";
 	readonly jti?: string;
@@ -43,3 +54,36 @@ export interface IntrospectResponse {
 	 */
 	readonly cnf?: Confirmation;
 }
+
+/**
+ * Validate and narrow a raw `cnf` claim value extracted from a JWT
+ * payload into a `Confirmation`. Returns `undefined` when the value
+ * is missing or fails any of:
+ *
+ * - non-object (null, array, primitive)
+ * - missing both `jkt` and `x5t#S256` members
+ * - member value is not a non-empty string
+ *
+ * Empty-string members are rejected because RFC 9449 §6 / RFC 8705 §3
+ * define both `jkt` (RFC 7638 JWK Thumbprint) and `x5t#S256` (DER cert
+ * SHA-256 thumbprint) as non-empty base64url strings.
+ *
+ * Compound binding (a cnf object carrying BOTH `jkt` and `x5t#S256`)
+ * is out of scope for Stage 1 (spec §1 "out of scope"). If both are
+ * present, this helper returns the `jkt` variant — matching the intent-
+ * explicit dispatch policy (spec §3.5) where DPoP wins over an ambient
+ * mTLS signal.
+ */
+export const extractConfirmation = (raw: unknown): Confirmation | undefined => {
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+	const obj = raw as Record<string, unknown>;
+	const jkt = obj.jkt;
+	if (typeof jkt === "string" && jkt.length > 0) {
+		return { jkt };
+	}
+	const x5t = obj["x5t#S256"];
+	if (typeof x5t === "string" && x5t.length > 0) {
+		return { "x5t#S256": x5t };
+	}
+	return undefined;
+};


### PR DESCRIPTION
## Summary

Phase 1a of Wave 2 Token-binding Cluster (spec at [`.claude/superpowers/specs/2026-05-18-wave-2-token-binding-cluster-spec.md`](./.claude/superpowers/specs/2026-05-18-wave-2-token-binding-cluster-spec.md)).

Lands the **cross-cutting type surface and claim emission insertion points** that DPoP (Phase 2) and mTLS (Phase 3) will plug into. Plus refactors the introspect endpoint's inline JSON to a typed shape with DPoP-aware `token_type` derivation and a validated `cnf` mirror.

**Zero behavior change for any consumer that does not opt into the cluster.** Every existing call site continues to produce byte-identical claims and wire responses.

## What lands

**Core types (`@o3co/auth-provider-core`):**
- `Confirmation` narrow readonly union (`{ jkt } | { "x5t#S256" }`) — RFC 7800 claim variants.
- `TokenBinding` extensible base interface (`{ kind: string; confirmation: Confirmation }`) — mechanism packages and downstream users extend with their own evidence fields.
- `GrantContext.tokenBinding?: TokenBinding` — optional readonly field populated by `tokenBindingMw` (Phase 1b).
- `GenerateTokenOptions.confirmation` drives the JWT `cnf` claim; `Token.confirmation` echoes the value.
- `generateTokenResponse(tokens, { tokenType?: "Bearer" | "DPoP" })` — explicit wire `token_type` option.
- `generateToken` refactored to spread construction so `readonly Token.confirmation` can be set without a cast.

**Introspect refactor (`@o3co/auth-provider-oauth`):**
- New `IntrospectResponse` interface (exported from package barrel).
- New `extractConfirmation(unknown): Confirmation | undefined` helper validates cnf members are non-empty strings (rejects `{ jkt: 123 }`, `{ jkt: "" }`, etc.) — prevents malformed cnf objects from leaking to the RS.
- DPoP-aware `token_type` derivation: tokens with `cnf.jkt` return `"DPoP"` per RFC 9449 §5; mTLS bindings (`cnf.x5t#S256`) keep `"Bearer"` per RFC 8705 §3; unbound tokens keep `"Bearer"`.
- `cnf` mirrored to introspect response per RFC 7662 §2.2.

## What does NOT land

- `tokenBindingMw` middleware + `/token` route bridge — Phase 1b.
- `Client.senderConstrained` 3-layer propagation + grant-dispatch enforcement — Phase 1c.
- DPoP package (`@o3co/auth-provider-dpop`) — Phase 2.
- mTLS package (`@o3co/auth-provider-mtls`) — Phase 3.

## Test plan

- [x] All pre-existing tests pass — full pnpm -r test green (1270 core + 507 oauth)
- [x] New type-shape + behavior tests:
  - `Confirmation` / `TokenBinding` compile + downstream-extension scenario + `@ts-expect-error` negative compile test
  - `GrantContext.tokenBinding` default `undefined` + populated
  - `generateToken` cnf emission (absent / jkt / x5t#S256 / Token echo / coexists with sub+scope+exp)
  - `generateTokenResponse` tokenType (default Bearer / DPoP / explicit Bearer / DPoP + refreshToken coexistence)
  - `IntrospectResponse` typed shape (4 variants)
  - `extractConfirmation` (10 cases: jkt/x5t / null / non-object / array / missing members / empty-string / numeric / compound-binding policy)
- [x] Existing introspect integration tests (`introspectCascade`, `revoke.introspect.integration`) unchanged
- [x] `pnpm lint` clean (486 files, biome)
- [x] `pnpm -r build` clean (tsc, all packages)

## Review history (in-repo)

5 commits on this branch:

1. `a4062940` — T1.1-T1.4: GrantContext + Confirmation + TokenBinding skeleton (initial implementation)
2. `409452d5` — T1.1-T1.4 code-review follow-up: JSDoc semver-minor sentence + negative compile test
3. `08aa4f43` — T1.5-T1.8: GenerateTokenOptions.confirmation + cnf claim + generateTokenResponse tokenType (initial implementation)
4. `5c4c9b19` — T1.5-T1.8 code-review follow-up: generateToken spread construction (cast removal) + RFC 7800 reference + cnf-coexistence tests
5. `7ee6dc43` — T1.9-T1.10: typed IntrospectResponse + DPoP-aware token_type (initial implementation)
6. `78cc7ff5` — T1.9-T1.10 code-review follow-up: extractConfirmation helper + public export + JSDoc clarifications
7. `aeea9da5` — CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)