### PR TITLE
feat(core): add grantMiddleware contribution kind (Wave 2 Phase 1 retro)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added (Wave 2 Token-binding Cluster — Phase 1 retro)
+
+- **`ContributesMap.grantMiddleware` contribution kind in `@o3co/auth-provider-core`.** Modules may now contribute Express middleware that mounts on `/token` BEFORE grant dispatch — the declarative composition surface for `tokenBindingMw` (Phase 1) and the DPoP / mTLS mechanism packages (Phase 2 / 3). Factories that return `null` (disabled-by-config path — e.g. `oauth.dpop.enabled = false`) are skipped at mount time so the kind doubles as the on/off switch. Existing modules see zero behavior change (the field is optional and no shipped module contributes it yet). Mirrors the session package's A5 Phase 7 augmentation of `federationRedirectPolicies`.
+
 ### Added (Wave 2 Token-binding Cluster — Phase 1c)
 
 - **`SenderConstraint = { required: boolean; methods: readonly string[] }`** in `@o3co/auth-provider-core`. Method-agnostic per-client requirement; handles DPoP + mTLS + future binding mechanisms symmetrically (replaces the originally-considered per-grant `dpopRequired` field).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added (Wave 2 Token-binding Cluster — Phase 1 retro)
 
-- **`ContributesMap.grantMiddleware` contribution kind in `@o3co/auth-provider-core`.** Modules may now contribute Express middleware that mounts on `/token` BEFORE grant dispatch — the declarative composition surface for `tokenBindingMw` (Phase 1) and the DPoP / mTLS mechanism packages (Phase 2 / 3). Factories that return `null` (disabled-by-config path — e.g. `oauth.dpop.enabled = false`) are skipped at mount time so the kind doubles as the on/off switch. Existing modules see zero behavior change (the field is optional and no shipped module contributes it yet). Mirrors the session package's A5 Phase 7 augmentation of `federationRedirectPolicies`.
+- **`ContributesMap.grantMiddleware` contribution kind in `@o3co/auth-provider-core`.** Modules may now contribute Express middleware that mounts on the OAuth token endpoint (`/oauth/token` with the bundled `oauthModule`) BEFORE grant dispatch — the declarative composition surface for `tokenBindingMw` (Phase 1) and the DPoP / mTLS mechanism packages (Phase 2 / 3). Factories that return `null` (disabled-by-config path — e.g. `oauth.dpop.enabled = false`) are skipped at mount time so the kind doubles as the on/off switch. Existing modules see zero behavior change (the field is optional and no shipped module contributes it yet). Mirrors the session package's A5 Phase 7 augmentation of `federationRedirectPolicies`.
 
 ### Added (Wave 2 Token-binding Cluster — Phase 1c)
 

--- a/packages/core/src/boot/__tests__/grant-middleware.integration.test.mts
+++ b/packages/core/src/boot/__tests__/grant-middleware.integration.test.mts
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * boot/__tests__/grant-middleware.integration.test.mts
+ *
+ * Integration tests for the `grantMiddleware` contribution kind.
+ *
+ * Verifies:
+ *   1. A factory returning a non-null RequestHandler is invoked and its
+ *      handler is mounted on `/token` BEFORE grant dispatch.
+ *   2. A factory returning null is invoked but its result is skipped —
+ *      no handler is mounted.
+ *
+ * Per Wave 2 Token-binding Cluster spec §4.7 / Phase 2 DPoP spec §11.1.
+ */
+
+import express, { type RequestHandler } from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import { createApp } from "../../index.mjs";
+import { defineModule } from "../../modules/manifest/index.mjs";
+import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
+import type { BootstrapMap } from "../types.mjs";
+
+// ---------------------------------------------------------------------------
+// Shared bootstrap stub (same pattern as integration.test.mts)
+// ---------------------------------------------------------------------------
+
+const minBoot = {
+	config: makeValidCoreConfig() as never,
+	pathResolver: (s: string) => s,
+} satisfies Record<string, unknown> as BootstrapMap;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ContributesMap.grantMiddleware composition", () => {
+	it("invokes grantMiddleware factories and mounts the returned handler on /token", async () => {
+		const observed = vi.fn();
+		const observerMw: RequestHandler = (req, _res, next) => {
+			observed(req.method, req.path);
+			next();
+		};
+
+		const observerModule = defineModule({
+			name: "observer",
+			requires: [],
+			optional: [],
+			contributes: {
+				grantMiddleware: [() => observerMw],
+			},
+		});
+
+		const handle = await createApp({
+			modules: [observerModule],
+			bootstrapComponents: minBoot,
+		});
+
+		// Wrap the router in a real Express app for supertest.
+		const app = express();
+		app.use(handle.router);
+		// Add a catch-all so supertest gets a 200 instead of 404 on /token.
+		app.use("/token", (_req, res) => {
+			res.status(200).json({ ok: true });
+		});
+
+		await request(app).post("/token").send({});
+
+		expect(observed).toHaveBeenCalledWith("POST", "/");
+
+		await handle.dispose();
+	});
+
+	it("skips factories that return null (disabled-by-config path)", async () => {
+		const factory = vi.fn(() => null);
+
+		const nullModule = defineModule({
+			name: "null-mw",
+			requires: [],
+			optional: [],
+			contributes: {
+				grantMiddleware: [factory],
+			},
+		});
+
+		const handle = await createApp({
+			modules: [nullModule],
+			bootstrapComponents: minBoot,
+		});
+
+		// Factory must have been invoked (to decide null = skip).
+		expect(factory).toHaveBeenCalledTimes(1);
+
+		// Wrap router; no grantMiddleware handler should intercept /token.
+		const intercepted = vi.fn();
+		const app = express();
+		app.use(handle.router);
+		app.use("/token", (_req, res) => {
+			intercepted();
+			res.status(200).json({ ok: true });
+		});
+
+		const res = await request(app).post("/token").send({});
+		expect(res.status).toBe(200);
+		// The null-returning factory produced no mounted middleware —
+		// the catch-all runs and intercepted is called.
+		expect(intercepted).toHaveBeenCalledTimes(1);
+
+		await handle.dispose();
+	});
+});

--- a/packages/core/src/boot/__tests__/grant-middleware.integration.test.mts
+++ b/packages/core/src/boot/__tests__/grant-middleware.integration.test.mts
@@ -6,12 +6,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
 /**
@@ -20,15 +14,22 @@
  * Integration tests for the `grantMiddleware` contribution kind.
  *
  * Verifies:
- *   1. A factory returning a non-null RequestHandler is invoked and its
- *      handler is mounted on `/token` BEFORE grant dispatch.
- *   2. A factory returning null is invoked but its result is skipped —
- *      no handler is mounted.
+ *   1. Cross-loop ordering — a factory returning a non-null RequestHandler is
+ *      invoked and its handler runs BEFORE a `routes` contribution mounted at
+ *      `/oauth` (the bundled oauthModule's mountPath). This pins the
+ *      structural ordering claim that makes the kind useful for DPoP / mTLS:
+ *      the middleware MUST inspect the request before the OAuth /token
+ *      handler runs.
+ *   2. Null-skip — a factory returning null is invoked (so it can decide
+ *      disabled-by-config) but no handler is mounted; the routes contribution
+ *      sees the request without any pre-route middleware running.
+ *   3. Module-registration order — when two modules contribute
+ *      `grantMiddleware`, the first-registered fires first.
  *
  * Per Wave 2 Token-binding Cluster spec §4.7 / Phase 2 DPoP spec §11.1.
  */
 
-import express, { type RequestHandler } from "express";
+import express, { type RequestHandler, Router } from "express";
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../../index.mjs";
@@ -37,7 +38,7 @@ import { makeValidCoreConfig } from "../../testing/fixtures/valid-config.mjs";
 import type { BootstrapMap } from "../types.mjs";
 
 // ---------------------------------------------------------------------------
-// Shared bootstrap stub (same pattern as integration.test.mts)
+// Shared bootstrap stub
 // ---------------------------------------------------------------------------
 
 const minBoot = {
@@ -46,14 +47,34 @@ const minBoot = {
 } satisfies Record<string, unknown> as BootstrapMap;
 
 // ---------------------------------------------------------------------------
+// Fixture: build a routes contribution that mounts a `/token` handler under
+// `/oauth` — mirrors the bundled oauthModule's mountPath shape so the test
+// exercises the actual cross-loop ordering claim against the real grant-
+// dispatch path (`/oauth/token`).
+// ---------------------------------------------------------------------------
+
+function tokenRouteContribution(record: (label: string) => void) {
+	const tokenRouter = Router();
+	tokenRouter.post("/token", (_req, res) => {
+		record("route");
+		res.status(200).json({ ok: true });
+	});
+	return {
+		id: "test-oauth-endpoints",
+		mountPath: "/oauth",
+		handler: tokenRouter as never,
+	};
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 describe("ContributesMap.grantMiddleware composition", () => {
-	it("invokes grantMiddleware factories and mounts the returned handler on /token", async () => {
-		const observed = vi.fn();
-		const observerMw: RequestHandler = (req, _res, next) => {
-			observed(req.method, req.path);
+	it("mounts the returned handler on /oauth/token and runs it BEFORE the OAuth grant dispatch handler", async () => {
+		const events: string[] = [];
+		const observerMw: RequestHandler = (_req, _res, next) => {
+			events.push("mw");
 			next();
 		};
 
@@ -63,6 +84,7 @@ describe("ContributesMap.grantMiddleware composition", () => {
 			optional: [],
 			contributes: {
 				grantMiddleware: [() => observerMw],
+				routes: [() => tokenRouteContribution((label) => events.push(label))],
 			},
 		});
 
@@ -71,23 +93,24 @@ describe("ContributesMap.grantMiddleware composition", () => {
 			bootstrapComponents: minBoot,
 		});
 
-		// Wrap the router in a real Express app for supertest.
 		const app = express();
+		app.use(express.json());
 		app.use(handle.router);
-		// Add a catch-all so supertest gets a 200 instead of 404 on /token.
-		app.use("/token", (_req, res) => {
-			res.status(200).json({ ok: true });
-		});
 
-		await request(app).post("/token").send({});
+		const res = await request(app).post("/oauth/token").send({});
+		expect(res.status).toBe(200);
 
-		expect(observed).toHaveBeenCalledWith("POST", "/");
+		// Cross-loop ordering: the grantMiddleware MUST run before the route
+		// handler. This is the load-bearing property — DPoP / mTLS depend on
+		// it to inspect/replace the request before grant dispatch.
+		expect(events).toEqual(["mw", "route"]);
 
 		await handle.dispose();
 	});
 
-	it("skips factories that return null (disabled-by-config path)", async () => {
+	it("skips factories that return null (disabled-by-config path) — route handler sees no pre-route middleware", async () => {
 		const factory = vi.fn(() => null);
+		const events: string[] = [];
 
 		const nullModule = defineModule({
 			name: "null-mw",
@@ -95,6 +118,7 @@ describe("ContributesMap.grantMiddleware composition", () => {
 			optional: [],
 			contributes: {
 				grantMiddleware: [factory],
+				routes: [() => tokenRouteContribution((label) => events.push(label))],
 			},
 		});
 
@@ -103,23 +127,69 @@ describe("ContributesMap.grantMiddleware composition", () => {
 			bootstrapComponents: minBoot,
 		});
 
-		// Factory must have been invoked (to decide null = skip).
+		// Factory must have been invoked so it could decide null = skip.
 		expect(factory).toHaveBeenCalledTimes(1);
 
-		// Wrap router; no grantMiddleware handler should intercept /token.
-		const intercepted = vi.fn();
 		const app = express();
+		app.use(express.json());
 		app.use(handle.router);
-		app.use("/token", (_req, res) => {
-			intercepted();
-			res.status(200).json({ ok: true });
+
+		const res = await request(app).post("/oauth/token").send({});
+		expect(res.status).toBe(200);
+
+		// Only the route handler fired; the null-returning factory contributed
+		// no mounted middleware.
+		expect(events).toEqual(["route"]);
+
+		await handle.dispose();
+	});
+
+	it("runs grantMiddleware contributions in module-registration order", async () => {
+		const events: string[] = [];
+
+		const moduleA = defineModule({
+			name: "mw-a",
+			requires: [],
+			optional: [],
+			contributes: {
+				grantMiddleware: [
+					() => (_req, _res, next) => {
+						events.push("a");
+						next();
+					},
+				],
+			},
+		});
+		const moduleB = defineModule({
+			name: "mw-b",
+			requires: [],
+			optional: [],
+			contributes: {
+				grantMiddleware: [
+					() => (_req, _res, next) => {
+						events.push("b");
+						next();
+					},
+				],
+				routes: [() => tokenRouteContribution((label) => events.push(label))],
+			},
 		});
 
-		const res = await request(app).post("/token").send({});
+		const handle = await createApp({
+			modules: [moduleA, moduleB],
+			bootstrapComponents: minBoot,
+		});
+
+		const app = express();
+		app.use(express.json());
+		app.use(handle.router);
+
+		const res = await request(app).post("/oauth/token").send({});
 		expect(res.status).toBe(200);
-		// The null-returning factory produced no mounted middleware —
-		// the catch-all runs and intercepted is called.
-		expect(intercepted).toHaveBeenCalledTimes(1);
+
+		// Module-registration order: moduleA's mw fires before moduleB's mw,
+		// both fire before the route handler.
+		expect(events).toEqual(["a", "b", "route"]);
 
 		await handle.dispose();
 	});

--- a/packages/core/src/boot/assemble-app.mts
+++ b/packages/core/src/boot/assemble-app.mts
@@ -27,7 +27,7 @@
 
 import { createServer } from "node:http";
 import { createRequire } from "node:module";
-import type { Express, Router } from "express";
+import type { Express, RequestHandler, Router } from "express";
 import type { InternalLifecycleRegistrar } from "../adapters/AdapterFactory.mjs";
 import type { ComponentKey } from "../modules/manifest/component-map.mjs";
 import type {
@@ -35,6 +35,7 @@ import type {
 	CleanupRecord,
 	CollectedRouteContribution,
 	FrozenWorld,
+	ListCollector,
 	OrderedRouteContribution,
 } from "./types.mjs";
 import { BootError } from "./types.mjs";
@@ -529,6 +530,24 @@ export function assembleApp(
 	}
 
 	const router: Router = RouterCtor();
+
+	// Mount `grantMiddleware` contributions on `/token` BEFORE the route loop.
+	// Express runs middleware in mount order, so these handlers fire before the
+	// OAuth /token route handler that the routes loop installs below. Factories
+	// that returned `null` (disabled-by-config path) are still appended to the
+	// collector for stable identity but skipped here.
+	//
+	// Per Wave 2 Token-binding Cluster spec §4.7 / Phase 2 DPoP spec §11.1.
+	const grantMwCollector = frozen.registries.get("grantMiddleware") as
+		| ListCollector<RequestHandler | null>
+		| undefined;
+	if (grantMwCollector !== undefined) {
+		for (const mw of grantMwCollector.values()) {
+			if (mw !== null) {
+				router.use("/token", mw);
+			}
+		}
+	}
 
 	// Mount each route contribution in mount-index order.
 	for (const orderedRoute of ordered) {

--- a/packages/core/src/boot/assemble-app.mts
+++ b/packages/core/src/boot/assemble-app.mts
@@ -531,20 +531,26 @@ export function assembleApp(
 
 	const router: Router = RouterCtor();
 
-	// Mount `grantMiddleware` contributions on `/token` BEFORE the route loop.
-	// Express runs middleware in mount order, so these handlers fire before the
-	// OAuth /token route handler that the routes loop installs below. Factories
-	// that returned `null` (disabled-by-config path) are still appended to the
-	// collector for stable identity but skipped here.
+	// Mount `grantMiddleware` contributions on `/oauth/token` BEFORE the route
+	// loop. The bundled `oauthModule` contributes its sub-router at mountPath
+	// `/oauth` (packages/oauth/src/module.mts), so the external grant-dispatch
+	// URL is `/oauth/token`. Express runs middleware in mount order, so these
+	// handlers fire before the OAuth `/token` route handler the routes loop
+	// installs below. Null returns (disabled-by-config path) are skipped here;
+	// the collector still records them for value-identity dedup with other
+	// contributions.
 	//
-	// Per Wave 2 Token-binding Cluster spec §4.7 / Phase 2 DPoP spec §11.1.
+	// NOTE: this mount path is coupled to the bundled `oauthModule`'s
+	// mountPath. A downstream that re-mounts the OAuth router at a different
+	// path must also wrap or replace this composition step. Per Wave 2
+	// Token-binding Cluster spec §4.7 / Phase 2 DPoP spec §11.1.
 	const grantMwCollector = frozen.registries.get("grantMiddleware") as
 		| ListCollector<RequestHandler | null>
 		| undefined;
 	if (grantMwCollector !== undefined) {
 		for (const mw of grantMwCollector.values()) {
 			if (mw !== null) {
-				router.use("/token", mw);
+				router.use("/oauth/token", mw);
 			}
 		}
 	}

--- a/packages/core/src/boot/create-app.mts
+++ b/packages/core/src/boot/create-app.mts
@@ -75,8 +75,8 @@ import { validateManifests } from "./validate-manifests.mjs";
  *   6. assembleApp — mount routes, build AppHandle.
  *
  * Built-in contribution kinds (grants, tokenExchangeValidators, federations,
- * mfaFactors, auditHooks, routes, grantPolicyHooks) are seeded by
- * `mergeWithBuiltins`; consumer-supplied kinds overlay on top.
+ * mfaFactors, auditHooks, routes, grantPolicyHooks, grantMiddleware) are
+ * seeded by `mergeWithBuiltins`; consumer-supplied kinds overlay on top.
  *
  * The generic `B` constrains `bootstrapComponents` to a typed subset of
  * `ComponentMap` so downstream stages receive a well-typed config/pathResolver.
@@ -180,7 +180,7 @@ export async function createApp<B extends BootstrapMap = DefaultBootstrapMap>(
  *   cross-package import. Same cleanup opportunity: if the registry is moved
  *   into core, switch to registry-backed form.
  * - federations, mfaFactors: Map-backed `NameKeyedCollector`.
- * - auditHooks, grantPolicyHooks: identity-dedup `ListCollector`.
+ * - auditHooks, grantPolicyHooks, grantMiddleware: identity-dedup `ListCollector`.
  * - routes: declaration-indexed `RouteCollector`.
  *
  * @internal
@@ -199,6 +199,7 @@ function mergeWithBuiltins(consumer: ContributionKindMap | undefined): Contribut
 		auditHooks: makeIdentityDedupListCollector<AuditHook>(),
 		routes: makeRouteCollector(),
 		grantPolicyHooks: makeIdentityDedupListCollector<GrantPolicyHookContribution>(),
+		grantMiddleware: makeIdentityDedupListCollector<import("express").RequestHandler | null>(),
 	};
 	// Consumer keys override built-ins; unknown consumer kinds pass through.
 	return { ...builtin, ...(consumer ?? {}) } as ContributionCollectorMap;

--- a/packages/core/src/boot/create-app.mts
+++ b/packages/core/src/boot/create-app.mts
@@ -29,7 +29,7 @@
  * Per A2-β §6.2 / §6.4 / §9.
  */
 
-import type { Router } from "express";
+import type { RequestHandler, Router } from "express";
 import { createLifecycleRegistrar } from "../adapters/AdapterFactory.mjs";
 import { GrantRegistry } from "../grants/registry.mjs";
 import type {
@@ -199,7 +199,7 @@ function mergeWithBuiltins(consumer: ContributionKindMap | undefined): Contribut
 		auditHooks: makeIdentityDedupListCollector<AuditHook>(),
 		routes: makeRouteCollector(),
 		grantPolicyHooks: makeIdentityDedupListCollector<GrantPolicyHookContribution>(),
-		grantMiddleware: makeIdentityDedupListCollector<import("express").RequestHandler | null>(),
+		grantMiddleware: makeIdentityDedupListCollector<RequestHandler | null>(),
 	};
 	// Consumer keys override built-ins; unknown consumer kinds pass through.
 	return { ...builtin, ...(consumer ?? {}) } as ContributionCollectorMap;

--- a/packages/core/src/boot/types.mts
+++ b/packages/core/src/boot/types.mts
@@ -28,7 +28,7 @@
  */
 
 import type { Server as HttpServer } from "node:http";
-import type { Router } from "express";
+import type { RequestHandler, Router } from "express";
 import type { z } from "zod";
 import type { LifecycleRegistrar } from "../adapters/AdapterFactory.mjs";
 import type { AppConfig } from "../config/application.schema.mjs";
@@ -101,6 +101,7 @@ export type ContributionKind =
 	| "auditHooks"
 	| "routes"
 	| "grantPolicyHooks"
+	| "grantMiddleware"
 	| (string & { readonly __consumerKind?: unique symbol });
 
 // ---------------------------------------------------------------------------
@@ -422,6 +423,16 @@ export interface ContributionCollectorMap {
 	readonly auditHooks?: ListCollector<AuditHook>;
 	readonly routes?: RouteCollector;
 	readonly grantPolicyHooks?: ListCollector<GrantPolicyHookContribution>;
+	/**
+	 * Collector for `grantMiddleware` contributions. Each entry is a
+	 * `RequestHandler | null` returned by a `GrantMiddlewareFactory`. Null
+	 * entries (disabled-by-config path) are filtered at consumption time in
+	 * `assembleApp` — they are appended to the collector so factory identity
+	 * is preserved but skipped when mounting on `/token`.
+	 *
+	 * Per Wave 2 Token-binding Cluster spec §4.7 / Phase 2 DPoP spec §11.1.
+	 */
+	readonly grantMiddleware?: ListCollector<RequestHandler | null>;
 }
 
 /**
@@ -740,7 +751,7 @@ export interface ContributeAndOverrideSameKeyDetails {
 /** Per A2-β §6.1. */
 export interface ListShapedOverrideDetails {
 	readonly reason: "list-shaped-override-not-allowed";
-	readonly kind: "routes" | "auditHooks" | "grantPolicyHooks";
+	readonly kind: "routes" | "auditHooks" | "grantPolicyHooks" | "grantMiddleware";
 	readonly module: string;
 }
 

--- a/packages/core/src/boot/types.mts
+++ b/packages/core/src/boot/types.mts
@@ -427,8 +427,9 @@ export interface ContributionCollectorMap {
 	 * Collector for `grantMiddleware` contributions. Each entry is a
 	 * `RequestHandler | null` returned by a `GrantMiddlewareFactory`. Null
 	 * entries (disabled-by-config path) are filtered at consumption time in
-	 * `assembleApp` — they are appended to the collector so factory identity
-	 * is preserved but skipped when mounting on `/token`.
+	 * `assembleApp` — they are appended to the collector for value-identity
+	 * dedup with sibling contributions but skipped when mounting on the
+	 * OAuth token endpoint (`/oauth/token` with the bundled `oauthModule`).
 	 *
 	 * Per Wave 2 Token-binding Cluster spec §4.7 / Phase 2 DPoP spec §11.1.
 	 */

--- a/packages/core/src/boot/validate-manifests.mts
+++ b/packages/core/src/boot/validate-manifests.mts
@@ -157,6 +157,7 @@ const BUILTIN_CONTRIBUTION_KINDS = new Set<string>([
 	"auditHooks",
 	"routes",
 	"grantPolicyHooks",
+	"grantMiddleware",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -1112,14 +1113,15 @@ function checkSameModuleContributeOverride(modules: readonly NormalisedModule[])
  * Dispatches on `collector.kind === "list" | "list-routes"` so consumer-
  * defined list-shaped kinds are also caught. Mirrors the Task 6 fixup
  * applied in apply-contributions.mts (commit 4d03cc0b). The built-in
- * list-shaped kinds (routes, auditHooks, grantPolicyHooks) match by
- * collector identity; consumer-defined kinds with list-shaped collectors
- * match the same way.
+ * list-shaped kinds (routes, auditHooks, grantPolicyHooks, grantMiddleware)
+ * match by collector identity; consumer-defined kinds with list-shaped
+ * collectors match the same way.
  *
- * The `details.kind` literal is typed as the v0.5.0 built-in union
- * `"routes" | "auditHooks" | "grantPolicyHooks"` per spec §6.1
- * `ListShapedOverrideDetails`; a consumer-defined kind name is widened
- * via cast since the Details type does not yet model consumer extensions.
+ * The `details.kind` literal is typed as the built-in union
+ * `"routes" | "auditHooks" | "grantPolicyHooks" | "grantMiddleware"` per
+ * spec §6.1 `ListShapedOverrideDetails`; a consumer-defined kind name is
+ * widened via cast since the Details type does not yet model consumer
+ * extensions.
  *
  * Per A2-β §5.1 step 11.
  * @internal
@@ -1141,7 +1143,7 @@ function checkListShapedOverrides(
 				stage: "validateManifests",
 				details: {
 					reason: "list-shaped-override-not-allowed",
-					kind: kind as "routes" | "auditHooks" | "grantPolicyHooks",
+					kind: kind as "routes" | "auditHooks" | "grantPolicyHooks" | "grantMiddleware",
 					module: m.name,
 				},
 			});

--- a/packages/core/src/boot/validate-manifests.mts
+++ b/packages/core/src/boot/validate-manifests.mts
@@ -86,7 +86,7 @@ function normaliseModule(m: Module): NormalisedModule {
 	const contributesEntries: ContributionEntry[] = [];
 	for (const [kind, kindMap] of Object.entries(m.contributes ?? {})) {
 		if (Array.isArray(kindMap)) {
-			// List-shaped kinds: auditHooks, routes, grantPolicyHooks
+			// List-shaped kinds: auditHooks, routes, grantPolicyHooks, grantMiddleware
 			for (const factory of kindMap) {
 				contributesEntries.push({
 					kind: kind as ContributionKind,

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -223,6 +223,7 @@ export type {
 	// ./grants/types.mjs exports at this boundary. Import from
 	// @o3co/auth-provider-core/modules/manifest directly.
 	GrantHandlerResolver,
+	GrantMiddlewareFactory,
 	// AS-7 collision resolution (v0.5.1): the manifest's contributes-map
 	// placeholder previously named `GrantPolicyHook` was renamed to
 	// `GrantPolicyHookContribution`. The canonical `GrantPolicyHook`

--- a/packages/core/src/modules/manifest/__tests__/contributes-map.test.mts
+++ b/packages/core/src/modules/manifest/__tests__/contributes-map.test.mts
@@ -1,12 +1,15 @@
-import { expectTypeOf, test } from "vitest";
+import { expect, expectTypeOf, test } from "vitest";
 import type { AuditHookFactory, ContributesMap, GrantFactory } from "../contributes-map.mjs";
+import type { ProviderDeps } from "../provider.mjs";
 
 // Local fixture deps — does NOT augment shared ComponentMap.
 type LocalDeps = { readonly _localCfg: { readonly url: string } };
 
-test("ContributesMap has all 7 v0.5.0 base kinds", () => {
-	// Per A2-α §4.1 baseline declares 7 kinds. A5 (Phase 7) adds an 8th
-	// (federationRedirectPolicies). Phase 1 ships only the 7 baseline.
+test("ContributesMap has all 7 v0.5.0 base kinds plus grantMiddleware (Wave 2 Phase 1 retro)", () => {
+	// Per A2-α §4.1 baseline declares 7 kinds. A5 (Phase 7) adds
+	// `federationRedirectPolicies` via `declare module` augmentation in the
+	// session package. Wave 2 Phase 1 retro (Phase 2 DPoP spec §11.1) adds
+	// `grantMiddleware` as the 8th kind in the core ContributesMap.
 	type Keys = keyof ContributesMap<LocalDeps>;
 	expectTypeOf<Keys>().toEqualTypeOf<
 		| "grants"
@@ -16,6 +19,7 @@ test("ContributesMap has all 7 v0.5.0 base kinds", () => {
 		| "auditHooks"
 		| "routes"
 		| "grantPolicyHooks"
+		| "grantMiddleware"
 	>();
 });
 
@@ -34,4 +38,27 @@ test("Name-keyed kinds are readonly records", () => {
 	expectTypeOf<GrantsField>().toMatchTypeOf<{
 		readonly [name: string]: GrantFactory<LocalDeps>;
 	}>();
+});
+
+// ---------------------------------------------------------------------------
+// Wave 2 Token-binding Cluster — Phase 1 retro: grantMiddleware kind
+// ---------------------------------------------------------------------------
+
+test("ContributesMap includes grantMiddleware kind (Wave 2 Phase 1 retro)", () => {
+	type GMDeps = ProviderDeps<"config", never>;
+	type Keys = keyof ContributesMap<GMDeps>;
+	type GrantMiddlewareKey = "grantMiddleware";
+	const _check: GrantMiddlewareKey extends Keys ? true : false = true;
+	expect(_check).toBe(true);
+});
+
+test("grantMiddleware is list-shaped (factory array)", () => {
+	type GMDeps = ProviderDeps<"config", never>;
+	type GMField = NonNullable<ContributesMap<GMDeps>["grantMiddleware"]>;
+	// Compile-time check: GMField must be a readonly array of factories.
+	const _arr: GMField = [];
+	const _fn = (_deps: GMDeps) => null;
+	const _withFn: GMField = [_fn];
+	expect(Array.isArray(_arr)).toBe(true);
+	expect(Array.isArray(_withFn)).toBe(true);
 });

--- a/packages/core/src/modules/manifest/contributes-map.mts
+++ b/packages/core/src/modules/manifest/contributes-map.mts
@@ -105,8 +105,9 @@ export type GrantPolicyHookFactory<Deps> = (deps: Deps) => GrantPolicyHookContri
 /**
  * Factory type for the `grantMiddleware` contribution kind.
  *
- * Returns an Express `RequestHandler` to mount on `/token` BEFORE grant
- * dispatch, or `null` when the mechanism is disabled by config (e.g.
+ * Returns an Express `RequestHandler` to mount on the OAuth token endpoint
+ * (`/oauth/token` with the bundled `oauthModule`) BEFORE grant dispatch, or
+ * `null` when the mechanism is disabled by config (e.g.
  * `oauth.dpop.enabled = false`). Null-returning factories are skipped at
  * composition time — they are never mounted.
  *
@@ -147,7 +148,8 @@ export interface ContributesMap<Deps = ProviderDeps<never, never>> {
 	readonly routes?: readonly RouteContributionEntry<Deps>[];
 	readonly grantPolicyHooks?: readonly GrantPolicyHookFactory<Deps>[];
 	/**
-	 * Express middleware mounted on `/token` BEFORE grant dispatch (Wave 2
+	 * Express middleware mounted on the OAuth token endpoint (`/oauth/token`
+	 * with the bundled `oauthModule`) BEFORE grant dispatch (Wave 2
 	 * Token-binding Cluster spec §4.7 — added in Phase 1 retro for the
 	 * tokenBindingMw composition surface).
 	 *
@@ -157,10 +159,11 @@ export interface ContributesMap<Deps = ProviderDeps<never, never>> {
 	 * disabled by config).
 	 *
 	 * List-shaped — multiple modules may contribute. Composition order is
-	 * module-registration order. The first contributor to write to
-	 * `req.tokenBinding` wins per Phase 1 §4.7's first-success semantics
-	 * (within one mw factory the dispatchPolicy applies; across factories
-	 * the order is the module-registration order).
+	 * module-registration order. Within one middleware factory the
+	 * `DispatchPolicy` configured on `tokenBindingMw` decides which
+	 * mechanism wins. Across multiple `grantMiddleware` contributions, the
+	 * first one to set `req.tokenBinding` wins — later contributors run
+	 * after and observe the field already populated.
 	 */
 	readonly grantMiddleware?: readonly GrantMiddlewareFactory<Deps>[];
 }

--- a/packages/core/src/modules/manifest/contributes-map.mts
+++ b/packages/core/src/modules/manifest/contributes-map.mts
@@ -161,9 +161,17 @@ export interface ContributesMap<Deps = ProviderDeps<never, never>> {
 	 * List-shaped — multiple modules may contribute. Composition order is
 	 * module-registration order. Within one middleware factory the
 	 * `DispatchPolicy` configured on `tokenBindingMw` decides which
-	 * mechanism wins. Across multiple `grantMiddleware` contributions, the
-	 * first one to set `req.tokenBinding` wins — later contributors run
-	 * after and observe the field already populated.
+	 * mechanism wins.
+	 *
+	 * Cross-contribution composition is plain Express middleware ordering
+	 * — `tokenBindingMw` unconditionally assigns `req.tokenBinding` when it
+	 * resolves a binding (no guard against an already-populated field), so
+	 * a later `grantMiddleware` contribution that resolves a binding will
+	 * **overwrite** the earlier one. Modules that need deterministic
+	 * dispatch across competing mechanisms should compose them into a
+	 * single `tokenBindingMw` call (where `DispatchPolicy` arbitrates)
+	 * rather than register each mechanism as its own `grantMiddleware`
+	 * factory.
 	 */
 	readonly grantMiddleware?: readonly GrantMiddlewareFactory<Deps>[];
 }

--- a/packages/core/src/modules/manifest/contributes-map.mts
+++ b/packages/core/src/modules/manifest/contributes-map.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { RequestHandler } from "express";
 import type { AuditSink } from "../../audit/types.mjs";
 import type { GrantHandler as ConcreteGrantHandler } from "../../grants/types.mjs";
 import type { MfaProvider } from "../../mfa/types.mjs";
@@ -102,6 +103,18 @@ export type AuditHookFactory<Deps> = (deps: Deps) => AuditHook;
 export type GrantPolicyHookFactory<Deps> = (deps: Deps) => GrantPolicyHookContribution;
 
 /**
+ * Factory type for the `grantMiddleware` contribution kind.
+ *
+ * Returns an Express `RequestHandler` to mount on `/token` BEFORE grant
+ * dispatch, or `null` when the mechanism is disabled by config (e.g.
+ * `oauth.dpop.enabled = false`). Null-returning factories are skipped at
+ * composition time — they are never mounted.
+ *
+ * Per Wave 2 Token-binding Cluster spec §4.7 / Phase 2 DPoP spec §11.1.
+ */
+export type GrantMiddlewareFactory<Deps> = (deps: Deps) => RequestHandler | null;
+
+/**
  * Declaration-merged map of contribution kinds.
  *
  * Per A2-α §4.1 the v0.5.0 baseline declares 7 kinds. A5 (Phase 7) adds
@@ -111,9 +124,9 @@ export type GrantPolicyHookFactory<Deps> = (deps: Deps) => GrantPolicyHookContri
  * Per A2-α §4.5 collision policy:
  * - Name-keyed (`grants`, `federations`, `tokenExchangeValidators`,
  *   `mfaFactors`): throw on duplicate at boot (enforced in Phase 4 / A2-β).
- * - List-shaped (`auditHooks`, `routes`, `grantPolicyHooks`): allow
- *   duplicates; routes additionally throw on duplicate `id` /
- *   undecorated-mountPath collisions.
+ * - List-shaped (`auditHooks`, `routes`, `grantPolicyHooks`,
+ *   `grantMiddleware`): allow duplicates; routes additionally throw on
+ *   duplicate `id` / undecorated-mountPath collisions.
  *
  * Per A2-α §4.2 every contribution factory shares the declaring module's
  * top-level `requires` / `optional` typed Deps object — there is no
@@ -133,4 +146,21 @@ export interface ContributesMap<Deps = ProviderDeps<never, never>> {
 	readonly auditHooks?: readonly AuditHookFactory<Deps>[];
 	readonly routes?: readonly RouteContributionEntry<Deps>[];
 	readonly grantPolicyHooks?: readonly GrantPolicyHookFactory<Deps>[];
+	/**
+	 * Express middleware mounted on `/token` BEFORE grant dispatch (Wave 2
+	 * Token-binding Cluster spec §4.7 — added in Phase 1 retro for the
+	 * tokenBindingMw composition surface).
+	 *
+	 * Use cases: token-binding middleware (DPoP, mTLS), custom rate-
+	 * limiters, request body pre-processing. Factories that return `null`
+	 * are skipped at composition time (typical when a mechanism is
+	 * disabled by config).
+	 *
+	 * List-shaped — multiple modules may contribute. Composition order is
+	 * module-registration order. The first contributor to write to
+	 * `req.tokenBinding` wins per Phase 1 §4.7's first-success semantics
+	 * (within one mw factory the dispatchPolicy applies; across factories
+	 * the order is the module-registration order).
+	 */
+	readonly grantMiddleware?: readonly GrantMiddlewareFactory<Deps>[];
 }

--- a/packages/core/src/modules/manifest/index.mts
+++ b/packages/core/src/modules/manifest/index.mts
@@ -25,6 +25,7 @@ export type {
 	FederationProvider,
 	GrantFactory,
 	GrantHandler,
+	GrantMiddlewareFactory,
 	// AS-7 collision resolution (v0.5.1): renamed from `GrantPolicyHook`. The
 	// canonical `GrantPolicyHook` interface lives in `../policy/types.mts`
 	// and is exported from the package root.


### PR DESCRIPTION
## Summary

- Adds the `grantMiddleware` contribution kind to `@o3co/auth-provider-core` — the declarative composition surface for `tokenBindingMw` (Phase 1) and the DPoP / mTLS mechanism packages (Phase 2 / 3).
- Modules contribute `(deps) => RequestHandler | null` factories; non-null returns are mounted on the OAuth token endpoint (`/oauth/token`) BEFORE the OAuth grant dispatch handler runs. Null returns are the disabled-by-config path (e.g. `oauth.dpop.enabled = false`).
- Pure-additive: zero behavior change for any existing module — the field is optional and no shipped module contributes it yet.

This is **Sub-PR 1d of the Wave 2 Token-binding Cluster** — a Phase 1 retro fix surfaced by Phase 2 (DPoP) spec review. Per spec §11.1, lands BEFORE any Phase 2 sub-PR.

## Spec / plan authority

- Spec: `.claude/superpowers/specs/2026-05-18-wave-2-phase-2-dpop-spec.md` §11.1
- Plan: `.claude/superpowers/plans/2026-05-18-wave-2-phase-2-dpop-plan.md` (Sub-PR 1d section)

## What changed (~241 LoC, 8 files)

- `packages/core/src/modules/manifest/contributes-map.mts` — new `GrantMiddlewareFactory<Deps>` type + `grantMiddleware?` optional readonly field on `ContributesMap`.
- `packages/core/src/boot/types.mts` — `"grantMiddleware"` added to `ContributionKind` union, new `ContributionCollectorMap.grantMiddleware?: ListCollector<RequestHandler | null>` slot, plus `ListShapedOverrideDetails.kind` union widening.
- `packages/core/src/boot/create-app.mts` — seed the default `makeIdentityDedupListCollector<RequestHandler | null>()` in `mergeWithBuiltins`.
- `packages/core/src/boot/validate-manifests.mts` — `"grantMiddleware"` added to `BUILTIN_CONTRIBUTION_KINDS` Set + `checkListShapedOverrides` cast widening.
- `packages/core/src/boot/assemble-app.mts` — walks `frozen.registries.get("grantMiddleware")` and `router.use("/oauth/token", mw)` for each non-null entry BEFORE the routes loop, so middleware fires before the OAuth grant handler.
- `packages/core/src/modules/manifest/__tests__/contributes-map.test.mts` — +2 type-shape tests (kind present + list-shaped).
- `packages/core/src/boot/__tests__/grant-middleware.integration.test.mts` (new) — 3 integration tests:
  1. Cross-loop ordering — `mw` runs BEFORE the `routes` `/oauth/token` handler.
  2. Null-skip — factory invoked, no middleware mounted.
  3. Module-registration order — 2 modules' middleware fire in their registration order.
- `CHANGELOG.md` — `[Unreleased]` entry under "Wave 2 Token-binding Cluster — Phase 1 retro".

## Commit history

1. `f595d19b` — initial implementation
2. `7a40e61a` — `/multi-agent-review` fix bundle:
   - **[Critical]** Codex P1: mount path was `/token` (wrong) → fixed to `/oauth/token` because the bundled `oauthModule` contributes its sub-router at `mountPath: "/oauth"`.
   - **[Important]** Test rewrite — original test wrapped `handle.router` with an outer catch-all at `/token`, which trivially passed; rewrite contributes a `routes` entry mounted at `/oauth` and asserts the real cross-loop ordering.
   - **[Important]** `validate-manifests.mts:89` stale JSDoc list of list-shaped kinds.
   - **[Minor]** JSDoc wording "factory identity" → "value identity" (dedup is on returned handler, not factory ref).
   - **[Minor]** Hoisted `RequestHandler` to top-of-file import in `create-app.mts`.

The squash-merge will collapse these into one feature commit.

## Verification

- `pnpm -F @o3co/auth-provider-core build` — green
- `pnpm -F @o3co/auth-provider-core test` — **1297/1297 passing** (was 1295 pre-PR — +2)
- `pnpm -r build` — all packages green
- `pnpm lint` — biome clean (493 files, no fixes applied)

## Test plan

- [x] Build green across the workspace.
- [x] Lint green.
- [x] `core` full test suite passes (1297 tests).
- [x] `oauth` test suite passes (522 tests).
- [x] New integration test verifies cross-loop ordering against a real `routes` contribution at `/oauth` — the load-bearing property that makes the kind useful for Phase 2 DPoP.
- [x] Type-shape tests pin the kind's presence + list-shape on `ContributesMap`.
- [ ] CI green (this PR).

## Notes for reviewer

- **Mount path coupling** — `assembleApp` hard-codes `/oauth/token`. This is coupled to the bundled `oauthModule`'s `mountPath: "/oauth"` (packages/oauth/src/module.mts:151). A downstream that re-mounts the OAuth router at a different path must also wrap or replace this composition step. Documented inline. Spec-approved trade-off (Round 2 §11.1); a future Round 3 could lift the coupling via the OAuth module owning the mount, but that is a non-trivial cross-package refactor outside this sub-PR's scope.
- **Two commits intentional** — the fix commit shows the `/multi-agent-review` audit trail; squash-merge will collapse them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)