### PR TITLE
feat(dpop): @o3co/auth-provider-dpop skeleton + replay store + proof parser (Phase 2 Sub-PR 2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added (Wave 2 Token-binding Cluster — Phase 2 Sub-PR 2a)
+
+- `@o3co/auth-provider-dpop` package skeleton (publishes as new opt-in OSS package).
+- `DPoPReplayStore` interface with in-memory implementation (dev/test only — multi-process deployments require the Redis adapter).
+- `@o3co/auth-provider-redis` Redis-backed `createRedisDPoPReplayStore` adapter using `SET NX PX` for atomic check-and-mark.
+- `parseProof` JOSE-shape validator + `DPoPProof` / `DPoPProofClaims` types.
+- `computeJkt` RFC 7638 SHA-256 thumbprint helper.
+- `DPoPError` with hard-coded `code: "invalid_dpop_proof"` + granular `reason` for audit emission.
+
 ### Added (Wave 2 Token-binding Cluster — Phase 1 retro)
 
 - **`ContributesMap.grantMiddleware` contribution kind in `@o3co/auth-provider-core`.** Modules may now contribute Express middleware that mounts on the OAuth token endpoint (`/oauth/token` with the bundled `oauthModule`) BEFORE grant dispatch — the declarative composition surface for `tokenBindingMw` (Phase 1) and the DPoP / mTLS mechanism packages (Phase 2 / 3). Factories that return `null` (disabled-by-config path — e.g. `oauth.dpop.enabled = false`) are skipped at mount time so the kind doubles as the on/off switch. Existing modules see zero behavior change (the field is optional and no shipped module contributes it yet). Mirrors the session package's A5 Phase 7 augmentation of `federationRedirectPolicies`.

--- a/create-app/scripts/copy-templates.mjs
+++ b/create-app/scripts/copy-templates.mjs
@@ -47,6 +47,7 @@ const readVersion = (pkgPath) => {
 
 const versions = {
 	"@o3co/auth-provider-core": readVersion("../../packages/core/package.json"),
+	"@o3co/auth-provider-dpop": readVersion("../../packages/dpop/package.json"),
 	"@o3co/auth-provider-federation-google": readVersion(
 		"../../packages/federation-google/package.json",
 	),

--- a/create-app/src/__tests__/index.test.mts
+++ b/create-app/src/__tests__/index.test.mts
@@ -149,6 +149,7 @@ describe("scaffold", () => {
 
 		const expectedPackages: Record<string, string> = {
 			"@o3co/auth-provider-core": "../packages/core/package.json",
+			"@o3co/auth-provider-dpop": "../packages/dpop/package.json",
 			"@o3co/auth-provider-federation-github": "../packages/federation-github/package.json",
 			"@o3co/auth-provider-federation-google": "../packages/federation-google/package.json",
 			"@o3co/auth-provider-foundation": "../packages/foundation/package.json",

--- a/packages/dpop/CHANGELOG.md
+++ b/packages/dpop/CHANGELOG.md
@@ -1,0 +1,1 @@
+# 0.0.0 — unreleased

--- a/packages/dpop/LICENSE
+++ b/packages/dpop/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/dpop/README.md
+++ b/packages/dpop/README.md
@@ -1,0 +1,16 @@
+# @o3co/auth-provider-dpop
+
+DPoP (RFC 9449) sender-constrained access token support for [@o3co/auth-provider].
+
+## Status
+
+Stage 1 (token-endpoint binding). See [the Phase 2 spec](https://github.com/o3co/auth.provider/blob/develop/.claude/superpowers/specs/2026-05-18-wave-2-phase-2-dpop-spec.md) for the scope boundary — Stage 2 will add nonce challenge (RFC 9449 §8) and the `dpop_jkt` query parameter at `/authorize` (RFC 9449 §10).
+
+## Quick start
+
+(Filled in by Sub-PR 2b/2c.)
+
+## Operator requirements
+
+- Express's `trust proxy` MUST be configured when the AS sits behind a TLS-terminating reverse proxy. Without it, `req.protocol` returns `http` and DPoP proof verification fails every request (`htu_mismatch`).
+- For multi-process / clustered deployments (PM2 cluster, Kubernetes replicas, etc.), the Redis replay store adapter is required. The in-memory adapter is for single-process dev / test use only.

--- a/packages/dpop/package.json
+++ b/packages/dpop/package.json
@@ -1,0 +1,66 @@
+{
+	"name": "@o3co/auth-provider-dpop",
+	"version": "0.0.0",
+	"description": "DPoP (RFC 9449) sender-constrained access token support for @o3co/auth-provider",
+	"license": "Apache-2.0",
+	"engines": {
+		"node": ">=18.19.0"
+	},
+	"type": "module",
+	"main": "./dist/index.mjs",
+	"types": "./dist/index.d.mts",
+	"exports": {
+		".": {
+			"import": "./dist/index.mjs",
+			"types": "./dist/index.d.mts"
+		},
+		"./reference.conf": "./src/reference.conf"
+	},
+	"files": [
+		"dist",
+		"src/reference.conf",
+		"README.md",
+		"LICENSE"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/o3co/auth.provider.git",
+		"directory": "packages/dpop"
+	},
+	"scripts": {
+		"prebuild": "rimraf dist",
+		"build": "tsc",
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage"
+	},
+	"imports": {
+		"#/*": {
+			"development": "./src/*",
+			"default": "./dist/*"
+		}
+	},
+	"peerDependencies": {
+		"@o3co/auth-provider-core": "workspace:*",
+		"express": "^5.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@o3co/auth-provider-core": {
+			"optional": true
+		},
+		"express": {
+			"optional": true
+		}
+	},
+	"dependencies": {
+		"jose": "^6.2.2"
+	},
+	"devDependencies": {
+		"@o3co/auth-provider-core": "workspace:*",
+		"@vitest/coverage-v8": "^4.1.6",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.6"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/dpop/package.json
+++ b/packages/dpop/package.json
@@ -13,12 +13,10 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"types": "./dist/index.d.mts"
-		},
-		"./reference.conf": "./src/reference.conf"
+		}
 	},
 	"files": [
 		"dist",
-		"src/reference.conf",
 		"README.md",
 		"LICENSE"
 	],
@@ -44,9 +42,6 @@
 		"express": "^5.0.0"
 	},
 	"peerDependenciesMeta": {
-		"@o3co/auth-provider-core": {
-			"optional": true
-		},
 		"express": {
 			"optional": true
 		}

--- a/packages/dpop/package.json
+++ b/packages/dpop/package.json
@@ -38,7 +38,7 @@
 		}
 	},
 	"peerDependencies": {
-		"@o3co/auth-provider-core": "workspace:*",
+		"@o3co/auth-provider-core": "^0.0.0",
 		"express": "^5.0.0"
 	},
 	"peerDependenciesMeta": {

--- a/packages/dpop/src/__tests__/errors.test.mts
+++ b/packages/dpop/src/__tests__/errors.test.mts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from "vitest";
+import { DPoPError } from "#/errors.mjs";
+
+describe("DPoPError", () => {
+	it("hard-codes code to invalid_dpop_proof", () => {
+		const err = new DPoPError("htu_mismatch", "no match");
+		expect(err.code).toBe("invalid_dpop_proof");
+		expect(err.reason).toBe("htu_mismatch");
+	});
+
+	it("preserves message and optional detail", () => {
+		const err = new DPoPError("replay_detected", "seen", { jti: "abc" });
+		expect(err.message).toBe("seen");
+		expect(err.detail).toEqual({ jti: "abc" });
+	});
+
+	it("omits detail when not provided", () => {
+		const err = new DPoPError("multiple_headers", "two values");
+		expect(err.detail).toBeUndefined();
+	});
+
+	it("matches Phase 1 hasOAuthErrorCode pattern (snake_case code)", () => {
+		const err = new DPoPError("missing_claim", "no htm");
+		expect(/^[a-z][a-z0-9_]*$/.test(err.code)).toBe(true);
+	});
+});

--- a/packages/dpop/src/__tests__/memory.replay-store.test.mts
+++ b/packages/dpop/src/__tests__/memory.replay-store.test.mts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from "vitest";
+import { createMemoryDPoPReplayStore } from "#/memory/replay-store.mjs";
+
+describe("createMemoryDPoPReplayStore", () => {
+	it("returns false on the first seen() and true on the second within TTL", async () => {
+		const store = createMemoryDPoPReplayStore();
+		const seen1 = await store.seen("jti-1", "jkt-A", 60);
+		const seen2 = await store.seen("jti-1", "jkt-A", 60);
+		expect(seen1).toBe(false);
+		expect(seen2).toBe(true);
+	});
+
+	it("isolates by jkt (same jti from different keys are NOT replays)", async () => {
+		const store = createMemoryDPoPReplayStore();
+		const seenA = await store.seen("jti-1", "jkt-A", 60);
+		const seenB = await store.seen("jti-1", "jkt-B", 60);
+		expect(seenA).toBe(false);
+		expect(seenB).toBe(false);
+	});
+
+	it("isolates by jti (different jtis from same key are NOT replays)", async () => {
+		const store = createMemoryDPoPReplayStore();
+		const seen1 = await store.seen("jti-1", "jkt-A", 60);
+		const seen2 = await store.seen("jti-2", "jkt-A", 60);
+		expect(seen1).toBe(false);
+		expect(seen2).toBe(false);
+	});
+
+	it("expires entries after TTL (uses injected clock)", async () => {
+		const clock = { now: 1_000_000 };
+		const store = createMemoryDPoPReplayStore({ now: () => clock.now });
+		await store.seen("jti-x", "jkt-X", 10);
+		clock.now += 11_000; // advance 11s — past 10s TTL
+		const seen = await store.seen("jti-x", "jkt-X", 10);
+		expect(seen).toBe(false); // entry expired; treated as fresh
+	});
+
+	it("is atomic under concurrent same-key calls (Promise.all)", async () => {
+		const store = createMemoryDPoPReplayStore();
+		const results = await Promise.all([
+			store.seen("jti-c", "jkt-C", 60),
+			store.seen("jti-c", "jkt-C", 60),
+			store.seen("jti-c", "jkt-C", 60),
+		]);
+		// Exactly one of the three sees false (was the first); the others see true.
+		const fresh = results.filter((r) => r === false).length;
+		expect(fresh).toBe(1);
+	});
+});

--- a/packages/dpop/src/__tests__/proof.test.mts
+++ b/packages/dpop/src/__tests__/proof.test.mts
@@ -36,11 +36,14 @@ beforeAll(async () => {
 });
 
 describe("parseProof — structural validation only (no signature check)", () => {
-	it("parses a well-formed DPoP proof and returns DPoPProof", () => {
-		const proof = parseProof(validProof);
-		expect(proof.header.typ).toBe("dpop+jwt");
-		expect(proof.header.alg).toBe("ES256");
-		expect(proof.header.jwk).toMatchObject({ kty: "EC", crv: "P-256" });
+	it("parses a well-formed DPoP proof and returns DPoPProof (flat layout per spec §5.3)", async () => {
+		const proof = await parseProof(validProof);
+		expect(proof.alg).toBe("ES256");
+		expect(proof.jwk).toMatchObject({ kty: "EC", crv: "P-256" });
+		// jkt is the RFC 7638 SHA-256 thumbprint over the proof JWK — non-empty
+		// base64url string, deterministic for the same key.
+		expect(typeof proof.jkt).toBe("string");
+		expect(proof.jkt.length).toBeGreaterThan(0);
 		expect(proof.claims.htm).toBe("POST");
 		expect(proof.claims.htu).toBe("https://as.example/token");
 		expect(typeof proof.claims.iat).toBe("number");
@@ -49,41 +52,29 @@ describe("parseProof — structural validation only (no signature check)", () =>
 	});
 
 	// Step 3: JWT shape (3 parts)
-	it("throws malformed_proof for non-string input", () => {
-		expect(() => parseProof(123 as unknown as string)).toThrow(DPoPError);
-		try {
-			parseProof(123 as unknown as string);
-		} catch (e) {
-			expect(e).toBeInstanceOf(DPoPError);
-			expect((e as DPoPError).reason).toBe("malformed_proof");
-		}
+	it("throws malformed_proof for non-string input", async () => {
+		await expect(parseProof(123 as unknown as string)).rejects.toMatchObject({
+			constructor: DPoPError,
+			reason: "malformed_proof",
+		});
 	});
 
-	it("throws malformed_proof for a non-JWT string (too few parts)", () => {
-		expect(() => parseProof("not.ajwt")).toThrow(DPoPError);
-		try {
-			parseProof("not.ajwt");
-		} catch (e) {
-			expect((e as DPoPError).reason).toBe("malformed_proof");
-		}
+	it("throws malformed_proof for a non-JWT string (too few parts)", async () => {
+		await expect(parseProof("not.ajwt")).rejects.toMatchObject({
+			reason: "malformed_proof",
+		});
 	});
 
-	it("throws malformed_proof for a non-JWT string (too many parts)", () => {
-		expect(() => parseProof("a.b.c.d")).toThrow(DPoPError);
-		try {
-			parseProof("a.b.c.d");
-		} catch (e) {
-			expect((e as DPoPError).reason).toBe("malformed_proof");
-		}
+	it("throws malformed_proof for a non-JWT string (too many parts)", async () => {
+		await expect(parseProof("a.b.c.d")).rejects.toMatchObject({
+			reason: "malformed_proof",
+		});
 	});
 
-	it("throws malformed_proof for unparseable header", () => {
-		expect(() => parseProof("!!!.aaa.bbb")).toThrow(DPoPError);
-		try {
-			parseProof("!!!.aaa.bbb");
-		} catch (e) {
-			expect((e as DPoPError).reason).toBe("malformed_proof");
-		}
+	it("throws malformed_proof for unparseable header", async () => {
+		await expect(parseProof("!!!.aaa.bbb")).rejects.toMatchObject({
+			reason: "malformed_proof",
+		});
 	});
 
 	// Step 4: typ must be dpop+jwt
@@ -93,12 +84,7 @@ describe("parseProof — structural validation only (no signature check)", () =>
 		const jwt = await new SignJWT({ htm: "POST", htu: "https://as/token", iat: 1, jti: "x" })
 			.setProtectedHeader({ typ: "JWT", alg: "ES256", jwk })
 			.sign(privateKey);
-		expect(() => parseProof(jwt)).toThrow(DPoPError);
-		try {
-			parseProof(jwt);
-		} catch (e) {
-			expect((e as DPoPError).reason).toBe("typ_mismatch");
-		}
+		await expect(parseProof(jwt)).rejects.toMatchObject({ reason: "typ_mismatch" });
 	});
 
 	it("throws typ_mismatch when typ is missing", async () => {
@@ -107,12 +93,23 @@ describe("parseProof — structural validation only (no signature check)", () =>
 		const jwt = await new SignJWT({ htm: "POST", htu: "https://as/token", iat: 1, jti: "x" })
 			.setProtectedHeader({ alg: "ES256", jwk } as Parameters<SignJWT["setProtectedHeader"]>[0])
 			.sign(privateKey);
-		expect(() => parseProof(jwt)).toThrow(DPoPError);
-		try {
-			parseProof(jwt);
-		} catch (e) {
-			expect((e as DPoPError).reason).toBe("typ_mismatch");
-		}
+		await expect(parseProof(jwt)).rejects.toMatchObject({ reason: "typ_mismatch" });
+	});
+
+	// Step 5: alg must be present and non-empty string
+	it("throws malformed_proof when alg is missing from header", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("ES256");
+		const jwk = await exportJWK(publicKey);
+		const jwt = await new SignJWT({ htm: "POST", htu: "https://as/token", iat: 1, jti: "x" })
+			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk })
+			.sign(privateKey);
+		const [hdrB64, payload, sig] = jwt.split(".");
+		expect(hdrB64).toBeDefined();
+		const hdrObj = JSON.parse(Buffer.from(hdrB64 as string, "base64url").toString());
+		delete hdrObj.alg;
+		const newHdr = Buffer.from(JSON.stringify(hdrObj)).toString("base64url");
+		const crafted = `${newHdr}.${payload}.${sig}`;
+		await expect(parseProof(crafted)).rejects.toMatchObject({ reason: "malformed_proof" });
 	});
 
 	// Step 6: jwk must be present
@@ -121,34 +118,44 @@ describe("parseProof — structural validation only (no signature check)", () =>
 		const jwt = await new SignJWT({ htm: "POST", htu: "https://as/token", iat: 1, jti: "x" })
 			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256" })
 			.sign(privateKey);
-		expect(() => parseProof(jwt)).toThrow(DPoPError);
-		try {
-			parseProof(jwt);
-		} catch (e) {
-			expect((e as DPoPError).reason).toBe("missing_jwk");
-		}
+		await expect(parseProof(jwt)).rejects.toMatchObject({ reason: "missing_jwk" });
 	});
 
-	// Step 7: JWK must not carry private material
-	it("throws private_jwk when JWK contains 'd' field", async () => {
+	// Step 7: JWK must not carry private material — parameterized for the 7 fields
+	// the parser checks (d, p, q, dp, dq, qi, k).
+	it.each([
+		"d",
+		"p",
+		"q",
+		"dp",
+		"dq",
+		"qi",
+		"k",
+	])("throws private_jwk when JWK contains '%s' field", async (field) => {
 		const { privateKey, publicKey } = await generateKeyPair("ES256", { extractable: true });
-		const fullJwk = await exportJWK(privateKey); // contains 'd'
-		// Build a valid proof, then surgically inject the private JWK into the header.
 		const pubJwk = await exportJWK(publicKey);
-		const legitProof = await new SignJWT({ htm: "POST", htu: "https://as/token", iat: 1, jti: "y" })
+		const legitProof = await new SignJWT({
+			htm: "POST",
+			htu: "https://as/token",
+			iat: 1,
+			jti: "y",
+		})
 			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk: pubJwk })
 			.sign(privateKey);
-		// Manually reconstruct with private jwk in header
 		const [_hdr, payload, sig] = legitProof.split(".");
-		const headerObj = { typ: "dpop+jwt", alg: "ES256", jwk: fullJwk };
+		// Surgically inject the private-key field into an otherwise-public JWK
+		// so each iteration exercises exactly one private field.
+		const headerObj = {
+			typ: "dpop+jwt",
+			alg: "ES256",
+			jwk: { ...pubJwk, [field]: "REDACTED" },
+		};
 		const fakeHeader = Buffer.from(JSON.stringify(headerObj)).toString("base64url");
 		const crafted = `${fakeHeader}.${payload}.${sig}`;
-		expect(() => parseProof(crafted)).toThrow(DPoPError);
-		try {
-			parseProof(crafted);
-		} catch (e) {
-			expect((e as DPoPError).reason).toBe("private_jwk");
-		}
+		await expect(parseProof(crafted)).rejects.toMatchObject({
+			reason: "private_jwk",
+			message: expect.stringContaining(field),
+		});
 	});
 
 	// Step 9: required claims
@@ -158,12 +165,7 @@ describe("parseProof — structural validation only (no signature check)", () =>
 		const jwt = await new SignJWT({ htu: "https://as/token", iat: 1, jti: "x" })
 			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk })
 			.sign(privateKey);
-		expect(() => parseProof(jwt)).toThrow(DPoPError);
-		try {
-			parseProof(jwt);
-		} catch (e) {
-			expect((e as DPoPError).reason).toBe("missing_claim");
-		}
+		await expect(parseProof(jwt)).rejects.toMatchObject({ reason: "missing_claim" });
 	});
 
 	it("throws missing_claim when htu is absent", async () => {
@@ -172,33 +174,22 @@ describe("parseProof — structural validation only (no signature check)", () =>
 		const jwt = await new SignJWT({ htm: "POST", iat: 1, jti: "x" })
 			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk })
 			.sign(privateKey);
-		expect(() => parseProof(jwt)).toThrow(DPoPError);
-		try {
-			parseProof(jwt);
-		} catch (e) {
-			expect((e as DPoPError).reason).toBe("missing_claim");
-		}
+		await expect(parseProof(jwt)).rejects.toMatchObject({ reason: "missing_claim" });
 	});
 
 	it("throws missing_claim when iat is absent", async () => {
 		const { privateKey, publicKey } = await generateKeyPair("ES256");
 		const jwk = await exportJWK(publicKey);
-		// SignJWT adds iat by default; avoid using setIssuedAt
 		const jwt = await new SignJWT({ htm: "POST", htu: "https://as/token", jti: "x" })
 			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk })
 			.sign(privateKey);
-		// Manually strip iat by reconstructing
 		const [hdr, payloadB64, sig] = jwt.split(".");
-		const payloadObj = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
+		expect(payloadB64).toBeDefined();
+		const payloadObj = JSON.parse(Buffer.from(payloadB64 as string, "base64url").toString());
 		delete payloadObj.iat;
 		const newPayload = Buffer.from(JSON.stringify(payloadObj)).toString("base64url");
 		const crafted = `${hdr}.${newPayload}.${sig}`;
-		expect(() => parseProof(crafted)).toThrow(DPoPError);
-		try {
-			parseProof(crafted);
-		} catch (e) {
-			expect((e as DPoPError).reason).toBe("missing_claim");
-		}
+		await expect(parseProof(crafted)).rejects.toMatchObject({ reason: "missing_claim" });
 	});
 
 	it("throws missing_claim when jti is absent", async () => {
@@ -207,39 +198,38 @@ describe("parseProof — structural validation only (no signature check)", () =>
 		const jwt = await new SignJWT({ htm: "POST", htu: "https://as/token", iat: 1 })
 			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk })
 			.sign(privateKey);
-		expect(() => parseProof(jwt)).toThrow(DPoPError);
-		try {
-			parseProof(jwt);
-		} catch (e) {
-			expect((e as DPoPError).reason).toBe("missing_claim");
-		}
+		await expect(parseProof(jwt)).rejects.toMatchObject({ reason: "missing_claim" });
 	});
 
-	it("throws missing_claim when iat is not a number", async () => {
+	// Step 9 continued: claim type mismatch — covers each of htm/htu/iat/jti.
+	it.each([
+		{ field: "htm", value: 1 },
+		{ field: "htu", value: 1 },
+		{ field: "iat", value: "not-a-number" },
+		{ field: "jti", value: 1 },
+	])("throws missing_claim when $field has wrong type", async ({ field, value }) => {
 		const { privateKey, publicKey } = await generateKeyPair("ES256");
 		const jwk = await exportJWK(publicKey);
-		const jwt = await new SignJWT({ htm: "POST", htu: "https://as/token", jti: "x" })
+		const jwt = await new SignJWT({
+			htm: "POST",
+			htu: "https://as/token",
+			iat: 1,
+			jti: "x",
+		})
 			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk })
 			.sign(privateKey);
-		// Inject string iat
 		const [hdr, payloadB64, sig] = jwt.split(".");
-		const payloadObj = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
-		payloadObj.iat = "not-a-number";
+		expect(payloadB64).toBeDefined();
+		const payloadObj = JSON.parse(Buffer.from(payloadB64 as string, "base64url").toString());
+		payloadObj[field] = value;
 		const newPayload = Buffer.from(JSON.stringify(payloadObj)).toString("base64url");
 		const crafted = `${hdr}.${newPayload}.${sig}`;
-		expect(() => parseProof(crafted)).toThrow(DPoPError);
-		try {
-			parseProof(crafted);
-		} catch (e) {
-			expect((e as DPoPError).reason).toBe("missing_claim");
-		}
+		await expect(parseProof(crafted)).rejects.toMatchObject({ reason: "missing_claim" });
 	});
 
-	it("code is always invalid_dpop_proof for all thrown DPoPErrors", () => {
-		try {
-			parseProof("a.b.c.d");
-		} catch (e) {
-			expect((e as DPoPError).code).toBe("invalid_dpop_proof");
-		}
+	it("code is always invalid_dpop_proof for all thrown DPoPErrors", async () => {
+		await expect(parseProof("a.b.c.d")).rejects.toMatchObject({
+			code: "invalid_dpop_proof",
+		});
 	});
 });

--- a/packages/dpop/src/__tests__/proof.test.mts
+++ b/packages/dpop/src/__tests__/proof.test.mts
@@ -230,12 +230,14 @@ describe("parseProof — structural validation only (no signature check)", () =>
 	});
 
 	// Step 9 continued: claim type mismatch — covers each of htm/htu/iat/jti.
+	// Wrong-type claims are reported as `malformed_proof` (structural error),
+	// distinct from `missing_claim` (claim absent) — operator audit triage.
 	it.each([
 		{ field: "htm", value: 1 },
 		{ field: "htu", value: 1 },
 		{ field: "iat", value: "not-a-number" },
 		{ field: "jti", value: 1 },
-	])("throws missing_claim when $field has wrong type", async ({ field, value }) => {
+	])("throws malformed_proof when $field has wrong type", async ({ field, value }) => {
 		const { privateKey, publicKey } = await generateKeyPair("ES256");
 		const jwk = await exportJWK(publicKey);
 		const jwt = await new SignJWT({
@@ -252,7 +254,7 @@ describe("parseProof — structural validation only (no signature check)", () =>
 		payloadObj[field] = value;
 		const newPayload = Buffer.from(JSON.stringify(payloadObj)).toString("base64url");
 		const crafted = `${hdr}.${newPayload}.${sig}`;
-		await expect(parseProof(crafted)).rejects.toMatchObject({ reason: "missing_claim" });
+		await expect(parseProof(crafted)).rejects.toMatchObject({ reason: "malformed_proof" });
 	});
 
 	it("code is always invalid_dpop_proof for all thrown DPoPErrors", async () => {

--- a/packages/dpop/src/__tests__/proof.test.mts
+++ b/packages/dpop/src/__tests__/proof.test.mts
@@ -158,6 +158,34 @@ describe("parseProof — structural validation only (no signature check)", () =>
 		});
 	});
 
+	// Step 8: invalid JWK shape (passes private-field name screen, fails
+	// jose's structural validation in `calculateJwkThumbprint`). Without
+	// the try/catch wrapper in `parseProof`, jose's raw `JWKInvalid` would
+	// leak out and break the documented `DPoPError` contract.
+	it("throws malformed_proof when JWK is structurally invalid (EC missing crv)", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("ES256");
+		const pubJwk = await exportJWK(publicKey);
+		const legitProof = await new SignJWT({
+			htm: "POST",
+			htu: "https://as/token",
+			iat: 1,
+			jti: "z",
+		})
+			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk: pubJwk })
+			.sign(privateKey);
+		const [_hdr, payload, sig] = legitProof.split(".");
+		// Drop `crv` so the JWK is structurally invalid for an EC key but
+		// still passes the public/private-field-name screen.
+		const { crv: _crv, ...badJwk } = pubJwk as Record<string, unknown> & { crv?: unknown };
+		const headerObj = { typ: "dpop+jwt", alg: "ES256", jwk: badJwk };
+		const fakeHeader = Buffer.from(JSON.stringify(headerObj)).toString("base64url");
+		const crafted = `${fakeHeader}.${payload}.${sig}`;
+		await expect(parseProof(crafted)).rejects.toMatchObject({
+			constructor: DPoPError,
+			reason: "malformed_proof",
+		});
+	});
+
 	// Step 9: required claims
 	it("throws missing_claim when htm is absent", async () => {
 		const { privateKey, publicKey } = await generateKeyPair("ES256");

--- a/packages/dpop/src/__tests__/proof.test.mts
+++ b/packages/dpop/src/__tests__/proof.test.mts
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import { beforeAll, describe, expect, it } from "vitest";
+import { DPoPError } from "#/errors.mjs";
+import { parseProof } from "#/proof.mjs";
+
+// Shared test key for valid proof minting
+let validProof: string;
+let publicJwk: Record<string, unknown>;
+
+beforeAll(async () => {
+	const { privateKey, publicKey } = await generateKeyPair("ES256");
+	publicJwk = await exportJWK(publicKey);
+	validProof = await new SignJWT({
+		htm: "POST",
+		htu: "https://as.example/token",
+		iat: Math.floor(Date.now() / 1000),
+		jti: crypto.randomUUID(),
+	})
+		.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk: publicJwk })
+		.sign(privateKey);
+});
+
+describe("parseProof — structural validation only (no signature check)", () => {
+	it("parses a well-formed DPoP proof and returns DPoPProof", () => {
+		const proof = parseProof(validProof);
+		expect(proof.header.typ).toBe("dpop+jwt");
+		expect(proof.header.alg).toBe("ES256");
+		expect(proof.header.jwk).toMatchObject({ kty: "EC", crv: "P-256" });
+		expect(proof.claims.htm).toBe("POST");
+		expect(proof.claims.htu).toBe("https://as.example/token");
+		expect(typeof proof.claims.iat).toBe("number");
+		expect(typeof proof.claims.jti).toBe("string");
+		expect(proof.raw).toBe(validProof);
+	});
+
+	// Step 3: JWT shape (3 parts)
+	it("throws malformed_proof for non-string input", () => {
+		expect(() => parseProof(123 as unknown as string)).toThrow(DPoPError);
+		try {
+			parseProof(123 as unknown as string);
+		} catch (e) {
+			expect(e).toBeInstanceOf(DPoPError);
+			expect((e as DPoPError).reason).toBe("malformed_proof");
+		}
+	});
+
+	it("throws malformed_proof for a non-JWT string (too few parts)", () => {
+		expect(() => parseProof("not.ajwt")).toThrow(DPoPError);
+		try {
+			parseProof("not.ajwt");
+		} catch (e) {
+			expect((e as DPoPError).reason).toBe("malformed_proof");
+		}
+	});
+
+	it("throws malformed_proof for a non-JWT string (too many parts)", () => {
+		expect(() => parseProof("a.b.c.d")).toThrow(DPoPError);
+		try {
+			parseProof("a.b.c.d");
+		} catch (e) {
+			expect((e as DPoPError).reason).toBe("malformed_proof");
+		}
+	});
+
+	it("throws malformed_proof for unparseable header", () => {
+		expect(() => parseProof("!!!.aaa.bbb")).toThrow(DPoPError);
+		try {
+			parseProof("!!!.aaa.bbb");
+		} catch (e) {
+			expect((e as DPoPError).reason).toBe("malformed_proof");
+		}
+	});
+
+	// Step 4: typ must be dpop+jwt
+	it("throws typ_mismatch when typ is not dpop+jwt", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("ES256");
+		const jwk = await exportJWK(publicKey);
+		const jwt = await new SignJWT({ htm: "POST", htu: "https://as/token", iat: 1, jti: "x" })
+			.setProtectedHeader({ typ: "JWT", alg: "ES256", jwk })
+			.sign(privateKey);
+		expect(() => parseProof(jwt)).toThrow(DPoPError);
+		try {
+			parseProof(jwt);
+		} catch (e) {
+			expect((e as DPoPError).reason).toBe("typ_mismatch");
+		}
+	});
+
+	it("throws typ_mismatch when typ is missing", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("ES256");
+		const jwk = await exportJWK(publicKey);
+		const jwt = await new SignJWT({ htm: "POST", htu: "https://as/token", iat: 1, jti: "x" })
+			.setProtectedHeader({ alg: "ES256", jwk } as Parameters<SignJWT["setProtectedHeader"]>[0])
+			.sign(privateKey);
+		expect(() => parseProof(jwt)).toThrow(DPoPError);
+		try {
+			parseProof(jwt);
+		} catch (e) {
+			expect((e as DPoPError).reason).toBe("typ_mismatch");
+		}
+	});
+
+	// Step 6: jwk must be present
+	it("throws missing_jwk when jwk is absent from header", async () => {
+		const { privateKey } = await generateKeyPair("ES256");
+		const jwt = await new SignJWT({ htm: "POST", htu: "https://as/token", iat: 1, jti: "x" })
+			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256" })
+			.sign(privateKey);
+		expect(() => parseProof(jwt)).toThrow(DPoPError);
+		try {
+			parseProof(jwt);
+		} catch (e) {
+			expect((e as DPoPError).reason).toBe("missing_jwk");
+		}
+	});
+
+	// Step 7: JWK must not carry private material
+	it("throws private_jwk when JWK contains 'd' field", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("ES256", { extractable: true });
+		const fullJwk = await exportJWK(privateKey); // contains 'd'
+		// Build a valid proof, then surgically inject the private JWK into the header.
+		const pubJwk = await exportJWK(publicKey);
+		const legitProof = await new SignJWT({ htm: "POST", htu: "https://as/token", iat: 1, jti: "y" })
+			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk: pubJwk })
+			.sign(privateKey);
+		// Manually reconstruct with private jwk in header
+		const [_hdr, payload, sig] = legitProof.split(".");
+		const headerObj = { typ: "dpop+jwt", alg: "ES256", jwk: fullJwk };
+		const fakeHeader = Buffer.from(JSON.stringify(headerObj)).toString("base64url");
+		const crafted = `${fakeHeader}.${payload}.${sig}`;
+		expect(() => parseProof(crafted)).toThrow(DPoPError);
+		try {
+			parseProof(crafted);
+		} catch (e) {
+			expect((e as DPoPError).reason).toBe("private_jwk");
+		}
+	});
+
+	// Step 9: required claims
+	it("throws missing_claim when htm is absent", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("ES256");
+		const jwk = await exportJWK(publicKey);
+		const jwt = await new SignJWT({ htu: "https://as/token", iat: 1, jti: "x" })
+			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk })
+			.sign(privateKey);
+		expect(() => parseProof(jwt)).toThrow(DPoPError);
+		try {
+			parseProof(jwt);
+		} catch (e) {
+			expect((e as DPoPError).reason).toBe("missing_claim");
+		}
+	});
+
+	it("throws missing_claim when htu is absent", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("ES256");
+		const jwk = await exportJWK(publicKey);
+		const jwt = await new SignJWT({ htm: "POST", iat: 1, jti: "x" })
+			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk })
+			.sign(privateKey);
+		expect(() => parseProof(jwt)).toThrow(DPoPError);
+		try {
+			parseProof(jwt);
+		} catch (e) {
+			expect((e as DPoPError).reason).toBe("missing_claim");
+		}
+	});
+
+	it("throws missing_claim when iat is absent", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("ES256");
+		const jwk = await exportJWK(publicKey);
+		// SignJWT adds iat by default; avoid using setIssuedAt
+		const jwt = await new SignJWT({ htm: "POST", htu: "https://as/token", jti: "x" })
+			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk })
+			.sign(privateKey);
+		// Manually strip iat by reconstructing
+		const [hdr, payloadB64, sig] = jwt.split(".");
+		const payloadObj = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
+		delete payloadObj.iat;
+		const newPayload = Buffer.from(JSON.stringify(payloadObj)).toString("base64url");
+		const crafted = `${hdr}.${newPayload}.${sig}`;
+		expect(() => parseProof(crafted)).toThrow(DPoPError);
+		try {
+			parseProof(crafted);
+		} catch (e) {
+			expect((e as DPoPError).reason).toBe("missing_claim");
+		}
+	});
+
+	it("throws missing_claim when jti is absent", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("ES256");
+		const jwk = await exportJWK(publicKey);
+		const jwt = await new SignJWT({ htm: "POST", htu: "https://as/token", iat: 1 })
+			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk })
+			.sign(privateKey);
+		expect(() => parseProof(jwt)).toThrow(DPoPError);
+		try {
+			parseProof(jwt);
+		} catch (e) {
+			expect((e as DPoPError).reason).toBe("missing_claim");
+		}
+	});
+
+	it("throws missing_claim when iat is not a number", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("ES256");
+		const jwk = await exportJWK(publicKey);
+		const jwt = await new SignJWT({ htm: "POST", htu: "https://as/token", jti: "x" })
+			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk })
+			.sign(privateKey);
+		// Inject string iat
+		const [hdr, payloadB64, sig] = jwt.split(".");
+		const payloadObj = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
+		payloadObj.iat = "not-a-number";
+		const newPayload = Buffer.from(JSON.stringify(payloadObj)).toString("base64url");
+		const crafted = `${hdr}.${newPayload}.${sig}`;
+		expect(() => parseProof(crafted)).toThrow(DPoPError);
+		try {
+			parseProof(crafted);
+		} catch (e) {
+			expect((e as DPoPError).reason).toBe("missing_claim");
+		}
+	});
+
+	it("code is always invalid_dpop_proof for all thrown DPoPErrors", () => {
+		try {
+			parseProof("a.b.c.d");
+		} catch (e) {
+			expect((e as DPoPError).code).toBe("invalid_dpop_proof");
+		}
+	});
+});

--- a/packages/dpop/src/__tests__/thumbprint.test.mts
+++ b/packages/dpop/src/__tests__/thumbprint.test.mts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from "vitest";
+import { computeJkt } from "#/thumbprint.mjs";
+
+describe("computeJkt — RFC 7638 SHA-256 JWK thumbprint", () => {
+	it("matches the RFC 9449 §B.1 worked example", async () => {
+		// RFC 9449 Appendix B example JWK (P-256 public key)
+		const jwk = {
+			kty: "EC",
+			x: "l8tFrhx-34tV3hRICRDY9zCkDlpBhF42UQUfWVAWBFs",
+			y: "9VE4jf_Ok_o64zbTTlcuNJajHmt6v9TDVrU0CdvGRDA",
+			crv: "P-256",
+		} as const;
+		const jkt = await computeJkt(jwk);
+		// The RFC 9449 Appendix B expected JKT value (SHA-256 base64url of canonical JWK)
+		expect(jkt).toBe("0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I");
+	});
+});

--- a/packages/dpop/src/errors.mts
+++ b/packages/dpop/src/errors.mts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Granular internal reason code for a DPoP validation failure.
+ *
+ * The wire-level error code is always `"invalid_dpop_proof"` (RFC 9449 §7).
+ * This reason field is for internal audit emission only — it MUST NOT be
+ * forwarded to the client.
+ *
+ * Per Wave 2 Phase 2 spec §5.6.
+ */
+export type DPoPReasonCode =
+	| "malformed_proof"
+	| "typ_mismatch"
+	| "alg_not_allowed"
+	| "missing_jwk"
+	| "private_jwk"
+	| "signature_invalid"
+	| "missing_claim"
+	| "htm_mismatch"
+	| "htu_mismatch"
+	| "iat_out_of_window"
+	| "replay_detected"
+	| "multiple_headers";
+
+/**
+ * Thrown by `parseProof` and `verifyProof` for any DPoP validation failure.
+ *
+ * Wire-level `code` is hard-coded to `"invalid_dpop_proof"` (the only
+ * RFC 9449 §7 token-endpoint code Phase 2 uses). The `reason` field carries
+ * a granular sub-classification for audit emission — it must never reach
+ * the wire.
+ *
+ * Per Wave 2 Phase 2 spec §5.6 + design principle §3.4.
+ */
+export class DPoPError extends Error {
+	readonly code = "invalid_dpop_proof" as const;
+	readonly reason: DPoPReasonCode;
+	readonly detail?: Record<string, unknown>;
+
+	constructor(reason: DPoPReasonCode, message: string, detail?: Record<string, unknown>) {
+		super(message);
+		this.name = "DPoPError";
+		this.reason = reason;
+		if (detail !== undefined) this.detail = detail;
+	}
+}

--- a/packages/dpop/src/errors.mts
+++ b/packages/dpop/src/errors.mts
@@ -59,3 +59,12 @@ export class DPoPError extends Error {
 		if (detail !== undefined) this.detail = detail;
 	}
 }
+
+/**
+ * The wire-level OAuth error code emitted by Phase 2 DPoP failures.
+ * Always `"invalid_dpop_proof"` per RFC 9449 §7 — the only token-endpoint
+ * error code Phase 2 uses. The alias is exported per spec §5.1 so consumers
+ * can name the wire-side surface explicitly when constructing wire-level
+ * error envelopes.
+ */
+export type DPoPErrorCode = DPoPError["code"];

--- a/packages/dpop/src/index.mts
+++ b/packages/dpop/src/index.mts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { DPoPError, type DPoPReasonCode } from "./errors.mjs";
+export { createMemoryDPoPReplayStore } from "./memory/replay-store.mjs";
+export type { DPoPProof, DPoPProofClaims, DPoPProofHeader } from "./proof.mjs";
+export { parseProof } from "./proof.mjs";
+export type { DPoPReplayStore } from "./replay-store.mjs";
+export { computeJkt } from "./thumbprint.mjs";

--- a/packages/dpop/src/index.mts
+++ b/packages/dpop/src/index.mts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { DPoPError, type DPoPReasonCode } from "./errors.mjs";
+export { DPoPError, type DPoPErrorCode, type DPoPReasonCode } from "./errors.mjs";
 export { createMemoryDPoPReplayStore } from "./memory/replay-store.mjs";
-export type { DPoPProof, DPoPProofClaims, DPoPProofHeader } from "./proof.mjs";
+export type { DPoPProof, DPoPProofClaims } from "./proof.mjs";
 export { parseProof } from "./proof.mjs";
 export type { DPoPReplayStore } from "./replay-store.mjs";
 export { computeJkt } from "./thumbprint.mjs";

--- a/packages/dpop/src/memory/replay-store.mts
+++ b/packages/dpop/src/memory/replay-store.mts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { DPoPReplayStore } from "../replay-store.mjs";
+
+interface MemoryReplayStoreOptions {
+	/** Override the clock for tests. Default: `() => Date.now()`. */
+	readonly now?: () => number;
+}
+
+export const createMemoryDPoPReplayStore = (
+	options: MemoryReplayStoreOptions = {},
+): DPoPReplayStore => {
+	const now = options.now ?? (() => Date.now());
+	// key = `${jkt}:${jti}`, value = expiry epoch ms
+	const seen = new Map<string, number>();
+
+	return {
+		async seen(jti, jkt, ttlSeconds) {
+			const key = `${jkt}:${jti}`;
+			const nowMs = now();
+			const existing = seen.get(key);
+			if (existing !== undefined && existing > nowMs) {
+				return true;
+			}
+			seen.set(key, nowMs + ttlSeconds * 1000);
+			// Opportunistic sweep — drop one expired key per call to amortize
+			// cleanup. Real production deployments use Redis where TTL is
+			// backend-native.
+			for (const [k, expiry] of seen) {
+				if (expiry <= nowMs) {
+					seen.delete(k);
+					break;
+				}
+			}
+			return false;
+		},
+	};
+};

--- a/packages/dpop/src/memory/replay-store.mts
+++ b/packages/dpop/src/memory/replay-store.mts
@@ -29,6 +29,11 @@ export const createMemoryDPoPReplayStore = (
 
 	return {
 		async seen(jti, jkt, ttlSeconds) {
+			if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
+				throw new RangeError(
+					`DPoPReplayStore.seen: ttlSeconds must be a positive finite number (got ${String(ttlSeconds)})`,
+				);
+			}
 			const key = `${jkt}:${jti}`;
 			const nowMs = now();
 			const existing = seen.get(key);

--- a/packages/dpop/src/proof.mts
+++ b/packages/dpop/src/proof.mts
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { decodeJwt, decodeProtectedHeader, type JWK } from "jose";
+import { DPoPError } from "./errors.mjs";
+
+export interface DPoPProofClaims {
+	readonly htm: string;
+	readonly htu: string;
+	readonly iat: number;
+	readonly jti: string;
+}
+
+export interface DPoPProofHeader {
+	readonly typ: string;
+	readonly alg: string;
+	readonly jwk: JWK;
+}
+
+export interface DPoPProof {
+	readonly header: DPoPProofHeader;
+	readonly claims: DPoPProofClaims;
+	readonly raw: string;
+}
+
+/**
+ * Parse a raw DPoP header value into a structured `DPoPProof`. Throws
+ * `DPoPError` for malformed input — does NOT verify the signature or
+ * validate semantic claims (htm, htu, iat). Those happen in the
+ * verifier (T2.5 / Sub-PR 2b).
+ *
+ * Validation order follows spec §6 step ordering for useful error messages:
+ *   Step 3: JWT shape (3 parts)
+ *   Step 4: typ = dpop+jwt
+ *   Step 5: alg present (whitelist check is in verifier)
+ *   Step 6: jwk present in header
+ *   Step 7: jwk is public-only (no private material)
+ *   Step 9: required claims present + correct types
+ *
+ * Per Wave 2 Phase 2 spec §6 + design principle §3.2 (total-order validation).
+ */
+export const parseProof = (raw: string): DPoPProof => {
+	// Step 3 (spec §6): JWT shape — must be exactly 3 dot-separated parts
+	if (typeof raw !== "string" || raw.split(".").length !== 3) {
+		throw new DPoPError("malformed_proof", "DPoP header is not a JWT");
+	}
+
+	let header: { typ?: unknown; alg?: unknown; jwk?: unknown };
+	try {
+		header = decodeProtectedHeader(raw);
+	} catch {
+		throw new DPoPError("malformed_proof", "DPoP header is not parseable");
+	}
+
+	// Step 4 (spec §6): typ must be exactly "dpop+jwt"
+	if (header.typ !== "dpop+jwt") {
+		throw new DPoPError("typ_mismatch", `expected typ=dpop+jwt, got ${String(header.typ)}`);
+	}
+
+	// alg must be present as a non-empty string (whitelist enforcement is in verifier)
+	if (typeof header.alg !== "string" || header.alg.length === 0) {
+		throw new DPoPError("malformed_proof", "missing or non-string alg");
+	}
+
+	// Step 6 (spec §6): jwk must be present in the protected header
+	if (!header.jwk || typeof header.jwk !== "object") {
+		throw new DPoPError("missing_jwk", "JOSE header has no jwk");
+	}
+
+	// Step 7 (spec §6): JWK must carry public key material only
+	const jwk = header.jwk as Record<string, unknown>;
+	const privateKeyFields = ["d", "p", "q", "dp", "dq", "qi", "k"];
+	for (const field of privateKeyFields) {
+		if (field in jwk) {
+			throw new DPoPError("private_jwk", `JWK carries private material: ${field}`);
+		}
+	}
+
+	let claims: Record<string, unknown>;
+	try {
+		claims = decodeJwt(raw) as Record<string, unknown>;
+	} catch {
+		throw new DPoPError("malformed_proof", "DPoP body is not parseable");
+	}
+
+	// Step 9 (spec §6): required claims must be present
+	for (const claim of ["htm", "htu", "iat", "jti"] as const) {
+		if (!(claim in claims)) {
+			throw new DPoPError("missing_claim", `missing required claim: ${claim}`);
+		}
+	}
+
+	// Step 9 continued: claim type validation
+	if (
+		typeof claims.htm !== "string" ||
+		typeof claims.htu !== "string" ||
+		typeof claims.iat !== "number" ||
+		typeof claims.jti !== "string"
+	) {
+		throw new DPoPError("missing_claim", "invalid claim types");
+	}
+
+	return {
+		header: { typ: header.typ, alg: header.alg, jwk: jwk as JWK },
+		claims: {
+			htm: claims.htm,
+			htu: claims.htu,
+			iat: claims.iat,
+			jti: claims.jti,
+		},
+		raw,
+	};
+};

--- a/packages/dpop/src/proof.mts
+++ b/packages/dpop/src/proof.mts
@@ -125,8 +125,18 @@ export const parseProof = async (raw: string): Promise<DPoPProof> => {
 		throw new DPoPError("missing_claim", "invalid claim types");
 	}
 
-	// Step 8 (spec §6): RFC 7638 SHA-256 thumbprint over the validated JWK
-	const jkt = await computeJkt(jwk as JWK);
+	// Step 8 (spec §6): RFC 7638 SHA-256 thumbprint over the validated JWK.
+	// `computeJkt` delegates to jose's `calculateJwkThumbprint`, which throws
+	// `JWKInvalid` for malformed JWK shapes (e.g. EC key missing `crv`/`x`/`y`,
+	// RSA missing `n`/`e`). Step 7 only screens for private-material *field
+	// names* — shape validity is jose's job. Wrap any jose error so the
+	// package's documented `DPoPError` contract holds at the boundary.
+	let jkt: string;
+	try {
+		jkt = await computeJkt(jwk as JWK);
+	} catch (err) {
+		throw new DPoPError("malformed_proof", `invalid JWK: ${(err as Error).message}`);
+	}
 
 	return {
 		jwk: jwk as JWK,

--- a/packages/dpop/src/proof.mts
+++ b/packages/dpop/src/proof.mts
@@ -15,6 +15,7 @@
  */
 import { decodeJwt, decodeProtectedHeader, type JWK } from "jose";
 import { DPoPError } from "./errors.mjs";
+import { computeJkt } from "./thumbprint.mjs";
 
 export interface DPoPProofClaims {
 	readonly htm: string;
@@ -23,15 +24,25 @@ export interface DPoPProofClaims {
 	readonly jti: string;
 }
 
-export interface DPoPProofHeader {
-	readonly typ: string;
-	readonly alg: string;
-	readonly jwk: JWK;
-}
-
+/**
+ * Result of structural DPoP proof parsing. Layout matches Wave 2 Phase 2
+ * spec §5.3 — flat fields, with the proof-key JWK and its RFC 7638 SHA-256
+ * thumbprint (`jkt`) computed at parse time so downstream consumers (the
+ * verifier in 2b, the grant-side cnf claim in 2c) can route on the binding
+ * identity without re-deriving the thumbprint.
+ *
+ * Signature verification is the verifier's responsibility (Sub-PR 2b) —
+ * `parseProof` only validates JOSE shape and claim presence.
+ */
 export interface DPoPProof {
-	readonly header: DPoPProofHeader;
+	/** Proof-of-possession public key from the JOSE protected header. */
+	readonly jwk: JWK;
+	/** JOSE `alg` header value (whitelist enforcement is in the verifier). */
+	readonly alg: string;
+	/** RFC 7638 SHA-256 thumbprint of `jwk` — the value used in `cnf.jkt`. */
+	readonly jkt: string;
 	readonly claims: DPoPProofClaims;
+	/** Original raw JWT — needed for signature verification in 2b. */
 	readonly raw: string;
 }
 
@@ -47,11 +58,12 @@ export interface DPoPProof {
  *   Step 5: alg present (whitelist check is in verifier)
  *   Step 6: jwk present in header
  *   Step 7: jwk is public-only (no private material)
+ *   Step 8: jkt computed via RFC 7638 SHA-256 thumbprint
  *   Step 9: required claims present + correct types
  *
  * Per Wave 2 Phase 2 spec §6 + design principle §3.2 (total-order validation).
  */
-export const parseProof = (raw: string): DPoPProof => {
+export const parseProof = async (raw: string): Promise<DPoPProof> => {
 	// Step 3 (spec §6): JWT shape — must be exactly 3 dot-separated parts
 	if (typeof raw !== "string" || raw.split(".").length !== 3) {
 		throw new DPoPError("malformed_proof", "DPoP header is not a JWT");
@@ -69,7 +81,8 @@ export const parseProof = (raw: string): DPoPProof => {
 		throw new DPoPError("typ_mismatch", `expected typ=dpop+jwt, got ${String(header.typ)}`);
 	}
 
-	// alg must be present as a non-empty string (whitelist enforcement is in verifier)
+	// Step 5 (spec §6): alg must be present as a non-empty string
+	// (whitelist enforcement is in the verifier).
 	if (typeof header.alg !== "string" || header.alg.length === 0) {
 		throw new DPoPError("malformed_proof", "missing or non-string alg");
 	}
@@ -112,8 +125,13 @@ export const parseProof = (raw: string): DPoPProof => {
 		throw new DPoPError("missing_claim", "invalid claim types");
 	}
 
+	// Step 8 (spec §6): RFC 7638 SHA-256 thumbprint over the validated JWK
+	const jkt = await computeJkt(jwk as JWK);
+
 	return {
-		header: { typ: header.typ, alg: header.alg, jwk: jwk as JWK },
+		jwk: jwk as JWK,
+		alg: header.alg,
+		jkt,
 		claims: {
 			htm: claims.htm,
 			htu: claims.htu,

--- a/packages/dpop/src/proof.mts
+++ b/packages/dpop/src/proof.mts
@@ -52,14 +52,21 @@ export interface DPoPProof {
  * validate semantic claims (htm, htu, iat). Those happen in the
  * verifier (T2.5 / Sub-PR 2b).
  *
- * Validation order follows spec §6 step ordering for useful error messages:
+ * Validation order follows spec §6 with one performance-driven deviation:
  *   Step 3: JWT shape (3 parts)
  *   Step 4: typ = dpop+jwt
  *   Step 5: alg present (whitelist check is in verifier)
  *   Step 6: jwk present in header
- *   Step 7: jwk is public-only (no private material)
- *   Step 8: jkt computed via RFC 7638 SHA-256 thumbprint
- *   Step 9: required claims present + correct types
+ *   Step 7: jwk is public-only (no private material — name-screened)
+ *   Step 9: required claims present + correct types       ← runs BEFORE step 8
+ *   Step 8: jkt computed via RFC 7638 SHA-256 thumbprint  ← runs LAST
+ *
+ * Step 8 is moved AFTER step 9 because `computeJkt` is the only cryptographic
+ * operation in the parser (canonical JSON serialization + SHA-256). Cheap
+ * structural / type checks run first so a proof with missing claims rejects
+ * without burning the thumbprint cost. The spec authorizes this ordering —
+ * §6's step numbering is the validation taxonomy, not a literal execution
+ * sequence, since steps 7 and 9 don't depend on the jkt value.
  *
  * Per Wave 2 Phase 2 spec §6 + design principle §3.2 (total-order validation).
  */
@@ -115,14 +122,17 @@ export const parseProof = async (raw: string): Promise<DPoPProof> => {
 		}
 	}
 
-	// Step 9 continued: claim type validation
+	// Step 9 continued: claim type validation.
+	// Wrong-type claims are a STRUCTURAL error (`malformed_proof`), distinct
+	// from the `missing_claim` branch above — operator audit triage needs to
+	// distinguish "client omitted htm" from "client sent iat as a string".
 	if (
 		typeof claims.htm !== "string" ||
 		typeof claims.htu !== "string" ||
 		typeof claims.iat !== "number" ||
 		typeof claims.jti !== "string"
 	) {
-		throw new DPoPError("missing_claim", "invalid claim types");
+		throw new DPoPError("malformed_proof", "invalid claim types");
 	}
 
 	// Step 8 (spec §6): RFC 7638 SHA-256 thumbprint over the validated JWK.

--- a/packages/dpop/src/replay-store.mts
+++ b/packages/dpop/src/replay-store.mts
@@ -27,5 +27,18 @@
  * (the in-memory adapter is dev-only).
  */
 export interface DPoPReplayStore {
+	/**
+	 * @param jti          DPoP proof JWT-ID (RFC 9449 §4.2 `jti` claim).
+	 * @param jkt          RFC 7638 SHA-256 thumbprint of the proof JWK —
+	 *                     pair-scopes the key so the same `jti` reissued
+	 *                     under a different key is NOT a replay.
+	 * @param ttlSeconds   Replay window in seconds; MUST be a positive
+	 *                     finite number. Implementations SHOULD throw
+	 *                     `RangeError` on non-positive values rather than
+	 *                     silently emitting an expired entry.
+	 * @returns `true` when this (jti, jkt) pair was already seen within
+	 *          the replay window; `false` when this call is the first
+	 *          observation (and the pair has been atomically recorded).
+	 */
 	seen(jti: string, jkt: string, ttlSeconds: number): Promise<boolean>;
 }

--- a/packages/dpop/src/replay-store.mts
+++ b/packages/dpop/src/replay-store.mts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * DPoP proof replay protection store. See Wave 2 Phase 2 spec §5.5.
+ *
+ * Atomic `seen(jti, jkt, ttl)` returns true when the (jti, jkt) pair
+ * was already seen within the replay window; false when not seen, AND
+ * atomically records the pair with the given TTL.
+ *
+ * Atomicity is REQUIRED — a two-step "check then mark" pattern would
+ * leave a TOCTOU window. In-memory implementations rely on JS single-
+ * threaded execution; clustered deployments MUST use a Redis backend
+ * (the in-memory adapter is dev-only).
+ */
+export interface DPoPReplayStore {
+	seen(jti: string, jkt: string, ttlSeconds: number): Promise<boolean>;
+}

--- a/packages/dpop/src/thumbprint.mts
+++ b/packages/dpop/src/thumbprint.mts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { calculateJwkThumbprint, type JWK } from "jose";
+
+/**
+ * Compute the JWK Thumbprint (JKT) for a public JWK using SHA-256.
+ *
+ * RFC 7638 §3 canonical JWK member selection + SHA-256 hash → base64url.
+ * Used to bind a DPoP access token to the client's public key per
+ * RFC 9449 §6.1 and to derive the `cnf.jkt` claim.
+ *
+ * Per Wave 2 Phase 2 spec §5.4 + RFC 7638.
+ */
+export const computeJkt = async (jwk: JWK): Promise<string> => {
+	return calculateJwkThumbprint(jwk, "sha256");
+};

--- a/packages/dpop/tsconfig.json
+++ b/packages/dpop/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist/",
+		"paths": {
+			"#/*": ["./src/*"]
+		}
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
+}

--- a/packages/dpop/vitest.config.mts
+++ b/packages/dpop/vitest.config.mts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/__tests__/**/*.test.mts"],
+		passWithNoTests: true,
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "json", "json-summary"],
+			reportsDirectory: "./coverage",
+			include: ["src/**/*.mts"],
+			exclude: ["src/**/__tests__/**", "src/**/*.d.mts", "dist/**"],
+			all: true,
+		},
+	},
+});

--- a/packages/redis/__tests__/dpop-replay-store.integration.test.mts
+++ b/packages/redis/__tests__/dpop-replay-store.integration.test.mts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Integration test for createRedisDPoPReplayStore.
+// Uses testcontainers to spin up a real Redis 7.2 instance — same pattern as
+// challenges.test.mts, replay-seen-set.test.mts, etc.
+
+import Redis from "ioredis";
+import { GenericContainer, type StartedTestContainer } from "testcontainers";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+	createRedisDPoPReplayStore,
+	type DPoPReplayStoreClient,
+} from "../src/dpop-replay-store.mjs";
+
+let container: StartedTestContainer;
+let redis: Redis;
+let keyCounter = 0;
+
+beforeAll(async () => {
+	container = await new GenericContainer("redis:7.2-alpine").withExposedPorts(6379).start();
+	redis = new Redis({
+		host: container.getHost(),
+		port: container.getMappedPort(6379),
+	});
+}, 60_000);
+
+afterAll(async () => {
+	await redis?.quit();
+	await container?.stop();
+});
+
+function makeStore() {
+	keyCounter += 1;
+	const prefix = `dpop:replay:test-${keyCounter}:`;
+	const client: DPoPReplayStoreClient = {
+		set: (k, v, _mode, ttlMs, _cond) => redis.set(k, v, "PX", ttlMs, "NX") as Promise<"OK" | null>,
+	};
+	return createRedisDPoPReplayStore({ client, keyPrefix: prefix });
+}
+
+afterEach(async () => {
+	// Clean up test keys for this counter value
+	const pattern = `dpop:replay:test-${keyCounter}:*`;
+	const keys = await redis.keys(pattern);
+	if (keys.length > 0) {
+		await redis.del(...keys);
+	}
+});
+
+describe("createRedisDPoPReplayStore — integration (Redis 7.2)", () => {
+	it("returns false on the first seen() and true on the second within TTL", async () => {
+		const store = makeStore();
+		const seen1 = await store.seen("jti-1", "jkt-A", 60);
+		const seen2 = await store.seen("jti-1", "jkt-A", 60);
+		expect(seen1).toBe(false);
+		expect(seen2).toBe(true);
+	});
+
+	it("isolates by jkt (same jti from different keys are NOT replays)", async () => {
+		const store = makeStore();
+		const seenA = await store.seen("jti-1", "jkt-A", 60);
+		const seenB = await store.seen("jti-1", "jkt-B", 60);
+		expect(seenA).toBe(false);
+		expect(seenB).toBe(false);
+	});
+
+	it("isolates by jti (different jtis from same key are NOT replays)", async () => {
+		const store = makeStore();
+		const seen1 = await store.seen("jti-1", "jkt-A", 60);
+		const seen2 = await store.seen("jti-2", "jkt-A", 60);
+		expect(seen1).toBe(false);
+		expect(seen2).toBe(false);
+	});
+
+	it("expires entries after TTL", async () => {
+		const store = makeStore();
+		// Use 1-second TTL and wait for expiry
+		await store.seen("jti-exp", "jkt-E", 1);
+		// Wait 1.2 seconds for key to expire
+		await new Promise((r) => setTimeout(r, 1200));
+		const seen = await store.seen("jti-exp", "jkt-E", 60);
+		expect(seen).toBe(false); // entry expired; treated as fresh
+	}, 10_000);
+
+	it("is atomic under concurrent same-key calls (Promise.all)", async () => {
+		const store = makeStore();
+		const results = await Promise.all([
+			store.seen("jti-c", "jkt-C", 60),
+			store.seen("jti-c", "jkt-C", 60),
+			store.seen("jti-c", "jkt-C", 60),
+		]);
+		// Exactly one of the three sees false (was the first); the others see true.
+		const fresh = results.filter((r) => r === false).length;
+		expect(fresh).toBe(1);
+	});
+});

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -45,10 +45,14 @@
 	},
 	"peerDependencies": {
 		"@o3co/auth-provider-core": "^0.0.0",
+		"@o3co/auth-provider-dpop": "workspace:*",
 		"ioredis": "^5.4.1",
 		"redis": "^5.10.0"
 	},
 	"peerDependenciesMeta": {
+		"@o3co/auth-provider-dpop": {
+			"optional": true
+		},
 		"ioredis": {
 			"optional": true
 		},
@@ -58,6 +62,7 @@
 	},
 	"devDependencies": {
 		"@o3co/auth-provider-core": "workspace:*",
+		"@o3co/auth-provider-dpop": "workspace:*",
 		"@vitest/coverage-v8": "^4.1.6",
 		"ioredis": "^5.4.1",
 		"redis": "^5.10.0",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -12,6 +12,10 @@
 			"import": "./dist/index.mjs",
 			"types": "./dist/index.d.mts"
 		},
+		"./dpop": {
+			"import": "./dist/dpop-replay-store.mjs",
+			"types": "./dist/dpop-replay-store.d.mts"
+		},
 		"./ioredis": {
 			"import": "./dist/ioredis.mjs",
 			"types": "./dist/ioredis.d.mts"

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -49,7 +49,7 @@
 	},
 	"peerDependencies": {
 		"@o3co/auth-provider-core": "^0.0.0",
-		"@o3co/auth-provider-dpop": "workspace:*",
+		"@o3co/auth-provider-dpop": "^0.0.0",
 		"ioredis": "^5.4.1",
 		"redis": "^5.10.0"
 	},

--- a/packages/redis/src/dpop-replay-store.mts
+++ b/packages/redis/src/dpop-replay-store.mts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { DPoPReplayStore } from "@o3co/auth-provider-dpop";
+
+/**
+ * Minimal backing client for the DPoP replay store.
+ * Separate from the general `ReplaySeenSetClient` because the DPoP store
+ * needs only the atomic SET NX PX operation — no `exists` query, no
+ * challenge lifecycle ops.
+ */
+export interface DPoPReplayStoreClient {
+	set(key: string, value: string, mode: "PX", ttlMs: number, condition: "NX"): Promise<"OK" | null>;
+}
+
+export interface RedisDPoPReplayStoreOptions {
+	readonly client: DPoPReplayStoreClient;
+	readonly keyPrefix?: string; // default: "dpop:replay:"
+}
+
+/**
+ * Redis-backed DPoPReplayStore. Uses `SET key 1 NX PX ttlMs` for atomic
+ * check-and-mark — a single round-trip with no TOCTOU window.
+ *
+ *   result === "OK"   → key was SET (not previously seen) → return false
+ *   result === null   → key already existed (replay)      → return true
+ *
+ * Per Wave 2 Phase 2 spec §5.5 and design principle §3.3 (atomicity).
+ * Required for multi-process / clustered deployments where the in-memory
+ * adapter cannot share state across processes.
+ */
+export const createRedisDPoPReplayStore = (
+	options: RedisDPoPReplayStoreOptions,
+): DPoPReplayStore => {
+	const prefix = options.keyPrefix ?? "dpop:replay:";
+	return {
+		async seen(jti, jkt, ttlSeconds) {
+			const key = `${prefix}${jkt}:${jti}`;
+			// SET key value NX PX ttlMillis — atomic check-and-set
+			const result = await options.client.set(key, "1", "PX", ttlSeconds * 1000, "NX");
+			// result === "OK" → set succeeded → was NOT seen before
+			// result === null → key already existed → IS a replay
+			return result === null;
+		},
+	};
+};

--- a/packages/redis/src/dpop-replay-store.mts
+++ b/packages/redis/src/dpop-replay-store.mts
@@ -47,6 +47,15 @@ export const createRedisDPoPReplayStore = (
 	const prefix = options.keyPrefix ?? "dpop:replay:";
 	return {
 		async seen(jti, jkt, ttlSeconds) {
+			// Mirror the memory adapter's RangeError guard so the
+			// `DPoPReplayStore.seen` interface contract holds uniformly across
+			// shipped adapters (replay-store.mts JSDoc: implementations SHOULD
+			// throw on non-positive / non-finite ttlSeconds).
+			if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
+				throw new RangeError(
+					`DPoPReplayStore.seen: ttlSeconds must be a positive finite number (got ${String(ttlSeconds)})`,
+				);
+			}
 			const key = `${prefix}${jkt}:${jti}`;
 			// SET key value NX PX ttlMillis — atomic check-and-set
 			const result = await options.client.set(key, "1", "PX", ttlSeconds * 1000, "NX");

--- a/packages/redis/src/index.mts
+++ b/packages/redis/src/index.mts
@@ -61,6 +61,16 @@ export {
 	redisCodeRepositoryModule,
 } from "./code-repository.mjs";
 // ---------------------------------------------------------------------------
+// DPoP replay store adapter (Wave 2 Phase 2 Sub-PR 2a).
+// Requires @o3co/auth-provider-dpop peer — consumers that do not use DPoP
+// need not install it. Exported separately so tree-shakers can elide it.
+// ---------------------------------------------------------------------------
+export {
+	createRedisDPoPReplayStore,
+	type DPoPReplayStoreClient,
+	type RedisDPoPReplayStoreOptions,
+} from "./dpop-replay-store.mjs";
+// ---------------------------------------------------------------------------
 // FederationTokenStore (Phase 10 Q1+Q5).
 // Adapter relocated from core; module pattern added for declarative wiring
 // parity with other v0.5.0 redis adapters.

--- a/packages/redis/src/index.mts
+++ b/packages/redis/src/index.mts
@@ -61,15 +61,15 @@ export {
 	redisCodeRepositoryModule,
 } from "./code-repository.mjs";
 // ---------------------------------------------------------------------------
-// DPoP replay store adapter (Wave 2 Phase 2 Sub-PR 2a).
-// Requires @o3co/auth-provider-dpop peer — consumers that do not use DPoP
-// need not install it. Exported separately so tree-shakers can elide it.
-// ---------------------------------------------------------------------------
-export {
-	createRedisDPoPReplayStore,
-	type DPoPReplayStoreClient,
-	type RedisDPoPReplayStoreOptions,
-} from "./dpop-replay-store.mjs";
+// DPoP replay store adapter (Wave 2 Phase 2 Sub-PR 2a) is exposed on the
+// dedicated `@o3co/auth-provider-redis/dpop` subpath rather than re-exported
+// here. The subpath segregation keeps the optional `@o3co/auth-provider-dpop`
+// peer out of the main entry's type graph so consumers that do not use DPoP
+// can compile against this main entry without installing the dpop peer
+// (otherwise `tsc` raises TS2307 on the transitive type import).
+//
+// Import path:
+//   import { createRedisDPoPReplayStore } from "@o3co/auth-provider-redis/dpop";
 // ---------------------------------------------------------------------------
 // FederationTokenStore (Phase 10 Q1+Q5).
 // Adapter relocated from core; module pattern added for declarative wiring

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,28 @@ importers:
         specifier: ^4.1.6
         version: 4.1.6(@types/node@25.7.0)(@vitest/coverage-v8@4.1.6)(msw@2.14.6(@types/node@25.7.0)(typescript@5.9.3))(vite@8.0.11(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.4))
 
+  packages/dpop:
+    dependencies:
+      express:
+        specifier: ^5.0.0
+        version: 5.2.1
+      jose:
+        specifier: ^6.2.2
+        version: 6.2.3
+    devDependencies:
+      '@o3co/auth-provider-core':
+        specifier: workspace:*
+        version: link:../core
+      '@vitest/coverage-v8':
+        specifier: ^4.1.6
+        version: 4.1.6(vitest@4.1.6)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@25.7.0)(@vitest/coverage-v8@4.1.6)(msw@2.14.6(@types/node@25.7.0)(typescript@5.9.3))(vite@8.0.11(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.4))
+
   packages/federation-github:
     dependencies:
       openid-client:
@@ -224,6 +246,9 @@ importers:
       '@o3co/auth-provider-core':
         specifier: workspace:*
         version: link:../core
+      '@o3co/auth-provider-dpop':
+        specifier: workspace:*
+        version: link:../dpop
       '@vitest/coverage-v8':
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)


### PR DESCRIPTION
## Summary

- Ships `@o3co/auth-provider-dpop` v0.0.0 — new opt-in OSS package providing the foundational primitives for RFC 9449 DPoP support: `DPoPReplayStore` interface + in-memory implementation, `DPoPError` taxonomy with hard-coded wire code, RFC 7638 JWK thumbprint helper, and the structural DPoP proof parser.
- Adds Redis-backed `createRedisDPoPReplayStore` to `@o3co/auth-provider-redis` exposed on the dedicated `./dpop` subpath (segregated so the optional dpop peer stays out of the main entry's type graph — non-DPoP Redis consumers see zero behavior change).
- Zero behavior change for any v0.7.x consumer that doesn't opt in: the dpop package is new, and the redis adapter is only reachable via explicit `@o3co/auth-provider-redis/dpop` import.

**Sub-PR 2a of 3** for Phase 2 of the Wave 2 Token-binding Cluster. Sub-PR 2b adds the htu-normalize logic + full verifier + `createDPoPMechanism` + `dpopModule` wiring. Sub-PR 2c adds the grant integration (cnf claim emission, RT binding matrix). The Phase 1 retro `grantMiddleware` contribution kind (Sub-PR 1d, PR #182) already merged at `5cf72c3`.

## Spec / plan authority

- Spec: `.claude/superpowers/specs/2026-05-18-wave-2-phase-2-dpop-spec.md` (§5.3 DPoPProof shape, §5.5 ReplayStore contract, §5.6 DPoPError, §6 15-step validation matrix step 3-9)
- Plan: `.claude/superpowers/plans/2026-05-18-wave-2-phase-2-dpop-plan.md` — Sub-PR 2a section (T2.1 skeleton, T2.2 replay store, T2.3 errors + thumbprint + parser)

## What changed (~1250 LoC across 22 files)

**New package `@o3co/auth-provider-dpop`:**
- `packages/dpop/package.json` — workspace package, jose@^6.2.2, required peer on core, optional peer on express
- `packages/dpop/LICENSE` — Apache 2.0 verbatim from apache.org (202 lines)
- `packages/dpop/src/replay-store.mts` — `DPoPReplayStore` interface (atomic check-and-mark, TTL-scoped, positive-TTL precondition)
- `packages/dpop/src/memory/replay-store.mts` — in-memory adapter with periodic sweep + `RangeError` guard on `ttlSeconds <= 0`
- `packages/dpop/src/errors.mts` — `DPoPError` class with hard-coded `code: "invalid_dpop_proof"` + granular `reason: DPoPReasonCode` (12 sub-codes) + `DPoPErrorCode` type alias
- `packages/dpop/src/thumbprint.mts` — `computeJkt` wrapping jose's `calculateJwkThumbprint` (RFC 7638)
- `packages/dpop/src/proof.mts` — `parseProof` async function producing the spec §5.3 flat shape `{ jwk, alg, jkt, claims, raw }`; covers spec §6 steps 3-9 (structural validation only — signature verification is Sub-PR 2b)
- `packages/dpop/src/index.mts` — public barrel

**Redis adapter** (segregated subpath):
- `packages/redis/src/dpop-replay-store.mts` — `createRedisDPoPReplayStore` using `SET NX PX` for single-roundtrip atomic check-and-mark
- `packages/redis/package.json` — `./dpop` subpath export added
- `packages/redis/__tests__/dpop-replay-store.integration.test.mts` — 5 testcontainers-backed integration tests

**Tests:** dpop 36/36 (35 unit + 1 regression); redis dpop integration 5/5; core regression 1297/1297; oauth regression 522/522.

## Commit history (3 commits — squash-merge to 1)

1. `2c545c6d` — initial implementation (skeleton + replay store + parser + errors + thumbprint)
2. `d236a9bf` — first `/multi-agent-review` fix bundle:
   - **[Critical]** Codex P1: segregated Redis dpop adapter behind `@o3co/auth-provider-redis/dpop` subpath so the optional dpop peer stays out of the main entry's `.d.mts` graph (was causing TS2307 for non-DPoP Redis consumers).
   - **[Important]** Lifted core from optional → required peer in dpop/package.json.
   - **[Important]** Reshaped `DPoPProof` to flat layout per spec §5.3 (`{ jwk, alg, jkt, claims, raw }`); parseProof now async + computes jkt inline.
   - **[Important]** Removed reference.conf placeholder (defer to 2b).
   - **[Minor]** Parser test coverage: parameterized private_jwk over all 7 fields; claim-type-mismatch over htm/htu/iat/jti; new alg-missing test (+10 tests).
   - **[Minor]** TTL precondition guard + interface JSDoc documentation.
   - **[Minor]** Added `DPoPErrorCode` type alias per spec §5.1.
3. `94c88d48` — re-review fix bundle:
   - **[Important]** Codex P2 regression introduced by the flat-DPoPProof reshape — `parseProof` now calls `computeJkt` which can throw jose `JWKInvalid` for malformed JWK shapes (EC missing crv/x/y, RSA missing n/e). Step 7 only screens for private-material field *names*, not JWK shape validity. Wrapped in try/catch → `DPoPError("malformed_proof", ...)`. Added regression test (EC public JWK with crv stripped).
   - **[Minor]** Normalized peer notation: `"workspace:*"` → `"^0.0.0"` in dpop + redis peerDependencies to match the established workspace convention (oauth-token-exchange, federation-github, federation-google).

The squash-merge will collapse these into one feature commit.

## Verification

- `pnpm -r build` — all packages green
- `pnpm lint` — biome clean (508 files, no fixes applied)
- `pnpm -F @o3co/auth-provider-dpop test` — **36/36**
- `pnpm -F @o3co/auth-provider-redis test dpop-replay-store` — **5/5**
- `pnpm -F @o3co/auth-provider-core test` — **1297/1297** (regression baseline preserved)
- `pnpm -F @o3co/auth-provider-oauth test` — **522/522** (regression baseline preserved)

## Test plan

- [x] Build green across the workspace.
- [x] Lint green.
- [x] dpop unit tests pass (36 tests covering parser steps 3-9 + thumbprint + memory replay store + errors).
- [x] Redis testcontainers integration tests pass (5 tests covering atomicity, key-pair scoping, TTL, prefix).
- [x] No `auth-provider-dpop` references in `packages/redis/dist/index.d.mts` (verified the subpath segregation).
- [x] Core + oauth regression baselines preserved.
- [ ] CI green (this PR).

## Notes for reviewer

- **Two `/multi-agent-review` rounds** ran (Claude + Codex parallel). Round 1 found 1 Critical + 4 Important + 3 Minor; round 2 caught 1 Important regression introduced by the round 1 fix bundle + 1 Minor. No Critical remained at round 2 close → proceeded to push per project CLAUDE.md.
- **DPoPProof shape now matches spec §5.3 verbatim** — flat `{ jwk, alg, jkt, claims, raw }`, jkt computed at parse time. Sub-PR 2b's verifier consumes this directly; Sub-PR 2c's cnf-claim emitter reads `.jkt` without re-deriving.
- **Redis dpop subpath** — consumers wire it explicitly: `import { createRedisDPoPReplayStore } from "@o3co/auth-provider-redis/dpop";`. Consumers that don't use DPoP need not install `@o3co/auth-provider-dpop` (now a verified clean compile path).
- **`DPoPError.code` is structurally hard-coded** — no constructor parameter for `code`, so a future verifier (2b) or grant integration (2c) cannot leak an internal sub-code through the wire envelope.
- **`reference.conf`** intentionally not shipped in 2a — that file lands in Sub-PR 2b along with the verifier config schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)