### PR TITLE
feat(wave2): Phase 4 polish — introspect e2e + ADR + READMEs + CHANGELOG roll-up

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added (Wave 2 Phase 4 — 2026-05-20)
+
+- **ADR `2026-05-20-token-binding-first-class-abstraction.md`** at
+  `packages/core/docs/adr/` documents the Wave 2 design rationale:
+  why `TokenBindingMechanism` is a first-class extension surface,
+  what the `Confirmation` union narrowness buys, why grant-side
+  mechanism allowlist is preferred over `confirmation !== undefined`,
+  and why the cross-mechanism refactor was inserted mid-flight after
+  Sub-PR 3b review.
+- **README section "Token-binding mechanisms (Wave 2)"** added to
+  `packages/core/README.md` documenting `TokenBinding`, `Confirmation`,
+  `TokenBindingMechanism`, `TokenBindingMechanismFactory`, the
+  built-in mechanism packages, and `oauth.tokenBinding.dispatch-policy`
+  semantics.
+
 ### Added (Cross-mechanism dispatch refactor — 2026-05-19)
 
 - **New `tokenBindingMechanisms` contribution kind.** Modules ship a

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -591,6 +591,41 @@ Five extension points introduced in v0.4.0 (see
 
 All five adapters are optional — absence = no-op default.
 
+### Token-binding mechanisms (Wave 2)
+
+Sender-constrained token binding is a first-class extension surface. The
+`tokenBindingMechanisms` contribution slot lets a module ship a custom
+`TokenBindingMechanism` without forking core. See [ADR
+2026-05-20-token-binding-first-class-abstraction.md](docs/adr/2026-05-20-token-binding-first-class-abstraction.md)
+for the full design rationale.
+
+#### Public types
+
+- `TokenBinding` — `{ readonly kind: string; readonly confirmation: Confirmation }`. The cross-cutting binding shape; `kind` is open so downstream mechanisms can extend additively.
+- `Confirmation` — narrow union `{ readonly jkt: string } | { readonly "x5t#S256": string }`. RFC 7800 cnf claim payload; adding a new variant is a core semver-minor change.
+- `TokenBindingMechanism` — `{ kind, intentExplicit, extract(req) }`. The verb-side abstraction; `intentExplicit: true` for header-driven mechanisms (DPoP), `false` for ambient ones (mTLS).
+- `TokenBindingMechanismFactory<Deps>` — `(deps) => TokenBindingMechanism | null`. The contribution-slot entry shape; return `null` when the module is disabled by config (secure-default opt-in).
+
+#### Built-in mechanism packages
+
+- `@o3co/auth-provider-dpop` — RFC 9449 DPoP (explicit-intent).
+- `@o3co/auth-provider-mtls` — RFC 8705 mTLS certificate-bound tokens (ambient).
+
+Both packages contribute via `tokenBindingMechanisms`. Core's `assembleApp` collects all contributions, filters nulls, and composes ONE `tokenBindingMw` mounted on `/oauth/token`.
+
+#### Dispatch policy
+
+When multiple mechanisms are installed, `oauth.tokenBinding.dispatch-policy` (in core's bundled `CoreConfigSchema` — single source of truth) arbitrates:
+
+- `intent-explicit` (default) — prefer explicit-intent mechanisms over ambient.
+- `strict-mutual-exclusion` — reject `invalid_request` if more than one mechanism's `extract` returns a binding.
+
+Env override: `OAUTH_TOKEN_BINDING_DISPATCH_POLICY`.
+
+#### Grant-side allowlist
+
+The grants in `@o3co/auth-provider-oauth` emit `cnf`-bound RTs only for mechanisms in an explicit allowlist (`bindingIsDpop || bindingIsMtls`). Adding a new mechanism to bound-RT issuance MUST land its refresh-time enforcement matrix in the same PR — see [`packages/oauth`](../oauth/) for the §9.2 matrix pattern.
+
 ### UserSessionStore / FederationTokenStore (TODO-F)
 
 Two new optional `AppOptions` fields introduced for federation + OIDC support:

--- a/packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md
+++ b/packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md
@@ -1,0 +1,234 @@
+# ADR 2026-05-20 — Token binding is a first-class extension surface
+
+## Status
+
+Accepted (2026-05-20). Implements the Wave 2 Token-binding Cluster (DPoP +
+mTLS + introspect cnf typing) — see
+`.claude/superpowers/specs/2026-05-18-wave-2-token-binding-cluster-spec.md`
+in the agent-scope.
+
+## Context
+
+Prior to Wave 2, sender-constrained token binding existed only as an
+ad-hoc DPoP integration:
+
+- `tokenBindingMw` was a hand-rolled middleware that consulted a hard-
+  coded DPoP verifier and stamped `req.tokenBinding`.
+- The `cnf` claim was emitted from a single grant-side gate
+  (`bindingIsDpop && isPublicClient`) hard-wired to DPoP semantics.
+- Downstream packages that wanted to add a new binding mechanism
+  (mTLS, FIDO attestation, BBS+, anything else) had no extension
+  surface. They would have had to fork `@o3co/auth-provider-core`,
+  edit the middleware, edit the grant gates, and edit the introspect
+  response shape.
+
+Three concrete forcing functions made this unsustainable:
+
+1. **RFC 8705 mTLS** (Phase 3) needed a second mechanism with its own
+   evidence shape (`x5t#S256` thumbprint) and its own validation
+   pipeline (PEM ↔ DER ↔ X509 ↔ PKI chain). Bolting it onto the
+   DPoP middleware would have produced an `if (kind === "dpop") ...
+   else if (kind === "mtls") ...` switch that every downstream
+   reviewer would have to re-audit.
+
+2. **Cross-mechanism arbitration**: a request can present both a DPoP
+   header and an mTLS client cert. Without a typed binding interface
+   there is no single place to express "DPoP wins because the header
+   is explicit-intent" or "reject both because the operator wants
+   strict mutual exclusion".
+
+3. **Compound `cnf` runtime defense** (Codex Critical #2): the
+   TypeScript layer can narrow `Confirmation` to a union of single-
+   arm shapes, but a JWT payload is decoded at runtime. A malformed
+   signed RT carrying BOTH `cnf.jkt` AND `cnf.x5t#S256` must be
+   rejected at the grant boundary, not silently honored by whichever
+   matrix runs first.
+
+The pre-Wave 2 surface could not express any of these structurally —
+each would have required ad-hoc workarounds layered on top of an
+already-DPoP-specific design.
+
+## Decision
+
+Token binding is now an extension surface in
+`@o3co/auth-provider-core` with three load-bearing types and one
+contribution slot.
+
+### 1. `TokenBinding` (core)
+
+```typescript
+export interface TokenBinding {
+    readonly kind: string;
+    readonly confirmation: Confirmation;
+}
+```
+
+The cross-cutting shape. `kind` is a string (not a fixed enum) so
+downstream mechanisms can extend the union additively. `confirmation`
+is the RFC 7800 cnf claim payload; its variants live in the
+`Confirmation` union below.
+
+### 2. `Confirmation` union (core)
+
+```typescript
+export type Confirmation =
+    | { readonly jkt: string }
+    | { readonly "x5t#S256": string };
+```
+
+Narrow single-arm union. RFC 7800 permits structured values
+(e.g. `jwk`) but adding a new variant is a deliberate core
+semver-minor change, not a downstream-only extension. The narrowness
+is the load-bearing safety property: a malformed `{ jkt, x5t#S256 }`
+cannot type-check at the TypeScript layer (the runtime compound-
+`cnf` reject is the cross-layer defense).
+
+### 3. `TokenBindingMechanism` (core)
+
+```typescript
+export interface TokenBindingMechanism {
+    readonly kind: string;
+    readonly intentExplicit: boolean;
+    extract(req: Request): Promise<TokenBinding | null>;
+}
+```
+
+The verb-side abstraction. A mechanism is anything that can look at a
+request and produce a `TokenBinding`. `intentExplicit` is the
+dispatch hint — `true` for DPoP (the client sent a header on
+purpose), `false` for mTLS (the cert is ambient).
+
+### 4. `tokenBindingMechanisms` contribution slot (core)
+
+```typescript
+export type TokenBindingMechanismFactory<Deps> =
+    (deps: Deps) => TokenBindingMechanism | null;
+```
+
+A new entry in `ContributesMap` declared in `@o3co/auth-provider-core`.
+Mechanism modules (`dpopModule`, `mtlsModule`, future) contribute
+factories that return their `TokenBindingMechanism`. Core's
+`assembleApp` collects all contributions, filters nulls, and composes
+ONE `tokenBindingMw` mounted on `/oauth/token` BEFORE the existing
+`grantMiddleware` loop. The configured `DispatchPolicy`
+(`oauth.tokenBinding.dispatch-policy`, single source of truth in
+core's `CoreConfigSchema`) arbitrates across mechanisms:
+
+- `intent-explicit` (default) — prefer mechanisms with
+  `intentExplicit: true`. Resolves "DPoP header + mTLS cert"
+  collisions in DPoP's favor.
+- `strict-mutual-exclusion` — reject with `invalid_request` if more
+  than one mechanism's `extract` returns a non-null binding.
+
+### 5. Grant-side allowlist (oauth)
+
+The Phase 3 §9.1 / §9.2 gate widening uses an explicit allowlist, not
+`confirmation !== undefined`:
+
+```typescript
+const bindRefreshToken =
+    (bindingIsDpop || bindingIsMtls) && isPublicClient;
+```
+
+The structural reason: the `Confirmation` union is mechanism-
+extensible, so a custom mechanism emitting `{ jkt: "..." }` or
+`{ "x5t#S256": "..." }` could otherwise satisfy a DPoP-bound or
+mTLS-bound RT without going through the right matrix. Restricting
+each matrix to its declared mechanism (`kind === "dpop"` /
+`kind === "mtls"`) enforces the boundary structurally. Adding a new
+mechanism to the allowlist MUST land its refresh-time matrix in the
+same PR so a bound RT can never be issued without enforcement.
+
+## Consequences
+
+### Good
+
+- **Downstream extensibility.** A new mechanism is a new package that
+  implements `TokenBindingMechanism` + ships a `Module` contributing
+  to `tokenBindingMechanisms`. No edit to `@o3co/auth-provider-core`,
+  no edit to `@o3co/auth-provider-oauth` grant code beyond the gate-
+  allowlist entry (which the new package's own PR adds).
+- **Cross-module arbitration is a single configurable policy** — not
+  a fork-per-deployment ad-hoc resolution rule.
+- **Compound-`cnf` runtime defense is in one place** (the grant's
+  refresh-time matrix), not duplicated per mechanism.
+- **Introspect cnf is mechanism-agnostic.** The introspect handler
+  reads `cnf` from the AT claims and decides `token_type` based on
+  whether `jkt` is present (DPoP → "DPoP" per RFC 9449 §5) or not
+  (Bearer for mTLS + unbound per RFC 8705 §3). No mechanism-specific
+  branches.
+
+### Bad
+
+- **More types to learn.** A first-time reader of the oauth package
+  now has to follow `TokenBinding`, `Confirmation`, and
+  `TokenBindingMechanism` to understand what `cnf` means. The
+  README updates in Wave 2 Phase 4 are the mitigation; long-term
+  the abstraction is the *only* way to keep mechanism additions from
+  needing a re-audit of unrelated code paths.
+- **The `intentExplicit` hint is a hand-set boolean.** Mechanism
+  authors have to know the convention. Today there are exactly two
+  values (DPoP true, mTLS false). If a future mechanism is hard to
+  classify, the spec will need to grow more dispatch policies.
+- **Mechanism allowlist requires manual gate updates.** Each new
+  mechanism added to bound-RT issuance must be added to
+  `bindingIsX` predicates in `authorization.mts` + `refreshToken.mts`.
+  Considered a `mechanism.bindRefreshToken: boolean` capability flag
+  but rejected — the gate is a security boundary, not a per-mechanism
+  preference, and changing it in two places is intentional friction.
+
+### Neutral
+
+- **`token_type` wire string stays mechanism-specific.** DPoP → "DPoP"
+  (RFC 9449 §5 MUST), mTLS → "Bearer" (RFC 8705 §3, the cert IS the
+  binding evidence, not the wire token type). This is RFC-driven and
+  not a design choice we own.
+- **Per-mechanism reference.conf removed.** `oauth.tokenBinding.dispatch-policy`
+  used to be redeclared by every binding-mechanism module's
+  reference.conf; now it lives in core's bundled reference.conf as
+  the single source of truth. Operators who set the key in their
+  `application.conf` are unaffected (HOCON `.withFallback()`
+  precedence preserves operator overrides).
+
+## Compliance & references
+
+- RFC 9449 (DPoP) §5 — explicit-intent token binding via JWS header
+  proof; `token_type: "DPoP"` on the wire.
+- RFC 8705 (mTLS) §3 + §3.1 + §4 — sender-constrained ATs via the
+  RFC 7800 `cnf.x5t#S256` confirmation; wire-level `token_type`
+  stays "Bearer".
+- RFC 7800 (cnf claim) — confirmation method registry. Today's union
+  variants (`jkt`, `x5t#S256`) come from RFC 9449 / RFC 8705
+  respectively, not from RFC 7800 itself.
+- RFC 7662 (token introspection) §2.2 — introspect echoes `cnf` so
+  downstream verifiers can require the right mechanism's proof at
+  resource-server boundaries.
+
+## Related ADRs
+
+- `2026-04-30-config-schema-strict-defaults-from-hocon.md` — explains
+  why the `oauth.tokenBinding.dispatch-policy` default ships in
+  `packages/core/config/reference.conf` rather than as a
+  `.default(...)` in `CoreConfigSchema`.
+- `2026-05-13-reference-conf-shipping.md` — the shipping mechanism
+  that made it possible for core's reference.conf to be the single
+  source of truth for `oauth.tokenBinding.dispatch-policy`.
+
+## Implementation history
+
+- Wave 2 Phase 1 (`5cf72c31`) — `grantMiddleware` contribution kind
+  retro; baseline for mechanism factories.
+- Wave 2 Phase 2 (`15e9389d` + `5de82c75` + `98f5f3e7`) — DPoP
+  package + replay store + cnf claim emission + DPoP refresh-time
+  matrix (5 rows).
+- Wave 2 Phase 3 (`f690c8a1` + `9f327b4f` + `ccf5d973`) — mTLS
+  package + PKI chain validation + mTLS RT binding + mTLS refresh-
+  time matrix (5 rows) + compound-cnf reject + mechanism allowlist
+  generalization.
+- Cross-mechanism dispatch refactor (`c324d8eb`, mid-Phase-3) —
+  `tokenBindingMechanisms` contribution slot in core + composed
+  `tokenBindingMw` + `DispatchPolicy` moved to core's bundled
+  schema. Resolves the Phase 3 §11.4 "single mechanism per
+  deployment" limitation discovered during Sub-PR 3b review.
+- Wave 2 Phase 4 — end-to-end introspect cnf test, this ADR, README
+  updates, CHANGELOG roll-up.

--- a/packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md
+++ b/packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md
@@ -2,10 +2,11 @@
 
 ## Status
 
-Accepted (2026-05-20). Implements the Wave 2 Token-binding Cluster (DPoP +
-mTLS + introspect cnf typing) — see
-`.claude/superpowers/specs/2026-05-18-wave-2-token-binding-cluster-spec.md`
-in the agent-scope.
+Accepted (2026-05-20). Implements the Wave 2 Token-binding Cluster
+(DPoP + mTLS + introspect cnf typing). The cluster spec lives in
+the internal agent-scope workspace alongside other planning material
+and is not shipped in the OSS repo; this ADR is the public summary
+of the load-bearing decisions.
 
 ## Context
 

--- a/packages/dpop/CHANGELOG.md
+++ b/packages/dpop/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Changed (Wave 2 Phase 4 — 2026-05-20)
+
+- **README quick-start filled in** with the composition-root snippet,
+  the `application.conf` opt-in block, and a "Cross-mechanism
+  dispatch (DPoP + mTLS)" section pointing at the symmetric mTLS-side
+  documentation. The pre-Phase-4 placeholder "(Filled in by Sub-PR
+  2b/2c)" is removed.
+- See [ADR 2026-05-20-token-binding-first-class-abstraction.md](../core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md)
+  for the cross-cutting Wave 2 design rationale.
+
 ### Changed (Cross-mechanism dispatch refactor — 2026-05-19)
 
 - **Contribution shape migrated** from `grantMiddleware` to the new

--- a/packages/dpop/README.md
+++ b/packages/dpop/README.md
@@ -45,7 +45,7 @@ When both `dpopModule` and `mtlsModule` are installed, the `oauth.tokenBinding.d
 - `intent-explicit` (default) — DPoP wins because the DPoP header is explicit-intent; mTLS cert is ambient.
 - `strict-mutual-exclusion` — both succeeding is rejected with HTTP 400 `invalid_request`.
 
-See [the cross-mechanism dispatch refactor spec](../../.claude/superpowers/specs/2026-05-19-wave-2-cross-mechanism-dispatch-refactor-spec.md) for the design rationale and [packages/mtls/README.md](../mtls/README.md#cross-mechanism-dispatch-dpop--mtls) for the symmetric view from the mTLS side.
+See [ADR 2026-05-20-token-binding-first-class-abstraction.md](../core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md) for the design rationale and [packages/mtls/README.md](../mtls/README.md#cross-mechanism-dispatch-dpop--mtls) for the symmetric view from the mTLS side.
 
 ## Operator requirements
 

--- a/packages/dpop/README.md
+++ b/packages/dpop/README.md
@@ -8,7 +8,44 @@ Stage 1 (token-endpoint binding). See [the Phase 2 spec](https://github.com/o3co
 
 ## Quick start
 
-(Filled in by Sub-PR 2b/2c.)
+```typescript
+import { createApp } from "@o3co/auth-provider-core";
+import { dpopModule } from "@o3co/auth-provider-dpop";
+
+const handle = await createApp({
+    modules: [dpopModule /* + your other modules */],
+    bootstrapComponents: { config, /* ... */ },
+});
+```
+
+Enable DPoP in your `application.conf`:
+
+```hocon
+oauth {
+  dpop {
+    enabled = true                  # default: false (secure-default opt-in)
+    iat-window-seconds = 60
+    alg-whitelist = ["ES256", "ES384", "EdDSA", "RS256"]
+    replay-store = "memory"         # or "redis" for clustered deployments
+    replay-store-ttl-seconds = 300
+  }
+  # Cross-mechanism dispatch policy (single source of truth in core):
+  tokenBinding {
+    dispatch-policy = "intent-explicit"   # or "strict-mutual-exclusion"
+  }
+}
+```
+
+Public-client tokens are bound to the DPoP JKT in both AT (`cnf.jkt`) and RT (`cnf.jkt`). Confidential clients get an AT-bound token + a plain RT (client_secret is the refresh-time authenticator per RFC 9449 §5). At refresh time the §9.2 5-row matrix enforces that the presented proof matches the persisted RT binding.
+
+## Cross-mechanism dispatch (DPoP + mTLS)
+
+When both `dpopModule` and `mtlsModule` are installed, the `oauth.tokenBinding.dispatch-policy` config key (owned by core's bundled `CoreConfigSchema`) decides what happens when both mechanisms succeed on the same request:
+
+- `intent-explicit` (default) — DPoP wins because the DPoP header is explicit-intent; mTLS cert is ambient.
+- `strict-mutual-exclusion` — both succeeding is rejected with HTTP 400 `invalid_request`.
+
+See [the cross-mechanism dispatch refactor spec](../../.claude/superpowers/specs/2026-05-19-wave-2-cross-mechanism-dispatch-refactor-spec.md) for the design rationale and [packages/mtls/README.md](../mtls/README.md#cross-mechanism-dispatch-dpop--mtls) for the symmetric view from the mTLS side.
 
 ## Operator requirements
 

--- a/packages/mtls/CHANGELOG.md
+++ b/packages/mtls/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Changed (Wave 2 Phase 4 — 2026-05-20)
+
+- **README status line updated** to reflect Phase 3 completion — the
+  Phase 3 Sub-PR 3c grant-side `cnf.x5t#S256` emission + §9.2
+  refresh-time matrix + compound-`cnf` reject + mechanism-boundary
+  regression are all shipped. The earlier "lands in Sub-PR 3c" hedge
+  is removed.
+- See [ADR 2026-05-20-token-binding-first-class-abstraction.md](../core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md)
+  for the cross-cutting Wave 2 design rationale.
+
 ### Added (Phase 3 Sub-PR 3c — 2026-05-20)
 
 - **mTLS refresh-token binding is now enforced end-to-end.** The gate

--- a/packages/mtls/README.md
+++ b/packages/mtls/README.md
@@ -2,7 +2,7 @@
 
 mTLS ([RFC 8705](https://www.rfc-editor.org/rfc/rfc8705)) sender-constrained access token support for `@o3co/auth-provider`.
 
-> **Status:** Phase 3 (Wave 2). Sub-PR 3a + 3b ship the package skeleton, dialect parsers, thumbprint, `createMtlsMechanism` factory, narrow-mode PKI chain validation, and `mtlsModule` wiring. Grant-side `cnf.x5t#S256` emission + refresh-token binding for public clients land in Sub-PR 3c.
+> **Status:** Phase 3 (Wave 2) complete. The package ships `createMtlsMechanism` (header / tls-layer sources, envoy + plain-pem dialects), narrow-mode PKI chain validation with explicit cryptographic signature verification at every hop, `mtlsModule` wiring via the core `tokenBindingMechanisms` contribution slot, grant-side `cnf.x5t#S256` emission, and the §9.2 mTLS refresh-time enforcement matrix (5 rows + compound-`cnf` pre-matrix reject + mechanism-boundary regression). RT binding for public clients per RFC 8705 §4 is enforced end-to-end.
 
 ## Overview
 

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog — @o3co/auth-provider-oauth
+
+All notable changes to this package will be documented in this file.
+
+## [Unreleased]
+
+### Added (Wave 2 Phase 4 — 2026-05-20)
+
+- **End-to-end integration test** `tokenBinding.introspect.integration.test.mts`
+  pairing the issuance side (Phase 2 DPoP, Phase 3 mTLS) with the
+  introspection side (Phase 1 typed `IntrospectResponse`). Three
+  cases: DPoP-bound AT introspects with `cnf.jkt` + `token_type:
+  "DPoP"`; mTLS-bound AT with `cnf.x5t#S256` + `token_type: "Bearer"`;
+  plain AT with no `cnf` + `token_type: "Bearer"`. First test that
+  exercises both code paths on the same token.
+- **README section "Token-binding cnf flow (Wave 2)"** documents AT
+  cnf mechanism-agnostic propagation, RT cnf public-client gate, the
+  §9.2 5-row matrix per mechanism, mechanism-boundary regression,
+  compound-`cnf` pre-matrix reject, and the introspect echo.
+
+### Added (Wave 2 Phase 3 Sub-PR 3c — 2026-05-20)
+
+- **Gate widened** in `authorization.mts` and `refreshToken.mts` from
+  `bindingIsDpop && isPublicClient` to `(bindingIsDpop ||
+  bindingIsMtls) && isPublicClient`. Mechanism allowlist preserved
+  structurally (the PR #185 / Codex Important #2 boundary survives
+  the widen).
+- **mTLS refresh-time matrix (§9.2 mTLS rows)** in `refreshToken.mts`,
+  parallel to the existing DPoP matrix. Five rows + distinct
+  errorDescription strings for cert-absent vs thumbprint-mismatch
+  rejections so SIEMs can distinguish "stolen RT replayed without
+  cert" from "mid-rotation / multi-cert attack".
+- **Compound-`cnf` pre-matrix reject** (Codex Critical #2): an RT
+  carrying BOTH `cnf.jkt` AND `cnf.x5t#S256` is rejected with
+  `invalid_grant` BEFORE either matrix runs. Closes the ambiguity
+  around multi-mechanism binding semantics at runtime; Phase 1's
+  narrow `Confirmation` union is the TypeScript-layer twin defense.
+- **Mechanism-boundary regression**: `proofX5t` extraction gates on
+  `kind === "mtls"`, symmetric to the PR #185 DPoP rule. A non-mTLS
+  mechanism emitting an `{ "x5t#S256": "..." }` confirmation cannot
+  satisfy an mTLS-bound RT.
+- **Phase 2 deferral pin tests inverted**: the two tests at PR #185
+  that asserted "mTLS public-client RT stays plain (deferred)" now
+  assert RT bound with `x5t#S256`. Docstrings + titles rewritten to
+  cite RFC 8705 §4 SHOULD as positive authority.
+- **New integration tests:**
+  - `mtls.clientCredentials.integration.test.mts` — AT cnf
+    propagation + no RT (RFC 6749 §4.4.3 pinned).
+  - `mtls.authorizationCode.integration.test.mts` — public + confidential
+    client paths.
+  - `mtls.refreshToken.integration.test.mts` — full 5-row matrix +
+    compound-cnf reject + mechanism boundary.
+  - `tokenBinding.dispatchPolicy.integration.test.mts` — grant-visible
+    side of the cross-mechanism dispatch contract.
+
+### Added (Wave 2 Phase 2 — 2026-04 → 2026-05-13)
+
+- DPoP `cnf.jkt` claim emission in `authorization.mts` and
+  `refreshToken.mts` for public clients (RFC 9449 §5).
+- 5-row refresh-time DPoP matrix in `refreshToken.mts` (Codex Round
+  1 Important #1) — pre-empts the mTLS matrix structure.
+- Mechanism boundary rule (Codex Important #2): `proofJkt`
+  extraction gates on `kind === "dpop"`.
+
+### Notes
+
+- See [ADR 2026-05-20-token-binding-first-class-abstraction.md](../core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md)
+  for the cross-cutting Wave 2 design rationale spanning core +
+  dpop + mtls + oauth.
+- Wire protocol unchanged. No public API removed.

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -121,9 +121,9 @@ When a token-binding mechanism is installed (`@o3co/auth-provider-dpop` and/or `
 - **RT cnf is gated on `(bindingIsDpop || bindingIsMtls) && isPublicClient`.** Confidential clients always get plain RTs (RFC 9449 §5 rationale generalized: client_secret is the refresh-time authenticator). Public clients with a bound AT get a bound RT so the next refresh enforces continuity.
 - **Wire-level `token_type`:** `"DPoP"` only when `kind === "dpop"` (RFC 9449 §5). mTLS keeps `"Bearer"` (RFC 8705 §3) — the cert IS the binding evidence, not the wire token type.
 
-### Refresh-time matrix (5 rows per mechanism)
+### Refresh-time matrix (5 outcomes — applied independently per mechanism)
 
-`refreshToken.mts` runs a per-mechanism matrix that correlates the RT's persisted `cnf` with the request-time binding:
+`refreshToken.mts` runs a separate matrix per binding mechanism (one for DPoP `cnf.jkt`, one for mTLS `cnf.x5t#S256`). Each matrix has the same 5 outcomes, expressed below in mechanism-agnostic form:
 
 | RT cnf | request binding | outcome |
 | --- | --- | --- |
@@ -133,7 +133,7 @@ When a token-binding mechanism is installed (`@o3co/auth-provider-dpop` and/or `
 | bound | bound, differs | reject `invalid_grant` (multi-key / cert-substitution attack) |
 | bound | bound, matches | rotation preserves binding |
 
-Each mechanism owns its own matrix; the proof field is extracted gated on `kind === "<mechanism>"` so a confirmation shape alone cannot satisfy a bound RT (mechanism-boundary regression from PR #185 / Codex Important #2). RT carrying BOTH `cnf.jkt` AND `cnf.x5t#S256` is rejected with `invalid_grant` BEFORE either matrix runs (compound-cnf reject from Codex Critical #2).
+The proof field is extracted gated on `kind === "<mechanism>"` so a confirmation shape alone cannot satisfy a bound RT (mechanism-boundary regression from PR #185 / Codex Important #2). RT carrying BOTH `cnf.jkt` AND `cnf.x5t#S256` is rejected with `invalid_grant` BEFORE either matrix runs (compound-cnf reject from Codex Critical #2).
 
 ### Introspect
 

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -111,6 +111,36 @@ server.listen(config.http.port);
 await handle.dispose();
 ```
 
+## Token-binding cnf flow (Wave 2)
+
+When a token-binding mechanism is installed (`@o3co/auth-provider-dpop` and/or `@o3co/auth-provider-mtls`), the grants here emit RFC 7800 `cnf` claims and the introspect handler echoes them back to resource servers.
+
+### Issuance
+
+- **AT cnf is mechanism-agnostic.** Any binding's `confirmation` flows through unchanged — DPoP `{ jkt }`, mTLS `{ "x5t#S256" }`, or future mechanisms (all variants in the [`Confirmation` union](../core/README.md#token-binding-mechanisms-wave-2)).
+- **RT cnf is gated on `(bindingIsDpop || bindingIsMtls) && isPublicClient`.** Confidential clients always get plain RTs (RFC 9449 §5 rationale generalized: client_secret is the refresh-time authenticator). Public clients with a bound AT get a bound RT so the next refresh enforces continuity.
+- **Wire-level `token_type`:** `"DPoP"` only when `kind === "dpop"` (RFC 9449 §5). mTLS keeps `"Bearer"` (RFC 8705 §3) — the cert IS the binding evidence, not the wire token type.
+
+### Refresh-time matrix (5 rows per mechanism)
+
+`refreshToken.mts` runs a per-mechanism matrix that correlates the RT's persisted `cnf` with the request-time binding:
+
+| RT cnf | request binding | outcome |
+| --- | --- | --- |
+| plain | none | issue plain Bearer (legacy) |
+| plain | bound | opt-in upgrade — bind new AT (RT bound only for public clients) |
+| bound | none | reject `invalid_grant` |
+| bound | bound, differs | reject `invalid_grant` (multi-key / cert-substitution attack) |
+| bound | bound, matches | rotation preserves binding |
+
+Each mechanism owns its own matrix; the proof field is extracted gated on `kind === "<mechanism>"` so a confirmation shape alone cannot satisfy a bound RT (mechanism-boundary regression from PR #185 / Codex Important #2). RT carrying BOTH `cnf.jkt` AND `cnf.x5t#S256` is rejected with `invalid_grant` BEFORE either matrix runs (compound-cnf reject from Codex Critical #2).
+
+### Introspect
+
+`/oauth/introspect` reads `cnf` from the AT claims and sets `token_type` based on whether `jkt` is present (DPoP) or not (Bearer for mTLS or unbound). The introspect response carries the full `cnf` so resource servers can require the right mechanism's proof at their boundary.
+
+See [ADR 2026-05-20-token-binding-first-class-abstraction.md](../core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md) for the design rationale.
+
 ## TODO-F-4 changes
 
 ### `authorization_code` grant — id_token issuance

--- a/packages/oauth/src/__tests__/tokenBinding.introspect.integration.test.mts
+++ b/packages/oauth/src/__tests__/tokenBinding.introspect.integration.test.mts
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Wave 2 Phase 4 T4.1 — end-to-end test pairing the issuance side
+ * (Phase 2 DPoP / Phase 3 mTLS) with the introspection side (Phase 1
+ * typed `IntrospectResponse`).
+ *
+ * The grant flow runs in full — `tokenBindingMw` extracts a binding
+ * from a fake mechanism, the client_credentials grant emits the AT
+ * with a `cnf` claim, and the same AT is then introspected via
+ * `/oauth/introspect`. The test asserts:
+ *
+ *   - DPoP-bound AT: introspect `cnf.jkt` matches the issued JKT;
+ *     `token_type === "DPoP"` (RFC 9449 §5).
+ *   - mTLS-bound AT: introspect `cnf.x5t#S256` matches the issued
+ *     thumbprint; `token_type === "Bearer"` (RFC 8705 §3).
+ *   - Plain AT: no `cnf` field; `token_type === "Bearer"`.
+ *
+ * This is the **first** test that exercises BOTH the issuance code
+ * path and the introspect code path on the same token. Earlier
+ * tests covered each side independently — Phase 2 §9.1 issuance,
+ * Phase 1 introspect typing — but never both on a single AT.
+ */
+
+import {
+	type AppConfig,
+	type CodeRepository,
+	createSymmetricKeyStore,
+	InMemoryClientRepository,
+	type TokenBinding,
+	type TokenBindingMechanism,
+	tokenBindingMw,
+} from "@o3co/auth-provider-core";
+import { GrantRegistry } from "@o3co/auth-provider-core/testing";
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { createClientCredentialsGrant } from "#/grants/clientCredentials.mjs";
+import { createOAuthRouter } from "#/routes.mjs";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SECRET = "test-secret-at-least-32-chars!!";
+const ISSUER = "https://auth.example";
+const TEST_CLIENT_ID = "introspect-e2e-client";
+const TEST_CLIENT_SECRET = "introspect-e2e-secret";
+const TEST_BASIC_AUTH = `Basic ${Buffer.from(`${TEST_CLIENT_ID}:${TEST_CLIENT_SECRET}`).toString("base64")}`;
+
+const fullConfig = {
+	oauth: {
+		jwt: { issuer: ISSUER },
+		accessToken: { expiresIn: 3600 },
+	},
+	rateLimit: { failMode: "open" as const },
+	endpoints: { login: { url: "/login" } },
+} as unknown as AppConfig;
+
+const codeRepoStub: CodeRepository = {
+	createCode: async () => ({ code: "x", client_id: TEST_CLIENT_ID, redirect_uri: "" }),
+	findByCode: async () => null,
+	consumeByCode: async () => null,
+	removeByCode: async () => {},
+};
+
+const clientRepo = new InMemoryClientRepository(
+	new Map([
+		[
+			TEST_CLIENT_ID,
+			{
+				clientSecret: TEST_CLIENT_SECRET,
+				tokenEndpointAuthMethod: "client_secret_basic" as const,
+				allowedRedirectUris: [],
+				allowedScopes: ["read"],
+				// AT audience defaults to allowedAudiences[0]; introspect's
+				// expectedAudience is the calling client's clientId. Align
+				// them so the AT introspects as active.
+				allowedAudiences: [TEST_CLIENT_ID],
+				allowedGrantTypes: ["client_credentials"],
+			},
+		],
+	]),
+);
+
+// ---------------------------------------------------------------------------
+// Fake mechanisms
+// ---------------------------------------------------------------------------
+
+function makeDpopMechanism(jkt: string): TokenBindingMechanism {
+	const binding: TokenBinding = { kind: "dpop", confirmation: { jkt } };
+	return { kind: "dpop", intentExplicit: true, extract: async () => binding };
+}
+
+function makeMtlsMechanism(thumbprint: string): TokenBindingMechanism {
+	const binding: TokenBinding = {
+		kind: "mtls",
+		confirmation: { "x5t#S256": thumbprint },
+	};
+	return { kind: "mtls", intentExplicit: false, extract: async () => binding };
+}
+
+// ---------------------------------------------------------------------------
+// App builder
+// ---------------------------------------------------------------------------
+
+async function buildApp(
+	mechanisms: readonly TokenBindingMechanism[] = [],
+): Promise<express.Express> {
+	const app = express();
+	app.set("trust proxy", 1);
+	app.use(express.json());
+	app.use(express.urlencoded({ extended: false }));
+	const keyStore = createSymmetricKeyStore(SECRET);
+
+	if (mechanisms.length > 0) {
+		app.use(
+			tokenBindingMw({
+				mechanisms,
+				dispatchPolicy: "intent-explicit",
+			}),
+		);
+	}
+
+	const registry = new GrantRegistry();
+	registry.register(
+		"client_credentials",
+		createClientCredentialsGrant({ config: fullConfig, keyStore }),
+	);
+	const { router } = await createOAuthRouter(express, {
+		registry,
+		config: fullConfig,
+		clientRepository: clientRepo,
+		codeRepository: codeRepoStub,
+		keyStore,
+	});
+	app.use("/oauth", router);
+	return app;
+}
+
+async function issueAndIntrospect(
+	app: express.Express,
+): Promise<{ accessToken: string; introspect: Record<string, unknown> }> {
+	const tokenRes = await request(app)
+		.post("/oauth/token")
+		.set("Authorization", TEST_BASIC_AUTH)
+		.type("form")
+		.send({ grant_type: "client_credentials" });
+	expect(tokenRes.status).toBe(200);
+	const accessToken = tokenRes.body.access_token as string;
+
+	const introspectRes = await request(app)
+		.post("/oauth/introspect")
+		.set("Authorization", TEST_BASIC_AUTH)
+		.type("form")
+		.send({ token: accessToken });
+	expect(introspectRes.status).toBe(200);
+	return { accessToken, introspect: introspectRes.body as Record<string, unknown> };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Phase 4 T4.1 — end-to-end issuance + introspection cnf propagation", () => {
+	it("DPoP-bound AT: /introspect echoes cnf.jkt and token_type DPoP", async () => {
+		const app = await buildApp([makeDpopMechanism("E2E-DPOP-JKT")]);
+
+		const { introspect } = await issueAndIntrospect(app);
+
+		expect(introspect.active).toBe(true);
+		expect(introspect.token_type).toBe("DPoP");
+		const cnf = introspect.cnf as Record<string, string> | undefined;
+		expect(cnf?.jkt).toBe("E2E-DPOP-JKT");
+		// mTLS thumbprint MUST NOT appear in a DPoP-bound token.
+		expect(cnf?.["x5t#S256"]).toBeUndefined();
+	});
+
+	it("mTLS-bound AT: /introspect echoes cnf.x5t#S256 and token_type Bearer", async () => {
+		// mTLS keeps wire-level Bearer (RFC 8705 §3) even though the token IS
+		// sender-constrained — the cnf carries the binding evidence.
+		const app = await buildApp([makeMtlsMechanism("E2E-MTLS-THUMB")]);
+
+		const { introspect } = await issueAndIntrospect(app);
+
+		expect(introspect.active).toBe(true);
+		expect(introspect.token_type).toBe("Bearer");
+		const cnf = introspect.cnf as Record<string, string> | undefined;
+		expect(cnf?.["x5t#S256"]).toBe("E2E-MTLS-THUMB");
+		// jkt MUST NOT appear in an mTLS-bound token.
+		expect(cnf?.jkt).toBeUndefined();
+	});
+
+	it("plain AT (no mechanism mounted): /introspect omits cnf and token_type stays Bearer", async () => {
+		const app = await buildApp(/* no mechanisms */);
+
+		const { introspect } = await issueAndIntrospect(app);
+
+		expect(introspect.active).toBe(true);
+		expect(introspect.token_type).toBe("Bearer");
+		expect(introspect.cnf).toBeUndefined();
+	});
+});

--- a/packages/oauth/src/__tests__/tokenBinding.introspect.integration.test.mts
+++ b/packages/oauth/src/__tests__/tokenBinding.introspect.integration.test.mts
@@ -128,7 +128,15 @@ async function buildApp(
 	const keyStore = createSymmetricKeyStore(SECRET);
 
 	if (mechanisms.length > 0) {
+		// Mount path-scoped to mirror production composition
+		// (`assembleApp` mounts `tokenBindingMw` on `/oauth/token` only).
+		// Without the path scope the middleware would also fire on
+		// `/oauth/introspect` and stamp `req.tokenBinding`, which could
+		// mask a future regression where introspect reads `req.tokenBinding`
+		// instead of decoding the AT's `cnf` claim. The introspect handler
+		// MUST derive `cnf` from the JWT payload, not from request state.
 		app.use(
+			"/oauth/token",
 			tokenBindingMw({
 				mechanisms,
 				dispatchPolicy: "intent-explicit",


### PR DESCRIPTION
## Summary

Phase 4 polish — closes Wave 2 Token-binding Cluster. Pairs the issuance side (Phase 2 DPoP, Phase 3 mTLS) with the introspection side (Phase 1 typed `IntrospectResponse`) end-to-end, and documents the design rationale + opt-in surface across packages.

## What this PR adds

- **T4.1 — end-to-end test** `tokenBinding.introspect.integration.test.mts` (3 cases: DPoP / mTLS / plain). First test exercising both the issuance code path and the introspect code path on the same AT.
- **T4.4 — ADR** `2026-05-20-token-binding-first-class-abstraction.md` at `packages/core/docs/adr/`. Documents why `TokenBindingMechanism` is a first-class extension surface, what the narrow `Confirmation` union buys, why the grant gate uses a mechanism allowlist, and the cross-mechanism refactor mid-Phase-3.
- **T4.5 — README updates** across core / oauth / dpop / mtls. Quick-start, opt-in HOCON, cross-mechanism dispatch, cnf flow, refresh-time matrix.
- **T4.6 — CHANGELOG roll-up** under `[Unreleased]` in all 4 packages (new `packages/oauth/CHANGELOG.md` created).
- **T4.7 — extensibility-immutability-check skill self-fire** on cumulative Wave 2 diff: zero new findings.

## Out of scope (preempted in Sub-PR 3c)

- T4.2 (dispatch policy contention) → `tokenBinding.dispatchPolicy.integration.test.mts`
- T4.3 (senderConstrained two-step reject) → `senderConstrained.integration.test.mts:229`

## Test plan

- [x] oauth tests: 560/560 (+3 introspect e2e cases)
- [x] workspace build clean
- [x] `pnpm run lint` clean (544 files)
- [x] No code changes in grant logic (Phase 3 Sub-PR 3c shipped that)
- [x] No public API change beyond docs + new test file
- [x] Extensibility skill self-fire: zero findings on cumulative Wave 2 diff (86 files / 9398 insertions)

🤖 Phase 4 closes Wave 2 Token-binding Cluster. Next: v0.8.0 release cut.