### PR TITLE
feat(oauth+mtls): mTLS RT binding + §9.2 mTLS matrix + compound-cnf reject (Phase 3 Sub-PR 3c)

### DIFF
--- a/packages/mtls/CHANGELOG.md
+++ b/packages/mtls/CHANGELOG.md
@@ -10,8 +10,11 @@ All notable changes to this package will be documented in this file.
   in `@o3co/auth-provider-oauth` grants (`authorization.mts` and
   `refreshToken.mts`) was widened from `bindingIsDpop && isPublicClient`
   to `(bindingIsDpop || bindingIsMtls) && isPublicClient`. Public clients
-  authenticating with mTLS now receive both an AT carrying
-  `cnf.x5t#S256` AND an RT carrying `cnf.x5t#S256` (RFC 8705 §4 SHOULD).
+  presenting an mTLS certificate for token binding now receive both an
+  AT carrying `cnf.x5t#S256` AND an RT carrying `cnf.x5t#S256` (RFC
+  8705 §4 SHOULD). Note: this is RFC 8705 §3-§4 sender-constrained
+  *token binding*, not the RFC 8705 §2 mTLS *client authentication*
+  flow (which remains out of scope).
 - **mTLS refresh-time matrix (§9.2 mTLS rows)** added in
   `refreshToken.mts`, parallel to the existing DPoP matrix. Five rows
   enforce that an RT promising mTLS binding is only honored when the

--- a/packages/mtls/CHANGELOG.md
+++ b/packages/mtls/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added (Phase 3 Sub-PR 3c — 2026-05-20)
+
+- **mTLS refresh-token binding is now enforced end-to-end.** The gate
+  in `@o3co/auth-provider-oauth` grants (`authorization.mts` and
+  `refreshToken.mts`) was widened from `bindingIsDpop && isPublicClient`
+  to `(bindingIsDpop || bindingIsMtls) && isPublicClient`. Public clients
+  authenticating with mTLS now receive both an AT carrying
+  `cnf.x5t#S256` AND an RT carrying `cnf.x5t#S256` (RFC 8705 §4 SHOULD).
+- **mTLS refresh-time matrix (§9.2 mTLS rows)** added in
+  `refreshToken.mts`, parallel to the existing DPoP matrix. Five rows
+  enforce that an RT promising mTLS binding is only honored when the
+  presented client certificate's `x5t#S256` matches the persisted
+  binding. Row 3 (cert absent) and row 4 (thumbprint mismatch) reject
+  with `invalid_grant` and distinct error descriptions so SIEMs can
+  distinguish "RT replayed without cert" from "mid-rotation /
+  multi-cert attack". Confidential clients continue to issue plain
+  RTs (mirroring the DPoP public-client gate per RFC 9449 §5 reasoning,
+  generalized to mTLS).
+- **Compound-cnf rejection** — an RT carrying BOTH `cnf.jkt` AND
+  `cnf.x5t#S256` is rejected with `invalid_grant` BEFORE either matrix
+  runs. Stage 1 only supports single-mechanism bindings; a compound
+  cnf could only arise from a bug or attacker-crafted RT. The reject
+  closes the ambiguity structurally (Codex Critical #2 from the
+  Phase 3 §11.4 review chain).
+- **Mechanism-boundary regression**: a non-mTLS-emitting mechanism that
+  hypothetically presents an `{ "x5t#S256": "..." }` confirmation
+  cannot satisfy an mTLS-bound RT — the `proofX5t` extraction gates on
+  `kind === "mtls"`. Symmetric to the PR #185 DPoP boundary rule.
+- The Phase 2 deferral pin tests in
+  `dpop.authorizationCode.integration.test.mts` and
+  `dpop.refreshToken.integration.test.mts` are inverted: mTLS public
+  clients are now asserted to receive bound RTs (was: asserted RT
+  plain). The RT-binding emission and the refresh-time matrix land
+  atomically — there is no release window where a bound RT could be
+  refreshed without a cert.
+
 ### Changed (Cross-mechanism dispatch refactor — 2026-05-19)
 
 - **Contribution shape migrated** from `grantMiddleware` to the new

--- a/packages/oauth/src/__tests__/dpop.authorizationCode.integration.test.mts
+++ b/packages/oauth/src/__tests__/dpop.authorizationCode.integration.test.mts
@@ -221,15 +221,20 @@ describe("DPoP cnf-claim propagation — authorization_code grant (§9.1)", () =
 			expect(result.tokens.token_type).toBe("DPoP");
 		});
 
-		it("token_type Bearer when kind === 'mtls' (mTLS binding shape); RT stays plain (Phase 3 mTLS RT-binding deferred)", async () => {
-			// mTLS keeps Bearer per RFC 8705 §3. AT cnf carries x5t#S256
-			// (RFC 7800 is mechanism-neutral). RT MUST remain plain in
-			// Phase 2 even for public clients — issuing an mTLS-bound RT
-			// without a corresponding refresh-time mTLS enforcement matrix
-			// would silently degrade to an unbound RT on next refresh.
-			// Phase 3 will add mTLS-aware refresh-time enforcement together
-			// with mTLS RT binding (Codex Important #1 + Claude #1
-			// convergence at PR #185).
+		it("public client + mTLS binding → RT bound with x5t#S256 (RFC 8705 §4 SHOULD)", async () => {
+			// Phase 3 inversion of the Phase 2 deferral: mTLS-bound RT now
+			// rides RFC 8705 §4 ("the authorization server SHOULD bind the
+			// refresh token to the certificate the client used"). mTLS still
+			// keeps wire-level token_type "Bearer" per RFC 8705 §3 — only
+			// DPoP signals "DPoP" in the response wrapper. AT cnf propagation
+			// remains mechanism-agnostic (RFC 7800).
+			//
+			// The previous "RT stays plain" assertion was pinned at PR #185
+			// because there was no refresh-time mTLS enforcement matrix in
+			// Phase 2. Phase 3 Sub-PR 3c adds that matrix (§9.2 mTLS rows)
+			// together with this RT-binding emission, so the pair lands
+			// atomically — no window where a bound RT could be refreshed
+			// without proof.
 			const deps = makeDeps(vi.fn().mockResolvedValue({ ...validPublicCode }));
 			const handler = createAuthorizationGrant(deps);
 
@@ -245,6 +250,7 @@ describe("DPoP cnf-claim propagation — authorization_code grant (§9.1)", () =
 
 			expect(result.status).toBe(200);
 			if (!("tokens" in result)) expect.fail("Expected tokens in result");
+			// mTLS keeps wire-level "Bearer" per RFC 8705 §3.
 			expect(result.tokens.token_type).toBe("Bearer");
 
 			// AT gets the mTLS cnf shape (mechanism-agnostic propagation)
@@ -253,9 +259,44 @@ describe("DPoP cnf-claim propagation — authorization_code grant (§9.1)", () =
 			expect(atCnf?.["x5t#S256"]).toBe("MTLS-THUMBPRINT-AC");
 			expect(atCnf?.jkt).toBeUndefined();
 
-			// Public client + mTLS → RT MUST be plain (Phase 2 contract).
-			// Pins the deferral so Phase 3 mTLS RT-binding lands as a
-			// deliberate additive change, not a side-effect.
+			// Public client + mTLS → RT MUST carry cnf.x5t#S256 (RFC 8705 §4).
+			const rtPayload = decodePayload(result.tokens.refresh_token as string);
+			const rtCnf = rtPayload.cnf as Record<string, string> | undefined;
+			expect(rtCnf?.["x5t#S256"]).toBe("MTLS-THUMBPRINT-AC");
+			expect(rtCnf?.jkt).toBeUndefined();
+		});
+
+		it("confidential client + mTLS binding → RT stays plain (gate restricts to public clients)", async () => {
+			// Phase 3: mTLS RT-binding mirrors DPoP's public-client gate
+			// (RFC 9449 §5 rationale generalized — confidential clients
+			// authenticate via client_secret at refresh time, so binding the
+			// RT to the cert adds no security and would force cert retention
+			// across the RT lifetime). The §9.1 comment in authorization.mts
+			// is the single source of truth on this.
+			const deps = makeDeps(vi.fn().mockResolvedValue({ ...validCode }));
+			const handler = createAuthorizationGrant(deps);
+
+			const ctx: GrantContext = {
+				...baseCtxConfidential,
+				tokenBinding: {
+					kind: "mtls",
+					confirmation: { "x5t#S256": "MTLS-THUMBPRINT-CONF" },
+				},
+			};
+
+			const { result } = await handler.handle(ctx);
+
+			expect(result.status).toBe(200);
+			if (!("tokens" in result)) expect.fail("Expected tokens in result");
+			expect(result.tokens.token_type).toBe("Bearer");
+
+			// AT cnf still propagates (mechanism-agnostic).
+			const atPayload = decodePayload(result.tokens.access_token as string);
+			expect((atPayload.cnf as { "x5t#S256"?: string } | undefined)?.["x5t#S256"]).toBe(
+				"MTLS-THUMBPRINT-CONF",
+			);
+
+			// Confidential client: RT MUST stay plain regardless of mechanism.
 			const rtPayload = decodePayload(result.tokens.refresh_token as string);
 			expect(rtPayload.cnf).toBeUndefined();
 		});

--- a/packages/oauth/src/__tests__/dpop.refreshToken.integration.test.mts
+++ b/packages/oauth/src/__tests__/dpop.refreshToken.integration.test.mts
@@ -334,13 +334,15 @@ describe("DPoP refresh-token mechanism boundary", () => {
 		expect(result.errorDescription).toContain("requires a DPoP proof");
 	});
 
-	it("mTLS public-client refresh leaves new RT plain (Phase 3 mTLS RT-binding deferred — Codex Important #1)", async () => {
-		// An mTLS binding on a public client refresh path MUST NOT issue an
-		// mTLS-bound RT in Phase 2 — there is no refresh-time mTLS
-		// enforcement matrix yet, so a bound RT could later be refreshed
-		// without proof and silently degrade to plain. Pins the Phase 2
-		// contract; Phase 3 will invert this assertion when mTLS RT-binding
-		// + refresh-time enforcement land together.
+	it("mTLS public-client row 2 (RT plain + cert) → opt-in upgrade, new RT bound with x5t#S256 (RFC 8705 §4)", async () => {
+		// Phase 3 inversion. The Phase 2 deferral has been removed: the mTLS
+		// refresh-time matrix (§9.2 mTLS rows) lands together with the §9.1
+		// RT-emission gate, so a public-client mTLS refresh now MUST emit a
+		// bound RT to enforce cross-refresh continuity (parallel to DPoP
+		// row 2 public-variant).
+		//
+		// Confidential clients still get RT-plain (public-client gate
+		// covers both mechanisms per the §9.1 comment).
 		const rt = await mintRefreshToken({ clientId: PUBLIC_CLIENT_ID });
 		const handler = createRefreshTokenGrant(mockDeps);
 		const ctx = buildCtx({
@@ -356,16 +358,18 @@ describe("DPoP refresh-token mechanism boundary", () => {
 
 		expect(result.status).toBe(200);
 		if (!("tokens" in result)) expect.fail("Expected tokens in result");
-		// mTLS keeps Bearer per RFC 8705 §3
+		// mTLS keeps Bearer per RFC 8705 §3.
 		expect(result.tokens.token_type).toBe("Bearer");
-		// AT gets mTLS cnf (mechanism-agnostic propagation per RFC 7800)
+		// AT gets mTLS cnf (mechanism-agnostic propagation per RFC 7800).
 		const atPayload = decodeJwt(result.tokens.access_token);
 		expect((atPayload.cnf as { "x5t#S256"?: string } | undefined)?.["x5t#S256"]).toBe(
 			"MTLS-RT-THUMB",
 		);
-		// New RT MUST be plain in Phase 2 (the deferred contract).
+		// Public client + mTLS → new RT MUST carry cnf.x5t#S256 (RFC 8705 §4).
 		expect(result.tokens.refresh_token).toBeTruthy();
 		const newRtPayload = decodeJwt(result.tokens.refresh_token as string);
-		expect(newRtPayload.cnf).toBeUndefined();
+		expect((newRtPayload.cnf as { "x5t#S256"?: string } | undefined)?.["x5t#S256"]).toBe(
+			"MTLS-RT-THUMB",
+		);
 	});
 });

--- a/packages/oauth/src/__tests__/mtls.authorizationCode.integration.test.mts
+++ b/packages/oauth/src/__tests__/mtls.authorizationCode.integration.test.mts
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Coverage for mTLS cnf-claim propagation in the authorization_code grant —
+ * Wave 2 Phase 3 §9.1 (mTLS-specific). Parallel to
+ * `dpop.authorizationCode.integration.test.mts` which now also includes
+ * inverted mTLS regression cases — this file covers the mTLS-only path.
+ *
+ * Pattern: direct grant handler invocation (mirrors authorization.test.mts).
+ *
+ * Key behavioral contracts:
+ *   - AT carries `cnf.x5t#S256` whenever ctx.tokenBinding.kind === "mtls"
+ *   - RT carries cnf only for public clients (RFC 8705 §4 SHOULD)
+ *   - Confidential client RTs stay plain (RFC 8705 §4 + the
+ *     `bindRefreshToken` public-client gate in `authorization.mts`)
+ *   - token_type stays "Bearer" regardless of mTLS binding (RFC 8705 §3)
+ */
+
+import {
+	type ClientRepository,
+	type CodeRepository,
+	createSymmetricKeyStore,
+	type GrantContext,
+	type GrantDependencies,
+} from "@o3co/auth-provider-core";
+import { decodeJwt } from "jose";
+import { describe, expect, it, vi } from "vitest";
+import { createAuthorizationGrant } from "#/grants/authorization.mjs";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const RP_URI = "https://rp.example/cb";
+const CLIENT_ID = "mtls-ac-client";
+const PUBLIC_CLIENT_ID = "mtls-ac-public-client";
+
+const validCode = {
+	client_id: CLIENT_ID,
+	redirect_uri: RP_URI,
+};
+
+const validPublicCode = {
+	client_id: PUBLIC_CLIENT_ID,
+	redirect_uri: RP_URI,
+};
+
+const confidentialClient = {
+	clientId: CLIENT_ID,
+	tokenEndpointAuthMethod: "client_secret_basic" as const,
+};
+
+const publicClient = {
+	clientId: PUBLIC_CLIENT_ID,
+	tokenEndpointAuthMethod: "none" as const,
+};
+
+const mockConfig = {
+	oauth: {
+		jwt: { secret: "test-secret-mtls-ac" },
+		accessToken: { expiresIn: 3600 },
+		refreshToken: { expiresIn: 86400 },
+		grants: {
+			authorization_code: { enabled: true },
+		},
+	},
+} as unknown as GrantDependencies["config"];
+
+const mockClientRepository: ClientRepository = {
+	findById: vi.fn().mockResolvedValue(null),
+	authenticate: vi.fn().mockResolvedValue(null),
+};
+
+function makeDeps(consumeByCodeImpl: CodeRepository["consumeByCode"]) {
+	return {
+		config: mockConfig,
+		keyStore: createSymmetricKeyStore("test-secret-mtls-ac"),
+		codeRepository: {
+			consumeByCode: consumeByCodeImpl,
+			createCode: vi.fn(),
+			findByCode: vi.fn(),
+			removeByCode: vi.fn(),
+		} as unknown as CodeRepository,
+		clientRepository: mockClientRepository,
+	};
+}
+
+function decodePayload(token: string): Record<string, unknown> {
+	return decodeJwt(token) as unknown as Record<string, unknown>;
+}
+
+const baseCtxConfidential: Omit<GrantContext, "tokenBinding"> = {
+	body: { code: "valid-code", redirect_uri: RP_URI },
+	session: {},
+	issuer: "localhost",
+	metadata: { ip: "127.0.0.1" },
+	authenticatedClient: confidentialClient,
+};
+
+const baseCtxPublic: Omit<GrantContext, "tokenBinding"> = {
+	body: { code: "valid-code-public", redirect_uri: RP_URI },
+	session: {},
+	issuer: "localhost",
+	metadata: { ip: "127.0.0.1" },
+	authenticatedClient: publicClient,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("mTLS cnf-claim propagation — authorization_code grant (§9.1)", () => {
+	describe("AT cnf propagation (mechanism-agnostic per RFC 7800)", () => {
+		it("confidential client + mTLS → AT bound with x5t#S256, RT plain", async () => {
+			const deps = makeDeps(vi.fn().mockResolvedValue({ ...validCode }));
+			const handler = createAuthorizationGrant(deps);
+
+			const ctx: GrantContext = {
+				...baseCtxConfidential,
+				tokenBinding: {
+					kind: "mtls",
+					confirmation: { "x5t#S256": "MTLS-AC-CONF-THUMB" },
+				},
+			};
+
+			const { result } = await handler.handle(ctx);
+
+			expect(result.status).toBe(200);
+			if (!("tokens" in result)) expect.fail("Expected tokens in result");
+			expect(result.tokens.token_type).toBe("Bearer");
+			const atCnf = decodePayload(result.tokens.access_token as string).cnf as
+				| Record<string, string>
+				| undefined;
+			expect(atCnf?.["x5t#S256"]).toBe("MTLS-AC-CONF-THUMB");
+			expect(atCnf?.jkt).toBeUndefined();
+			// Confidential client: RT MUST stay plain regardless of mechanism.
+			const rtPayload = decodePayload(result.tokens.refresh_token as string);
+			expect(rtPayload.cnf).toBeUndefined();
+		});
+
+		it("public client + mTLS → AT bound, RT bound with same thumbprint (RFC 8705 §4 SHOULD)", async () => {
+			const deps = makeDeps(vi.fn().mockResolvedValue({ ...validPublicCode }));
+			const handler = createAuthorizationGrant(deps);
+
+			const ctx: GrantContext = {
+				...baseCtxPublic,
+				tokenBinding: {
+					kind: "mtls",
+					confirmation: { "x5t#S256": "MTLS-AC-PUB-THUMB" },
+				},
+			};
+
+			const { result } = await handler.handle(ctx);
+
+			expect(result.status).toBe(200);
+			if (!("tokens" in result)) expect.fail("Expected tokens in result");
+			expect(result.tokens.token_type).toBe("Bearer");
+			const atCnf = decodePayload(result.tokens.access_token as string).cnf as
+				| Record<string, string>
+				| undefined;
+			expect(atCnf?.["x5t#S256"]).toBe("MTLS-AC-PUB-THUMB");
+			// Public client + mTLS → RT MUST carry cnf.x5t#S256 (RFC 8705 §4).
+			const rtCnf = decodePayload(result.tokens.refresh_token as string).cnf as
+				| Record<string, string>
+				| undefined;
+			expect(rtCnf?.["x5t#S256"]).toBe("MTLS-AC-PUB-THUMB");
+			expect(rtCnf?.jkt).toBeUndefined();
+		});
+	});
+
+	describe("no binding (Bearer baseline)", () => {
+		it("unbound AT + unbound RT when ctx.tokenBinding is undefined", async () => {
+			const deps = makeDeps(vi.fn().mockResolvedValue({ ...validPublicCode }));
+			const handler = createAuthorizationGrant(deps);
+
+			const ctx: GrantContext = { ...baseCtxPublic };
+
+			const { result } = await handler.handle(ctx);
+
+			expect(result.status).toBe(200);
+			if (!("tokens" in result)) expect.fail("Expected tokens in result");
+			expect(result.tokens.token_type).toBe("Bearer");
+			expect(decodePayload(result.tokens.access_token as string).cnf).toBeUndefined();
+			expect(decodePayload(result.tokens.refresh_token as string).cnf).toBeUndefined();
+		});
+	});
+});

--- a/packages/oauth/src/__tests__/mtls.clientCredentials.integration.test.mts
+++ b/packages/oauth/src/__tests__/mtls.clientCredentials.integration.test.mts
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Coverage for mTLS cnf-claim propagation in the client_credentials grant —
+ * Wave 2 Phase 3 §9.1 (mTLS-specific, parallel to `dpop.clientCredentials`).
+ *
+ * Uses a fake `TokenBindingMechanism` whose `extract` returns a fixed mTLS
+ * binding so the test is decoupled from the real mTLS extractor + PKI chain
+ * validation (those are exercised independently in `@o3co/auth-provider-mtls`).
+ * Full HTTP path exercises tokenBindingMw → ctx.tokenBinding → grant →
+ * token-issuance.
+ *
+ * Key behavioral contracts:
+ *   - AT carries `cnf.x5t#S256` when an mTLS mechanism extracted a cert
+ *   - token_type stays "Bearer" — mTLS never sets "DPoP" (RFC 8705 §3)
+ *   - client_credentials never issues a refresh_token regardless of binding
+ *     (RFC 6749 §4.4.3) — pins that the mTLS RT-binding work in §9.2 does
+ *     NOT regress this grant-level prohibition.
+ */
+
+import {
+	type AppConfig,
+	type CodeRepository,
+	createSymmetricKeyStore,
+	InMemoryClientRepository,
+	type TokenBinding,
+	type TokenBindingMechanism,
+	tokenBindingMw,
+} from "@o3co/auth-provider-core";
+import { GrantRegistry } from "@o3co/auth-provider-core/testing";
+import express from "express";
+import { decodeJwt } from "jose";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { createClientCredentialsGrant } from "#/grants/clientCredentials.mjs";
+import { createOAuthRouter } from "#/routes.mjs";
+
+// ---------------------------------------------------------------------------
+// Shared test fixtures
+// ---------------------------------------------------------------------------
+
+const SECRET = "test-secret-at-least-32-chars!!";
+const ISSUER = "https://auth.example";
+const TEST_CLIENT_ID = "mtls-cc-client";
+const TEST_CLIENT_SECRET = "mtls-cc-secret";
+const TEST_BASIC_AUTH = `Basic ${Buffer.from(`${TEST_CLIENT_ID}:${TEST_CLIENT_SECRET}`).toString("base64")}`;
+
+const fullConfig = {
+	oauth: {
+		jwt: { issuer: ISSUER },
+		accessToken: { expiresIn: 3600 },
+	},
+	rateLimit: { failMode: "open" as const },
+	endpoints: { login: { url: "/login" } },
+} as unknown as AppConfig;
+
+const codeRepoStub: CodeRepository = {
+	createCode: async () => ({ code: "code-x", client_id: TEST_CLIENT_ID, redirect_uri: "" }),
+	findByCode: async () => null,
+	consumeByCode: async () => null,
+	removeByCode: async () => {},
+};
+
+const clientRepo = new InMemoryClientRepository(
+	new Map([
+		[
+			TEST_CLIENT_ID,
+			{
+				clientSecret: TEST_CLIENT_SECRET,
+				tokenEndpointAuthMethod: "client_secret_basic" as const,
+				allowedRedirectUris: [],
+				allowedScopes: ["read"],
+				allowedAudiences: ["https://api.example"],
+				allowedGrantTypes: ["client_credentials"],
+			},
+		],
+	]),
+);
+
+// ---------------------------------------------------------------------------
+// App builder
+// ---------------------------------------------------------------------------
+
+async function buildApp(
+	mechanisms: readonly TokenBindingMechanism[] = [],
+): Promise<express.Express> {
+	const app = express();
+	app.set("trust proxy", 1);
+	app.use(express.json());
+	app.use(express.urlencoded({ extended: false }));
+	const keyStore = createSymmetricKeyStore(SECRET);
+
+	if (mechanisms.length > 0) {
+		app.use(
+			tokenBindingMw({
+				mechanisms,
+				dispatchPolicy: "intent-explicit",
+			}),
+		);
+	}
+
+	const registry = new GrantRegistry();
+	registry.register(
+		"client_credentials",
+		createClientCredentialsGrant({ config: fullConfig, keyStore }),
+	);
+	const { router } = await createOAuthRouter(express, {
+		registry,
+		config: fullConfig,
+		clientRepository: clientRepo,
+		codeRepository: codeRepoStub,
+		keyStore,
+	});
+	app.use("/oauth", router);
+	return app;
+}
+
+// ---------------------------------------------------------------------------
+// Fake mTLS mechanism — returns a fixed thumbprint binding
+// ---------------------------------------------------------------------------
+
+function makeMtlsMechanism(thumbprint: string): TokenBindingMechanism {
+	const binding: TokenBinding = {
+		kind: "mtls",
+		confirmation: { "x5t#S256": thumbprint },
+	};
+	return {
+		kind: "mtls",
+		// mTLS is ambient (RFC 8705) — not explicit-intent like DPoP.
+		intentExplicit: false,
+		extract: async () => binding,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("mTLS cnf-claim propagation — client_credentials grant (§9.1)", () => {
+	describe("AT cnf propagation", () => {
+		it("issues mTLS-bound AT with cnf.x5t#S256 when a cert is presented", async () => {
+			const app = await buildApp([makeMtlsMechanism("MTLS-CC-THUMB")]);
+
+			const res = await request(app)
+				.post("/oauth/token")
+				.set("Authorization", TEST_BASIC_AUTH)
+				.type("form")
+				.send({ grant_type: "client_credentials" });
+
+			expect(res.status).toBe(200);
+			// mTLS keeps wire-level Bearer per RFC 8705 §3.
+			expect(res.body.token_type).toBe("Bearer");
+			const payload = decodeJwt(res.body.access_token as string);
+			// RFC 8705 §3.1 + RFC 7800 §3.5: cnf.x5t#S256 IS the binding.
+			const cnf = payload.cnf as Record<string, string> | undefined;
+			expect(cnf?.["x5t#S256"]).toBe("MTLS-CC-THUMB");
+			// jkt MUST NOT appear in an mTLS-bound token.
+			expect(cnf?.jkt).toBeUndefined();
+		});
+
+		it("issues plain Bearer AT when no mTLS mechanism is mounted", async () => {
+			const app = await buildApp(/* no mechanisms */);
+
+			const res = await request(app)
+				.post("/oauth/token")
+				.set("Authorization", TEST_BASIC_AUTH)
+				.type("form")
+				.send({ grant_type: "client_credentials" });
+
+			expect(res.status).toBe(200);
+			expect(res.body.token_type).toBe("Bearer");
+			const payload = decodeJwt(res.body.access_token as string);
+			expect(payload.cnf).toBeUndefined();
+		});
+	});
+
+	describe("refresh_token absence (RFC 6749 §4.4.3 — pins grant-level prohibition)", () => {
+		it("refresh_token is NOT issued for client_credentials even with mTLS binding", async () => {
+			// The Phase 3 RT-binding gate (`bindRefreshToken` in
+			// `authorization.mts`) is irrelevant here: client_credentials
+			// itself never emits a refresh_token. This test is the explicit
+			// regression guard that the mTLS RT-binding work in §9.2 does
+			// NOT accidentally turn on RTs for grants that should never have
+			// them.
+			const app = await buildApp([makeMtlsMechanism("NO-RT-MTLS-THUMB")]);
+
+			const res = await request(app)
+				.post("/oauth/token")
+				.set("Authorization", TEST_BASIC_AUTH)
+				.type("form")
+				.send({ grant_type: "client_credentials" });
+
+			expect(res.status).toBe(200);
+			expect(res.body.refresh_token).toBeUndefined();
+		});
+	});
+});

--- a/packages/oauth/src/__tests__/mtls.refreshToken.integration.test.mts
+++ b/packages/oauth/src/__tests__/mtls.refreshToken.integration.test.mts
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Coverage for the mTLS refresh-token binding matrix — Wave 2 Phase 3 §9.2.
+ *
+ * Parallel structure to `dpop.refreshToken.integration.test.mts` — the
+ * 5-row matrix (mirroring RFC 8705 §4 with a refresh-time enforcement model
+ * identical to RFC 9449 §5's DPoP rotation rule) governs how the
+ * refresh_token grant correlates the RT's persisted `cnf.x5t#S256` claim
+ * with the request-time client certificate presented via `ctx.tokenBinding`:
+ *
+ *   RT cnf.x5t#S256 | client cert     | Outcome
+ *   no              | no              | row 1: issue plain Bearer (legacy)
+ *   no              | yes             | row 2: opt-in upgrade — bind new AT (RT bound only for public)
+ *   yes             | no              | row 3: reject invalid_grant "requires a client certificate"
+ *   yes             | yes, differs    | row 4: reject invalid_grant "does not match refresh_token binding"
+ *   yes             | yes, equal      | row 5: rotation preserves binding (AT + RT for public)
+ *
+ * Plus:
+ *   - Compound-cnf rejection (Codex Critical #2): RT carrying BOTH `jkt`
+ *     and `x5t#S256` is rejected BEFORE either matrix runs.
+ *   - Mechanism-boundary regression: a non-mTLS mechanism emitting an
+ *     `{ "x5t#S256": "..." }` confirmation cannot satisfy an mTLS-bound
+ *     RT (parallel to PR #185 / Codex Important #2 for DPoP).
+ */
+
+import { createSecretKey } from "node:crypto";
+import {
+	createSymmetricKeyStore,
+	type GrantContext,
+	type GrantDependencies,
+	type TokenBinding,
+} from "@o3co/auth-provider-core";
+import { decodeJwt, SignJWT } from "jose";
+import { describe, expect, it } from "vitest";
+import { createRefreshTokenGrant } from "#/grants/refreshToken.mjs";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const SECRET = "test-secret-at-least-32-chars!!";
+const keyStore = createSymmetricKeyStore(SECRET);
+const secretKey = createSecretKey(Buffer.from(SECRET));
+
+const CONFIDENTIAL_CLIENT_ID = "mtls-rt-confidential-client";
+const PUBLIC_CLIENT_ID = "mtls-rt-public-client";
+
+const mockConfig = {
+	oauth: {
+		jwt: { secret: SECRET },
+		accessToken: { expiresIn: 3600 },
+		refreshToken: {
+			expiresIn: 86400,
+			unknownFamilyPolicy: "reject",
+			legacyRtPolicy: "reject",
+		},
+		grants: {
+			refresh_token: { enabled: true },
+		},
+	},
+} as unknown as GrantDependencies["config"];
+
+const mockDeps: GrantDependencies = {
+	config: mockConfig,
+	keyStore,
+};
+
+const confidentialAuthClient = {
+	clientId: CONFIDENTIAL_CLIENT_ID,
+	tokenEndpointAuthMethod: "client_secret_basic" as const,
+};
+
+const publicAuthClient = {
+	clientId: PUBLIC_CLIENT_ID,
+	tokenEndpointAuthMethod: "none" as const,
+};
+
+// ---------------------------------------------------------------------------
+// RT minter — produces signed JWTs with optional cnf claim shapes
+// ---------------------------------------------------------------------------
+
+interface MintRtOptions {
+	readonly clientId: string;
+	readonly cnf?: Record<string, string>;
+	readonly sub?: string;
+	readonly scope?: string;
+}
+
+async function mintRefreshToken(opts: MintRtOptions): Promise<string> {
+	const payload: Record<string, unknown> = {
+		sub: opts.sub ?? "u1",
+		scope: opts.scope ?? "read write",
+	};
+	if (opts.cnf !== undefined) {
+		payload.cnf = opts.cnf;
+	}
+	return new SignJWT(payload)
+		.setProtectedHeader({ alg: "HS256", kid: "v0", typ: "rt+jwt" })
+		.setIssuer("localhost")
+		.setAudience(opts.clientId)
+		.setExpirationTime("24h")
+		.sign(secretKey);
+}
+
+function buildCtx(opts: {
+	readonly refreshToken: string;
+	readonly authenticatedClient: typeof confidentialAuthClient | typeof publicAuthClient;
+	readonly tokenBinding?: TokenBinding;
+}): GrantContext {
+	const ctx: GrantContext = {
+		body: { refresh_token: opts.refreshToken },
+		session: {},
+		issuer: "localhost",
+		metadata: { ip: "127.0.0.1" },
+		authenticatedClient: opts.authenticatedClient,
+	};
+	if (opts.tokenBinding) {
+		(ctx as { tokenBinding?: TokenBinding }).tokenBinding = opts.tokenBinding;
+	}
+	return ctx;
+}
+
+const mtlsBinding = (thumbprint: string): TokenBinding => ({
+	kind: "mtls",
+	confirmation: { "x5t#S256": thumbprint },
+});
+
+// ---------------------------------------------------------------------------
+// 5-row matrix tests
+// ---------------------------------------------------------------------------
+
+describe("mTLS refresh-token binding matrix — §9.2 (5 rows)", () => {
+	it("row 1: RT plain + no cert → unbound AT, Bearer", async () => {
+		// Pre-mTLS legacy path: RT was never bound, no cert presented.
+		const rt = await mintRefreshToken({ clientId: CONFIDENTIAL_CLIENT_ID });
+		const handler = createRefreshTokenGrant(mockDeps);
+		const ctx = buildCtx({
+			refreshToken: rt,
+			authenticatedClient: confidentialAuthClient,
+		});
+
+		const { result } = await handler.handle(ctx);
+
+		expect(result.status).toBe(200);
+		if (!("tokens" in result)) expect.fail("Expected tokens in result");
+		expect(result.tokens.token_type).toBe("Bearer");
+		expect(decodeJwt(result.tokens.access_token).cnf).toBeUndefined();
+		expect(result.tokens.refresh_token).toBeTruthy();
+		expect(decodeJwt(result.tokens.refresh_token as string).cnf).toBeUndefined();
+	});
+
+	it("row 2 (public client): RT plain + cert → opt-in upgrade, new AT + RT bound", async () => {
+		// Public client opt-in upgrade — cert presented for a previously
+		// unbound RT. Per §9.1's public-client gate the new RT MUST also
+		// carry cnf so a subsequent refresh enforces continuity.
+		const rt = await mintRefreshToken({ clientId: PUBLIC_CLIENT_ID });
+		const handler = createRefreshTokenGrant(mockDeps);
+		const ctx = buildCtx({
+			refreshToken: rt,
+			authenticatedClient: publicAuthClient,
+			tokenBinding: mtlsBinding("PUB-THUMB"),
+		});
+
+		const { result } = await handler.handle(ctx);
+
+		expect(result.status).toBe(200);
+		if (!("tokens" in result)) expect.fail("Expected tokens in result");
+		// mTLS keeps wire-level Bearer (RFC 8705 §3).
+		expect(result.tokens.token_type).toBe("Bearer");
+		const atCnf = decodeJwt(result.tokens.access_token).cnf as Record<string, string> | undefined;
+		expect(atCnf?.["x5t#S256"]).toBe("PUB-THUMB");
+		const newRtCnf = decodeJwt(result.tokens.refresh_token as string).cnf as
+			| Record<string, string>
+			| undefined;
+		expect(newRtCnf?.["x5t#S256"]).toBe("PUB-THUMB");
+	});
+
+	it("row 2 (confidential variant): RT plain + cert → AT bound, RT remains plain", async () => {
+		// Confidential clients authenticate via client_secret at refresh
+		// time (RFC 9449 §5 rationale, generalized to mTLS). RT-binding
+		// adds no security and would force cert retention across the RT
+		// lifetime.
+		const rt = await mintRefreshToken({ clientId: CONFIDENTIAL_CLIENT_ID });
+		const handler = createRefreshTokenGrant(mockDeps);
+		const ctx = buildCtx({
+			refreshToken: rt,
+			authenticatedClient: confidentialAuthClient,
+			tokenBinding: mtlsBinding("CONF-THUMB"),
+		});
+
+		const { result } = await handler.handle(ctx);
+
+		expect(result.status).toBe(200);
+		if (!("tokens" in result)) expect.fail("Expected tokens in result");
+		expect(result.tokens.token_type).toBe("Bearer");
+		const atCnf = decodeJwt(result.tokens.access_token).cnf as Record<string, string> | undefined;
+		expect(atCnf?.["x5t#S256"]).toBe("CONF-THUMB");
+		// Confidential client → new RT MUST remain plain.
+		expect(decodeJwt(result.tokens.refresh_token as string).cnf).toBeUndefined();
+	});
+
+	it("row 3: RT bound + no cert → reject invalid_grant", async () => {
+		// The RT itself promised mTLS binding (carries cnf.x5t#S256). A
+		// subsequent refresh without a cert would let an attacker who
+		// exfiltrated the RT use it freely — the entire point of binding
+		// is broken. Hard reject.
+		const rt = await mintRefreshToken({
+			clientId: PUBLIC_CLIENT_ID,
+			cnf: { "x5t#S256": "PROMISED-THUMB" },
+		});
+		const handler = createRefreshTokenGrant(mockDeps);
+		const ctx = buildCtx({
+			refreshToken: rt,
+			authenticatedClient: publicAuthClient,
+			// No tokenBinding — cert absent
+		});
+
+		const { result } = await handler.handle(ctx);
+
+		expect(result.status).toBe(400);
+		if (!("error" in result)) expect.fail("Expected error in result");
+		expect(result.error).toBe("invalid_grant");
+		expect(result.errorDescription).toContain("requires a client certificate");
+	});
+
+	it("row 4: RT bound + cert mismatch → reject invalid_grant", async () => {
+		// Cert-substitution attack: attacker has stolen the RT but uses
+		// their own cert. The thumbprint comparison MUST catch this even
+		// though the cert was structurally validated by the mTLS extractor.
+		const rt = await mintRefreshToken({
+			clientId: PUBLIC_CLIENT_ID,
+			cnf: { "x5t#S256": "PROMISED-THUMB" },
+		});
+		const handler = createRefreshTokenGrant(mockDeps);
+		const ctx = buildCtx({
+			refreshToken: rt,
+			authenticatedClient: publicAuthClient,
+			tokenBinding: mtlsBinding("ATTACKER-THUMB"),
+		});
+
+		const { result } = await handler.handle(ctx);
+
+		expect(result.status).toBe(400);
+		if (!("error" in result)) expect.fail("Expected error in result");
+		expect(result.error).toBe("invalid_grant");
+		expect(result.errorDescription).toContain("does not match refresh_token binding");
+	});
+
+	it("row 5: RT bound + cert match → rotation preserves binding (public client)", async () => {
+		// Happy path for an already-bound public-client RT: the cert's
+		// thumbprint equals the persisted cnf.x5t#S256. New AT inherits
+		// the binding, new RT also carries it so the next refresh enforces
+		// continuity.
+		const rt = await mintRefreshToken({
+			clientId: PUBLIC_CLIENT_ID,
+			cnf: { "x5t#S256": "MATCH-THUMB" },
+		});
+		const handler = createRefreshTokenGrant(mockDeps);
+		const ctx = buildCtx({
+			refreshToken: rt,
+			authenticatedClient: publicAuthClient,
+			tokenBinding: mtlsBinding("MATCH-THUMB"),
+		});
+
+		const { result } = await handler.handle(ctx);
+
+		expect(result.status).toBe(200);
+		if (!("tokens" in result)) expect.fail("Expected tokens in result");
+		expect(result.tokens.token_type).toBe("Bearer");
+		const atCnf = decodeJwt(result.tokens.access_token).cnf as Record<string, string> | undefined;
+		expect(atCnf?.["x5t#S256"]).toBe("MATCH-THUMB");
+		const newRtCnf = decodeJwt(result.tokens.refresh_token as string).cnf as
+			| Record<string, string>
+			| undefined;
+		expect(newRtCnf?.["x5t#S256"]).toBe("MATCH-THUMB");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Compound-cnf rejection (Codex Critical #2 — Phase 3 §9.2 pre-matrix)
+// ---------------------------------------------------------------------------
+
+describe("mTLS refresh-token compound-cnf rejection", () => {
+	it("RT carrying BOTH cnf.jkt AND cnf.x5t#S256 → reject before either matrix runs", async () => {
+		// Stage 1 supports single-mechanism bindings only. A compound cnf
+		// could only arise from a bug or attacker-crafted RT; accepting it
+		// would create ambiguous enforcement semantics (which matrix wins?
+		// what if jkt matches but x5t doesn't?). The pre-matrix reject
+		// closes that ambiguity structurally.
+		const rt = await mintRefreshToken({
+			clientId: PUBLIC_CLIENT_ID,
+			cnf: { jkt: "STALE-JKT", "x5t#S256": "STALE-THUMB" },
+		});
+		const handler = createRefreshTokenGrant(mockDeps);
+		const ctx = buildCtx({
+			refreshToken: rt,
+			authenticatedClient: publicAuthClient,
+			tokenBinding: mtlsBinding("STALE-THUMB"),
+		});
+
+		const { result } = await handler.handle(ctx);
+
+		expect(result.status).toBe(400);
+		if (!("error" in result)) expect.fail("Expected error in result");
+		expect(result.error).toBe("invalid_grant");
+		expect(result.errorDescription).toContain("compound cnf binding");
+	});
+
+	it("compound cnf rejected even when no proof presented (defense-in-depth)", async () => {
+		// The reject must fire pre-matrix regardless of whether a binding
+		// is presented in this request. Even if the attacker omits the
+		// proof entirely they should hit the compound-cnf branch (not the
+		// DPoP "requires a DPoP proof" branch which could leak which
+		// matrix is active).
+		const rt = await mintRefreshToken({
+			clientId: PUBLIC_CLIENT_ID,
+			cnf: { jkt: "X", "x5t#S256": "Y" },
+		});
+		const handler = createRefreshTokenGrant(mockDeps);
+		const ctx = buildCtx({
+			refreshToken: rt,
+			authenticatedClient: publicAuthClient,
+		});
+
+		const { result } = await handler.handle(ctx);
+
+		expect(result.status).toBe(400);
+		if (!("error" in result)) expect.fail("Expected error in result");
+		expect(result.error).toBe("invalid_grant");
+		expect(result.errorDescription).toContain("compound cnf binding");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Mechanism-boundary regression (T3c.7 — parallel to PR #185 DPoP rule)
+// ---------------------------------------------------------------------------
+
+describe("mTLS refresh-token mechanism boundary", () => {
+	it("non-mTLS mechanism emitting cnf.x5t#S256 cannot satisfy an mTLS-bound RT", async () => {
+		// The Confirmation union is mechanism-extensible. A custom binding
+		// (e.g. a future FIDO attestation mechanism) could emit
+		// `{ "x5t#S256": "..." }` without being mTLS. The matrix's
+		// `proofX5t` extraction MUST gate on `kind === "mtls"` so a
+		// non-mTLS mechanism cannot satisfy an mTLS-bound RT just by
+		// reusing the x5t#S256 confirmation shape.
+		const rt = await mintRefreshToken({
+			clientId: PUBLIC_CLIENT_ID,
+			cnf: { "x5t#S256": "RT-MTLS-BOUND-THUMB" },
+		});
+		const handler = createRefreshTokenGrant(mockDeps);
+		const ctx = buildCtx({
+			refreshToken: rt,
+			authenticatedClient: publicAuthClient,
+			tokenBinding: {
+				// Hypothetical non-mTLS mechanism emitting an x5t-shaped cnf.
+				// `as TokenBinding` is required because "fido" isn't a known
+				// kind value, but the type system allows downstream
+				// mechanism authors to extend `kind` via string union.
+				kind: "fido",
+				confirmation: { "x5t#S256": "RT-MTLS-BOUND-THUMB" },
+			} as TokenBinding,
+		});
+
+		const { result } = await handler.handle(ctx);
+
+		// MUST reject as row 3 (RT bound, cert absent for mTLS purposes)
+		// rather than passing the matrix on x5t structural match. The kind
+		// boundary is enforced structurally — not by convention.
+		expect(result.status).toBe(400);
+		if (!("error" in result)) expect.fail("Expected error in result");
+		expect(result.error).toBe("invalid_grant");
+		expect(result.errorDescription).toContain("requires a client certificate");
+	});
+});

--- a/packages/oauth/src/__tests__/tokenBinding.dispatchPolicy.integration.test.mts
+++ b/packages/oauth/src/__tests__/tokenBinding.dispatchPolicy.integration.test.mts
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Cross-mechanism dispatch policy — Wave 2 Phase 3 §12.3.
+ *
+ * The cross-mechanism dispatch refactor (PR #188) gave `tokenBindingMw` a
+ * single configurable `DispatchPolicy` that arbitrates when more than one
+ * mechanism's `extract` succeeds against the same request. This file pins
+ * the grant-visible side of that contract:
+ *
+ *   `intent-explicit` (default) — DPoP wins over mTLS because DPoP is
+ *     explicit-intent (the client sent a header on purpose) while mTLS is
+ *     ambient (the TLS handshake produces a cert whether the client meant
+ *     to bind or not). The grant's AT cnf carries `jkt`, NOT `x5t#S256`.
+ *
+ *   `strict-mutual-exclusion` — both mechanisms succeeding is treated as
+ *     a malformed request (the client is presenting contradictory binding
+ *     evidence). The grant never runs; tokenBindingMw rejects with HTTP
+ *     400 `invalid_request`.
+ *
+ * Uses fake mechanisms (no real DPoP proof / cert chain validation) so the
+ * test is decoupled from the upstream verifier packages — those have their
+ * own dedicated test files. The cross-mechanism plumbing itself was already
+ * exercised at the middleware layer in
+ * `@o3co/auth-provider-mtls/__tests__/dual-mechanism.integration.test.mts`;
+ * this file is the grant-visible regression guard at the HTTP boundary.
+ */
+
+import {
+	type AppConfig,
+	type CodeRepository,
+	createSymmetricKeyStore,
+	type DispatchPolicy,
+	InMemoryClientRepository,
+	type TokenBinding,
+	type TokenBindingMechanism,
+	tokenBindingMw,
+} from "@o3co/auth-provider-core";
+import { GrantRegistry } from "@o3co/auth-provider-core/testing";
+import express from "express";
+import { decodeJwt } from "jose";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { createClientCredentialsGrant } from "#/grants/clientCredentials.mjs";
+import { createOAuthRouter } from "#/routes.mjs";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const SECRET = "test-secret-at-least-32-chars!!";
+const ISSUER = "https://auth.example";
+const TEST_CLIENT_ID = "dispatch-policy-client";
+const TEST_CLIENT_SECRET = "dispatch-policy-secret";
+const TEST_BASIC_AUTH = `Basic ${Buffer.from(`${TEST_CLIENT_ID}:${TEST_CLIENT_SECRET}`).toString("base64")}`;
+
+const fullConfig = {
+	oauth: {
+		jwt: { issuer: ISSUER },
+		accessToken: { expiresIn: 3600 },
+	},
+	rateLimit: { failMode: "open" as const },
+	endpoints: { login: { url: "/login" } },
+} as unknown as AppConfig;
+
+const codeRepoStub: CodeRepository = {
+	createCode: async () => ({ code: "code-x", client_id: TEST_CLIENT_ID, redirect_uri: "" }),
+	findByCode: async () => null,
+	consumeByCode: async () => null,
+	removeByCode: async () => {},
+};
+
+const clientRepo = new InMemoryClientRepository(
+	new Map([
+		[
+			TEST_CLIENT_ID,
+			{
+				clientSecret: TEST_CLIENT_SECRET,
+				tokenEndpointAuthMethod: "client_secret_basic" as const,
+				allowedRedirectUris: [],
+				allowedScopes: ["read"],
+				allowedAudiences: ["https://api.example"],
+				allowedGrantTypes: ["client_credentials"],
+			},
+		],
+	]),
+);
+
+// ---------------------------------------------------------------------------
+// Fake mechanisms — both succeed for every request
+// ---------------------------------------------------------------------------
+
+function makeDpopMechanism(jkt: string): TokenBindingMechanism {
+	const binding: TokenBinding = { kind: "dpop", confirmation: { jkt } };
+	return {
+		kind: "dpop",
+		intentExplicit: true,
+		extract: async () => binding,
+	};
+}
+
+function makeMtlsMechanism(thumbprint: string): TokenBindingMechanism {
+	const binding: TokenBinding = {
+		kind: "mtls",
+		confirmation: { "x5t#S256": thumbprint },
+	};
+	return {
+		kind: "mtls",
+		intentExplicit: false,
+		extract: async () => binding,
+	};
+}
+
+async function buildApp(dispatchPolicy: DispatchPolicy): Promise<express.Express> {
+	const app = express();
+	app.set("trust proxy", 1);
+	app.use(express.json());
+	app.use(express.urlencoded({ extended: false }));
+	const keyStore = createSymmetricKeyStore(SECRET);
+
+	app.use(
+		tokenBindingMw({
+			// Order intentionally puts mTLS first to prove that DispatchPolicy
+			// (not registration order) picks the winner under intent-explicit.
+			mechanisms: [makeMtlsMechanism("DISPATCH-THUMB"), makeDpopMechanism("DISPATCH-JKT")],
+			dispatchPolicy,
+		}),
+	);
+
+	const registry = new GrantRegistry();
+	registry.register(
+		"client_credentials",
+		createClientCredentialsGrant({ config: fullConfig, keyStore }),
+	);
+	const { router } = await createOAuthRouter(express, {
+		registry,
+		config: fullConfig,
+		clientRepository: clientRepo,
+		codeRepository: codeRepoStub,
+		keyStore,
+	});
+	app.use("/oauth", router);
+	return app;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Cross-mechanism dispatch policy (§12.3) — grant-visible behavior", () => {
+	it("intent-explicit: DPoP + mTLS both succeed → DPoP wins; AT carries jkt only", async () => {
+		const app = await buildApp("intent-explicit");
+
+		const res = await request(app)
+			.post("/oauth/token")
+			.set("Authorization", TEST_BASIC_AUTH)
+			.type("form")
+			.send({ grant_type: "client_credentials" });
+
+		expect(res.status).toBe(200);
+		// DPoP won → token_type wrapper reflects DPoP per RFC 9449.
+		expect(res.body.token_type).toBe("DPoP");
+		const payload = decodeJwt(res.body.access_token as string);
+		const cnf = payload.cnf as Record<string, string> | undefined;
+		expect(cnf?.jkt).toBe("DISPATCH-JKT");
+		// x5t#S256 MUST NOT appear — the mTLS branch lost arbitration.
+		expect(cnf?.["x5t#S256"]).toBeUndefined();
+	});
+
+	it("strict-mutual-exclusion: DPoP + mTLS both succeed → 400 invalid_request", async () => {
+		const app = await buildApp("strict-mutual-exclusion");
+
+		const res = await request(app)
+			.post("/oauth/token")
+			.set("Authorization", TEST_BASIC_AUTH)
+			.type("form")
+			.send({ grant_type: "client_credentials" });
+
+		expect(res.status).toBe(400);
+		expect(res.body.error).toBe("invalid_request");
+		// Token was never issued — the grant code didn't run.
+		expect(res.body.access_token).toBeUndefined();
+	});
+});

--- a/packages/oauth/src/grants/authorization.mts
+++ b/packages/oauth/src/grants/authorization.mts
@@ -361,38 +361,43 @@ export const createAuthorizationGrant = (
 			// consumers can't distinguish from "scope claim omitted").
 			const scopeClaim = grantedScopes && grantedScopes.length > 0 ? grantedScopes.join(" ") : null;
 
-			// Wave 2 Phase 2 §9.1: propagate the token-binding confirmation
-			// (RFC 7800 `cnf`) into the issued tokens.
+			// Wave 2 Phase 2 §9.1 + Phase 3 §9.1 (mTLS RT binding):
+			// propagate the token-binding confirmation (RFC 7800 `cnf`) into
+			// the issued tokens.
 			//
 			// **AT cnf** is mechanism-agnostic: any binding's confirmation
 			// (DPoP `{jkt}`, mTLS `{x5t#S256}`, future mechanisms) flows
 			// through unchanged because RFC 7800 cnf claim shape is
 			// mechanism-neutral.
 			//
-			// **RT cnf** is gated on `kind === "dpop"` for Phase 2:
+			// **RT cnf** is gated on `(bindingIsDpop || bindingIsMtls) &&
+			// isPublicClient`:
 			//   1. RT binding is restricted to **public clients**
 			//      (`tokenEndpointAuthMethod === "none"`): confidential
 			//      clients use the client secret as the refresh-time
-			//      authenticator (RFC 9449 §5), so RT-key-binding adds no
-			//      security and would force key retention across the RT
-			//      lifetime.
-			//   2. **mTLS RT binding semantics are deliberately out of Phase
-			//      2 scope.** The §9.2 refresh-time matrix only enforces
-			//      DPoP `jkt` continuity. Issuing an mTLS-bound RT (`cnf:
-			//      {"x5t#S256"}`) here without a corresponding refresh-time
-			//      enforcement would silently degrade to an unbound RT on
-			//      next refresh — a multi-reviewer convergence finding
-			//      (Codex Important #1 + Claude #1) at PR #185. Phase 3
-			//      will add mTLS-aware refresh-time enforcement together
-			//      with mTLS RT binding.
+			//      authenticator (RFC 9449 §5 for DPoP; the same rationale
+			//      generalizes to mTLS per RFC 8705 §4 which talks about
+			//      client-cert-bound RTs for clients that have no other
+			//      strong refresh-time credential). RT-key-binding adds no
+			//      security for confidential clients and would force key /
+			//      cert retention across the RT lifetime.
+			//   2. The gate is a **mechanism allowlist** — only the binding
+			//      kinds whose refresh-time enforcement matrix this grant
+			//      knows how to honor are admitted. A future mechanism
+			//      (FIDO attestation etc.) MUST land its refresh-time
+			//      matrix in `refreshToken.mts` BEFORE being added here,
+			//      mirroring the PR #185 mechanism-allowlist rationale that
+			//      stopped Phase 2 from silently emitting unenforceable
+			//      mTLS-bound RTs.
 			//
 			// The wire-level `token_type` is "DPoP" only for the DPoP kind
 			// (mTLS keeps "Bearer" per RFC 8705 §3).
 			const confirmation = ctx.tokenBinding?.confirmation;
 			const bindingIsDpop = ctx.tokenBinding?.kind === "dpop";
+			const bindingIsMtls = ctx.tokenBinding?.kind === "mtls";
 			const tokenType = bindingIsDpop ? "DPoP" : "Bearer";
 			const isPublicClient = ctx.authenticatedClient.tokenEndpointAuthMethod === "none";
-			const bindRefreshToken = bindingIsDpop && isPublicClient;
+			const bindRefreshToken = (bindingIsDpop || bindingIsMtls) && isPublicClient;
 
 			// TODO-F-3: both access_token and refresh_token carry family_id and, when
 			// sid is present, the sid claim so introspect (Task 5) and refresh (Task 4)

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -131,14 +131,16 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				};
 			}
 
-			// Wave 2 Phase 2 §9.2: refresh-time DPoP binding matrix (RFC 9449
-			// §5 + Codex Round 1 Important #1). RT carries `cnf.jkt` only
-			// when issued to a public client with proof; confidential-client
-			// RTs are always plain (no `cnf`). Five rows, evaluated BEFORE
-			// any further work so the rejection short-circuits ahead of
-			// policy evaluation, store I/O, and `generateToken` keystore
-			// signatures:
+			// Wave 2 Phase 2 §9.2 + Phase 3 §9.2 (mTLS rows): refresh-time
+			// binding matrices for DPoP (RFC 9449 §5) and mTLS (RFC 8705 §4).
+			// RT carries `cnf` (jkt or x5t#S256) only when issued to a public
+			// client with proof; confidential-client RTs are always plain.
+			// Each mechanism owns its own 5-row matrix (parallel structure)
+			// and they are evaluated BEFORE any further work so rejections
+			// short-circuit ahead of policy evaluation, store I/O, and
+			// `generateToken` keystore signatures.
 			//
+			// DPoP matrix (unchanged from Phase 2):
 			//   RT cnf.jkt | proof JKT       | Outcome
 			//   no         | no              | issue plain Bearer (legacy)
 			//   no         | yes             | issue DPoP-bound AT (opt-in upgrade)
@@ -146,12 +148,30 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			//   yes        | yes, differs    | reject invalid_grant (multi-key attack)
 			//   yes        | yes, equal      | issue DPoP-bound AT + bound RT (rotation preserves)
 			//
+			// mTLS matrix (new in Phase 3, parallel to DPoP):
+			//   RT cnf.x5t#S256 | client cert    | Outcome
+			//   no              | no             | issue plain Bearer (legacy)
+			//   no              | yes            | issue mTLS-bound AT (opt-in upgrade)
+			//   yes             | no             | reject invalid_grant ("cert_absent")
+			//   yes             | yes, differs   | reject invalid_grant ("thumbprint_mismatch")
+			//   yes             | yes, equal     | issue mTLS-bound AT + bound RT (rotation preserves)
+			//
+			// **Compound-cnf rejection (Codex Critical #2):** if the RT
+			// carries BOTH `cnf.jkt` AND `cnf.x5t#S256` we short-circuit
+			// with `invalid_grant` BEFORE running either matrix. Stage 1
+			// only supports single-mechanism bindings; a compound cnf could
+			// only arise from a bug or an attacker-crafted RT and accepting
+			// it would create ambiguous enforcement semantics. The reject
+			// makes the boundary explicit and structural.
+			//
 			// Error code is `invalid_grant` (RFC 6749 §5.2) — at refresh
 			// time the RT IS the grant; a missing/mismatched proof means
-			// the grant cannot be used. RFC 9449 §5 does not pin a specific
-			// OAuth error code for this branch; `invalid_grant` is more
-			// caller-actionable than `invalid_dpop_proof` (the proof itself
-			// is well-formed; the grant is what cannot be honored).
+			// the grant cannot be used. Neither RFC 9449 §5 nor RFC 8705
+			// §4 pin a specific OAuth error code for this branch;
+			// `invalid_grant` is more caller-actionable than
+			// `invalid_dpop_proof` / a future `invalid_client_certificate`
+			// (the proof / cert itself is well-formed; the grant is what
+			// cannot be honored).
 			const cnfClaim = (tokenPayload as { cnf?: unknown }).cnf;
 			const rtCnfJkt =
 				typeof cnfClaim === "object" &&
@@ -160,20 +180,46 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 				typeof (cnfClaim as { jkt: unknown }).jkt === "string"
 					? (cnfClaim as { jkt: string }).jkt
 					: undefined;
+			const rtCnfX5t =
+				typeof cnfClaim === "object" &&
+				cnfClaim !== null &&
+				"x5t#S256" in cnfClaim &&
+				typeof (cnfClaim as { "x5t#S256": unknown })["x5t#S256"] === "string"
+					? (cnfClaim as { "x5t#S256": string })["x5t#S256"]
+					: undefined;
+
+			// Compound-cnf pre-matrix reject — see comment above.
+			if (rtCnfJkt !== undefined && rtCnfX5t !== undefined) {
+				return {
+					result: {
+						status: 400,
+						error: "invalid_grant",
+						errorDescription:
+							"refresh_token has compound cnf binding which is not supported (Stage 1)",
+					},
+				};
+			}
+
 			// `presentedConfirmation` is mechanism-agnostic and feeds the
 			// AT cnf claim emission below (RFC 7800 — mechanism-neutral).
-			// `proofJkt` extraction is gated on `kind === "dpop"` (Codex
-			// Important #2 at PR #185): the `Confirmation` union is
-			// mechanism-extensible, so a non-DPoP mechanism that emits
-			// `{ jkt: "..." }` could otherwise satisfy a DPoP-bound RT
-			// without actually presenting a DPoP proof. Restrict the
-			// matrix to its declared mechanism so the kind boundary is
-			// enforced structurally, not by convention.
+			// Each mechanism's matrix extracts its own proof field gated on
+			// `kind === "<mechanism>"` (PR #185 / Codex Important #2): the
+			// `Confirmation` union is mechanism-extensible, so a non-DPoP
+			// mechanism emitting `{ jkt: "..." }` (or a non-mTLS mechanism
+			// emitting `{ "x5t#S256": "..." }`) could otherwise satisfy a
+			// bound RT without actually presenting the right proof.
+			// Restrict each matrix to its declared mechanism so the kind
+			// boundary is enforced structurally, not by convention.
 			const presentedConfirmation = ctx.tokenBinding?.confirmation;
 			const bindingIsDpop = ctx.tokenBinding?.kind === "dpop";
+			const bindingIsMtls = ctx.tokenBinding?.kind === "mtls";
 			const proofJkt =
 				bindingIsDpop && presentedConfirmation && "jkt" in presentedConfirmation
 					? presentedConfirmation.jkt
+					: undefined;
+			const proofX5t =
+				bindingIsMtls && presentedConfirmation && "x5t#S256" in presentedConfirmation
+					? presentedConfirmation["x5t#S256"]
 					: undefined;
 			if (rtCnfJkt !== undefined) {
 				if (proofJkt === undefined) {
@@ -197,6 +243,31 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 							status: 400,
 							error: "invalid_grant",
 							errorDescription: "DPoP proof does not match refresh_token binding",
+						},
+					};
+				}
+			}
+			if (rtCnfX5t !== undefined) {
+				if (proofX5t === undefined) {
+					return {
+						result: {
+							status: 400,
+							error: "invalid_grant",
+							errorDescription: "refresh_token requires a client certificate",
+						},
+					};
+				}
+				// Plain `!==` is acceptable here: x5t#S256 is a SHA-256
+				// thumbprint of the cert's DER (RFC 8705 §3.1), which is
+				// presented openly during the TLS handshake. No secret
+				// material is leaked by timing — same rationale as the
+				// DPoP `jkt` comparison above.
+				if (proofX5t !== rtCnfX5t) {
+					return {
+						result: {
+							status: 400,
+							error: "invalid_grant",
+							errorDescription: "client certificate does not match refresh_token binding",
 						},
 					};
 				}
@@ -406,8 +477,8 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			// token response omits scope rather than emitting `scope: ""`.
 			const scopeClaim = finalScope && finalScope.length > 0 ? finalScope : null;
 
-			// Wave 2 Phase 2 §9.2: new tokens inherit the request-time
-			// binding.
+			// Wave 2 Phase 2 §9.2 + Phase 3 §9.2 (mTLS rows): new tokens
+			// inherit the request-time binding.
 			//
 			// **AT cnf** is mechanism-agnostic. `presentedConfirmation`
 			// (defined above) is the full `ctx.tokenBinding?.confirmation`
@@ -415,17 +486,20 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			// future mechanisms all flow through unchanged because RFC 7800
 			// cnf claim shape is mechanism-neutral.
 			//
-			// **New RT cnf** is gated on `bindingIsDpop && isPublicClient`,
-			// mirroring §9.1's auth_code rule. mTLS RT-binding semantics
-			// belong to Phase 3 — issuing an mTLS-bound RT here without
-			// corresponding refresh-time enforcement would create a silent
-			// degradation surface on the next refresh (Codex Important #1
-			// + Claude #1 convergence at PR #185).
+			// **New RT cnf** is gated on
+			// `(bindingIsDpop || bindingIsMtls) && isPublicClient`,
+			// mirroring §9.1's auth_code rule. The gate is a mechanism
+			// allowlist: only the mechanisms whose refresh-time matrix
+			// (above) actually enforces continuity may emit a bound RT.
+			// Adding a future mechanism MUST land its refresh-time matrix
+			// BEFORE being added here (PR #185 / Codex Important #1
+			// convergence — silent degradation prevention).
 			//
-			// The wire-level `token_type` is "DPoP" only for the DPoP kind.
+			// The wire-level `token_type` is "DPoP" only for the DPoP kind
+			// (mTLS keeps "Bearer" per RFC 8705 §3).
 			const tokenType = bindingIsDpop ? "DPoP" : "Bearer";
 			const isPublicClient = ctx.authenticatedClient.tokenEndpointAuthMethod === "none";
-			const bindNewRefreshToken = bindingIsDpop && isPublicClient;
+			const bindNewRefreshToken = (bindingIsDpop || bindingIsMtls) && isPublicClient;
 
 			const newAccessToken = await generateToken(
 				{ family_id: newFamilyId, ...(sid ? { sid } : {}) },

--- a/packages/oauth/src/grants/refreshToken.mts
+++ b/packages/oauth/src/grants/refreshToken.mts
@@ -152,9 +152,19 @@ export const createRefreshTokenGrant = (deps: GrantDependencies): GrantHandler =
 			//   RT cnf.x5t#S256 | client cert    | Outcome
 			//   no              | no             | issue plain Bearer (legacy)
 			//   no              | yes            | issue mTLS-bound AT (opt-in upgrade)
-			//   yes             | no             | reject invalid_grant ("cert_absent")
-			//   yes             | yes, differs   | reject invalid_grant ("thumbprint_mismatch")
+			//   yes             | no             | reject invalid_grant — errorDescription
+			//                                       "refresh_token requires a client certificate"
+			//   yes             | yes, differs   | reject invalid_grant — errorDescription
+			//                                       "client certificate does not match refresh_token binding"
 			//   yes             | yes, equal     | issue mTLS-bound AT + bound RT (rotation preserves)
+			//
+			// Row 3 vs row 4 use distinct errorDescription strings so SIEMs
+			// can distinguish "stolen RT replayed without cert" from
+			// "mid-rotation / multi-cert attack" today. A future cross-cutting
+			// sub-PR will add audit-emission reason codes (spec §12.2:
+			// `rt_binding_mismatch` with `reason: "cert_absent" |
+			// "thumbprint_mismatch"`) — those are NOT wire strings and are
+			// out of Sub-PR 3c scope; do not grep the code for them.
 			//
 			// **Compound-cnf rejection (Codex Critical #2):** if the RT
 			// carries BOTH `cnf.jkt` AND `cnf.x5t#S256` we short-circuit


### PR DESCRIPTION
## Summary

Phase 3 mTLS Sub-PR 3c (the grant-side closure). Lands on the
cross-mechanism dispatch foundation from PR #188.

Sub-PR 3b shipped the mTLS extractor + PKI chain validation, but the
grant code still treated mTLS as AT-only (cnf.x5t#S256 on the AT; RT
remained plain). Sub-PR 3c closes that gap atomically — the §9.1 RT
emission gate AND the §9.2 refresh-time enforcement matrix land
together so there is no release window where an mTLS-bound RT could
be refreshed without a cert.

## Changes

- **Gate widening** in `packages/oauth/src/grants/authorization.mts` and
  `refreshToken.mts`: `bindingIsDpop && isPublicClient` →
  `(bindingIsDpop || bindingIsMtls) && isPublicClient`. The gate is a
  mechanism allowlist — only mechanisms whose refresh-time matrix
  enforces continuity are admitted (PR #185 / Codex Important #1
  rationale, generalized to mTLS).

- **mTLS refresh-time matrix (§9.2 mTLS rows)** in `refreshToken.mts`,
  parallel to the existing DPoP matrix. Five rows + distinct error
  descriptions so SIEMs can distinguish "stolen RT replayed without
  cert" from "mid-rotation / multi-cert attack":

    Row 1: RT plain + no cert         → Bearer legacy (no change)
    Row 2: RT plain + cert            → opt-in upgrade (RT bound for public client)
    Row 3: RT bound + no cert         → reject "requires a client certificate"
    Row 4: RT bound + cert mismatch   → reject "does not match refresh_token binding"
    Row 5: RT bound + cert match      → rotation preserves binding

- **Compound-cnf pre-matrix reject (Codex Critical #2)** — RT carrying
  BOTH `cnf.jkt` AND `cnf.x5t#S256` is rejected with `invalid_grant`
  BEFORE either matrix runs. Closes the multi-mechanism binding
  ambiguity structurally.

- **Mechanism-boundary regression**: `proofX5t` extraction gates on
  `kind === "mtls"`, so a non-mTLS mechanism emitting an
  `{ "x5t#S256": "..." }` confirmation cannot satisfy an mTLS-bound
  RT. Symmetric to the PR #185 DPoP rule.

- **Phase 2 deferral pins inverted** — the two tests at PR #185 that
  asserted "mTLS public-client RT stays plain (deferred)" now assert
  RT bound with `x5t#S256`. Docstrings + titles updated to cite RFC
  8705 §4 SHOULD.

- **New integration tests** (full HTTP stack via `tokenBindingMw` +
  fake mechanism + supertest):
    - `mtls.clientCredentials.integration.test.mts` (2 cases)
    - `mtls.authorizationCode.integration.test.mts` (public + confidential coverage)
    - `mtls.refreshToken.integration.test.mts` (5-row matrix + compound-cnf reject + mech-boundary regression)
    - `tokenBinding.dispatchPolicy.integration.test.mts` (grant-visible side of the PR #188 dispatch policy contract)

## Spec / scope

- Spec authority: `.claude/superpowers/specs/2026-05-18-wave-2-phase-3-mtls-spec.md` §13 T3c.1-T3c.9 + §12.3.
- **This PR completes Phase 3 mTLS.** Phase 3 is now ready for PC3 completion checks.

## What this PR does NOT touch (out of scope)

- mTLS extractor + PKI chain (`createMtlsMechanism`, `validateCertChain`) — unchanged from Sub-PR 3b.
- Cross-mechanism dispatch wiring (`tokenBindingMechanisms` slot, synthesized middleware) — unchanged from PR #188.
- Public API surface — no new exports. `extensibility-immutability-check` skill self-fire: zero findings.

## Test plan

- [x] oauth tests: 557/557 (was 540 → +17 new across mtls.*, tokenBinding.dispatchPolicy.*, and the inverted Phase 2 pins)
- [x] mtls tests: 90/90 (unchanged after gate widening)
- [x] core tests: 1311/1311 (unchanged)
- [x] dpop tests: 85/85 (unchanged — DPoP matrix logic untouched)
- [x] `pnpm run build` clean across workspace
- [x] `pnpm run lint` clean (543 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)