### PR TITLE
feat(mtls): @o3co/auth-provider-mtls skeleton + dialect parsers + thumbprint (Phase 3 Sub-PR 3a)

### DIFF
--- a/create-app/scripts/copy-templates.mjs
+++ b/create-app/scripts/copy-templates.mjs
@@ -48,6 +48,7 @@ const readVersion = (pkgPath) => {
 const versions = {
 	"@o3co/auth-provider-core": readVersion("../../packages/core/package.json"),
 	"@o3co/auth-provider-dpop": readVersion("../../packages/dpop/package.json"),
+	"@o3co/auth-provider-mtls": readVersion("../../packages/mtls/package.json"),
 	"@o3co/auth-provider-federation-google": readVersion(
 		"../../packages/federation-google/package.json",
 	),

--- a/create-app/src/__tests__/index.test.mts
+++ b/create-app/src/__tests__/index.test.mts
@@ -150,6 +150,7 @@ describe("scaffold", () => {
 		const expectedPackages: Record<string, string> = {
 			"@o3co/auth-provider-core": "../packages/core/package.json",
 			"@o3co/auth-provider-dpop": "../packages/dpop/package.json",
+			"@o3co/auth-provider-mtls": "../packages/mtls/package.json",
 			"@o3co/auth-provider-federation-github": "../packages/federation-github/package.json",
 			"@o3co/auth-provider-federation-google": "../packages/federation-google/package.json",
 			"@o3co/auth-provider-foundation": "../packages/foundation/package.json",

--- a/packages/mtls/CHANGELOG.md
+++ b/packages/mtls/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog — @o3co/auth-provider-mtls
+
+All notable changes to this package will be documented in this file.
+
+## [Unreleased]
+
+### Added (Phase 3 Sub-PR 3a)
+
+- Initial `@o3co/auth-provider-mtls` package skeleton.
+- `pemToDer` + `derToPem` codec helpers (internal).
+- `parseEnvoyXfccHeader` + `parsePlainPemHeader` dialect parsers (internal).
+- `computeCertThumbprint` (RFC 8705 §3.1 — base64url-encoded SHA-256 hash of DER, trailing `=` padding stripped).
+- `ClientCertificate` type + `parseDerToCertificate`.
+- `MtlsError` + `MtlsReasonCode` union.
+
+Implements the Phase 3 spec at `.claude/superpowers/specs/2026-05-18-wave-2-phase-3-mtls-spec.md` §13 T3a.

--- a/packages/mtls/LICENSE
+++ b/packages/mtls/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/mtls/README.md
+++ b/packages/mtls/README.md
@@ -1,0 +1,19 @@
+# @o3co/auth-provider-mtls
+
+mTLS (RFC 8705) sender-constrained access token support for `@o3co/auth-provider`.
+
+> **Status:** Phase 3 in progress. Sub-PR 3a ships the package skeleton + dialect parsers + thumbprint + cert type. The mechanism factory, module wiring, and grant integration land in Sub-PR 3b / 3c. The package is NOT yet usable end-to-end; see `CHANGELOG.md` for the current contributions.
+
+## Overview
+
+Sender-constrained access tokens per [RFC 8705](https://www.rfc-editor.org/rfc/rfc8705) §3 (Mutual TLS Client Certificate-Bound Access Tokens). The mechanism extracts the client cert presented during the TLS handshake (or forwarded by a reverse proxy), computes the SHA-256 thumbprint of the DER encoding, and emits it as the `cnf.x5t#S256` claim on the issued access token.
+
+Implements:
+
+- RFC 8705 §3 — AT binding (Sub-PR 3a + 3b).
+- RFC 8705 §3.1 — `x5t#S256` thumbprint algorithm (Sub-PR 3a).
+- RFC 8705 §4 — public-client RT binding SHOULD (Sub-PR 3c).
+
+The package plugs into the existing `tokenBindingMw` from `@o3co/auth-provider-core` (Phase 1b) and emits a `TokenBinding` with `kind: "mtls"`.
+
+Further documentation (Trusted-Proxy Security Guidance, PKI Mode Scope, sample proxy configs) lands with Sub-PR 3b.

--- a/packages/mtls/README.md
+++ b/packages/mtls/README.md
@@ -2,7 +2,7 @@
 
 mTLS (RFC 8705) sender-constrained access token support for `@o3co/auth-provider`.
 
-> **Status:** Phase 3 in progress. Sub-PR 3a ships the package skeleton + dialect parsers + thumbprint + cert type. The mechanism factory, module wiring, and grant integration land in Sub-PR 3b / 3c. The package is NOT yet usable end-to-end; see `CHANGELOG.md` for the current contributions.
+> **Status:** Phase 3 in progress. Sub-PR 3a ships the package skeleton + dialect parsers + thumbprint + cert type. The mechanism factory, module wiring, and grant integration land in Sub-PR 3b / 3c. The package is NOT yet usable end-to-end.
 
 ## Overview
 

--- a/packages/mtls/package.json
+++ b/packages/mtls/package.json
@@ -13,12 +13,10 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"types": "./dist/index.d.mts"
-		},
-		"./reference.conf": "./src/reference.conf"
+		}
 	},
 	"files": [
 		"dist",
-		"src/reference.conf",
 		"README.md",
 		"LICENSE"
 	],

--- a/packages/mtls/package.json
+++ b/packages/mtls/package.json
@@ -46,9 +46,6 @@
 			"optional": true
 		}
 	},
-	"dependencies": {
-		"zod": "^4.3.6"
-	},
 	"devDependencies": {
 		"@o3co/auth-provider-core": "workspace:*",
 		"@types/express": "^5.0.6",

--- a/packages/mtls/package.json
+++ b/packages/mtls/package.json
@@ -1,0 +1,67 @@
+{
+	"name": "@o3co/auth-provider-mtls",
+	"version": "0.0.0",
+	"description": "mTLS (RFC 8705) sender-constrained access token support for @o3co/auth-provider",
+	"license": "Apache-2.0",
+	"engines": {
+		"node": ">=18.19.0"
+	},
+	"type": "module",
+	"main": "./dist/index.mjs",
+	"types": "./dist/index.d.mts",
+	"exports": {
+		".": {
+			"import": "./dist/index.mjs",
+			"types": "./dist/index.d.mts"
+		},
+		"./reference.conf": "./src/reference.conf"
+	},
+	"files": [
+		"dist",
+		"src/reference.conf",
+		"README.md",
+		"LICENSE"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/o3co/auth.provider.git",
+		"directory": "packages/mtls"
+	},
+	"scripts": {
+		"prebuild": "rimraf dist",
+		"build": "tsc",
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage"
+	},
+	"imports": {
+		"#/*": {
+			"development": "./src/*",
+			"default": "./dist/*"
+		}
+	},
+	"peerDependencies": {
+		"@o3co/auth-provider-core": "^0.0.0",
+		"express": "^5.0.0"
+	},
+	"peerDependenciesMeta": {
+		"express": {
+			"optional": true
+		}
+	},
+	"dependencies": {
+		"zod": "^4.3.6"
+	},
+	"devDependencies": {
+		"@o3co/auth-provider-core": "workspace:*",
+		"@types/express": "^5.0.6",
+		"@types/supertest": "^7.2.0",
+		"@vitest/coverage-v8": "^4.1.6",
+		"express": "^5.0.0",
+		"supertest": "^7.2.2",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.6"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/mtls/src/__tests__/certificate.test.mts
+++ b/packages/mtls/src/__tests__/certificate.test.mts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { X509Certificate } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { parseDerToCertificate } from "#/certificate.mjs";
+
+/**
+ * Same fixed test certificate used in thumbprint.test.mts — a committed
+ * fixture so tests are deterministic without network access or keygen.
+ */
+const TEST_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIBdDCCARmgAwIBAgIUaBppoI8WPFk51saIFsb3ITafYDMwCgYIKoZIzj0EAwIw
+DzENMAsGA1UEAwwEdGVzdDAeFw0yNjA1MTkwMzM5MDdaFw0yNzA1MTkwMzM5MDda
+MA8xDTALBgNVBAMMBHRlc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT/xsy0
+D008eq7Qp+cyWHxqcThSc9YFSl9v/FGE9s9HqbMY5ku00iXUW2R/Nu18PN1y6Osa
+MdfFxFOqPFLl180po1MwUTAdBgNVHQ4EFgQUQey1RDkeBYfD/xuliPfC0Qv0WEow
+HwYDVR0jBBgwFoAUQey1RDkeBYfD/xuliPfC0Qv0WEowDwYDVR0TAQH/BAUwAwEB
+/zAKBggqhkjOPQQDAgNJADBGAiEAzIC0cVYrlH7qLZ2r0OqYXFci9/EveGi0yhGi
+hXs25+0CIQDITvqroFES8r+bSdPCJGaQMVxps8L823m1axWCE+eUvA==
+-----END CERTIFICATE-----`;
+
+const TEST_CERT_DER = new X509Certificate(TEST_CERT_PEM).raw as unknown as Uint8Array;
+
+describe("parseDerToCertificate", () => {
+	it("populates all four parsed fields from a valid DER certificate", () => {
+		const cert = parseDerToCertificate(TEST_CERT_DER);
+		// All four diagnostic fields must be present and non-empty strings.
+		expect(typeof cert.parsed.subject).toBe("string");
+		expect(cert.parsed.subject.length).toBeGreaterThan(0);
+		expect(typeof cert.parsed.issuer).toBe("string");
+		expect(cert.parsed.issuer.length).toBeGreaterThan(0);
+		expect(typeof cert.parsed.notBefore).toBe("string");
+		expect(cert.parsed.notBefore.length).toBeGreaterThan(0);
+		expect(typeof cert.parsed.notAfter).toBe("string");
+		expect(cert.parsed.notAfter.length).toBeGreaterThan(0);
+	});
+
+	it("preserves the input DER bytes as the der field (same reference)", () => {
+		const cert = parseDerToCertificate(TEST_CERT_DER);
+		// The `der` field must be the same reference — no copy (for thumbprinting efficiency).
+		expect(cert.der).toBe(TEST_CERT_DER);
+	});
+
+	it("attaches the chain when provided and omits the chain property when not provided", () => {
+		const fakeDer = new Uint8Array([0x30, 0x01]);
+		const certWithChain = parseDerToCertificate(TEST_CERT_DER, [fakeDer]);
+		expect(certWithChain.chain).toHaveLength(1);
+		expect(certWithChain.chain?.[0]).toBe(fakeDer);
+
+		const certWithoutChain = parseDerToCertificate(TEST_CERT_DER);
+		expect(certWithoutChain.chain).toBeUndefined();
+	});
+
+	it("throws on malformed DER bytes", () => {
+		// `new X509Certificate(der)` will throw on garbage input — the call site
+		// wraps this into MtlsError("cert_decode_failed") but parseDerToCertificate
+		// itself propagates the raw error per spec §6.3.
+		const garbage = new Uint8Array([0x00, 0x01, 0x02]);
+		expect(() => parseDerToCertificate(garbage)).toThrow();
+	});
+});

--- a/packages/mtls/src/__tests__/certificate.test.mts
+++ b/packages/mtls/src/__tests__/certificate.test.mts
@@ -32,7 +32,9 @@ HwYDVR0jBBgwFoAUQey1RDkeBYfD/xuliPfC0Qv0WEowDwYDVR0TAQH/BAUwAwEB
 hXs25+0CIQDITvqroFES8r+bSdPCJGaQMVxps8L823m1axWCE+eUvA==
 -----END CERTIFICATE-----`;
 
-const TEST_CERT_DER = new X509Certificate(TEST_CERT_PEM).raw as unknown as Uint8Array;
+// X509Certificate.raw returns Buffer; Buffer extends Uint8Array, so this widens
+// cleanly without the previous redundant `as unknown as Uint8Array` cast.
+const TEST_CERT_DER: Uint8Array = new X509Certificate(TEST_CERT_PEM).raw;
 
 describe("parseDerToCertificate", () => {
 	it("populates all four parsed fields from a valid DER certificate", () => {
@@ -48,17 +50,35 @@ describe("parseDerToCertificate", () => {
 		expect(cert.parsed.notAfter.length).toBeGreaterThan(0);
 	});
 
-	it("preserves the input DER bytes as the der field (same reference)", () => {
+	it("copies the input DER bytes into the der field (defensive — not same reference)", () => {
+		// Codex Round 1 Important #4: `readonly der: Uint8Array` only protects
+		// property assignment, not byte mutation. parseDerToCertificate copies
+		// the bytes so a caller mutating the input buffer after parse cannot
+		// tamper with the thumbprint source.
 		const cert = parseDerToCertificate(TEST_CERT_DER);
-		// The `der` field must be the same reference — no copy (for thumbprinting efficiency).
-		expect(cert.der).toBe(TEST_CERT_DER);
+		// Different reference (defensive copy)
+		expect(cert.der).not.toBe(TEST_CERT_DER);
+		// But same content (byte-equal)
+		expect(cert.der.length).toBe(TEST_CERT_DER.length);
+		expect(Array.from(cert.der)).toEqual(Array.from(TEST_CERT_DER));
 	});
 
-	it("attaches the chain when provided and omits the chain property when not provided", () => {
+	it("input buffer mutation does NOT affect the stored DER (defensive copy verification)", () => {
+		// Adversarial scenario: caller modifies their original buffer after parse.
+		const mutableInput = new Uint8Array(TEST_CERT_DER);
+		const cert = parseDerToCertificate(mutableInput);
+		const originalFirstByte = cert.der[0];
+		mutableInput[0] = 0xff; // tamper with caller's buffer
+		expect(cert.der[0]).toBe(originalFirstByte); // stored bytes unaffected
+	});
+
+	it("attaches the chain when provided (defensive-copied) and omits chain property when not provided", () => {
 		const fakeDer = new Uint8Array([0x30, 0x01]);
 		const certWithChain = parseDerToCertificate(TEST_CERT_DER, [fakeDer]);
 		expect(certWithChain.chain).toHaveLength(1);
-		expect(certWithChain.chain?.[0]).toBe(fakeDer);
+		// Chain entries are also defensively copied per Codex Important #4.
+		expect(certWithChain.chain?.[0]).not.toBe(fakeDer);
+		expect(Array.from(certWithChain.chain?.[0] ?? [])).toEqual([0x30, 0x01]);
 
 		const certWithoutChain = parseDerToCertificate(TEST_CERT_DER);
 		expect(certWithoutChain.chain).toBeUndefined();

--- a/packages/mtls/src/__tests__/errors.test.mts
+++ b/packages/mtls/src/__tests__/errors.test.mts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from "vitest";
+import { MtlsError } from "#/errors.mjs";
+
+describe("MtlsError", () => {
+	it("hard-codes code to invalid_certificate regardless of reason", () => {
+		const err = new MtlsError("cert_expired", "certificate has expired");
+		expect(err.code).toBe("invalid_certificate");
+		expect(err.reason).toBe("cert_expired");
+	});
+
+	it("preserves message and optional detail bag", () => {
+		const err = new MtlsError("chain_validation_failed", "chain broken", {
+			step: "intermediate expired",
+		});
+		expect(err.message).toBe("chain broken");
+		expect(err.detail).toEqual({ step: "intermediate expired" });
+	});
+
+	it("omits detail property when not provided", () => {
+		const err = new MtlsError("malformed_header", "bad header");
+		expect(err.detail).toBeUndefined();
+	});
+
+	it("is instanceof Error so callers can catch generically", () => {
+		const err = new MtlsError("cert_decode_failed", "cannot decode PEM");
+		expect(err).toBeInstanceOf(Error);
+		expect(err).toBeInstanceOf(MtlsError);
+	});
+
+	it("accepts all MtlsReasonCode variants without TypeScript error", () => {
+		// Each variant should be constructable — validates the union is correct.
+		const reasons = [
+			"malformed_header",
+			"unknown_dialect",
+			"cert_decode_failed",
+			"cert_expired",
+			"cert_not_yet_valid",
+			"chain_validation_failed",
+			"trusted_cas_unconfigured",
+			"tls_peer_unavailable",
+		] as const;
+		for (const reason of reasons) {
+			const err = new MtlsError(reason, "test");
+			expect(err.reason).toBe(reason);
+		}
+	});
+});

--- a/packages/mtls/src/__tests__/headers.test.mts
+++ b/packages/mtls/src/__tests__/headers.test.mts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from "vitest";
+import { parseEnvoyXfccHeader, parsePlainPemHeader } from "#/headers.mjs";
+
+/**
+ * Test fixture: fixed self-signed P-256 cert (same as used in other tests).
+ * Used verbatim and in URL-encoded form to test both header dialects.
+ */
+const TEST_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIBdDCCARmgAwIBAgIUaBppoI8WPFk51saIFsb3ITafYDMwCgYIKoZIzj0EAwIw
+DzENMAsGA1UEAwwEdGVzdDAeFw0yNjA1MTkwMzM5MDdaFw0yNzA1MTkwMzM5MDda
+MA8xDTALBgNVBAMMBHRlc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT/xsy0
+D008eq7Qp+cyWHxqcThSc9YFSl9v/FGE9s9HqbMY5ku00iXUW2R/Nu18PN1y6Osa
+MdfFxFOqPFLl180po1MwUTAdBgNVHQ4EFgQUQey1RDkeBYfD/xuliPfC0Qv0WEow
+HwYDVR0jBBgwFoAUQey1RDkeBYfD/xuliPfC0Qv0WEowDwYDVR0TAQH/BAUwAwEB
+/zAKBggqhkjOPQQDAgNJADBGAiEAzIC0cVYrlH7qLZ2r0OqYXFci9/EveGi0yhGi
+hXs25+0CIQDITvqroFES8r+bSdPCJGaQMVxps8L823m1axWCE+eUvA==
+-----END CERTIFICATE-----`;
+
+/** Second PEM block used to simulate a chain or multi-cert scenarios. */
+const TEST_CHAIN_PEM = `-----BEGIN CERTIFICATE-----
+MIIBdDCCARmgAwIBAgIUaBppoI8WPFk51saIFsb3ITafYDMwCgYIKoZIzj0EAwIw
+DzENMAsGA1UEAwwEdGVzdDAeFw0yNjA1MTkwMzM5MDdaFw0yNzA1MTkwMzM5MDda
+MA8xDTALBgNVBAMMBHRlc3QAAAA=
+-----END CERTIFICATE-----`;
+
+const ENCODED_CERT = encodeURIComponent(TEST_CERT_PEM);
+const ENCODED_CHAIN = encodeURIComponent(TEST_CHAIN_PEM);
+
+describe("parseEnvoyXfccHeader", () => {
+	it("parses a well-formed XFCC header with Cert= only", () => {
+		const xfcc = `By=spiffe://cluster.local/ns/default/sa/server;Hash=abc123;Cert=${ENCODED_CERT}`;
+		const result = parseEnvoyXfccHeader(xfcc);
+		expect(result.certPem).toBe(TEST_CERT_PEM);
+		expect(result.chainPem).toBeUndefined();
+	});
+
+	it("parses a well-formed XFCC header with both Cert= and Chain=", () => {
+		const xfcc = `By=spiffe://cluster.local;Hash=abc;Cert=${ENCODED_CERT};Chain=${ENCODED_CHAIN}`;
+		const result = parseEnvoyXfccHeader(xfcc);
+		expect(result.certPem).toBe(TEST_CERT_PEM);
+		expect(result.chainPem).toBe(TEST_CHAIN_PEM);
+	});
+
+	it("throws when Cert= field is missing from the XFCC header", () => {
+		const xfcc = `By=spiffe://cluster.local;Hash=abc123`;
+		expect(() => parseEnvoyXfccHeader(xfcc)).toThrow("Cert=");
+	});
+
+	it("uses only the first XFCC element when multiple comma-separated elements are present", () => {
+		// Envoy prepends the client-facing hop first — subsequent elements are
+		// from inner hops and MUST NOT be used for binding.
+		const xfcc = `Cert=${ENCODED_CERT},Cert=otherstuff`;
+		const result = parseEnvoyXfccHeader(xfcc);
+		expect(result.certPem).toBe(TEST_CERT_PEM);
+	});
+
+	it("URL-decodes the Cert= value correctly (roundtrip)", () => {
+		const xfcc = `Cert=${ENCODED_CERT}`;
+		const result = parseEnvoyXfccHeader(xfcc);
+		// After URL-decoding, the PEM must match the original exactly.
+		expect(result.certPem).toContain("-----BEGIN CERTIFICATE-----");
+		expect(result.certPem).toContain("-----END CERTIFICATE-----");
+	});
+});
+
+describe("parsePlainPemHeader", () => {
+	it("accepts a literal PEM value and returns it unchanged", () => {
+		const result = parsePlainPemHeader(TEST_CERT_PEM);
+		expect(result.certPem).toBe(TEST_CERT_PEM);
+		expect(result.chainPem).toBeUndefined();
+	});
+
+	it("URL-decodes the header value when it is percent-encoded", () => {
+		const result = parsePlainPemHeader(ENCODED_CERT);
+		expect(result.certPem).toBe(TEST_CERT_PEM);
+	});
+
+	it("rejects a header containing multiple PEM blocks (spec OQ1 §14.1 strict)", () => {
+		// Multi-cert concatenation is explicitly forbidden — operators must use
+		// the envoy dialect's Chain= field instead.
+		const multiPem = `${TEST_CERT_PEM}\n${TEST_CHAIN_PEM}`;
+		expect(() => parsePlainPemHeader(multiPem)).toThrow("multiple PEM blocks");
+	});
+
+	it("throws when the header value contains no PEM block at all", () => {
+		expect(() => parsePlainPemHeader("not-a-pem-value")).toThrow();
+	});
+
+	it("throws when the header value is empty", () => {
+		expect(() => parsePlainPemHeader("")).toThrow();
+	});
+});

--- a/packages/mtls/src/__tests__/headers.test.mts
+++ b/packages/mtls/src/__tests__/headers.test.mts
@@ -76,6 +76,41 @@ describe("parseEnvoyXfccHeader", () => {
 		expect(result.certPem).toContain("-----BEGIN CERTIFICATE-----");
 		expect(result.certPem).toContain("-----END CERTIFICATE-----");
 	});
+
+	it("strips enclosing double-quotes from Cert= value (Envoy 1.18+ quoted-string form)", () => {
+		// Codex Round 1 Important #2 / Claude Minor #2 convergence: Envoy may
+		// quote field values whose payloads contain structural characters.
+		const xfcc = `By="spiffe://cluster.local/sa/server";Hash=abc;Cert="${ENCODED_CERT}"`;
+		const result = parseEnvoyXfccHeader(xfcc);
+		expect(result.certPem).toBe(TEST_CERT_PEM);
+	});
+
+	it("rejects mismatched leading-only quote on Cert= field", () => {
+		const xfcc = `Cert="${ENCODED_CERT}`; // missing trailing quote
+		expect(() => parseEnvoyXfccHeader(xfcc)).toThrow("mismatched quoting");
+	});
+
+	it("rejects an XFCC header that exceeds the raw size cap", () => {
+		// Defense-in-depth size cap (Codex Round 1 Important #1).
+		const oversize = `Cert=${"x".repeat(20 * 1024)}`;
+		expect(() => parseEnvoyXfccHeader(oversize)).toThrow("size cap");
+	});
+
+	it("normalizes invalid percent-encoding into a plain Error (not URIError)", () => {
+		// safeDecodeURIComponent wrapper (Codex Round 1 Important #3).
+		// `%C3` is a partial UTF-8 multi-byte sequence — looks URL-encoded
+		// (matches the isUrlEncoded regex), but decodeURIComponent throws
+		// URIError mid-decode. The wrapper MUST rethrow as a plain Error.
+		const xfcc = "Cert=%C3-truncated";
+		expect(() => parseEnvoyXfccHeader(xfcc)).toThrow("invalid percent-encoding");
+		// MUST be a plain Error, never a URIError — verify by class name.
+		try {
+			parseEnvoyXfccHeader(xfcc);
+		} catch (err) {
+			expect(err).toBeInstanceOf(Error);
+			expect((err as Error).constructor.name).toBe("Error");
+		}
+	});
 });
 
 describe("parsePlainPemHeader", () => {
@@ -103,5 +138,26 @@ describe("parsePlainPemHeader", () => {
 
 	it("throws when the header value is empty", () => {
 		expect(() => parsePlainPemHeader("")).toThrow();
+	});
+
+	it("rejects a plain-PEM header that exceeds the raw size cap", () => {
+		// Defense-in-depth size cap (Codex Round 1 Important #1).
+		const oversize = `-----BEGIN CERTIFICATE-----\n${"A".repeat(20 * 1024)}\n-----END CERTIFICATE-----`;
+		expect(() => parsePlainPemHeader(oversize)).toThrow("size cap");
+	});
+
+	it("normalizes invalid percent-encoding into a plain Error (not URIError)", () => {
+		// safeDecodeURIComponent wrapper (Codex Round 1 Important #3).
+		// `%C3` is a partial UTF-8 multi-byte sequence — matches isUrlEncoded
+		// so triggers decode, but decodeURIComponent throws URIError. The
+		// wrapper MUST rethrow as a plain Error.
+		const value = "%C3-truncated";
+		expect(() => parsePlainPemHeader(value)).toThrow("invalid percent-encoding");
+		try {
+			parsePlainPemHeader(value);
+		} catch (err) {
+			expect(err).toBeInstanceOf(Error);
+			expect((err as Error).constructor.name).toBe("Error");
+		}
 	});
 });

--- a/packages/mtls/src/__tests__/headers.test.mts
+++ b/packages/mtls/src/__tests__/headers.test.mts
@@ -96,6 +96,16 @@ describe("parseEnvoyXfccHeader", () => {
 		expect(() => parseEnvoyXfccHeader(oversize)).toThrow("size cap");
 	});
 
+	it("measures the raw size cap in UTF-8 bytes, not UTF-16 code units (multi-byte cannot bypass)", () => {
+		// Copilot review Round 2 Important #1: an attacker who emits non-ASCII
+		// characters could bypass a cap measured in `value.length` (UTF-16 code
+		// units) because multi-byte UTF-8 chars take fewer code units than bytes.
+		// Each "あ" is 1 UTF-16 code unit but 3 UTF-8 bytes; 6KB code units = 18KB
+		// UTF-8 bytes, which exceeds the 16KB raw cap.
+		const multibyte = `Cert=${"あ".repeat(6 * 1024)}`;
+		expect(() => parseEnvoyXfccHeader(multibyte)).toThrow("size cap");
+	});
+
 	it("normalizes invalid percent-encoding into a plain Error (not URIError)", () => {
 		// safeDecodeURIComponent wrapper (Codex Round 1 Important #3).
 		// `%C3` is a partial UTF-8 multi-byte sequence — looks URL-encoded
@@ -144,6 +154,20 @@ describe("parsePlainPemHeader", () => {
 		// Defense-in-depth size cap (Codex Round 1 Important #1).
 		const oversize = `-----BEGIN CERTIFICATE-----\n${"A".repeat(20 * 1024)}\n-----END CERTIFICATE-----`;
 		expect(() => parsePlainPemHeader(oversize)).toThrow("size cap");
+	});
+
+	it("applies the raw size cap BEFORE trim/empty check (parity with parseEnvoyXfccHeader)", () => {
+		// Copilot review Round 2 Minor #2: don't do trim work on oversize input.
+		// A whitespace-only value larger than the raw cap must be rejected by the
+		// size check, not the empty check.
+		const oversizeWhitespace = " ".repeat(20 * 1024);
+		expect(() => parsePlainPemHeader(oversizeWhitespace)).toThrow("size cap");
+	});
+
+	it("measures the raw size cap in UTF-8 bytes, not UTF-16 code units (multi-byte cannot bypass)", () => {
+		// Copilot review Round 2 Important #1: see parallel envoy test.
+		const multibyte = "あ".repeat(6 * 1024); // 6KB UTF-16 code units = 18KB UTF-8 bytes
+		expect(() => parsePlainPemHeader(multibyte)).toThrow("size cap");
 	});
 
 	it("normalizes invalid percent-encoding into a plain Error (not URIError)", () => {

--- a/packages/mtls/src/__tests__/pem.test.mts
+++ b/packages/mtls/src/__tests__/pem.test.mts
@@ -33,7 +33,7 @@ HwYDVR0jBBgwFoAUQey1RDkeBYfD/xuliPfC0Qv0WEowDwYDVR0TAQH/BAUwAwEB
 hXs25+0CIQDITvqroFES8r+bSdPCJGaQMVxps8L823m1axWCE+eUvA==
 -----END CERTIFICATE-----`;
 
-const TEST_CERT_DER = new X509Certificate(TEST_CERT_PEM).raw as unknown as Uint8Array;
+const TEST_CERT_DER: Uint8Array = new X509Certificate(TEST_CERT_PEM).raw;
 
 describe("derToPem", () => {
 	it("wraps DER bytes in correct BEGIN/END CERTIFICATE markers", () => {

--- a/packages/mtls/src/__tests__/pem.test.mts
+++ b/packages/mtls/src/__tests__/pem.test.mts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { X509Certificate } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { derToPem, pemToDer } from "#/pem.mjs";
+
+/**
+ * Fixed test certificate DER — extracted from the same P-256 self-signed cert
+ * used in certificate.test.mts and thumbprint.test.mts.
+ * Using a real X509Certificate to get structurally valid DER for roundtrip tests.
+ */
+const TEST_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIBdDCCARmgAwIBAgIUaBppoI8WPFk51saIFsb3ITafYDMwCgYIKoZIzj0EAwIw
+DzENMAsGA1UEAwwEdGVzdDAeFw0yNjA1MTkwMzM5MDdaFw0yNzA1MTkwMzM5MDda
+MA8xDTALBgNVBAMMBHRlc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT/xsy0
+D008eq7Qp+cyWHxqcThSc9YFSl9v/FGE9s9HqbMY5ku00iXUW2R/Nu18PN1y6Osa
+MdfFxFOqPFLl180po1MwUTAdBgNVHQ4EFgQUQey1RDkeBYfD/xuliPfC0Qv0WEow
+HwYDVR0jBBgwFoAUQey1RDkeBYfD/xuliPfC0Qv0WEowDwYDVR0TAQH/BAUwAwEB
+/zAKBggqhkjOPQQDAgNJADBGAiEAzIC0cVYrlH7qLZ2r0OqYXFci9/EveGi0yhGi
+hXs25+0CIQDITvqroFES8r+bSdPCJGaQMVxps8L823m1axWCE+eUvA==
+-----END CERTIFICATE-----`;
+
+const TEST_CERT_DER = new X509Certificate(TEST_CERT_PEM).raw as unknown as Uint8Array;
+
+describe("derToPem", () => {
+	it("wraps DER bytes in correct BEGIN/END CERTIFICATE markers", () => {
+		const pem = derToPem(new Uint8Array([0x30, 0x01, 0x00]));
+		expect(pem).toContain("-----BEGIN CERTIFICATE-----");
+		expect(pem).toContain("-----END CERTIFICATE-----");
+	});
+
+	it("uses 64-character line wrapping per RFC 7468 §2", () => {
+		// 60 bytes → 80 base64 chars → 2 lines of ≤64 chars each.
+		const der = new Uint8Array(60).fill(0xab);
+		const pem = derToPem(der);
+		const lines = pem.split("\n").slice(1, -1); // strip BEGIN/END lines
+		for (const line of lines) {
+			expect(line.length).toBeLessThanOrEqual(64);
+		}
+	});
+
+	it("accepts a custom type label for non-certificate PEM blocks", () => {
+		const der = new Uint8Array([0x30]);
+		const pem = derToPem(der, "PUBLIC KEY");
+		expect(pem).toContain("-----BEGIN PUBLIC KEY-----");
+		expect(pem).toContain("-----END PUBLIC KEY-----");
+	});
+});
+
+describe("pemToDer", () => {
+	it("decodes PEM back to the original DER bytes (roundtrip via real X509 cert)", () => {
+		// Re-encode the cert DER to PEM and decode back — both directions exercised.
+		// Compare as Uint8Array (Buffer is a subclass) to avoid toEqual type mismatch.
+		const rePem = derToPem(TEST_CERT_DER);
+		const decoded = pemToDer(rePem);
+		expect(Buffer.from(decoded).equals(Buffer.from(TEST_CERT_DER))).toBe(true);
+	});
+
+	it("throws when BEGIN marker is missing", () => {
+		const noBEgin = "MIID...base64...==\n-----END CERTIFICATE-----";
+		expect(() => pemToDer(noBEgin)).toThrow("BEGIN");
+	});
+
+	it("throws when END marker is missing", () => {
+		const noEnd = "-----BEGIN CERTIFICATE-----\nMIID...base64...==";
+		expect(() => pemToDer(noEnd)).toThrow("END");
+	});
+
+	it("throws when BEGIN and END type labels do not match", () => {
+		const mismatched = "-----BEGIN CERTIFICATE-----\nMIID\n-----END PRIVATE KEY-----";
+		expect(() => pemToDer(mismatched)).toThrow("mismatch");
+	});
+
+	it("decodes the original test certificate PEM directly", () => {
+		// Verify that our pemToDer handles the fixed test cert PEM verbatim.
+		// Compare via Buffer.equals to avoid vitest's Uint8Array vs Buffer toEqual mismatch.
+		const decoded = pemToDer(TEST_CERT_PEM);
+		expect(Buffer.from(decoded).equals(Buffer.from(TEST_CERT_DER))).toBe(true);
+	});
+});

--- a/packages/mtls/src/__tests__/thumbprint.test.mts
+++ b/packages/mtls/src/__tests__/thumbprint.test.mts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { X509Certificate } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { computeCertThumbprint } from "#/thumbprint.mjs";
+
+/**
+ * Fixed test certificate (P-256, CN=test, self-signed, valid 2026-05-19).
+ *
+ * This PEM is committed as a test fixture for deterministic thumbprint
+ * assertions. The cert is not trusted anywhere — it exists purely to pin
+ * the thumbprint computation against a known value.
+ *
+ * Pre-computed expected thumbprint (SHA-256 of DER, base64url, no padding):
+ *   ixxC3Iu02KfsoIX8SaMQS0-nHDkhl4CtXw-kKsC1Lws
+ */
+const TEST_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIBdDCCARmgAwIBAgIUaBppoI8WPFk51saIFsb3ITafYDMwCgYIKoZIzj0EAwIw
+DzENMAsGA1UEAwwEdGVzdDAeFw0yNjA1MTkwMzM5MDdaFw0yNzA1MTkwMzM5MDda
+MA8xDTALBgNVBAMMBHRlc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT/xsy0
+D008eq7Qp+cyWHxqcThSc9YFSl9v/FGE9s9HqbMY5ku00iXUW2R/Nu18PN1y6Osa
+MdfFxFOqPFLl180po1MwUTAdBgNVHQ4EFgQUQey1RDkeBYfD/xuliPfC0Qv0WEow
+HwYDVR0jBBgwFoAUQey1RDkeBYfD/xuliPfC0Qv0WEowDwYDVR0TAQH/BAUwAwEB
+/zAKBggqhkjOPQQDAgNJADBGAiEAzIC0cVYrlH7qLZ2r0OqYXFci9/EveGi0yhGi
+hXs25+0CIQDITvqroFES8r+bSdPCJGaQMVxps8L823m1axWCE+eUvA==
+-----END CERTIFICATE-----`;
+
+const TEST_CERT_DER = new X509Certificate(TEST_CERT_PEM).raw as unknown as Uint8Array;
+const EXPECTED_THUMBPRINT = "ixxC3Iu02KfsoIX8SaMQS0-nHDkhl4CtXw-kKsC1Lws";
+
+describe("computeCertThumbprint — RFC 8705 §3.1 DER SHA-256 thumbprint", () => {
+	it("produces the pre-computed thumbprint for the fixed test certificate", () => {
+		// Pins the computation against a known DER → thumbprint mapping.
+		// If this test fails, the hash function or encoding changed.
+		const thumbprint = computeCertThumbprint(TEST_CERT_DER);
+		expect(thumbprint).toBe(EXPECTED_THUMBPRINT);
+	});
+
+	it("output is base64url-encoded — no +, /, or = characters", () => {
+		const thumbprint = computeCertThumbprint(TEST_CERT_DER);
+		// base64url alphabet uses - and _ instead of + and /; no = padding.
+		expect(thumbprint).not.toMatch(/[+/=]/);
+		expect(thumbprint).toMatch(/^[A-Za-z0-9_-]+$/);
+	});
+
+	it("output length is 43 characters (SHA-256 base64url without padding)", () => {
+		// SHA-256 produces 32 bytes → 256 bits → ceil(256/6) = 43 base64url chars
+		// (no trailing = because 32 * 8 = 256 is divisible by 6 with 2 bits left,
+		// yielding 43 full base64url characters and 0 padding characters).
+		const thumbprint = computeCertThumbprint(TEST_CERT_DER);
+		expect(thumbprint.length).toBe(43);
+	});
+
+	it("is deterministic — same DER input always yields the same thumbprint", () => {
+		const first = computeCertThumbprint(TEST_CERT_DER);
+		const second = computeCertThumbprint(TEST_CERT_DER);
+		expect(first).toBe(second);
+	});
+
+	it("produces different thumbprints for different DER inputs", () => {
+		// A one-byte change in the DER produces a completely different hash.
+		const mutated = Uint8Array.from(TEST_CERT_DER);
+		mutated[0] ^= 0xff; // flip all bits in the first byte
+		const original = computeCertThumbprint(TEST_CERT_DER);
+		const modified = computeCertThumbprint(mutated);
+		expect(original).not.toBe(modified);
+	});
+});

--- a/packages/mtls/src/__tests__/thumbprint.test.mts
+++ b/packages/mtls/src/__tests__/thumbprint.test.mts
@@ -57,9 +57,11 @@ describe("computeCertThumbprint — RFC 8705 §3.1 DER SHA-256 thumbprint", () =
 	});
 
 	it("output length is 43 characters (SHA-256 base64url without padding)", () => {
-		// SHA-256 produces 32 bytes → 256 bits → ceil(256/6) = 43 base64url chars
-		// (no trailing = because 32 * 8 = 256 is divisible by 6 with 2 bits left,
-		// yielding 43 full base64url characters and 0 padding characters).
+		// SHA-256 produces 32 bytes = 256 bits. Base64 encodes in 6-bit groups,
+		// so 256 / 6 = 42 full chars + 4 leftover bits → 43 chars total (the
+		// 43rd char encodes those 4 bits with 2 zero-padding bits). Standard
+		// base64 would then pad to 44 chars with one trailing `=`; base64url
+		// without padding drops the `=`, yielding 43 chars.
 		const thumbprint = computeCertThumbprint(TEST_CERT_DER);
 		expect(thumbprint.length).toBe(43);
 	});

--- a/packages/mtls/src/__tests__/thumbprint.test.mts
+++ b/packages/mtls/src/__tests__/thumbprint.test.mts
@@ -38,7 +38,7 @@ HwYDVR0jBBgwFoAUQey1RDkeBYfD/xuliPfC0Qv0WEowDwYDVR0TAQH/BAUwAwEB
 hXs25+0CIQDITvqroFES8r+bSdPCJGaQMVxps8L823m1axWCE+eUvA==
 -----END CERTIFICATE-----`;
 
-const TEST_CERT_DER = new X509Certificate(TEST_CERT_PEM).raw as unknown as Uint8Array;
+const TEST_CERT_DER: Uint8Array = new X509Certificate(TEST_CERT_PEM).raw;
 const EXPECTED_THUMBPRINT = "ixxC3Iu02KfsoIX8SaMQS0-nHDkhl4CtXw-kKsC1Lws";
 
 describe("computeCertThumbprint — RFC 8705 §3.1 DER SHA-256 thumbprint", () => {

--- a/packages/mtls/src/certificate.mts
+++ b/packages/mtls/src/certificate.mts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { X509Certificate } from "node:crypto";
+
+/**
+ * Parsed leaf certificate with DER bytes, optional chain, and diagnostic
+ * metadata populated from `node:crypto`'s `X509Certificate`.
+ *
+ * The `der` field is the canonical source of truth for thumbprinting per
+ * RFC 8705 §3.1: `SHA-256(der)` → `cnf.x5t#S256`.
+ *
+ * The `parsed` sub-object is a diagnostic convenience — field names mirror
+ * the `X509Certificate` property names, serialized as ISO-8601 / RFC 5280
+ * GeneralizedTime strings for logging and audit emission.
+ *
+ * Per Wave 2 Phase 3 spec §5.3.
+ */
+export interface ClientCertificate {
+	/** DER-encoded leaf certificate bytes — the thumbprint input. */
+	readonly der: Uint8Array;
+	/**
+	 * DER-encoded intermediate certificates in presentation order (leaf's
+	 * issuer first, root-CA-signed last). Populated from the XFCC `Chain=`
+	 * parameter when source is `"header"` + dialect `"envoy"`.
+	 */
+	readonly chain?: readonly Uint8Array[];
+	/** Diagnostic fields populated by `X509Certificate` — NOT used for trust decisions. */
+	readonly parsed: {
+		readonly subject: string;
+		readonly issuer: string;
+		/** ISO-8601 string from `X509Certificate.validFrom` */
+		readonly notBefore: string;
+		/** ISO-8601 string from `X509Certificate.validTo` */
+		readonly notAfter: string;
+	};
+}
+
+/**
+ * Parse DER bytes into a `ClientCertificate`, optionally attaching intermediate
+ * chain DER entries.
+ *
+ * Uses `new X509Certificate(der)` from `node:crypto` (Node ≥ 15.6) per
+ * RFC 8705 §7.5's mandate to use an established X.509 library rather than
+ * a custom parser.
+ *
+ * Throws a plain `Error` on parse failure — the call site (extractor.mts
+ * step 3) wraps it into `MtlsError("cert_decode_failed", …)`.
+ *
+ * Per Wave 2 Phase 3 spec §5.3 + §6.3.
+ */
+export const parseDerToCertificate = (
+	der: Uint8Array,
+	chain?: readonly Uint8Array[],
+): ClientCertificate => {
+	// `new X509Certificate(der)` throws DOMException / Error on malformed DER —
+	// we let the error propagate unmodified so the call site can wrap it with
+	// the correct MtlsReasonCode context.
+	const x509 = new X509Certificate(der);
+
+	return {
+		der,
+		...(chain !== undefined ? { chain } : {}),
+		parsed: {
+			subject: x509.subject,
+			issuer: x509.issuer,
+			// `validFrom` / `validTo` are ISO 8601 date strings from Node's X509Certificate.
+			notBefore: x509.validFrom,
+			notAfter: x509.validTo,
+		},
+	};
+};

--- a/packages/mtls/src/certificate.mts
+++ b/packages/mtls/src/certificate.mts
@@ -70,9 +70,18 @@ export const parseDerToCertificate = (
 	// the correct MtlsReasonCode context.
 	const x509 = new X509Certificate(der);
 
+	// Defense-in-depth: copy DER bytes on construction so a downstream
+	// caller holding a reference to the input buffer cannot tamper with the
+	// thumbprint source after parse (Codex Round 1 Important #4). The
+	// `readonly` modifier on the type only protects the property *assignment*,
+	// not the underlying byte mutation. Realistic cert size is 1-3KB; one
+	// allocation per parse is a free defensive lock-down.
+	const derCopy = new Uint8Array(der);
+	const chainCopy = chain !== undefined ? chain.map((entry) => new Uint8Array(entry)) : undefined;
+
 	return {
-		der,
-		...(chain !== undefined ? { chain } : {}),
+		der: derCopy,
+		...(chainCopy !== undefined ? { chain: chainCopy } : {}),
 		parsed: {
 			subject: x509.subject,
 			issuer: x509.issuer,

--- a/packages/mtls/src/errors.mts
+++ b/packages/mtls/src/errors.mts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Granular internal reason code for an mTLS certificate validation failure.
+ *
+ * The wire-level error code is always `"invalid_certificate"` (see §3.4).
+ * This reason field is for internal audit emission only — it MUST NOT be
+ * forwarded to the client verbatim (the wire `error_description` may contain
+ * a safe, user-facing variant).
+ *
+ * Per Wave 2 Phase 3 spec §5.5 + §3.4.
+ */
+export type MtlsReasonCode =
+	| "malformed_header"
+	| "unknown_dialect"
+	| "cert_decode_failed"
+	| "cert_expired"
+	| "cert_not_yet_valid"
+	| "chain_validation_failed"
+	| "trusted_cas_unconfigured"
+	| "tls_peer_unavailable";
+
+/**
+ * Thrown by the mTLS cert extraction and validation pipeline for any
+ * certificate validation failure.
+ *
+ * Wire-level `code` is hard-coded to `"invalid_certificate"` — the single
+ * stable error code Phase 3 emits. The `reason` field carries a granular
+ * sub-classification for audit emission; it must never reach the wire
+ * verbatim (use a safe error description instead).
+ *
+ * Per Wave 2 Phase 3 spec §5.5 + design principle §3.4.
+ */
+export class MtlsError extends Error {
+	readonly code = "invalid_certificate" as const;
+	readonly reason: MtlsReasonCode;
+	readonly detail?: Record<string, unknown>;
+
+	constructor(reason: MtlsReasonCode, message: string, detail?: Record<string, unknown>) {
+		super(message);
+		this.name = "MtlsError";
+		this.reason = reason;
+		if (detail !== undefined) this.detail = detail;
+	}
+}
+
+/**
+ * The wire-level OAuth error code emitted by Phase 3 mTLS failures.
+ * Always `"invalid_certificate"` — the stable audit + wire surface exported
+ * per spec §5.1 so consumers can name the wire-side surface explicitly when
+ * constructing error envelopes without importing the class.
+ */
+export type MtlsErrorCode = MtlsError["code"];

--- a/packages/mtls/src/headers.mts
+++ b/packages/mtls/src/headers.mts
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Header dialect parsers for extracting client certificate PEM from reverse-
+ * proxy forwarded-cert headers.
+ *
+ * Two dialects ship in Phase 3 Stage 1 per spec §1.3:
+ *   - `"envoy"`: Envoy XFCC (x-forwarded-client-cert) header format.
+ *   - `"plain-pem"`: Raw PEM value, possibly URL-encoded.
+ *
+ * Both parsers are internal — NOT re-exported from index.mts. Consumers
+ * select a dialect via the `certHeaderDialect` config key; `createMtlsMechanism`
+ * dispatches to the correct parser at extraction time.
+ *
+ * Per Wave 2 Phase 3 spec §5.4 (CertHeaderDialect) + §6.2 (step 2 — dialect parse).
+ */
+
+/**
+ * The set of supported certificate header dialect identifiers.
+ *
+ * Exported from index.mts per spec §5.1 so operators can reference the type
+ * when building typed config objects. The union is closed at Stage 1 — a
+ * future nginx dialect adds a new arm via a semver-minor bump, not a
+ * catch-all `string`.
+ *
+ * Per Wave 2 Phase 3 spec §5.4.
+ */
+export type CertHeaderDialect = "envoy" | "plain-pem";
+
+/** Structured output from both dialect parsers. */
+interface ParsedCertHeader {
+	/** PEM-encoded leaf certificate (already URL-decoded if applicable). */
+	readonly certPem: string;
+	/** PEM-encoded intermediate chain (XFCC `Chain=` value). Absent in plain-PEM dialect. */
+	readonly chainPem?: string;
+}
+
+/**
+ * Detect whether a string contains URL-percent-encoded characters.
+ *
+ * Used internally to decide whether to URL-decode before further processing.
+ * A string that contains neither `%20` nor `%0A` (and no `%` at all) is
+ * treated as literal.
+ */
+const isUrlEncoded = (value: string): boolean => /%[0-9A-Fa-f]{2}/.test(value);
+
+/**
+ * Parse an Envoy XFCC (x-forwarded-client-cert) header value.
+ *
+ * XFCC grammar (simplified from Envoy docs):
+ *   XFCC = element *("," element)
+ *   element = field *(";" field)
+ *   field = token "=" value
+ *
+ * Phase 3 Stage 1 processes only the FIRST element (the client-facing hop).
+ * Required field: `Cert=<url-encoded-pem>`. Optional field: `Chain=<url-encoded-pem>`.
+ * `By=` and `Hash=` are parsed-past but not used — they are informational.
+ *
+ * Parse failure → throws a plain `Error`. The call site (extractor.mts step 2)
+ * wraps it into `MtlsError("malformed_header", "envoy XFCC parse failure: <detail>")`.
+ *
+ * Per Wave 2 Phase 3 spec §6.2.
+ */
+export const parseEnvoyXfccHeader = (value: string): ParsedCertHeader => {
+	// Use only the first XFCC element — Envoy prepends the client-facing hop at
+	// the front of the comma-separated list when chaining proxies.
+	const firstElement = value.split(",")[0]?.trim();
+	if (!firstElement) {
+		throw new Error("XFCC header is empty");
+	}
+
+	// Parse semicolon-delimited key=value fields.
+	// NOTE: PEM values themselves can contain "=", "+" etc., so we split on the
+	// FIRST "=" only within each semicolon-delimited field.
+	const fields = new Map<string, string>();
+	for (const field of firstElement.split(";")) {
+		const eqIdx = field.indexOf("=");
+		if (eqIdx === -1) {
+			// Field with no value (e.g. a standalone token) — skip silently.
+			continue;
+		}
+		const key = field.slice(0, eqIdx).trim();
+		const rawValue = field.slice(eqIdx + 1).trim();
+		if (key.length > 0) {
+			fields.set(key, rawValue);
+		}
+	}
+
+	const rawCert = fields.get("Cert");
+	if (!rawCert) {
+		throw new Error('XFCC header is missing required "Cert=" field');
+	}
+
+	// Cert= and Chain= values are URL-percent-encoded per the XFCC spec.
+	const certPem = decodeURIComponent(rawCert);
+
+	const rawChain = fields.get("Chain");
+	const chainPem = rawChain !== undefined ? decodeURIComponent(rawChain) : undefined;
+
+	return { certPem, ...(chainPem !== undefined ? { chainPem } : {}) };
+};
+
+/**
+ * Parse a plain-PEM certificate header.
+ *
+ * The header value is either a literal PEM block or a URL-percent-encoded
+ * PEM block. URL-encoded values are decoded automatically.
+ *
+ * **Multi-PEM concatenation is rejected** (spec OQ1 §14.1 strict decision):
+ * a header value containing multiple `-----BEGIN CERTIFICATE-----` blocks is
+ * malformed_header. Operators who need to convey a chain MUST use the `envoy`
+ * dialect with its `Chain=` field instead.
+ *
+ * Parse failure → throws a plain `Error`. The call site wraps it into
+ * `MtlsError("malformed_header", …)`.
+ *
+ * Per Wave 2 Phase 3 spec §6.2 + OQ1 §14.1.
+ */
+export const parsePlainPemHeader = (value: string): ParsedCertHeader => {
+	if (!value || value.trim().length === 0) {
+		throw new Error("plain-pem header value is empty");
+	}
+
+	// URL-decode if the value contains percent-encoded sequences.
+	// This handles the common case of an HTTP header that was URL-encoded
+	// by the reverse proxy (e.g. nginx `$ssl_client_escaped_cert`).
+	const decoded = isUrlEncoded(value) ? decodeURIComponent(value) : value;
+
+	// OQ1 strict: reject multi-PEM concatenations. A legitimate single cert
+	// has exactly one BEGIN marker; two or more indicates a chain was passed
+	// where only a leaf cert is expected. Reject rather than silently use the
+	// first cert (downgrade-prevention, per spec §3.3).
+	const beginCount = (decoded.match(/-----BEGIN CERTIFICATE-----/g) ?? []).length;
+	if (beginCount === 0) {
+		throw new Error("plain-pem header does not contain a PEM certificate block");
+	}
+	if (beginCount > 1) {
+		throw new Error(
+			"plain-pem header contains multiple PEM blocks; use the envoy dialect for chain transport",
+		);
+	}
+
+	return { certPem: decoded };
+};

--- a/packages/mtls/src/headers.mts
+++ b/packages/mtls/src/headers.mts
@@ -42,10 +42,13 @@
 export type CertHeaderDialect = "envoy" | "plain-pem";
 
 /**
- * Maximum permitted raw header value size in bytes (UTF-16 code units, which
- * for ASCII PEM bodies is 1:1 with bytes). Defense-in-depth against DoS via
- * oversize XFCC headers from a misbehaving or malicious upstream (Codex review
- * Round 1 Important #1, PR for Sub-PR 3a).
+ * Maximum permitted raw header value size in UTF-8 bytes. Defense-in-depth
+ * against DoS via oversize XFCC headers from a misbehaving or malicious
+ * upstream (Codex review Round 1 Important #1, PR for Sub-PR 3a).
+ *
+ * Measured against `Buffer.byteLength(value, "utf8")` rather than `value.length`
+ * (UTF-16 code units), so non-ASCII payloads cannot bypass the cap by
+ * representing more bytes per character than the JS string length suggests.
  *
  * Realistic XFCC values are well under 10KB for a single cert + chain (≈3KB
  * per typical RSA-2048 cert). 16KB caps the upper realistic envelope plus
@@ -139,9 +142,12 @@ const unquoteXfccField = (raw: string, fieldName: string): string => {
  */
 export const parseEnvoyXfccHeader = (value: string): ParsedCertHeader => {
 	// Defense-in-depth size cap before any string ops (Codex Round 1 Important #1).
-	if (value.length > MAX_RAW_HEADER_BYTES) {
+	// Measure UTF-8 bytes, not JS string length (UTF-16 code units), so multi-byte
+	// characters cannot bypass the cap (Copilot review Round 2 Important #1).
+	const rawByteLen = Buffer.byteLength(value, "utf8");
+	if (rawByteLen > MAX_RAW_HEADER_BYTES) {
 		throw new Error(
-			`XFCC header value exceeds size cap (${value.length} > ${MAX_RAW_HEADER_BYTES} bytes)`,
+			`XFCC header value exceeds size cap (${rawByteLen} > ${MAX_RAW_HEADER_BYTES} bytes)`,
 		);
 	}
 
@@ -178,9 +184,10 @@ export const parseEnvoyXfccHeader = (value: string): ParsedCertHeader => {
 	// Envoy 1.18+ may also wrap structural-character values in quoted-strings —
 	// unquoteXfccField handles `Cert="..."` and the standard `\"`/`\\` escapes.
 	const certPem = safeDecodeURIComponent(unquoteXfccField(rawCert, "Cert"), "Cert");
-	if (certPem.length > MAX_DECODED_PAYLOAD_BYTES) {
+	const certByteLen = Buffer.byteLength(certPem, "utf8");
+	if (certByteLen > MAX_DECODED_PAYLOAD_BYTES) {
 		throw new Error(
-			`XFCC Cert= decoded payload exceeds size cap (${certPem.length} > ${MAX_DECODED_PAYLOAD_BYTES} bytes)`,
+			`XFCC Cert= decoded payload exceeds size cap (${certByteLen} > ${MAX_DECODED_PAYLOAD_BYTES} bytes)`,
 		);
 	}
 
@@ -189,10 +196,13 @@ export const parseEnvoyXfccHeader = (value: string): ParsedCertHeader => {
 		rawChain !== undefined
 			? safeDecodeURIComponent(unquoteXfccField(rawChain, "Chain"), "Chain")
 			: undefined;
-	if (chainPem !== undefined && chainPem.length > MAX_DECODED_PAYLOAD_BYTES) {
-		throw new Error(
-			`XFCC Chain= decoded payload exceeds size cap (${chainPem.length} > ${MAX_DECODED_PAYLOAD_BYTES} bytes)`,
-		);
+	if (chainPem !== undefined) {
+		const chainByteLen = Buffer.byteLength(chainPem, "utf8");
+		if (chainByteLen > MAX_DECODED_PAYLOAD_BYTES) {
+			throw new Error(
+				`XFCC Chain= decoded payload exceeds size cap (${chainByteLen} > ${MAX_DECODED_PAYLOAD_BYTES} bytes)`,
+			);
+		}
 	}
 
 	return { certPem, ...(chainPem !== undefined ? { chainPem } : {}) };
@@ -215,15 +225,19 @@ export const parseEnvoyXfccHeader = (value: string): ParsedCertHeader => {
  * Per Wave 2 Phase 3 spec §6.2 + OQ1 §14.1.
  */
 export const parsePlainPemHeader = (value: string): ParsedCertHeader => {
-	if (!value || value.trim().length === 0) {
-		throw new Error("plain-pem header value is empty");
+	// Defense-in-depth size cap BEFORE any string-shaping work (trim/decode),
+	// so a malicious oversize header is rejected without doing the expensive
+	// work first (Copilot review Round 2 Minor #2 — parity with parseEnvoyXfccHeader).
+	// Measure UTF-8 bytes, not JS string length (Copilot Round 2 Important #1).
+	const rawByteLen = Buffer.byteLength(value, "utf8");
+	if (rawByteLen > MAX_RAW_HEADER_BYTES) {
+		throw new Error(
+			`plain-pem header value exceeds size cap (${rawByteLen} > ${MAX_RAW_HEADER_BYTES} bytes)`,
+		);
 	}
 
-	// Defense-in-depth size cap (Codex Round 1 Important #1).
-	if (value.length > MAX_RAW_HEADER_BYTES) {
-		throw new Error(
-			`plain-pem header value exceeds size cap (${value.length} > ${MAX_RAW_HEADER_BYTES} bytes)`,
-		);
+	if (!value || value.trim().length === 0) {
+		throw new Error("plain-pem header value is empty");
 	}
 
 	// URL-decode if the value contains percent-encoded sequences.
@@ -232,9 +246,10 @@ export const parsePlainPemHeader = (value: string): ParsedCertHeader => {
 	// safeDecodeURIComponent normalizes URIError → plain Error so the
 	// extractor wraps it consistently (Codex Round 1 Important #3).
 	const decoded = isUrlEncoded(value) ? safeDecodeURIComponent(value, "plain-pem value") : value;
-	if (decoded.length > MAX_DECODED_PAYLOAD_BYTES) {
+	const decodedByteLen = Buffer.byteLength(decoded, "utf8");
+	if (decodedByteLen > MAX_DECODED_PAYLOAD_BYTES) {
 		throw new Error(
-			`plain-pem decoded payload exceeds size cap (${decoded.length} > ${MAX_DECODED_PAYLOAD_BYTES} bytes)`,
+			`plain-pem decoded payload exceeds size cap (${decodedByteLen} > ${MAX_DECODED_PAYLOAD_BYTES} bytes)`,
 		);
 	}
 

--- a/packages/mtls/src/headers.mts
+++ b/packages/mtls/src/headers.mts
@@ -41,6 +41,28 @@
  */
 export type CertHeaderDialect = "envoy" | "plain-pem";
 
+/**
+ * Maximum permitted raw header value size in bytes (UTF-16 code units, which
+ * for ASCII PEM bodies is 1:1 with bytes). Defense-in-depth against DoS via
+ * oversize XFCC headers from a misbehaving or malicious upstream (Codex review
+ * Round 1 Important #1, PR for Sub-PR 3a).
+ *
+ * Realistic XFCC values are well under 10KB for a single cert + chain (≈3KB
+ * per typical RSA-2048 cert). 16KB caps the upper realistic envelope plus
+ * headroom for URL-percent-encoding bloat (≤3× expansion).
+ *
+ * A value exceeding this cap → `Error("header value exceeds size cap")`, which
+ * the extractor wraps as `MtlsError("malformed_header", …)`.
+ */
+const MAX_RAW_HEADER_BYTES = 16 * 1024;
+
+/**
+ * Maximum permitted decoded PEM payload size in bytes. URL-decode can expand
+ * up to ~3× from `%XX` sequences; the raw-cap above bounds the input, this
+ * cap bounds the working set after decode.
+ */
+const MAX_DECODED_PAYLOAD_BYTES = 64 * 1024;
+
 /** Structured output from both dialect parsers. */
 interface ParsedCertHeader {
 	/** PEM-encoded leaf certificate (already URL-decoded if applicable). */
@@ -57,6 +79,46 @@ interface ParsedCertHeader {
  * treated as literal.
  */
 const isUrlEncoded = (value: string): boolean => /%[0-9A-Fa-f]{2}/.test(value);
+
+/**
+ * URL-decode a percent-encoded value, normalizing `decodeURIComponent`'s
+ * native `URIError` into a plain `Error` so the dialect parsers never leak
+ * a `URIError` to the call site. The extractor (Sub-PR 3b) wraps all
+ * primitive errors as `MtlsError("malformed_header", …)` — without this
+ * wrapper, a `URIError` would surface as the wrong reason code (Codex
+ * review Round 1 Important #3).
+ */
+const safeDecodeURIComponent = (value: string, field: string): string => {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		throw new Error(`invalid percent-encoding in ${field}`);
+	}
+};
+
+/**
+ * Strip enclosing double-quotes from an XFCC field value per Envoy's
+ * documented format. Envoy 1.18+ emits quoted values for fields whose
+ * payload contains structural characters (`Cert="…"`, `Chain="…"`).
+ * Backslash-escapes within quotes are handled per RFC 7230 quoted-string
+ * grammar (the common cases are `\"` and `\\`).
+ *
+ * Non-quoted values are returned verbatim. Mismatched leading-only or
+ * trailing-only quote raises a parse error to surface the malformed
+ * dialect to operators rather than silently passing through (Codex review
+ * Round 1 Important #2 / Claude Minor #2 convergence).
+ */
+const unquoteXfccField = (raw: string, fieldName: string): string => {
+	if (raw.length === 0) return raw;
+	const leading = raw.startsWith('"');
+	const trailing = raw.endsWith('"');
+	if (!leading && !trailing) return raw;
+	if (leading !== trailing || raw.length < 2) {
+		throw new Error(`XFCC field "${fieldName}" has mismatched quoting`);
+	}
+	// Strip enclosing quotes + un-escape \" and \\ per quoted-string grammar.
+	return raw.slice(1, -1).replace(/\\(["\\])/g, "$1");
+};
 
 /**
  * Parse an Envoy XFCC (x-forwarded-client-cert) header value.
@@ -76,6 +138,13 @@ const isUrlEncoded = (value: string): boolean => /%[0-9A-Fa-f]{2}/.test(value);
  * Per Wave 2 Phase 3 spec §6.2.
  */
 export const parseEnvoyXfccHeader = (value: string): ParsedCertHeader => {
+	// Defense-in-depth size cap before any string ops (Codex Round 1 Important #1).
+	if (value.length > MAX_RAW_HEADER_BYTES) {
+		throw new Error(
+			`XFCC header value exceeds size cap (${value.length} > ${MAX_RAW_HEADER_BYTES} bytes)`,
+		);
+	}
+
 	// Use only the first XFCC element — Envoy prepends the client-facing hop at
 	// the front of the comma-separated list when chaining proxies.
 	const firstElement = value.split(",")[0]?.trim();
@@ -106,10 +175,25 @@ export const parseEnvoyXfccHeader = (value: string): ParsedCertHeader => {
 	}
 
 	// Cert= and Chain= values are URL-percent-encoded per the XFCC spec.
-	const certPem = decodeURIComponent(rawCert);
+	// Envoy 1.18+ may also wrap structural-character values in quoted-strings —
+	// unquoteXfccField handles `Cert="..."` and the standard `\"`/`\\` escapes.
+	const certPem = safeDecodeURIComponent(unquoteXfccField(rawCert, "Cert"), "Cert");
+	if (certPem.length > MAX_DECODED_PAYLOAD_BYTES) {
+		throw new Error(
+			`XFCC Cert= decoded payload exceeds size cap (${certPem.length} > ${MAX_DECODED_PAYLOAD_BYTES} bytes)`,
+		);
+	}
 
 	const rawChain = fields.get("Chain");
-	const chainPem = rawChain !== undefined ? decodeURIComponent(rawChain) : undefined;
+	const chainPem =
+		rawChain !== undefined
+			? safeDecodeURIComponent(unquoteXfccField(rawChain, "Chain"), "Chain")
+			: undefined;
+	if (chainPem !== undefined && chainPem.length > MAX_DECODED_PAYLOAD_BYTES) {
+		throw new Error(
+			`XFCC Chain= decoded payload exceeds size cap (${chainPem.length} > ${MAX_DECODED_PAYLOAD_BYTES} bytes)`,
+		);
+	}
 
 	return { certPem, ...(chainPem !== undefined ? { chainPem } : {}) };
 };
@@ -135,10 +219,24 @@ export const parsePlainPemHeader = (value: string): ParsedCertHeader => {
 		throw new Error("plain-pem header value is empty");
 	}
 
+	// Defense-in-depth size cap (Codex Round 1 Important #1).
+	if (value.length > MAX_RAW_HEADER_BYTES) {
+		throw new Error(
+			`plain-pem header value exceeds size cap (${value.length} > ${MAX_RAW_HEADER_BYTES} bytes)`,
+		);
+	}
+
 	// URL-decode if the value contains percent-encoded sequences.
 	// This handles the common case of an HTTP header that was URL-encoded
 	// by the reverse proxy (e.g. nginx `$ssl_client_escaped_cert`).
-	const decoded = isUrlEncoded(value) ? decodeURIComponent(value) : value;
+	// safeDecodeURIComponent normalizes URIError → plain Error so the
+	// extractor wraps it consistently (Codex Round 1 Important #3).
+	const decoded = isUrlEncoded(value) ? safeDecodeURIComponent(value, "plain-pem value") : value;
+	if (decoded.length > MAX_DECODED_PAYLOAD_BYTES) {
+		throw new Error(
+			`plain-pem decoded payload exceeds size cap (${decoded.length} > ${MAX_DECODED_PAYLOAD_BYTES} bytes)`,
+		);
+	}
 
 	// OQ1 strict: reject multi-PEM concatenations. A legitimate single cert
 	// has exactly one BEGIN marker; two or more indicates a chain was passed

--- a/packages/mtls/src/index.mts
+++ b/packages/mtls/src/index.mts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Public exports for `@o3co/auth-provider-mtls`.
+ *
+ * Sub-PR 3a exports: the stable primitive types and the cert thumbprint
+ * utility. `createMtlsMechanism`, `mtlsModule`, and `mtlsConfigSchema` are
+ * NOT exported here — they land in Sub-PR 3b (extractor + module wiring).
+ *
+ * Per Wave 2 Phase 3 spec §5.1.
+ */
+
+export type { ClientCertificate } from "./certificate.mjs";
+export { MtlsError, type MtlsErrorCode, type MtlsReasonCode } from "./errors.mjs";
+export type { CertHeaderDialect } from "./headers.mjs";
+export { computeCertThumbprint } from "./thumbprint.mjs";

--- a/packages/mtls/src/pem.mts
+++ b/packages/mtls/src/pem.mts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal PEM <-> DER codec helpers.
+ *
+ * These are NOT exported from the package index — consumers never need raw
+ * DER bytes directly. The wrapping `MtlsError("cert_decode_failed", …)` is
+ * applied by the call site (extractor.mts step 3) so this module stays
+ * exception-agnostic, throwing plain `Error` on malformed input.
+ *
+ * Per Wave 2 Phase 3 spec §4 (package layout) + §6.3 (step 3, PEM→DER decode).
+ */
+
+/**
+ * Decode a single PEM block to its DER bytes.
+ *
+ * Accepts standard PEM with `-----BEGIN CERTIFICATE-----` / `-----END
+ * CERTIFICATE-----` markers. The base64 body may contain newlines, spaces,
+ * or CRLF — all whitespace is stripped before decoding.
+ *
+ * Throws a plain `Error` on parse failure; the call site wraps it into
+ * `MtlsError("cert_decode_failed", …)`.
+ *
+ * NOTE: URL-encoded PEM (from XFCC `Cert=` values) must be URL-decoded
+ * BEFORE calling this function — the dialect parsers in headers.mts own that
+ * responsibility (per spec §6.2).
+ */
+export const pemToDer = (pem: string): Uint8Array => {
+	// Strip leading/trailing whitespace to be tolerant of copy-paste noise.
+	const trimmed = pem.trim();
+
+	// Locate the required BEGIN/END markers — RFC 7468 §2.
+	const beginMatch = /-----BEGIN ([A-Z0-9 ]+)-----/.exec(trimmed);
+	const endMatch = /-----END ([A-Z0-9 ]+)-----/.exec(trimmed);
+
+	if (!beginMatch || !endMatch) {
+		throw new Error("PEM block is missing BEGIN or END marker");
+	}
+
+	// Verify marker type consistency — a stray BEGIN PRIVATE KEY / END CERTIFICATE
+	// pair would silently corrupt the DER if we didn't check.
+	if (beginMatch[1] !== endMatch[1]) {
+		throw new Error(`PEM BEGIN/END type mismatch: BEGIN ${beginMatch[1]} vs END ${endMatch[1]}`);
+	}
+
+	// Extract the base64 body between markers, stripping all whitespace.
+	// We use the indexes from the regex rather than a multi-step split so
+	// embedded whitespace (including CRLF) doesn't silently produce an empty body.
+	const bodyStart = beginMatch.index + beginMatch[0].length;
+	const bodyEnd = endMatch.index;
+	const base64Body = trimmed.slice(bodyStart, bodyEnd).replace(/\s/g, "");
+
+	if (base64Body.length === 0) {
+		throw new Error("PEM block has empty base64 body");
+	}
+
+	// Validate that the body contains only valid base64 characters.
+	if (!/^[A-Za-z0-9+/]*={0,2}$/.test(base64Body)) {
+		throw new Error("PEM base64 body contains invalid characters");
+	}
+
+	return new Uint8Array(Buffer.from(base64Body, "base64"));
+};
+
+/**
+ * Encode DER bytes back to a PEM string with 64-character line wrapping.
+ *
+ * The `type` parameter (default `"CERTIFICATE"`) controls the marker label,
+ * matching the convention from RFC 7468 §13 for certificate PEM.
+ *
+ * Per Wave 2 Phase 3 spec §4 (pem.mts internal codec).
+ */
+export const derToPem = (der: Uint8Array, type = "CERTIFICATE"): string => {
+	const base64 = Buffer.from(der).toString("base64");
+
+	// RFC 7468 §2 mandates 64-character line length for interoperability.
+	const lines: string[] = [];
+	for (let i = 0; i < base64.length; i += 64) {
+		lines.push(base64.slice(i, i + 64));
+	}
+
+	return [`-----BEGIN ${type}-----`, ...lines, `-----END ${type}-----`].join("\n");
+};

--- a/packages/mtls/src/thumbprint.mts
+++ b/packages/mtls/src/thumbprint.mts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createHash } from "node:crypto";
+
+/**
+ * Compute the RFC 8705 §3.1 certificate thumbprint from the DER-encoded
+ * leaf certificate.
+ *
+ * The thumbprint is `base64url(SHA-256(der))` with trailing `=` pad
+ * characters stripped — the RFC 8705 §3.1 normative requirement is:
+ *   "The base64url-encoded value MUST omit all trailing pad '=' characters."
+ *
+ * This value is placed in `cnf.x5t#S256` on the issued access token and (for
+ * public clients) on the issued refresh token (RFC 8705 §4 SHOULD).
+ *
+ * Per Wave 2 Phase 3 spec §6.6 + RFC 8705 §3.1.
+ */
+export const computeCertThumbprint = (der: Uint8Array): string => {
+	// `digest()` returns a Buffer in Node — Buffer inherits from Uint8Array,
+	// and `toString("base64url")` performs the RFC 4648 §5 URL-safe encoding.
+	// Node's `"base64url"` already omits trailing `=` padding, but the explicit
+	// `.replace(/=+$/, "")` is a defensive guard against future Node changes
+	// that might re-introduce padding (per spec §6.6 comment).
+	return createHash("sha256").update(der).digest("base64url").replace(/=+$/, "");
+};

--- a/packages/mtls/tsconfig.json
+++ b/packages/mtls/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist/",
+		"paths": {
+			"#/*": ["./src/*"]
+		}
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
+}

--- a/packages/mtls/vitest.config.mts
+++ b/packages/mtls/vitest.config.mts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/__tests__/**/*.test.mts"],
+		passWithNoTests: true,
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "json", "json-summary"],
+			reportsDirectory: "./coverage",
+			include: ["src/**/*.mts"],
+			exclude: ["src/**/__tests__/**", "src/**/*.d.mts", "dist/**"],
+			all: true,
+		},
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,37 @@ importers:
         specifier: ^4.1.6
         version: 4.1.6(@types/node@25.7.0)(@vitest/coverage-v8@4.1.6)(msw@2.14.6(@types/node@25.7.0)(typescript@5.9.3))(vite@8.0.11(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.4))
 
+  packages/mtls:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
+    devDependencies:
+      '@o3co/auth-provider-core':
+        specifier: workspace:*
+        version: link:../core
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
+      '@types/supertest':
+        specifier: ^7.2.0
+        version: 7.2.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.6
+        version: 4.1.6(vitest@4.1.6)
+      express:
+        specifier: ^5.0.0
+        version: 5.2.1
+      supertest:
+        specifier: ^7.2.2
+        version: 7.2.2
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@25.7.0)(@vitest/coverage-v8@4.1.6)(msw@2.14.6(@types/node@25.7.0)(typescript@5.9.3))(vite@8.0.11(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.4))
+
   packages/oauth:
     dependencies:
       '@o3co/auth-provider-core':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,10 +185,6 @@ importers:
         version: 4.1.6(@types/node@25.7.0)(@vitest/coverage-v8@4.1.6)(msw@2.14.6(@types/node@25.7.0)(typescript@5.9.3))(vite@8.0.11(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.4))
 
   packages/mtls:
-    dependencies:
-      zod:
-        specifier: ^4.3.6
-        version: 4.4.3
     devDependencies:
       '@o3co/auth-provider-core':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Wave 2 Token-binding Cluster — Phase 3 Sub-PR 3a. Initial `@o3co/auth-provider-mtls` package: skeleton + RFC 8705 §3.1 thumbprint + dialect parsers + cert type + error class. Mechanical implementation from spec §13 T3a.1-T3a.9. `createMtlsMechanism` / `mtlsModule` / PKI chain validation land in Sub-PR 3b.

- `src/errors.mts` — `MtlsError` + 8-code `MtlsReasonCode` union, mirrors `DPoPError` pattern.
- `src/pem.mts` — internal PEM↔DER codec (NOT exported from index).
- `src/thumbprint.mts` — `computeCertThumbprint` per RFC 8705 §3.1 (base64url SHA-256 of DER, `=` padding stripped per the RFC's explicit normative requirement).
- `src/certificate.mts` — `ClientCertificate` type + `parseDerToCertificate` via `node:crypto.X509Certificate` (RFC 8705 §7.5 well-established library). DER bytes + chain entries defensively copied on construction (Codex review hardening).
- `src/headers.mts` — internal `parseEnvoyXfccHeader` + `parsePlainPemHeader`. 16KB raw / 64KB decoded size caps, Envoy 1.18+ quoted-string unwrap, `safeDecodeURIComponent` URIError normalization. Plain-PEM multi-cert rejected per spec OQ1.
- `src/index.mts` — public exports per spec §5.1.

Spec authority: `.claude/superpowers/specs/2026-05-18-wave-2-phase-3-mtls-spec.md` Draft 3 (RFC 8705 §3.1 + §4 + §7.5 conformance, including 2 Critical + 3 Important Codex spec-review-round-1 findings already incorporated).

## Review history

- Round 1 `/multi-agent-review`:
  - 🔵 Claude: Verdict **Yes** (ready), Critical 0 / Important 0 / Minor 3.
  - 🟠 Codex: Verdict **With-fixes**, Critical 0 / Important 5 / Minor 3.
  - Fix bundle `73a22de3`: 4 Important applied + 1 Important dismissed (Verified-empirical: DPoPError parity, audit-emitter is proper sanitization layer) + 1 Minor applied (Codex) + 1 Minor applied (Claude / convergence with Codex Important #2).

## Test plan

- [x] 32 → 39 mtls tests (+7 regression for size cap, quoted XFCC, mismatched quote, percent-encoding error normalization, defensive der/chain copy, post-parse buffer mutation invariance)
- [x] `pnpm --filter @o3co/auth-provider-mtls build` clean
- [x] `pnpm --filter @o3co/auth-provider-mtls test` 39/39 passing
- [x] `pnpm lint` clean (531 files checked)
- [x] `pnpm --filter @o3co/create-auth-provider test` 77/77 passing (versions.json + expectedPackages synced)

`createMtlsMechanism`, `mtlsModule`, `mtlsConfigSchema`, PKI chain validation, `reference.conf`, grant integration are all intentionally absent (Sub-PR 3b / 3c scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)