### PR TITLE
feat(dpop): htu normalize + DPoP verifier + dpopModule (Phase 2 Sub-PR 2b)

### DIFF
--- a/packages/dpop/package.json
+++ b/packages/dpop/package.json
@@ -13,10 +13,12 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"types": "./dist/index.d.mts"
-		}
+		},
+		"./reference.conf": "./src/reference.conf"
 	},
 	"files": [
 		"dist",
+		"src/reference.conf",
 		"README.md",
 		"LICENSE"
 	],
@@ -51,9 +53,14 @@
 	},
 	"devDependencies": {
 		"@o3co/auth-provider-core": "workspace:*",
+		"@types/express": "^5.0.6",
+		"@types/supertest": "^7.2.0",
 		"@vitest/coverage-v8": "^4.1.6",
+		"express": "^5.0.0",
+		"supertest": "^7.2.2",
 		"typescript": "^5.9.3",
-		"vitest": "^4.1.6"
+		"vitest": "^4.1.6",
+		"zod": "^4.3.6"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/dpop/package.json
+++ b/packages/dpop/package.json
@@ -49,7 +49,8 @@
 		}
 	},
 	"dependencies": {
-		"jose": "^6.2.2"
+		"jose": "^6.2.2",
+		"zod": "^4.3.6"
 	},
 	"devDependencies": {
 		"@o3co/auth-provider-core": "workspace:*",
@@ -59,8 +60,7 @@
 		"express": "^5.0.0",
 		"supertest": "^7.2.2",
 		"typescript": "^5.9.3",
-		"vitest": "^4.1.6",
-		"zod": "^4.3.6"
+		"vitest": "^4.1.6"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/dpop/src/__tests__/htu-normalize.test.mts
+++ b/packages/dpop/src/__tests__/htu-normalize.test.mts
@@ -77,4 +77,16 @@ describe("normalizeHtu — RFC 3986 §6.2.2 conformant", () => {
 	it("preserves path case (RFC 3986 §6.2.2.1: scheme-dependent; preserve for http/s)", () => {
 		expect(normalizeHtu("https://as/Token/Endpoint")).toBe("https://as/Token/Endpoint");
 	});
+
+	// RFC 9449 §4 — userinfo has no meaning at the token endpoint. Without
+	// rejection, the canonical reconstruction drops `username` / `password`
+	// and a proof for `https://attacker:pwn@as.example/...` would silently
+	// equality-match the server-built URL → htu binding weakened.
+	it("throws when URL contains userinfo (username only)", () => {
+		expect(() => normalizeHtu("https://attacker@as.example/token")).toThrow(/userinfo/);
+	});
+
+	it("throws when URL contains userinfo (username + password)", () => {
+		expect(() => normalizeHtu("https://attacker:pwn@as.example/token")).toThrow(/userinfo/);
+	});
 });

--- a/packages/dpop/src/__tests__/htu-normalize.test.mts
+++ b/packages/dpop/src/__tests__/htu-normalize.test.mts
@@ -78,6 +78,17 @@ describe("normalizeHtu — RFC 3986 §6.2.2 conformant", () => {
 		expect(normalizeHtu("https://as/Token/Endpoint")).toBe("https://as/Token/Endpoint");
 	});
 
+	// RFC 3986 §3.2.2: IPv6 literal hosts must remain bracketed in the URI.
+	// WHATWG `url.hostname` keeps the brackets verbatim per the URL Standard
+	// host serializer (e.g. `[::1]` for `http://[::1]/`), so the canonical
+	// reconstruction in normalizeHtu — which embeds `url.hostname` directly
+	// — already produces a valid IP-literal URI. This test pins that
+	// contract so a future refactor cannot regress the IPv6 surface.
+	it("preserves IPv6 brackets on the canonical reconstruction", () => {
+		expect(normalizeHtu("http://[::1]/token")).toBe("http://[::1]/token");
+		expect(normalizeHtu("http://[2001:db8::1]:8080/token")).toBe("http://[2001:db8::1]:8080/token");
+	});
+
 	// RFC 9449 §4 — userinfo has no meaning at the token endpoint. Without
 	// rejection, the canonical reconstruction drops `username` / `password`
 	// and a proof for `https://attacker:pwn@as.example/...` would silently

--- a/packages/dpop/src/__tests__/htu-normalize.test.mts
+++ b/packages/dpop/src/__tests__/htu-normalize.test.mts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { normalizeHtu } from "#/htu-normalize.mjs";
+
+describe("normalizeHtu — RFC 3986 §6.2.2 conformant", () => {
+	it("lowercases scheme and host", () => {
+		expect(normalizeHtu("HTTPS://AS.Example.com/Token")).toBe("https://as.example.com/Token");
+	});
+
+	it("keeps host in ASCII-compatible (Punycode) form", () => {
+		// xn-- form preserved; not decoded to unicode
+		expect(normalizeHtu("https://xn--80akhbyknj4f.example/path")).toBe(
+			"https://xn--80akhbyknj4f.example/path",
+		);
+	});
+
+	it("removes default port 443 for https", () => {
+		expect(normalizeHtu("https://as.example:443/token")).toBe("https://as.example/token");
+	});
+
+	it("removes default port 80 for http", () => {
+		expect(normalizeHtu("http://as.example:80/token")).toBe("http://as.example/token");
+	});
+
+	it("preserves non-default port", () => {
+		expect(normalizeHtu("https://as.example:8443/token")).toBe("https://as.example:8443/token");
+	});
+
+	it("decodes unreserved characters in path", () => {
+		// %7E = ~ (unreserved)
+		expect(normalizeHtu("https://as/%7Eu/profile")).toBe("https://as/~u/profile");
+	});
+
+	it("preserves percent-encoding for non-unreserved characters", () => {
+		// %20 = space (reserved/needs encoding)
+		expect(normalizeHtu("https://as/path%20with%20spaces")).toBe("https://as/path%20with%20spaces");
+	});
+
+	it("normalizes empty path to /", () => {
+		expect(normalizeHtu("https://as.example")).toBe("https://as.example/");
+	});
+
+	it("removes dot segments per RFC 3986 §6.2.2.3", () => {
+		expect(normalizeHtu("https://as/a/./b")).toBe("https://as/a/b");
+		expect(normalizeHtu("https://as/a/../b")).toBe("https://as/b");
+		expect(normalizeHtu("https://as/a/b/..")).toBe("https://as/a");
+	});
+
+	it("preserves multiple slashes (does not collapse //)", () => {
+		expect(normalizeHtu("https://as/a//b")).toBe("https://as/a//b");
+	});
+
+	it("preserves trailing slash verbatim", () => {
+		expect(normalizeHtu("https://as/token/")).toBe("https://as/token/");
+		expect(normalizeHtu("https://as/token")).toBe("https://as/token");
+	});
+
+	it("strips query and fragment", () => {
+		expect(normalizeHtu("https://as/token?foo=bar#anchor")).toBe("https://as/token");
+	});
+
+	it("preserves path case (RFC 3986 §6.2.2.1: scheme-dependent; preserve for http/s)", () => {
+		expect(normalizeHtu("https://as/Token/Endpoint")).toBe("https://as/Token/Endpoint");
+	});
+});

--- a/packages/dpop/src/__tests__/module.integration.test.mts
+++ b/packages/dpop/src/__tests__/module.integration.test.mts
@@ -44,6 +44,7 @@ import { exportJWK, generateKeyPair, SignJWT } from "jose";
 import request from "supertest";
 import { describe, expect, it } from "vitest";
 import { dpopModule } from "#/module.mjs";
+import type { DPoPReplayStore } from "#/replay-store.mjs";
 import { computeJkt } from "#/thumbprint.mjs";
 
 // ---------------------------------------------------------------------------
@@ -243,6 +244,110 @@ describe("dpopModule — integration via createApp", () => {
 		expect(res.body).toMatchObject({ error: "invalid_dpop_proof" });
 
 		await handle.dispose();
+	});
+
+	it("when enabled: consumer-wired dpopReplayStore is passed through to the mechanism (ComponentMap slot contract)", async () => {
+		// Spy store: records each (jti, jkt) call so we can confirm the
+		// composition root's store reached the mechanism — not the
+		// in-memory fallback. The whole reason `dpopReplayStore` is a
+		// ComponentMap slot is so production deployments can substitute
+		// a Redis-backed adapter without forking core or dpop.
+		const calls: { jti: string; jkt: string; ttlSeconds: number }[] = [];
+		const consumerStore: DPoPReplayStore = {
+			seen: async (jti, jkt, ttlSeconds) => {
+				calls.push({ jti, jkt, ttlSeconds });
+				return false;
+			},
+		};
+
+		const boot = {
+			...makeBoot(true),
+			// Wire the slot via bootstrapComponents. Cast required because
+			// the ambient `declare module` augmentation that adds
+			// `dpopReplayStore` to ComponentMap only loads when @o3co/auth-
+			// provider-dpop is in scope; the test imports it, but
+			// BootstrapMap's structural typing here is satisfied via cast.
+			dpopReplayStore: consumerStore,
+		} as never as BootstrapMap;
+		const { proof, jkt } = await mintProof();
+
+		const observerModule = defineModule({
+			name: "observer",
+			requires: [],
+			optional: [],
+			contributes: {
+				routes: [
+					() => {
+						const router = Router();
+						router.use(express.json());
+						router.post("/token", (_req, res) => {
+							res.status(200).json({ ok: true });
+						});
+						return { id: "test-token", mountPath: "/oauth", handler: router };
+					},
+				],
+			},
+		});
+
+		const handle = await createApp({
+			modules: [dpopModule, observerModule],
+			bootstrapComponents: boot,
+		});
+
+		const app = express();
+		app.use(express.json());
+		app.use(handle.router);
+
+		const res = await request(app)
+			.post("/oauth/token")
+			.set("DPoP", proof)
+			.set("Host", "as.example")
+			.send({});
+
+		expect(res.status).toBe(200);
+		// The consumer store recorded exactly one (jti, jkt) call — proving
+		// the slot was forwarded to the mechanism and the in-memory
+		// fallback was NOT used.
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.jkt).toBe(jkt);
+		expect(calls[0]?.ttlSeconds).toBe(300);
+
+		await handle.dispose();
+	});
+
+	it("when enabled with replay-store=redis but slot unset: createApp fails fast (no silent in-memory fallback)", async () => {
+		// Multi-replica deployments rely on Redis for cross-process
+		// replay protection. A silent fallback to memory would let the
+		// same (jti, jkt) be accepted by another replica — replay
+		// protection bypassed. The module's factory throws at boot when
+		// the config asks for redis but the slot is unwired.
+		const boot = {
+			config: {
+				...makeValidCoreConfig(),
+				oauth: {
+					...makeValidCoreConfig().oauth,
+					dpop: {
+						enabled: true,
+						"iat-window-seconds": 60,
+						"alg-whitelist": ["ES256"],
+						"replay-store": "redis", // ← contract: slot MUST be wired
+						"replay-store-ttl-seconds": 300,
+					},
+					tokenBinding: {
+						"dispatch-policy": "intent-explicit",
+					},
+				},
+			} as never,
+			pathResolver: (s: string) => s,
+			// NOTE: dpopReplayStore intentionally NOT wired.
+		} satisfies Record<string, unknown> as BootstrapMap;
+
+		await expect(
+			createApp({
+				modules: [dpopModule],
+				bootstrapComponents: boot,
+			}),
+		).rejects.toThrow(/replay-store = "redis" requires the `dpopReplayStore` ComponentMap slot/);
 	});
 
 	it("when enabled: absent DPoP header leaves req.tokenBinding unset (mechanism returns null)", async () => {

--- a/packages/dpop/src/__tests__/module.integration.test.mts
+++ b/packages/dpop/src/__tests__/module.integration.test.mts
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * module.integration.test.mts
+ *
+ * Integration test for `dpopModule` composition via `createApp`.
+ *
+ * Sub-PR 2b scope (narrower than the full spec §12.2):
+ *   - Verify `dpopModule` wires correctly with `createApp`.
+ *   - When `oauth.dpop.enabled = false` (default), no DPoP middleware is
+ *     mounted — requests succeed without a DPoP header.
+ *   - When `oauth.dpop.enabled = true`, a valid DPoP proof populates
+ *     `req.tokenBinding` with the correct `kind` and `confirmation.jkt`.
+ *   - An invalid proof returns HTTP 400 with `error: "invalid_dpop_proof"`.
+ *
+ * Sub-PR 2c deferred:
+ *   - `token_type: "DPoP"` in the response body.
+ *   - `cnf.jkt` claim in the issued access token.
+ *
+ * Test pattern: copied from packages/core/src/boot/__tests__/
+ *   grant-middleware.integration.test.mts (Phase 1d retro integration).
+ *
+ * Per Wave 2 Phase 2 spec §12.2 (narrowed) + Phase 2 plan T2.6.3.
+ */
+
+import { type BootstrapMap, createApp, defineModule } from "@o3co/auth-provider-core";
+import { makeValidCoreConfig } from "@o3co/auth-provider-core/testing";
+import express, { type RequestHandler, Router } from "express";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { dpopModule } from "#/module.mjs";
+import { computeJkt } from "#/thumbprint.mjs";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** Minimal bootstrap with extended dpop config. */
+const makeBoot = (dpopEnabled: boolean): BootstrapMap =>
+	({
+		config: {
+			...makeValidCoreConfig(),
+			oauth: {
+				...makeValidCoreConfig().oauth,
+				dpop: {
+					enabled: dpopEnabled,
+					"iat-window-seconds": 60,
+					"alg-whitelist": ["ES256", "ES384", "EdDSA", "RS256"],
+					"replay-store": "memory",
+					"replay-store-ttl-seconds": 300,
+				},
+				tokenBinding: {
+					"dispatch-policy": "intent-explicit",
+				},
+			},
+		} as never,
+		pathResolver: (s: string) => s,
+	}) satisfies Record<string, unknown> as BootstrapMap;
+
+/**
+ * Mint a valid DPoP proof for POST http://as.example/oauth/token.
+ *
+ * supertest binds to http (not https). The request is sent with
+ * `Host: as.example`, so the verifier's buildRequestUrl yields
+ * `http://as.example/oauth/token` — the `htu` below must match exactly
+ * (after normalizeHtu strips query/fragment and lowercases scheme+host).
+ */
+const mintProof = async () => {
+	const { publicKey, privateKey } = await generateKeyPair("ES256");
+	const jwk = await exportJWK(publicKey);
+	const jkt = await computeJkt(jwk);
+	const proof = await new SignJWT({
+		htm: "POST",
+		htu: "http://as.example/oauth/token",
+		iat: Math.floor(Date.now() / 1000),
+		jti: crypto.randomUUID(),
+	})
+		.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk })
+		.sign(privateKey);
+	return { proof, jkt };
+};
+
+/**
+ * Build a route contribution that records the token binding on the request
+ * and responds 200 with the binding JSON for assertion. Mirrors the Phase 1d
+ * retro test pattern.
+ */
+const makeTokenBindingObserver =
+	(received: { tokenBinding?: unknown }): RequestHandler =>
+	(req, res) => {
+		// biome-ignore lint/suspicious/noExplicitAny: test-only req augmentation access
+		received.tokenBinding = (req as any).tokenBinding;
+		res.status(200).json({ ok: true });
+	};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("dpopModule — integration via createApp", () => {
+	it("dpopModule has kind 'dpop' and intentExplicit from its mechanism", () => {
+		// Structural smoke test: module name is stable.
+		expect(dpopModule.name).toBe("dpop");
+	});
+
+	it("when disabled: no DPoP middleware; requests without DPoP header succeed", async () => {
+		const boot = makeBoot(false);
+
+		// Observer route: records req.tokenBinding, responds 200.
+		const received: { tokenBinding?: unknown } = {};
+		const observerModule = defineModule({
+			name: "observer",
+			requires: [],
+			optional: [],
+			contributes: {
+				routes: [
+					() => {
+						const router = Router();
+						router.use(express.json());
+						router.post("/token", makeTokenBindingObserver(received));
+						return { id: "test-token", mountPath: "/oauth", handler: router };
+					},
+				],
+			},
+		});
+
+		const handle = await createApp({
+			modules: [dpopModule, observerModule],
+			bootstrapComponents: boot,
+		});
+
+		const app = express();
+		app.use(express.json());
+		app.use(handle.router);
+
+		const res = await request(app).post("/oauth/token").send({});
+		expect(res.status).toBe(200);
+		// No DPoP header → tokenBinding should be undefined.
+		expect(received.tokenBinding).toBeUndefined();
+
+		await handle.dispose();
+	});
+
+	it("when enabled: valid DPoP proof populates req.tokenBinding with kind=dpop and confirmation.jkt", async () => {
+		const boot = makeBoot(true);
+		const { proof, jkt } = await mintProof();
+
+		const received: { tokenBinding?: unknown } = {};
+		const observerModule = defineModule({
+			name: "observer",
+			requires: [],
+			optional: [],
+			contributes: {
+				routes: [
+					() => {
+						const router = Router();
+						router.use(express.json());
+						router.post("/token", makeTokenBindingObserver(received));
+						return { id: "test-token", mountPath: "/oauth", handler: router };
+					},
+				],
+			},
+		});
+
+		const handle = await createApp({
+			modules: [dpopModule, observerModule],
+			bootstrapComponents: boot,
+		});
+
+		const app = express();
+		app.use(express.json());
+		app.use(handle.router);
+
+		const res = await request(app)
+			.post("/oauth/token")
+			.set("DPoP", proof)
+			.set("Host", "as.example")
+			.send({});
+
+		expect(res.status).toBe(200);
+		// req.tokenBinding should be populated with DPoP binding.
+		expect(received.tokenBinding).toMatchObject({
+			kind: "dpop",
+			confirmation: { jkt },
+		});
+
+		await handle.dispose();
+	});
+
+	it("when enabled: invalid DPoP proof returns HTTP 400 with error=invalid_dpop_proof", async () => {
+		const boot = makeBoot(true);
+
+		const observerModule = defineModule({
+			name: "observer",
+			requires: [],
+			optional: [],
+			contributes: {
+				routes: [
+					() => {
+						const router = Router();
+						router.use(express.json());
+						router.post("/token", (_req, res) => {
+							res.status(200).json({ ok: true });
+						});
+						return { id: "test-token", mountPath: "/oauth", handler: router };
+					},
+				],
+			},
+		});
+
+		const handle = await createApp({
+			modules: [dpopModule, observerModule],
+			bootstrapComponents: boot,
+		});
+
+		const app = express();
+		app.use(express.json());
+		app.use(handle.router);
+
+		const res = await request(app)
+			.post("/oauth/token")
+			.set("DPoP", "not.a.valid.dpop.proof")
+			.set("Host", "as.example")
+			.send({});
+
+		// tokenBindingMw returns 400 for invalid proofs.
+		expect(res.status).toBe(400);
+		expect(res.body).toMatchObject({ error: "invalid_dpop_proof" });
+
+		await handle.dispose();
+	});
+
+	it("when enabled: absent DPoP header leaves req.tokenBinding unset (mechanism returns null)", async () => {
+		const boot = makeBoot(true);
+
+		const received: { tokenBinding?: unknown } = {};
+		const observerModule = defineModule({
+			name: "observer",
+			requires: [],
+			optional: [],
+			contributes: {
+				routes: [
+					() => {
+						const router = Router();
+						router.use(express.json());
+						router.post("/token", makeTokenBindingObserver(received));
+						return { id: "test-token", mountPath: "/oauth", handler: router };
+					},
+				],
+			},
+		});
+
+		const handle = await createApp({
+			modules: [dpopModule, observerModule],
+			bootstrapComponents: boot,
+		});
+
+		const app = express();
+		app.use(express.json());
+		app.use(handle.router);
+
+		// No DPoP header → mechanism.extract returns null → tokenBinding unset.
+		const res = await request(app).post("/oauth/token").set("Host", "as.example").send({});
+
+		expect(res.status).toBe(200);
+		expect(received.tokenBinding).toBeUndefined();
+
+		await handle.dispose();
+	});
+});

--- a/packages/dpop/src/__tests__/verifier.test.mts
+++ b/packages/dpop/src/__tests__/verifier.test.mts
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Request } from "express";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import { beforeEach, describe, expect, it } from "vitest";
+import { DPoPError } from "#/errors.mjs";
+import { createMemoryDPoPReplayStore } from "#/memory/replay-store.mjs";
+import { computeJkt } from "#/thumbprint.mjs";
+import { createDPoPMechanism } from "#/verifier.mjs";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface MintOptions {
+	htm?: string;
+	htu?: string;
+	iat?: number;
+	jti?: string;
+	alg?: string;
+	/** Extra claims to merge into the payload */
+	extraClaims?: Record<string, unknown>;
+	/** If provided, use this key pair instead of generating a new one */
+	keyPair?: Awaited<ReturnType<typeof generateKeyPair>>;
+	/** If true, tamper with the signature after signing */
+	tamperSignature?: boolean;
+}
+
+/**
+ * Mint a valid DPoP proof JWT for tests. Returns the compact JWT and the
+ * public JWK used to sign it.
+ */
+const mintProof = async (opts: MintOptions = {}) => {
+	const {
+		htm = "POST",
+		htu = "https://as.example/token",
+		iat = Math.floor(Date.now() / 1000),
+		jti = crypto.randomUUID(),
+		alg = "ES256",
+		extraClaims = {},
+		tamperSignature = false,
+	} = opts;
+	const keyPair = opts.keyPair ?? (await generateKeyPair(alg));
+	const { publicKey, privateKey } = keyPair;
+	const jwk = await exportJWK(publicKey);
+
+	const proof = await new SignJWT({ htm, htu, iat, jti, ...extraClaims })
+		.setProtectedHeader({ typ: "dpop+jwt", alg, jwk })
+		.sign(privateKey);
+
+	const jkt = await computeJkt(jwk);
+
+	if (tamperSignature) {
+		// Flip one character in the signature to produce an invalid JWT.
+		const parts = proof.split(".");
+		const sig = parts[2];
+		// Replace first char with a different char.
+		const altered = sig.charAt(0) === "A" ? `B${sig.slice(1)}` : `A${sig.slice(1)}`;
+		return { proof: `${parts[0]}.${parts[1]}.${altered}`, jwk, jkt };
+	}
+
+	return { proof, jwk, jkt };
+};
+
+/**
+ * Build a minimal Express-like Request stub for the verifier.
+ */
+const makeReq = (
+	dpopHeader: string | undefined,
+	method = "POST",
+	path = "/token",
+	host = "as.example",
+	proto = "https",
+): Partial<Request> => ({
+	get: (name: string) => {
+		const lc = name.toLowerCase();
+		if (lc === "dpop") return dpopHeader;
+		if (lc === "host") return host;
+		return undefined;
+	},
+	method,
+	originalUrl: path,
+	protocol: proto,
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createDPoPMechanism", () => {
+	let replayStore: ReturnType<typeof createMemoryDPoPReplayStore>;
+	let mechanism: ReturnType<typeof createDPoPMechanism>;
+
+	beforeEach(() => {
+		replayStore = createMemoryDPoPReplayStore();
+		mechanism = createDPoPMechanism({
+			replayStore,
+			iatWindowSeconds: 60,
+			algWhitelist: ["ES256", "ES384", "EdDSA", "RS256"],
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Step 1: DPoP header absent → null (not throw)
+	// -------------------------------------------------------------------------
+
+	it("returns null when DPoP header is absent (step 1)", async () => {
+		const req = makeReq(undefined);
+		const result = await mechanism.extract(req as Request);
+		expect(result).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// Step 2: Multiple DPoP headers → throw
+	// -------------------------------------------------------------------------
+
+	it("throws when DPoP header contains a comma (multiple values, step 2)", async () => {
+		const req = makeReq("token1,token2");
+		await expect(mechanism.extract(req as Request)).rejects.toThrow(DPoPError);
+		await expect(mechanism.extract(req as Request)).rejects.toMatchObject({
+			reason: "multiple_headers",
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Step 5: alg whitelist
+	// -------------------------------------------------------------------------
+
+	it("accepts a proof with alg=ES256 (in default whitelist, step 5)", async () => {
+		const { proof } = await mintProof({ alg: "ES256" });
+		const req = makeReq(proof);
+		const result = await mechanism.extract(req as Request);
+		expect(result).not.toBeNull();
+		expect(result?.kind).toBe("dpop");
+	});
+
+	it("rejects a proof with alg not in whitelist (step 5)", async () => {
+		// HS256 requires a symmetric key; not in the allowlist.
+		// We use RS256 mechanism but override alg in header — parseProof will
+		// accept it structurally, but the verifier's whitelist check rejects it.
+		// Simplest approach: use custom mechanism with restricted whitelist.
+		const restrictedMechanism = createDPoPMechanism({
+			replayStore: createMemoryDPoPReplayStore(),
+			algWhitelist: ["ES256"],
+		});
+		const { proof } = await mintProof({ alg: "ES384" });
+		const req = makeReq(proof);
+		await expect(restrictedMechanism.extract(req as Request)).rejects.toThrow(DPoPError);
+		await expect(
+			createDPoPMechanism({
+				replayStore: createMemoryDPoPReplayStore(),
+				algWhitelist: ["ES256"],
+			}).extract(makeReq(proof) as Request),
+		).rejects.toMatchObject({ reason: "alg_not_allowed" });
+	});
+
+	// -------------------------------------------------------------------------
+	// Step 8: Signature verification
+	// -------------------------------------------------------------------------
+
+	it("accepts a validly signed proof (step 8)", async () => {
+		const { proof } = await mintProof();
+		const req = makeReq(proof);
+		const result = await mechanism.extract(req as Request);
+		expect(result).not.toBeNull();
+	});
+
+	it("rejects a tampered proof signature (step 8)", async () => {
+		const { proof } = await mintProof({ tamperSignature: true });
+		const req = makeReq(proof);
+		await expect(mechanism.extract(req as Request)).rejects.toThrow(DPoPError);
+		await expect(
+			createDPoPMechanism({ replayStore: createMemoryDPoPReplayStore() }).extract(
+				makeReq(proof) as Request,
+			),
+		).rejects.toMatchObject({ reason: "signature_invalid" });
+	});
+
+	// -------------------------------------------------------------------------
+	// Step 10: htm match
+	// -------------------------------------------------------------------------
+
+	it("accepts when htm matches request method (step 10)", async () => {
+		const { proof } = await mintProof({ htm: "GET", htu: "https://as.example/token" });
+		const req = makeReq(proof, "GET", "/token");
+		const result = await mechanism.extract(req as Request);
+		expect(result).not.toBeNull();
+	});
+
+	it("rejects when htm does not match request method (step 10)", async () => {
+		const { proof } = await mintProof({ htm: "GET" });
+		const req = makeReq(proof, "POST"); // proof says GET, request is POST
+		await expect(mechanism.extract(req as Request)).rejects.toThrow(DPoPError);
+		await expect(
+			createDPoPMechanism({ replayStore: createMemoryDPoPReplayStore() }).extract(req as Request),
+		).rejects.toMatchObject({ reason: "htm_mismatch" });
+	});
+
+	it("accepts htm case-insensitively (step 10)", async () => {
+		const { proof } = await mintProof({ htm: "post" });
+		const req = makeReq(proof, "POST");
+		const result = await mechanism.extract(req as Request);
+		expect(result).not.toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// Step 11: htu match (including normalization)
+	// -------------------------------------------------------------------------
+
+	it("accepts when htu matches request URL (step 11)", async () => {
+		const { proof } = await mintProof({ htu: "https://as.example/token" });
+		const req = makeReq(proof, "POST", "/token", "as.example", "https");
+		const result = await mechanism.extract(req as Request);
+		expect(result).not.toBeNull();
+	});
+
+	it("rejects when htu does not match request URL (step 11)", async () => {
+		const { proof } = await mintProof({ htu: "https://other.example/token" });
+		const req = makeReq(proof, "POST", "/token", "as.example", "https");
+		await expect(mechanism.extract(req as Request)).rejects.toThrow(DPoPError);
+		await expect(
+			createDPoPMechanism({ replayStore: createMemoryDPoPReplayStore() }).extract(req as Request),
+		).rejects.toMatchObject({ reason: "htu_mismatch" });
+	});
+
+	it("accepts when htu matches after normalization (trailing slash difference, step 11)", async () => {
+		// Proof says /token (no slash); request URL would also normalize the same.
+		const { proof } = await mintProof({ htu: "HTTPS://AS.EXAMPLE/token" });
+		const req = makeReq(proof, "POST", "/token", "as.example", "https");
+		const result = await mechanism.extract(req as Request);
+		expect(result).not.toBeNull();
+	});
+
+	it("accepts when htu has default port removed (step 11)", async () => {
+		const { proof } = await mintProof({ htu: "https://as.example:443/token" });
+		const req = makeReq(proof, "POST", "/token", "as.example", "https");
+		const result = await mechanism.extract(req as Request);
+		expect(result).not.toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// Step 12: iat window
+	// -------------------------------------------------------------------------
+
+	it("accepts a proof with iat within the window (step 12)", async () => {
+		const iat = Math.floor(Date.now() / 1000) - 30; // 30s ago, window = 60s
+		const { proof } = await mintProof({ iat });
+		const req = makeReq(proof);
+		const result = await mechanism.extract(req as Request);
+		expect(result).not.toBeNull();
+	});
+
+	it("rejects a proof with iat outside the window — too old (step 12)", async () => {
+		const iat = Math.floor(Date.now() / 1000) - 120; // 120s ago, window = 60s
+		const { proof } = await mintProof({ iat });
+		const req = makeReq(proof);
+		await expect(mechanism.extract(req as Request)).rejects.toThrow(DPoPError);
+		await expect(
+			createDPoPMechanism({
+				replayStore: createMemoryDPoPReplayStore(),
+				iatWindowSeconds: 60,
+			}).extract(req as Request),
+		).rejects.toMatchObject({ reason: "iat_out_of_window" });
+	});
+
+	it("rejects a proof with iat in the future beyond window (step 12)", async () => {
+		const iat = Math.floor(Date.now() / 1000) + 120; // 120s in future, window = 60s
+		const { proof } = await mintProof({ iat });
+		const req = makeReq(proof);
+		await expect(mechanism.extract(req as Request)).rejects.toThrow(DPoPError);
+		await expect(
+			createDPoPMechanism({
+				replayStore: createMemoryDPoPReplayStore(),
+				iatWindowSeconds: 60,
+			}).extract(req as Request),
+		).rejects.toMatchObject({ reason: "iat_out_of_window" });
+	});
+
+	// -------------------------------------------------------------------------
+	// Step 14: replay protection
+	// -------------------------------------------------------------------------
+
+	it("first use of a (jti, jkt) pair returns a binding (step 14)", async () => {
+		const { proof, jkt } = await mintProof();
+		const req = makeReq(proof);
+		const result = await mechanism.extract(req as Request);
+		expect(result).not.toBeNull();
+		expect(result?.confirmation).toMatchObject({ jkt });
+	});
+
+	it("second use of the same (jti, jkt) pair throws replay_detected (step 14)", async () => {
+		const { proof } = await mintProof();
+		const req = makeReq(proof);
+		// First call succeeds.
+		await mechanism.extract(req as Request);
+		// Second call with the same proof should throw.
+		await expect(mechanism.extract(req as Request)).rejects.toThrow(DPoPError);
+		await expect(mechanism.extract(makeReq(proof) as Request)).rejects.toMatchObject({
+			reason: "replay_detected",
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Confirmation shape
+	// -------------------------------------------------------------------------
+
+	it("returned binding has kind='dpop' and confirmation.jkt matching proof.jkt", async () => {
+		const keyPair = await generateKeyPair("ES256");
+		const jwk = await exportJWK(keyPair.publicKey);
+		const expectedJkt = await computeJkt(jwk);
+		const { proof } = await mintProof({ keyPair });
+		const req = makeReq(proof);
+		const result = await mechanism.extract(req as Request);
+		expect(result?.kind).toBe("dpop");
+		expect(result?.confirmation).toEqual({ jkt: expectedJkt });
+	});
+
+	it("uses proof.jkt (no redundant re-computation)", async () => {
+		// This test documents the no-re-compute contract: the binding's
+		// confirmation.jkt must equal the value computed from the proof's
+		// JWK, which parseProof already computed.
+		const { proof, jkt } = await mintProof();
+		const req = makeReq(proof);
+		const result = await mechanism.extract(req as Request);
+		expect(result?.confirmation).toEqual({ jkt });
+	});
+
+	// -------------------------------------------------------------------------
+	// kind and intentExplicit flags
+	// -------------------------------------------------------------------------
+
+	it("mechanism has kind='dpop' and intentExplicit=true", () => {
+		expect(mechanism.kind).toBe("dpop");
+		expect(mechanism.intentExplicit).toBe(true);
+	});
+});

--- a/packages/dpop/src/__tests__/verifier.test.mts
+++ b/packages/dpop/src/__tests__/verifier.test.mts
@@ -414,6 +414,28 @@ describe("createDPoPMechanism", () => {
 		});
 	});
 
+	// Narrow the replay-store catch so RangeError (programming/config bug)
+	// is NOT misclassified as `replay_store_unavailable` (availability
+	// fault). Operator triage signal must distinguish "fix the ttl config"
+	// from "check Redis health".
+	it("lets RangeError from replay store propagate (programmer/config bug, not transport)", async () => {
+		const rangingStore = {
+			seen: async (_jti: string, _jkt: string, ttlSeconds: number) => {
+				if (ttlSeconds <= 0) {
+					throw new RangeError(`ttlSeconds must be positive (got ${ttlSeconds})`);
+				}
+				return false;
+			},
+		};
+		const rangingMechanism = createDPoPMechanism({
+			replayStore: rangingStore,
+			replayTtlSeconds: -1, // forces RangeError at the store layer
+		});
+		const { proof } = await mintProof();
+		// RangeError must surface as RangeError, NOT wrapped as DPoPError.
+		await expect(rangingMechanism.extract(makeReq(proof) as Request)).rejects.toThrow(RangeError);
+	});
+
 	// I-2: pin that replay-store transport faults surface as the dedicated
 	// `replay_store_unavailable` audit signal — not a raw Error that would
 	// otherwise propagate up to `tokenBindingMw` and lose operator triage.

--- a/packages/dpop/src/__tests__/verifier.test.mts
+++ b/packages/dpop/src/__tests__/verifier.test.mts
@@ -347,4 +347,72 @@ describe("createDPoPMechanism", () => {
 		expect(mechanism.kind).toBe("dpop");
 		expect(mechanism.intentExplicit).toBe(true);
 	});
+
+	// -------------------------------------------------------------------------
+	// Coverage gap follow-ups from /multi-agent-review (Sub-PR 2b round 1)
+	// -------------------------------------------------------------------------
+
+	// I-4: pin whitelist case-sensitivity. RFC 9449 §4.3 + JOSE treat `alg`
+	// as case-sensitive. An operator misconfiguring HOCON with lowercase
+	// (`alg-whitelist = ["es256"]`) would otherwise silently reject every
+	// valid ES256 proof — or worse, a lowercased entry might be assumed
+	// equivalent to an uppercased proof when it is not.
+	it("whitelist comparison is case-sensitive — lowercase whitelist entry does not match uppercase alg", async () => {
+		const { proof } = await mintProof({ alg: "ES256" });
+		const lowerCaseMechanism = createDPoPMechanism({
+			replayStore: createMemoryDPoPReplayStore(),
+			algWhitelist: ["es256"], // operator typo: lowercase
+		});
+		await expect(lowerCaseMechanism.extract(makeReq(proof) as Request)).rejects.toMatchObject({
+			reason: "alg_not_allowed",
+		});
+	});
+
+	// I-5: pin that parseProof's private_jwk screen (Sub-PR 2a step 7)
+	// propagates through the verifier intact. Without this regression
+	// test, a refactor of the verifier's parseProof call site could
+	// accidentally swallow the parser-layer error.
+	it("propagates private_jwk error from parseProof (step 7 / Sub-PR 2a)", async () => {
+		const { publicKey, privateKey } = await generateKeyPair("ES256", { extractable: true });
+		const pubJwk = await exportJWK(publicKey);
+		const legitProof = await new SignJWT({
+			htm: "POST",
+			htu: "https://as.example/token",
+			iat: Math.floor(Date.now() / 1000),
+			jti: crypto.randomUUID(),
+		})
+			.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk: pubJwk })
+			.sign(privateKey);
+		const [_h, payload, sig] = legitProof.split(".");
+		// Surgically inject a private-key field (`d`) so the JWK passes
+		// parseProof's structural shape but fails its private-field screen.
+		const headerObj = {
+			typ: "dpop+jwt",
+			alg: "ES256",
+			jwk: { ...pubJwk, d: "REDACTED" },
+		};
+		const fakeHeader = Buffer.from(JSON.stringify(headerObj)).toString("base64url");
+		const crafted = `${fakeHeader}.${payload}.${sig}`;
+		await expect(mechanism.extract(makeReq(crafted) as Request)).rejects.toMatchObject({
+			reason: "private_jwk",
+			code: "invalid_dpop_proof",
+		});
+	});
+
+	// I-2: pin that replay-store transport faults surface as the dedicated
+	// `replay_store_unavailable` audit signal — not a raw Error that would
+	// otherwise propagate up to `tokenBindingMw` and lose operator triage.
+	it("wraps replay store transport errors as replay_store_unavailable (audit signal distinct from client-garbage)", async () => {
+		const failingStore = {
+			seen: async () => {
+				throw new Error("ECONNREFUSED — Redis down");
+			},
+		};
+		const failingMechanism = createDPoPMechanism({ replayStore: failingStore });
+		const { proof } = await mintProof();
+		await expect(failingMechanism.extract(makeReq(proof) as Request)).rejects.toMatchObject({
+			reason: "replay_store_unavailable",
+			code: "invalid_dpop_proof",
+		});
+	});
 });

--- a/packages/dpop/src/__tests__/verifier.test.mts
+++ b/packages/dpop/src/__tests__/verifier.test.mts
@@ -399,6 +399,21 @@ describe("createDPoPMechanism", () => {
 		});
 	});
 
+	// I-(round-2): pin that an `htu` containing userinfo is rejected as
+	// `malformed_proof` rather than being silently normalized away (RFC 9449
+	// §4 — userinfo has no meaning at the token endpoint). Without this
+	// guard, a proof for `https://attacker:pwn@as.example/...` would
+	// equality-match the server-built `https://as.example/...` after the
+	// canonical reconstruction drops the credentials.
+	it("rejects htu containing userinfo as malformed_proof (RFC 9449 §4)", async () => {
+		const { proof } = await mintProof({ htu: "https://attacker:pwn@as.example/token" });
+		await expect(mechanism.extract(makeReq(proof) as Request)).rejects.toMatchObject({
+			reason: "malformed_proof",
+			code: "invalid_dpop_proof",
+			message: expect.stringContaining("userinfo"),
+		});
+	});
+
 	// I-2: pin that replay-store transport faults surface as the dedicated
 	// `replay_store_unavailable` audit signal — not a raw Error that would
 	// otherwise propagate up to `tokenBindingMw` and lose operator triage.

--- a/packages/dpop/src/errors.mts
+++ b/packages/dpop/src/errors.mts
@@ -35,6 +35,7 @@ export type DPoPReasonCode =
 	| "htu_mismatch"
 	| "iat_out_of_window"
 	| "replay_detected"
+	| "replay_store_unavailable"
 	| "multiple_headers";
 
 /**

--- a/packages/dpop/src/htu-normalize.mts
+++ b/packages/dpop/src/htu-normalize.mts
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * RFC 3986 §6.2.2 unreserved character set: ALPHA / DIGIT / "-" / "." / "_" / "~".
+ * Characters matching this set MUST be decoded from percent-encoded form.
+ * All other percent-encoded sequences MUST be preserved (uppercased for
+ * canonical form, though most WHATWG URL output is already uppercase).
+ */
+const UNRESERVED = /^[A-Za-z0-9\-._~]$/;
+
+/**
+ * Decode percent-encoded sequences that encode unreserved characters
+ * (RFC 3986 §2.3). Sequences that encode reserved or special characters
+ * are left as-is. This is required because WHATWG URL does NOT perform
+ * this normalisation for the path component.
+ */
+const decodeUnreservedPercent = (s: string): string => {
+	return s.replace(/%([0-9A-Fa-f]{2})/g, (match, hex) => {
+		const code = parseInt(hex, 16);
+		const ch = String.fromCharCode(code);
+		return UNRESERVED.test(ch) ? ch : match.toUpperCase();
+	});
+};
+
+/**
+ * Remove dot segments from a URI path per RFC 3986 §5.2.4 + §6.2.2.3.
+ *
+ * Preserves multiple consecutive slashes (the spec only removes dot segments,
+ * not double-slashes). Preserves trailing slash if the *original input* had
+ * one — trailing slash produced by resolving a `..` segment (e.g. `/a/b/..`
+ * → `/a/`) is stripped since the original input didn't end with `/`.
+ *
+ * NOTE: The WHATWG URL API resolves `.` and `..` during parsing, so
+ * `url.pathname` for `https://as/a/b/..` already yields `/a/`. We operate on
+ * the original raw URL path (before WHATWG parsing) to detect whether the
+ * caller supplied a trailing slash.
+ */
+const removeDotSegments = (path: string, originalHadTrailingSlash: boolean): string => {
+	// Split preserves empty strings between consecutive slashes.
+	const parts = path.split("/");
+	const segments: string[] = [];
+	for (const seg of parts) {
+		if (seg === ".") {
+			// Dot segment — discard.
+			continue;
+		}
+		if (seg === "..") {
+			// Parent segment — pop last (but never pop the leading empty string
+			// that corresponds to the root slash).
+			if (segments.length > 1) {
+				segments.pop();
+			}
+			continue;
+		}
+		segments.push(seg);
+	}
+	const result = segments.join("/");
+	// Re-append trailing slash only when the original input had one.
+	return originalHadTrailingSlash && !result.endsWith("/") ? `${result}/` : result;
+};
+
+/**
+ * Normalise an `htu` URI per RFC 9449 §6 / RFC 3986 §6.2.2.
+ *
+ * Rules applied (in order):
+ *   1. Parse via WHATWG URL — handles scheme/host lowercase + IDN ASCII.
+ *   2. Strip query (`?`) and fragment (`#`).
+ *   3. Remove default port (443 for https, 80 for http).
+ *   4. Decode unreserved percent-encoded sequences in the path.
+ *   5. Remove dot segments from the path (RFC 3986 §5.2.4).
+ *   6. Normalise empty path to `/`.
+ *
+ * WHATWG URL (used internally) already performs:
+ *   - Scheme + host lowercasing.
+ *   - IDN (internationalized domain) → ASCII-compatible (Punycode) form.
+ *
+ * It does NOT perform:
+ *   - Unreserved character decoding in the path (rule 4).
+ *   - Dot-segment removal for already-parsed inputs (rule 5).
+ *
+ * Returns the canonical `htu` string ready for equality comparison.
+ *
+ * Per Wave 2 Phase 2 spec §7.
+ */
+export const normalizeHtu = (raw: string): string => {
+	const url = new URL(raw);
+	// Strip query and fragment (rules from spec §7 / RFC 3986 §6.2.2).
+	url.search = "";
+	url.hash = "";
+
+	// Remove default ports (RFC 3986 §6.2.3).
+	if (
+		(url.protocol === "https:" && url.port === "443") ||
+		(url.protocol === "http:" && url.port === "80")
+	) {
+		url.port = "";
+	}
+
+	// Determine whether the original input had a trailing slash BEFORE the
+	// WHATWG URL parser resolves dot segments (which may add `/` for `..`).
+	// Strip query/fragment from the raw string first, then check the last char.
+	const rawWithoutQF = raw.split("?")[0].split("#")[0];
+	const originalHadTrailingSlash = rawWithoutQF.length > 1 && rawWithoutQF.endsWith("/");
+
+	// Normalise path: unreserved decode + dot-segment removal + empty → /.
+	//
+	// WHATWG URL resolves `.` / `..` segments at parse time, which may
+	// introduce a trailing slash (e.g. `/a/b/..` → `/a/`). Strip it when
+	// the original input did not have a trailing slash, so the normalised
+	// form respects the caller's intent rather than the resolver's artifact.
+	let rawPath = url.pathname; // WHATWG URL always starts pathname with "/".
+	if (!originalHadTrailingSlash && rawPath.length > 1 && rawPath.endsWith("/")) {
+		rawPath = rawPath.slice(0, -1);
+	}
+	const decodedPath = decodeUnreservedPercent(rawPath);
+	const normalizedPath =
+		decodedPath === "" ? "/" : removeDotSegments(decodedPath, originalHadTrailingSlash);
+
+	// Reconstruct the canonical URL string without using url.toString()
+	// to avoid WHATWG URL applying its own re-encoding to our decoded characters.
+	const portPart = url.port ? `:${url.port}` : "";
+	return `${url.protocol}//${url.hostname}${portPart}${normalizedPath}`;
+};

--- a/packages/dpop/src/htu-normalize.mts
+++ b/packages/dpop/src/htu-normalize.mts
@@ -98,6 +98,18 @@ const removeDotSegments = (path: string, originalHadTrailingSlash: boolean): str
  */
 export const normalizeHtu = (raw: string): string => {
 	const url = new URL(raw);
+	// Reject userinfo: WHATWG URL preserves `username`/`password` but the
+	// canonical reconstruction below drops them, so without this check a
+	// proof carrying `https://attacker:pwn@as.example/oauth/token` would
+	// normalize to `https://as.example/oauth/token` and equality-match the
+	// server-built URL — weakening the htu binding check. RFC 9449 §4
+	// gives userinfo no meaning at the token endpoint; reject loudly so
+	// the verifier surfaces a `malformed_proof` audit signal.
+	if (url.username !== "" || url.password !== "") {
+		throw new Error(
+			`normalizeHtu: htu must not contain userinfo (got "${url.username}:***" prefix)`,
+		);
+	}
 	// Strip query and fragment (rules from spec §7 / RFC 3986 §6.2.2).
 	url.search = "";
 	url.hash = "";

--- a/packages/dpop/src/htu-normalize.mts
+++ b/packages/dpop/src/htu-normalize.mts
@@ -143,7 +143,12 @@ export const normalizeHtu = (raw: string): string => {
 		decodedPath === "" ? "/" : removeDotSegments(decodedPath, originalHadTrailingSlash);
 
 	// Reconstruct the canonical URL string without using url.toString()
-	// to avoid WHATWG URL applying its own re-encoding to our decoded characters.
+	// to avoid WHATWG URL applying its own re-encoding to our decoded
+	// characters. WHATWG `url.hostname` keeps IPv6 brackets verbatim
+	// (e.g. `[::1]` for `http://[::1]/` per the URL Standard host
+	// serializer), so the IP-literal form survives reconstruction
+	// unchanged — confirmed by the IPv6 regression test in
+	// `__tests__/htu-normalize.test.mts`.
 	const portPart = url.port ? `:${url.port}` : "";
 	return `${url.protocol}//${url.hostname}${portPart}${normalizedPath}`;
 };

--- a/packages/dpop/src/index.mts
+++ b/packages/dpop/src/index.mts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 export { DPoPError, type DPoPErrorCode, type DPoPReasonCode } from "./errors.mjs";
-export { normalizeHtu } from "./htu-normalize.mjs";
+// `normalizeHtu` intentionally NOT exported per spec §7 — internal utility
+// only. The verifier consumes it via relative import. Promoting it to the
+// public surface would commit the package to maintaining its exact shape
+// (semver lock); the spec keeps it deliberately tight.
 export { createMemoryDPoPReplayStore } from "./memory/replay-store.mjs";
 export { dpopConfigSchema, dpopModule } from "./module.mjs";
 export type { DPoPProof, DPoPProofClaims } from "./proof.mjs";

--- a/packages/dpop/src/index.mts
+++ b/packages/dpop/src/index.mts
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 export { DPoPError, type DPoPErrorCode, type DPoPReasonCode } from "./errors.mjs";
+export { normalizeHtu } from "./htu-normalize.mjs";
 export { createMemoryDPoPReplayStore } from "./memory/replay-store.mjs";
+export { dpopConfigSchema, dpopModule } from "./module.mjs";
 export type { DPoPProof, DPoPProofClaims } from "./proof.mjs";
 export { parseProof } from "./proof.mjs";
 export type { DPoPReplayStore } from "./replay-store.mjs";
 export { computeJkt } from "./thumbprint.mjs";
+export { createDPoPMechanism, type DPoPMechanismOptions } from "./verifier.mjs";

--- a/packages/dpop/src/module.mts
+++ b/packages/dpop/src/module.mts
@@ -59,7 +59,7 @@ import { createDPoPMechanism } from "./verifier.mjs";
  * deployments wire the Redis-backed implementation via:
  *
  * ```ts
- * import { createRedisDPoPReplayStore } from "@o3co/auth-provider-redis";
+ * import { createRedisDPoPReplayStore } from "@o3co/auth-provider-redis/dpop";
  * // ... in your composition module's `provides`:
  * dpopReplayStore: (deps) => createRedisDPoPReplayStore(deps.redisClient)
  * ```

--- a/packages/dpop/src/module.mts
+++ b/packages/dpop/src/module.mts
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * DPoP module manifest — wires `createDPoPMechanism` into the grant
+ * middleware contribution slot (Wave 2 Token-binding Cluster spec §4.7 /
+ * Phase 2 DPoP spec §11.2).
+ *
+ * Contributions:
+ *   - `grantMiddleware[0]` — `tokenBindingMw` wrapping the DPoP mechanism.
+ *     Returns `null` (skip) when `config.oauth.dpop.enabled === false`.
+ *
+ * DI requires:
+ *   - `config` — reads `config.oauth.dpop` + `config.oauth.tokenBinding`.
+ *
+ * DI optional:
+ *   - `logger`           — forwarded to `tokenBindingMw` + `createDPoPMechanism`.
+ *   - `dpopReplayStore`  — consumer-wired Redis adapter for production.
+ *                          Falls back to in-memory store when absent (dev/test only).
+ *
+ * The `dpopReplayStore` optional slot is declared here via ComponentMap
+ * augmentation so consumers (e.g. `@o3co/auth-provider-redis`) can provide
+ * a Redis-backed implementation without modifying this package.
+ *
+ * Secure-default-opt-in: `oauth.dpop.enabled = false` in reference.conf.
+ * Operators must explicitly set `enabled = true` to activate DPoP.
+ *
+ * Per Wave 2 Phase 2 spec §10 (config) + §11.2 (module) + feedback_secure_default_opt_in.md.
+ */
+
+// biome-ignore lint/correctness/noUnusedImports: ComponentMap is used in the `declare module` augmentation below
+import type { ComponentMap as _ComponentMap } from "@o3co/auth-provider-core";
+import { defineModule, tokenBindingMw } from "@o3co/auth-provider-core";
+import { z } from "zod";
+import { createMemoryDPoPReplayStore } from "./memory/replay-store.mjs";
+import type { DPoPReplayStore } from "./replay-store.mjs";
+import { createDPoPMechanism } from "./verifier.mjs";
+
+// ---------------------------------------------------------------------------
+// ComponentMap augmentation — dpopReplayStore slot
+// ---------------------------------------------------------------------------
+
+/**
+ * Optional ComponentMap slot for the DPoP replay store. When absent,
+ * `dpopModule` falls back to the in-memory adapter (dev/test only). Production
+ * deployments wire the Redis-backed implementation via:
+ *
+ * ```ts
+ * import { createRedisDPoPReplayStore } from "@o3co/auth-provider-redis";
+ * // ... in your composition module's `provides`:
+ * dpopReplayStore: (deps) => createRedisDPoPReplayStore(deps.redisClient)
+ * ```
+ *
+ * Pattern mirrors `webauthnCredentialStore` in core + `accessTokenDenylist`.
+ * Per Wave 2 Phase 2 spec §11.2.
+ */
+declare module "@o3co/auth-provider-core" {
+	interface ComponentMap {
+		/** Optional DPoP replay store. Defaults to in-memory when absent. */
+		readonly dpopReplayStore?: DPoPReplayStore;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Config schema
+// ---------------------------------------------------------------------------
+
+/**
+ * Zod schema for the `oauth.dpop` config slice.
+ *
+ * Keys use kebab-case to match the HOCON reference.conf keys exactly.
+ * HOCON preserves key names verbatim; TypeScript accesses them via
+ * bracket notation: `config.oauth.dpop["iat-window-seconds"]`.
+ *
+ * Per Wave 2 Phase 2 spec §10.
+ */
+export const dpopConfigSchema = z.object({
+	oauth: z.object({
+		tokenBinding: z
+			.object({
+				"dispatch-policy": z
+					.enum(["intent-explicit", "strict-mutual-exclusion"])
+					.default("intent-explicit"),
+			})
+			.default(() => ({ "dispatch-policy": "intent-explicit" as const })),
+		dpop: z
+			.object({
+				/** When false (default), dpopModule contributes null — no DPoP middleware mounted. */
+				enabled: z.boolean().default(false),
+				/** Acceptance window for the iat claim in seconds. Default: 60. */
+				"iat-window-seconds": z.number().int().positive().default(60),
+				/** JOSE algorithm allowlist. Default: ES256, ES384, EdDSA, RS256. */
+				"alg-whitelist": z.array(z.string()).default(["ES256", "ES384", "EdDSA", "RS256"]),
+				/** Replay store backend selector. "memory" is dev/test only. */
+				"replay-store": z.enum(["memory", "redis"]).default("memory"),
+				/** TTL for replay entries in seconds. Default: 300. */
+				"replay-store-ttl-seconds": z.number().int().positive().default(300),
+			})
+			.default(() => ({
+				enabled: false,
+				"iat-window-seconds": 60,
+				"alg-whitelist": ["ES256", "ES384", "EdDSA", "RS256"],
+				"replay-store": "memory" as const,
+				"replay-store-ttl-seconds": 300,
+			})),
+	}),
+});
+
+// ---------------------------------------------------------------------------
+// Module manifest
+// ---------------------------------------------------------------------------
+
+/**
+ * Declarative manifest for the DPoP package.
+ *
+ * When `config.oauth.dpop.enabled` is `false` (the secure default), the
+ * `grantMiddleware` factory returns `null` and the boot planner skips it —
+ * no DPoP middleware is mounted. When `enabled` is `true`, a
+ * `tokenBindingMw` wrapping the DPoP mechanism is mounted BEFORE grant
+ * dispatch at `/oauth/token`.
+ *
+ * The `dpopReplayStore` optional slot is backed by `createMemoryDPoPReplayStore`
+ * when absent. Production deployments provide a Redis-backed implementation
+ * by wiring the `dpopReplayStore` slot via their composition root.
+ *
+ * Per Wave 2 Phase 2 spec §11.2.
+ */
+export const dpopModule = defineModule<"config", "logger" | "dpopReplayStore">({
+	name: "dpop",
+	configSchema: dpopConfigSchema,
+	requires: ["config"],
+	optional: ["logger", "dpopReplayStore"],
+	contributes: {
+		grantMiddleware: [
+			(deps) => {
+				const dpopConfig = (deps.config as { oauth?: { dpop?: { enabled?: unknown } } }).oauth
+					?.dpop;
+				if (!dpopConfig || dpopConfig.enabled !== true) {
+					// Disabled by config — no middleware mounted.
+					return null;
+				}
+
+				const typedConfig = deps.config as unknown as {
+					oauth: {
+						dpop: {
+							enabled: boolean;
+							"iat-window-seconds": number;
+							"alg-whitelist": readonly string[];
+							"replay-store-ttl-seconds": number;
+						};
+						tokenBinding?: {
+							"dispatch-policy"?: "intent-explicit" | "strict-mutual-exclusion";
+						};
+					};
+				};
+
+				const replayStore: DPoPReplayStore = deps.dpopReplayStore ?? createMemoryDPoPReplayStore();
+
+				return tokenBindingMw({
+					mechanisms: [
+						createDPoPMechanism({
+							replayStore,
+							iatWindowSeconds: typedConfig.oauth.dpop["iat-window-seconds"],
+							algWhitelist: typedConfig.oauth.dpop["alg-whitelist"],
+							replayTtlSeconds: typedConfig.oauth.dpop["replay-store-ttl-seconds"],
+							logger: deps.logger,
+						}),
+					],
+					dispatchPolicy: typedConfig.oauth.tokenBinding?.["dispatch-policy"] ?? "intent-explicit",
+					logger: deps.logger,
+				});
+			},
+		],
+	},
+});

--- a/packages/dpop/src/module.mts
+++ b/packages/dpop/src/module.mts
@@ -159,14 +159,28 @@ export const dpopModule = defineModule<"config", "logger" | "dpopReplayStore">({
 							enabled: boolean;
 							"iat-window-seconds": number;
 							"alg-whitelist": readonly string[];
+							"replay-store": "memory" | "redis";
 							"replay-store-ttl-seconds": number;
 						};
-						tokenBinding?: {
-							"dispatch-policy"?: "intent-explicit" | "strict-mutual-exclusion";
+						tokenBinding: {
+							"dispatch-policy": "intent-explicit" | "strict-mutual-exclusion";
 						};
 					};
 				};
 
+				// `replay-store = "redis"` is a load-bearing contract for
+				// multi-replica deployments: per-process in-memory state would
+				// silently accept the same (jti, jkt) on a second replica → replay
+				// protection bypassed. Fail boot loudly when config promises redis
+				// but the composition root forgot to wire `dpopReplayStore`. The
+				// reverse asymmetry (config says "memory" + slot wired) is fine:
+				// the wired slot wins because it expresses a stronger guarantee.
+				const replayStoreBackend = typedConfig.oauth.dpop["replay-store"];
+				if (replayStoreBackend === "redis" && deps.dpopReplayStore === undefined) {
+					throw new Error(
+						'dpopModule: config.oauth.dpop.replay-store = "redis" requires the `dpopReplayStore` ComponentMap slot to be wired (e.g. via `createRedisDPoPReplayStore` from `@o3co/auth-provider-redis/dpop`). Configuring "redis" without the slot would silently fall back to a per-process in-memory store and bypass cross-replica replay protection.',
+					);
+				}
 				const replayStore: DPoPReplayStore = deps.dpopReplayStore ?? createMemoryDPoPReplayStore();
 
 				return tokenBindingMw({
@@ -179,7 +193,9 @@ export const dpopModule = defineModule<"config", "logger" | "dpopReplayStore">({
 							logger: deps.logger,
 						}),
 					],
-					dispatchPolicy: typedConfig.oauth.tokenBinding?.["dispatch-policy"] ?? "intent-explicit",
+					// dispatchPolicy is guaranteed by dpopConfigSchema (default
+					// "intent-explicit"); no nullish-coalesce needed.
+					dispatchPolicy: typedConfig.oauth.tokenBinding["dispatch-policy"],
 					logger: deps.logger,
 				});
 			},

--- a/packages/dpop/src/reference.conf
+++ b/packages/dpop/src/reference.conf
@@ -1,0 +1,33 @@
+# packages/dpop/src/reference.conf
+# Default configuration for @o3co/auth-provider-dpop.
+# Concatenated into the application config via the HOCON withFallback chain.
+#
+# oauth.tokenBinding is shipped here (not in core's reference.conf) because
+# the dispatch-policy key only makes sense when at least one binding mechanism
+# package is installed. Operators see it only when they install this package.
+#
+# Per Wave 2 Phase 2 spec §10 + secure-default-opt-in discipline
+# (project feedback_secure_default_opt_in.md).
+
+oauth.tokenBinding {
+  dispatch-policy = "intent-explicit"
+}
+
+oauth.dpop {
+  # Set to true to enable DPoP proof verification at the token endpoint.
+  # Default: false — secure-default-opt-in (operators must explicitly enable).
+  enabled = false
+
+  # Acceptance window for the DPoP proof's iat claim (seconds).
+  iat-window-seconds = 60
+
+  # JOSE algorithm allowlist for DPoP proof keys.
+  alg-whitelist = ["ES256", "ES384", "EdDSA", "RS256"]
+
+  # Backend for replay protection. "memory" is for dev/test only.
+  # Production deployments MUST use "redis" with @o3co/auth-provider-redis.
+  replay-store = "memory"
+
+  # TTL for replay entries in seconds. Should be >= iat-window-seconds.
+  replay-store-ttl-seconds = 300
+}

--- a/packages/dpop/src/verifier.mts
+++ b/packages/dpop/src/verifier.mts
@@ -173,8 +173,22 @@ export const createDPoPMechanism = (options: DPoPMechanismOptions): TokenBinding
 			}
 
 			// Step 11 (spec §6): HTTP URI match — both sides normalized per §7.
-			const expectedHtu = normalizeHtu(buildRequestUrl(req));
-			const presentedHtu = normalizeHtu(proof.claims.htu);
+			// `normalizeHtu` throws when either URL contains userinfo (the
+			// reconstruction drops `username`/`password`, which would otherwise
+			// let `https://attacker:pwn@as.example/...` equality-match the
+			// server-built URL after canonicalization). Wrap so the contract
+			// stays inside `DPoPError`.
+			let expectedHtu: string;
+			let presentedHtu: string;
+			try {
+				expectedHtu = normalizeHtu(buildRequestUrl(req));
+				presentedHtu = normalizeHtu(proof.claims.htu);
+			} catch (err) {
+				throw new DPoPError(
+					"malformed_proof",
+					`DPoP htu canonicalization failed: ${(err as Error).message}`,
+				);
+			}
 			if (expectedHtu !== presentedHtu) {
 				throw new DPoPError("htu_mismatch", "DPoP proof htu does not match request URI", {
 					expected: expectedHtu,

--- a/packages/dpop/src/verifier.mts
+++ b/packages/dpop/src/verifier.mts
@@ -225,11 +225,20 @@ export const createDPoPMechanism = (options: DPoPMechanismOptions): TokenBinding
 			try {
 				alreadySeen = await replayStore.seen(proof.claims.jti, jkt, replayTtlSeconds);
 			} catch (err) {
-				// DPoPError (e.g. RangeError-shaped programming bugs that
-				// arrive here as DPoPError after a future refactor) should
-				// propagate as-is; everything else is a transport / availability
-				// fault and gets the dedicated reason code.
+				// Narrow the catch so only TRANSPORT / availability faults
+				// surface as `replay_store_unavailable`. Programming-contract
+				// violations propagate as-is:
+				//   - DPoPError: a future refactor might shape replay-store
+				//     errors directly as DPoPError; preserve that classification.
+				//   - RangeError: `DPoPReplayStore.seen`'s interface JSDoc says
+				//     implementations SHOULD throw `RangeError` on non-positive
+				//     `ttlSeconds`. That is a programmer / config bug, NOT an
+				//     availability fault — misclassifying it as
+				//     `replay_store_unavailable` would mislead operator triage
+				//     into checking Redis health when the actual fix is the
+				//     ttl config.
 				if (err instanceof DPoPError) throw err;
+				if (err instanceof RangeError) throw err;
 				logger?.error({ err, jti: proof.claims.jti }, "dpop_replay_store_unavailable");
 				throw new DPoPError(
 					"replay_store_unavailable",

--- a/packages/dpop/src/verifier.mts
+++ b/packages/dpop/src/verifier.mts
@@ -17,22 +17,24 @@
 /**
  * DPoP proof verifier — `createDPoPMechanism` factory.
  *
- * Implements the RFC 9449 §6 validation sequence (13 steps) for the
+ * Implements the RFC 9449 §6 validation sequence (15 steps) for the
  * token endpoint. Step ordering follows the spec's taxonomy:
  *
  *   Step 1:  DPoP header presence check  (null when absent)
  *   Step 2:  Single header value         (throw on comma)
- *   Steps 3-9: parseProof (structural + JWK + claims + jkt)
+ *   Steps 3–9, 13: parseProof (structural + JWK + claims + jkt thumbprint)
  *   Step 5:  alg whitelist               (after parseProof, uses proof.alg)
  *   Step 8:  Signature verification      (importJWK + jwtVerify)
  *   Step 10: htm match
  *   Step 11: htu match (both sides normalized)
  *   Step 12: iat window
- *   Step 14: Replay check (atomic seen)
+ *   Step 14: Replay check (atomic seen) — wrapped so transport faults
+ *            surface as `replay_store_unavailable` audit signal rather
+ *            than leaking raw Redis errors through `tokenBindingMw`.
  *   Step 15: Return TokenBinding
  *
- * The verifier relies on `parseProof` (Sub-PR 2a) for steps 3–9 and reuses
- * the `jkt` already computed there (no re-derive at step 13).
+ * The verifier relies on `parseProof` (Sub-PR 2a) for steps 3–9 + 13 and
+ * reuses the `jkt` already computed there (no re-derive in this layer).
  *
  * Per Wave 2 Phase 2 spec §6 + §8 factory contract.
  */
@@ -199,7 +201,27 @@ export const createDPoPMechanism = (options: DPoPMechanismOptions): TokenBinding
 			const { jkt } = proof;
 
 			// Step 14 (spec §6): Replay check — atomic (jti, jkt) pair seen/mark.
-			const alreadySeen = await replayStore.seen(proof.claims.jti, jkt, replayTtlSeconds);
+			// Wrap so that transport faults (Redis ECONNREFUSED, etc.) surface
+			// as the distinct `replay_store_unavailable` audit signal rather
+			// than leaking a raw infrastructure error through `tokenBindingMw`
+			// — operators triaging audit events need to distinguish "client
+			// sent garbage" from "replay store is down" even when both map to
+			// the same RFC 9449 §7 wire code `invalid_dpop_proof`.
+			let alreadySeen: boolean;
+			try {
+				alreadySeen = await replayStore.seen(proof.claims.jti, jkt, replayTtlSeconds);
+			} catch (err) {
+				// DPoPError (e.g. RangeError-shaped programming bugs that
+				// arrive here as DPoPError after a future refactor) should
+				// propagate as-is; everything else is a transport / availability
+				// fault and gets the dedicated reason code.
+				if (err instanceof DPoPError) throw err;
+				logger?.error({ err, jti: proof.claims.jti }, "dpop_replay_store_unavailable");
+				throw new DPoPError(
+					"replay_store_unavailable",
+					"DPoP replay store is unavailable; cannot determine replay status",
+				);
+			}
 			if (alreadySeen) {
 				throw new DPoPError(
 					"replay_detected",

--- a/packages/dpop/src/verifier.mts
+++ b/packages/dpop/src/verifier.mts
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * DPoP proof verifier — `createDPoPMechanism` factory.
+ *
+ * Implements the RFC 9449 §6 validation sequence (13 steps) for the
+ * token endpoint. Step ordering follows the spec's taxonomy:
+ *
+ *   Step 1:  DPoP header presence check  (null when absent)
+ *   Step 2:  Single header value         (throw on comma)
+ *   Steps 3-9: parseProof (structural + JWK + claims + jkt)
+ *   Step 5:  alg whitelist               (after parseProof, uses proof.alg)
+ *   Step 8:  Signature verification      (importJWK + jwtVerify)
+ *   Step 10: htm match
+ *   Step 11: htu match (both sides normalized)
+ *   Step 12: iat window
+ *   Step 14: Replay check (atomic seen)
+ *   Step 15: Return TokenBinding
+ *
+ * The verifier relies on `parseProof` (Sub-PR 2a) for steps 3–9 and reuses
+ * the `jkt` already computed there (no re-derive at step 13).
+ *
+ * Per Wave 2 Phase 2 spec §6 + §8 factory contract.
+ */
+
+import type { Logger, TokenBindingMechanism } from "@o3co/auth-provider-core";
+import type { Request } from "express";
+import { importJWK, jwtVerify } from "jose";
+import { DPoPError } from "./errors.mjs";
+import { normalizeHtu } from "./htu-normalize.mjs";
+import { parseProof } from "./proof.mjs";
+import type { DPoPReplayStore } from "./replay-store.mjs";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface DPoPMechanismOptions {
+	/** Replay protection store. */
+	readonly replayStore: DPoPReplayStore;
+	/**
+	 * Acceptance window for the `iat` claim in seconds.
+	 * Default: 60 (1 minute).
+	 */
+	readonly iatWindowSeconds?: number;
+	/**
+	 * Allowlist of JOSE `alg` values. Proofs using any other algorithm are
+	 * rejected with `alg_not_allowed`. Default: ES256, ES384, EdDSA, RS256.
+	 */
+	readonly algWhitelist?: readonly string[];
+	/**
+	 * TTL in seconds for replay entries in the store. Default: 300 (5 minutes).
+	 * SHOULD be at least `iatWindowSeconds` to cover the acceptance window.
+	 */
+	readonly replayTtlSeconds?: number;
+	readonly logger?: Logger;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_ALG_WHITELIST: readonly string[] = ["ES256", "ES384", "EdDSA", "RS256"];
+const DEFAULT_IAT_WINDOW_SECONDS = 60;
+const DEFAULT_REPLAY_TTL_SECONDS = 300;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconstruct the effective request URL for htu comparison. Includes the
+ * query string so `normalizeHtu` can strip it uniformly from both sides.
+ */
+const buildRequestUrl = (req: Request): string => {
+	const proto = req.protocol;
+	const host = req.get("host") ?? "";
+	// req.originalUrl includes query string; normalizeHtu strips it.
+	return `${proto}://${host}${req.originalUrl}`;
+};
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a DPoP `TokenBindingMechanism` for use with `tokenBindingMw`.
+ *
+ * The returned mechanism:
+ *   - Returns `null` when the `DPoP` header is absent (non-DPoP request).
+ *   - Throws `DPoPError` for any proof invalidity.
+ *   - Returns `{ kind: "dpop", confirmation: { jkt } }` on success.
+ *
+ * The `jkt` in the confirmation is the RFC 7638 SHA-256 thumbprint of the
+ * proof's JWK, computed by `parseProof` (Sub-PR 2a) — not re-derived here.
+ *
+ * Per Wave 2 Phase 2 spec §8 (factory contract) + §6 (validation sequence).
+ */
+export const createDPoPMechanism = (options: DPoPMechanismOptions): TokenBindingMechanism => {
+	const algWhitelist = options.algWhitelist ?? DEFAULT_ALG_WHITELIST;
+	const iatWindowSeconds = options.iatWindowSeconds ?? DEFAULT_IAT_WINDOW_SECONDS;
+	const replayTtlSeconds = options.replayTtlSeconds ?? DEFAULT_REPLAY_TTL_SECONDS;
+	const { replayStore, logger } = options;
+
+	return {
+		kind: "dpop",
+		/**
+		 * `true` — DPoP is an explicit application-layer construction: the
+		 * client intentionally presents the `DPoP` header. Per cluster spec
+		 * §3.5, explicit-intent mechanisms win over ambient-intent mechanisms
+		 * (mTLS) in `intent-explicit` dispatch mode.
+		 */
+		intentExplicit: true,
+
+		extract: async (req: Request) => {
+			// Step 1 (spec §6): DPoP header presence.
+			const header = req.get("dpop");
+			if (header === undefined) {
+				return null; // non-DPoP request — no binding
+			}
+
+			// Step 2 (spec §6): Only a single DPoP header value is permitted.
+			if (header.includes(",")) {
+				throw new DPoPError("multiple_headers", "Multiple DPoP header values presented");
+			}
+
+			// Steps 3–9 (spec §6): Structural validation + JWK screening + jkt.
+			// `parseProof` is async (computes jkt via SubtleCrypto in proof.mts).
+			// The flat DPoPProof shape from Sub-PR 2a: proof.jwk, proof.alg, proof.jkt.
+			const proof = await parseProof(header);
+
+			// Step 5 (spec §6): Algorithm allowlist check.
+			// parseProof ensures alg is a non-empty string; whitelist check is here.
+			if (!algWhitelist.includes(proof.alg)) {
+				logger?.warn({ alg: proof.alg, whitelist: algWhitelist }, "dpop_alg_not_allowed");
+				throw new DPoPError("alg_not_allowed", `alg ${proof.alg} is not in the allowlist`);
+			}
+
+			// Step 8 (spec §6): Signature verification.
+			// Import the public key from proof.jwk (flat field from Sub-PR 2a).
+			try {
+				const publicKey = await importJWK(proof.jwk, proof.alg);
+				await jwtVerify(header, publicKey, { typ: "dpop+jwt" });
+			} catch (err) {
+				// Re-throw DPoPError as-is (shouldn't happen here, but safe).
+				if (err instanceof DPoPError) throw err;
+				logger?.warn({ err }, "dpop_signature_invalid");
+				throw new DPoPError("signature_invalid", "DPoP proof signature verification failed");
+			}
+
+			// Step 10 (spec §6): HTTP method match.
+			if (proof.claims.htm.toUpperCase() !== req.method.toUpperCase()) {
+				throw new DPoPError("htm_mismatch", "DPoP proof htm does not match request method", {
+					expected: req.method.toUpperCase(),
+					presented: proof.claims.htm,
+				});
+			}
+
+			// Step 11 (spec §6): HTTP URI match — both sides normalized per §7.
+			const expectedHtu = normalizeHtu(buildRequestUrl(req));
+			const presentedHtu = normalizeHtu(proof.claims.htu);
+			if (expectedHtu !== presentedHtu) {
+				throw new DPoPError("htu_mismatch", "DPoP proof htu does not match request URI", {
+					expected: expectedHtu,
+					presented: presentedHtu,
+				});
+			}
+
+			// Step 12 (spec §6): iat acceptance window.
+			const nowSec = Math.floor(Date.now() / 1000);
+			const drift = Math.abs(nowSec - proof.claims.iat);
+			if (drift > iatWindowSeconds) {
+				throw new DPoPError(
+					"iat_out_of_window",
+					"DPoP proof iat is outside the acceptance window",
+					{
+						windowSeconds: iatWindowSeconds,
+						drift,
+					},
+				);
+			}
+
+			// Step 13 (spec §6): JKT — already computed by parseProof (Sub-PR 2a).
+			// Do NOT re-compute: proof.jkt is the canonical value.
+			const { jkt } = proof;
+
+			// Step 14 (spec §6): Replay check — atomic (jti, jkt) pair seen/mark.
+			const alreadySeen = await replayStore.seen(proof.claims.jti, jkt, replayTtlSeconds);
+			if (alreadySeen) {
+				throw new DPoPError(
+					"replay_detected",
+					"DPoP proof (jti, jkt) already seen in replay window",
+					{
+						jti: proof.claims.jti,
+					},
+				);
+			}
+
+			// Step 15 (spec §6): Return the sender-constrained token binding.
+			// Confirmation shape is the RFC 7800 `cnf.jkt` variant only (Stage 1).
+			// The `proof` object is NOT forwarded — sub-PR 2c reads only
+			// `tokenBinding.confirmation.jkt` for cnf claim issuance.
+			return {
+				kind: "dpop",
+				confirmation: { jkt },
+			};
+		},
+	};
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,9 +84,6 @@ importers:
 
   packages/dpop:
     dependencies:
-      express:
-        specifier: ^5.0.0
-        version: 5.2.1
       jose:
         specifier: ^6.2.2
         version: 6.2.3
@@ -94,15 +91,30 @@ importers:
       '@o3co/auth-provider-core':
         specifier: workspace:*
         version: link:../core
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
+      '@types/supertest':
+        specifier: ^7.2.0
+        version: 7.2.0
       '@vitest/coverage-v8':
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
+      express:
+        specifier: ^5.0.0
+        version: 5.2.1
+      supertest:
+        specifier: ^7.2.2
+        version: 7.2.2
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@types/node@25.7.0)(@vitest/coverage-v8@4.1.6)(msw@2.14.6(@types/node@25.7.0)(typescript@5.9.3))(vite@8.0.11(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.4))
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
 
   packages/federation-github:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       jose:
         specifier: ^6.2.2
         version: 6.2.3
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
     devDependencies:
       '@o3co/auth-provider-core':
         specifier: workspace:*
@@ -112,9 +115,6 @@ importers:
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@types/node@25.7.0)(@vitest/coverage-v8@4.1.6)(msw@2.14.6(@types/node@25.7.0)(typescript@5.9.3))(vite@8.0.11(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.4))
-      zod:
-        specifier: ^4.3.6
-        version: 4.4.3
 
   packages/federation-github:
     dependencies:


### PR DESCRIPTION
## Summary

- Ships the **DPoP proof verifier** (`createDPoPMechanism`) implementing RFC 9449 §6 15-step validation sequence — the security-critical core of Phase 2.
- Adds **`normalizeHtu`** (RFC 3986 §6.2.2-conformant URI canonicalization) — internal helper, not exported per spec §7.
- Adds **`dpopModule`** wiring — opt-in module with `oauth.dpop.enabled = false` default. When enabled, contributes `tokenBindingMw` wrapping the DPoP mechanism via the Phase 1d `grantMiddleware` contribution kind.
- Adds **`packages/dpop/src/reference.conf`** — secure-default config (DPoP disabled by default).
- Optional `dpopReplayStore` ComponentMap slot for production Redis adapter wiring; in-memory fallback for dev/test.

**Sub-PR 2b of 3** for Phase 2 of the Wave 2 Token-binding Cluster. Sub-PR 2c adds the grant integration (cnf claim emission, RT 5-row binding matrix). Sub-PRs 1d + 2a already merged.

## Spec / plan authority

- Spec: `.claude/superpowers/specs/2026-05-18-wave-2-phase-2-dpop-spec.md` §6 (15-step validation), §7 (htu normalization), §8 (factory contract), §11.2 (dpopModule shape)
- Plan: `.claude/superpowers/plans/2026-05-18-wave-2-phase-2-dpop-plan.md` Sub-PR 2b section

## What changed (~1380 LoC across 10 files)

**New:**
- `packages/dpop/src/htu-normalize.mts` (149 lines) — WHATWG URL + manual percent-decode + dot-segment removal; rejects userinfo
- `packages/dpop/src/verifier.mts` (241 lines) — `createDPoPMechanism` implementing all 15 spec §6 steps; reuses `proof.jkt` from Sub-PR 2a's parseProof (no re-derivation); wraps transport faults as `replay_store_unavailable`
- `packages/dpop/src/module.mts` (203 lines) — `dpopModule` + `dpopConfigSchema`; fails boot when `replay-store = "redis"` without the slot wired
- `packages/dpop/src/reference.conf` (33 lines) — secure-default-opt-in
- 3 test files: `htu-normalize.test.mts` (15 tests), `verifier.test.mts` (25 tests), `module.integration.test.mts` (7 tests)

**Modified:**
- `packages/dpop/src/index.mts` — barrel exports (`normalizeHtu` deliberately NOT exported per spec §7)
- `packages/dpop/src/errors.mts` — added `replay_store_unavailable` reason code
- `packages/dpop/package.json` — `zod` moved from devDependencies to dependencies (Critical fix); `./reference.conf` subpath re-added

## Commit history (3 commits — squash-merge to 1)

1. `7b586848` — initial implementation (htu + verifier + module + reference.conf)
2. `8751d4f4` — Round 1 `/multi-agent-review` fix bundle (1 Critical + 6 Important + 5 Minor):
   - **[Critical]** zod moved to dependencies (was in devDeps; published consumers would hit `Cannot find package 'zod'`)
   - **[Important]** `replay-store = "redis"` honored: fails boot when slot unwired (was silently falling back to memory → cross-replica replay protection bypassed)
   - **[Important]** `normalizeHtu` removed from barrel (spec §7 says internal-only)
   - **[Important]** `replayStore.seen` transport faults → `replay_store_unavailable` reason (distinct audit signal)
   - **[Important]** consumer-wired slot integration test
   - **[Important]** whitelist case-sensitivity + private_jwk verifier regression tests
   - **[Minor]** doc cleanup (15 vs 13 step count, header comments, dispatchPolicy `??` dead defense)
3. `4dbfb578` — Round 2 Codex P2 fix:
   - **[Important]** Reject `htu` containing userinfo as `malformed_proof` — WHATWG URL preserves `username`/`password` but canonical reconstruction dropped them, weakening the htu binding check. RFC 9449 §4 gives userinfo no meaning at the token endpoint.

The squash-merge will collapse these into one feature commit.

## Verification

- `pnpm -F @o3co/auth-provider-dpop build` — green
- `pnpm -F @o3co/auth-provider-dpop test` — **83/83 passing** (was 36 pre-Sub-PR-2b)
- `pnpm -F @o3co/auth-provider-core test` — **1297/1297** (regression baseline preserved)
- `pnpm -F @o3co/auth-provider-oauth test` — **522/522** (regression baseline preserved)
- `pnpm -r build` — all packages green
- `pnpm lint` — biome clean (514 files)

## Test plan

- [x] All RFC 9449 §6 steps (1-15) have at least 1 positive + 1 negative test
- [x] All RFC 3986 §6.2.2 normalization rules (11 rules) tested
- [x] `dpopModule` integration tested via `createApp` (5 scenarios: disabled, enabled-valid, enabled-invalid, no-header, consumer-wired-slot)
- [x] Replay store contract pinned: atomic check-and-mark, transport faults → `replay_store_unavailable`, `replay-store=redis` without slot fails fast
- [x] No `auth-provider-dpop` references in `packages/redis/dist/index.d.mts` (Critical fix from Sub-PR 2a preserved — confirmed by `grep`)
- [x] zod is in dependencies (Critical Round-1 fix preserved)
- [ ] CI green (this PR)

## Notes for reviewer

- **Two `/multi-agent-review` rounds** ran. Round 1: 1 Critical + 6 Important + 5 Minor. Round 2: all 12 Round-1 findings VERIFIED clean + Codex caught 1 P2 (userinfo bypass) which is a pre-existing 2b issue. Round 2 fix landed in `4dbfb578`. Critical 0 at close → proceeded to push per project CLAUDE.md.
- **`DPoPProof` flat shape** (`{ jwk, alg, jkt, claims, raw }`) from Sub-PR 2a is consumed end-to-end: verifier reuses `proof.jkt` rather than re-deriving (performance investment from 2a paid back).
- **Wire/internal error separation** structurally enforced: `DPoPError.code` is a const `"invalid_dpop_proof"`; `reason: DPoPReasonCode` is the only sub-classification surface. The new `replay_store_unavailable` reason maps to the same wire code (RFC 9449 §7 conformant) while keeping operator audit triage signals distinct from "client garbage".
- **`replay-store = "redis"` without slot fails boot** — distinct from "silent fallback to memory" which would be a security regression in multi-replica deployments.
- **`oauth.dpop.enabled = false` by default** — secure-default-opt-in discipline. Operators must explicitly enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)