### PR TITLE
chore(docs): scrub agent-scope .claude/superpowers/specs/ references from shipped OSS sources

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -40,8 +40,8 @@ All notable changes to this package will be documented in this file.
   reads this with a defensive fallback to `"intent-explicit"`. The
   default also ships in `packages/core/config/reference.conf` with the
   `OAUTH_TOKEN_BINDING_DISPATCH_POLICY` env-var override hook.
-- Per cross-mechanism dispatch refactor spec at
-  `.claude/superpowers/specs/2026-05-19-wave-2-cross-mechanism-dispatch-refactor-spec.md`.
+- See ADR `packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md`
+  for the cross-mechanism design rationale.
 
 ### Notes
 

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -510,8 +510,7 @@ const userRepo = new InMemoryUserRepository(users);
 
 ### 拡張ポイント (v0.4.0)
 
-v0.4.0 で追加された 5 つの拡張ポイント (詳細:
-`.claude/superpowers/specs/2026-04-21-extension-surface-decisions-design.md`)。
+v0.4.0 で追加された 5 つの拡張ポイント。
 
 #### MFA
 
@@ -554,7 +553,7 @@ Federation + OIDC 対応のために `AppOptions` に追加された 2 つのオ
 - `userSessionStore`: sid キーの session metadata (auth_time、active RP、family ID、OIDC claim)。Built-in: `memory`、`redis`。
 - `federationTokenStore`: `(sid, federationName)` キーの upstream IdP token。Built-in: `memory`、`redis` (refresh_token は AES-256-GCM による暗号化必須。`allow-plaintext` は opt-in で警告を出力)。
 
-両 store は TODO-F-3 (cascading revoke)、F-4 (id_token + /userinfo)、F-5 (logout)、F-6 (/oauth/federation/:name/token) で消費される。本 F-1 では plumbing のみを追加する。詳細な interface + encryption contract は [TODO-F spec](../../.claude/superpowers/specs/2026-04-21-todo-f-federation-token-lifecycle-design.md) を参照。
+両 store は TODO-F-3 (cascading revoke)、F-4 (id_token + /userinfo)、F-5 (logout)、F-6 (/oauth/federation/:name/token) で消費される。本 F-1 では plumbing のみを追加する。
 
 **F-3 での consumer 有効化。** `CodeData` にログインパスが書き込む 2 つのオプションフィールドが追加された:
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -632,7 +632,7 @@ Two new optional `AppOptions` fields introduced for federation + OIDC support:
 - `userSessionStore`: sid-keyed session metadata (auth_time, active RPs, family IDs, OIDC claims). Built-in adapters: `memory`, `redis`.
 - `federationTokenStore`: `(sid, federationName)`-keyed upstream IdP tokens. Built-in adapters: `memory`, `redis` (with mandatory AES-256-GCM encryption of refresh_token; `allow-plaintext` is opt-in and emits a warning).
 
-Both stores are consumed by upcoming TODO-F-3 (cascading revocation), F-4 (id_token + /userinfo), F-5 (logout), and F-6 (/oauth/federation/:name/token). This plan (F-1) only adds the plumbing. The full interface + encryption contract is summarized below.
+Both stores are consumed by upcoming TODO-F-3 (cascading revocation), F-4 (id_token + /userinfo), F-5 (logout), and F-6 (/oauth/federation/:name/token). This plan (F-1) only adds the plumbing. See the exported type signatures in `@o3co/auth-provider-core` (`UserSessionStore`, `FederationTokenStore`) for the full interface; the redis adapter's encryption contract is documented inline at its construction site.
 
 **F-3 consumers activated.** `CodeData` now carries two optional fields wired by the login paths:
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -554,8 +554,7 @@ const userRepo = new InMemoryUserRepository(users);
 
 ### Extension points (v0.4.0)
 
-Five extension points introduced in v0.4.0 (see
-`.claude/superpowers/specs/2026-04-21-extension-surface-decisions-design.md`).
+Five extension points introduced in v0.4.0.
 
 #### MFA
 
@@ -633,7 +632,7 @@ Two new optional `AppOptions` fields introduced for federation + OIDC support:
 - `userSessionStore`: sid-keyed session metadata (auth_time, active RPs, family IDs, OIDC claims). Built-in adapters: `memory`, `redis`.
 - `federationTokenStore`: `(sid, federationName)`-keyed upstream IdP tokens. Built-in adapters: `memory`, `redis` (with mandatory AES-256-GCM encryption of refresh_token; `allow-plaintext` is opt-in and emits a warning).
 
-Both stores are consumed by upcoming TODO-F-3 (cascading revocation), F-4 (id_token + /userinfo), F-5 (logout), and F-6 (/oauth/federation/:name/token). This plan (F-1) only adds the plumbing. See [the TODO-F spec](../../.claude/superpowers/specs/2026-04-21-todo-f-federation-token-lifecycle-design.md) for the full interface + encryption contract.
+Both stores are consumed by upcoming TODO-F-3 (cascading revocation), F-4 (id_token + /userinfo), F-5 (logout), and F-6 (/oauth/federation/:name/token). This plan (F-1) only adds the plumbing. The full interface + encryption contract is summarized below.
 
 **F-3 consumers activated.** `CodeData` now carries two optional fields wired by the login paths:
 

--- a/packages/core/config/reference.conf
+++ b/packages/core/config/reference.conf
@@ -133,7 +133,8 @@ oauth {
   #     mechanisms succeeding → 400 invalid_request.
   #   "strict-mutual-exclusion": any 2+ mechanisms succeeding → 400.
   #
-  # Per `.claude/superpowers/specs/2026-05-19-wave-2-cross-mechanism-dispatch-refactor-spec.md` §4.2.
+  # See ADR `packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md`
+  # for the design rationale.
   tokenBinding {
     dispatch-policy = "intent-explicit"
     dispatch-policy = ${?OAUTH_TOKEN_BINDING_DISPATCH_POLICY}

--- a/packages/core/docs/adr/2026-05-13-reference-conf-shipping.md
+++ b/packages/core/docs/adr/2026-05-13-reference-conf-shipping.md
@@ -120,7 +120,9 @@ registration. HOCON `${?ENV_VAR}` substitution returns a string when the variabl
 
 ## Implementation reference
 
-- Spec: `.claude/superpowers/specs/2026-05-13-reference-conf-shipping.md`
+- The internal design spec lives in the agent-scope workspace, not in
+  the OSS repo. This ADR is the public summary of the load-bearing
+  decisions.
 - PR commits: TBD (filled in at release tag time per release-policy R6 step 5).
 
 ## Related

--- a/packages/core/src/__tests__/contributes-map-substitution.test.mts
+++ b/packages/core/src/__tests__/contributes-map-substitution.test.mts
@@ -64,13 +64,12 @@ describe("AS-M1: same-package concrete substitutions in contributes-map", () => 
 });
 
 describe("AS-M1: cross-package types still deferred to Phase F", () => {
-	// Per spec (`auth/.claude/superpowers/specs/2026-05-05-as-export-pattern-batch.md`
-	// lines 197-199): substituting `FederationProvider` (session package)
-	// and `ExchangeTokenValidator` (oauth-token-exchange package) requires
+	// Substituting `FederationProvider` (session package) and
+	// `ExchangeTokenValidator` (oauth-token-exchange package) requires
 	// resolving a circular package-import concern. The pragmatic v0.5.1
 	// resolution leaves these two as `unknown`. These pins fail-closed if
-	// a future PR substitutes them without the documented cross-package
-	// mechanism.
+	// a future PR substitutes them without first resolving the cross-
+	// package import cycle.
 
 	it("FederationProvider is still `unknown` (Phase F deferral)", () => {
 		expectTypeOf<FederationProvider>().toEqualTypeOf<unknown>();

--- a/packages/core/src/boot/__tests__/token-binding-mechanisms.integration.test.mts
+++ b/packages/core/src/boot/__tests__/token-binding-mechanisms.integration.test.mts
@@ -30,8 +30,8 @@
  *   5. Factory returns null → filtered; not included in the composition.
  *   6. dispatch-policy absent from config → defaults to `intent-explicit`.
  *
- * Per cross-mechanism dispatch refactor spec §6.1 at
- * `.claude/superpowers/specs/2026-05-19-wave-2-cross-mechanism-dispatch-refactor-spec.md`.
+ * See ADR `packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md`
+ * for the cross-mechanism design rationale.
  */
 
 import express, { type Request, type RequestHandler, Router } from "express";

--- a/packages/core/src/boot/assemble-app.mts
+++ b/packages/core/src/boot/assemble-app.mts
@@ -542,9 +542,9 @@ export function assembleApp(
 	// middleware. Multiple mechanism modules (DPoP, mTLS, ...) contribute
 	// raw mechanisms; core composes them into one middleware so the
 	// configured `DispatchPolicy` (`intent-explicit` / `strict-mutual-
-	// exclusion`) arbitrates across modules. See the cross-mechanism
-	// dispatch refactor spec at
-	// `.claude/superpowers/specs/2026-05-19-wave-2-cross-mechanism-dispatch-refactor-spec.md`.
+	// exclusion`) arbitrates across modules. See ADR
+	// `packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md`
+	// for the design rationale.
 	//
 	// Null entries (disabled-by-config) are filtered. When no mechanisms
 	// are contributed, no middleware is synthesized.

--- a/packages/core/src/boot/types.mts
+++ b/packages/core/src/boot/types.mts
@@ -445,9 +445,9 @@ export interface ContributionCollectorMap {
 	 * Unlike `grantMiddleware` which contributes pre-composed middleware,
 	 * this slot contributes raw mechanisms. `assembleApp` composes ONE
 	 * `tokenBindingMw` across all collected mechanisms so the configured
-	 * `DispatchPolicy` can arbitrate cross-module. See the cross-mechanism
-	 * dispatch refactor spec at
-	 * `.claude/superpowers/specs/2026-05-19-wave-2-cross-mechanism-dispatch-refactor-spec.md`.
+	 * `DispatchPolicy` can arbitrate cross-module. See ADR
+	 * `packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md`
+	 * for the cross-mechanism design rationale.
 	 */
 	readonly tokenBindingMechanisms?: ListCollector<TokenBindingMechanism | null>;
 }

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -323,8 +323,8 @@ export const CoreConfigSchema = z.object({
 		// `config.oauth.tokenBinding["dispatch-policy"]` and falls back to
 		// `"intent-explicit"` when absent.
 		//
-		// Per cross-mechanism dispatch refactor spec §4.2 at
-		// `.claude/superpowers/specs/2026-05-19-wave-2-cross-mechanism-dispatch-refactor-spec.md`.
+		// See ADR `packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md`
+		// for the cross-mechanism design rationale.
 		tokenBinding: z
 			.object({
 				"dispatch-policy": z.enum(["intent-explicit", "strict-mutual-exclusion"]),

--- a/packages/core/src/modules/manifest/contributes-map.mts
+++ b/packages/core/src/modules/manifest/contributes-map.mts
@@ -132,8 +132,8 @@ export type GrantMiddlewareFactory<Deps> = (deps: Deps) => RequestHandler | null
  * (`intent-explicit` / `strict-mutual-exclusion`) arbitrate cross-module
  * when multiple mechanism modules (DPoP, mTLS, ...) are installed.
  *
- * Per Wave 2 Token-binding Cluster cross-mechanism dispatch refactor spec
- * `.claude/superpowers/specs/2026-05-19-wave-2-cross-mechanism-dispatch-refactor-spec.md`.
+ * See ADR `packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md`
+ * for the cross-mechanism design rationale.
  */
 export type TokenBindingMechanismFactory<Deps> = (deps: Deps) => TokenBindingMechanism | null;
 
@@ -221,8 +221,8 @@ export interface ContributesMap<Deps = ProviderDeps<never, never>> {
 	 * config), but the list is allowed to contain multiple factories to
 	 * support a single module shipping multiple mechanisms.
 	 *
-	 * Per cross-mechanism dispatch refactor spec at
-	 * `.claude/superpowers/specs/2026-05-19-wave-2-cross-mechanism-dispatch-refactor-spec.md`.
+	 * See ADR `packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md`
+	 * for the cross-mechanism design rationale.
 	 */
 	readonly tokenBindingMechanisms?: readonly TokenBindingMechanismFactory<Deps>[];
 }

--- a/packages/core/src/repositories/types.mts
+++ b/packages/core/src/repositories/types.mts
@@ -116,8 +116,8 @@ export interface User {
  *
  * `consumeByCode` (atomic single-use) is the sole authenticity gate; `client_id`
  * and `redirect_uri` embedded in the record replace the session-based identity
- * gates removed in v0.5.1 (see CHANGELOG and the D-1 spec at
- * `auth/.claude/superpowers/specs/2026-05-05-d1-code-repository-rewrite.md`).
+ * gates removed in v0.5.1 (see CHANGELOG for the historical context — the
+ * design rationale is the D-1 code-repository rewrite shipped in that release).
  *
  * Breaking change for custom CodeRepository implementations: `client_id` and
  * `redirect_uri` are now required. The compile-time guard

--- a/packages/dpop/CHANGELOG.md
+++ b/packages/dpop/CHANGELOG.md
@@ -21,7 +21,8 @@ All notable changes to this package will be documented in this file.
   `dpopModule` now contributes the raw `TokenBindingMechanism` and core
   composes ONE `tokenBindingMw` from all installed binding-mechanism
   modules so the configured `DispatchPolicy` arbitrates cross-module.
-  See `.claude/superpowers/specs/2026-05-19-wave-2-cross-mechanism-dispatch-refactor-spec.md`.
+  See ADR `packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md`
+  for the design rationale.
 - **Removed `oauth.tokenBinding` declarations** from `dpopConfigSchema`
   and `reference.conf`. The `oauth.tokenBinding.dispatch-policy` key is
   now owned by core's bundled config schema (single source of truth

--- a/packages/dpop/README.md
+++ b/packages/dpop/README.md
@@ -4,7 +4,7 @@ DPoP (RFC 9449) sender-constrained access token support for [@o3co/auth-provider
 
 ## Status
 
-Stage 1 (token-endpoint binding). See [the Phase 2 spec](https://github.com/o3co/auth.provider/blob/develop/.claude/superpowers/specs/2026-05-18-wave-2-phase-2-dpop-spec.md) for the scope boundary — Stage 2 will add nonce challenge (RFC 9449 §8) and the `dpop_jkt` query parameter at `/authorize` (RFC 9449 §10).
+Stage 1 (token-endpoint binding). Stage 2 will add nonce challenge (RFC 9449 §8) and the `dpop_jkt` query parameter at `/authorize` (RFC 9449 §10).
 
 ## Quick start
 

--- a/packages/dpop/src/module.mts
+++ b/packages/dpop/src/module.mts
@@ -139,8 +139,8 @@ export const dpopConfigSchema = z.object({
  * so the `DispatchPolicy` can arbitrate cross-module when both DPoP and
  * mTLS are installed. The mechanism itself is unchanged.
  *
- * Per Wave 2 Phase 2 spec §11.2 + cross-mechanism dispatch refactor spec at
- * `.claude/superpowers/specs/2026-05-19-wave-2-cross-mechanism-dispatch-refactor-spec.md`.
+ * See ADR `packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md`
+ * for the cross-mechanism design rationale.
  */
 export const dpopModule = defineModule<"config", "logger" | "dpopReplayStore">({
 	name: "dpop",

--- a/packages/mtls/CHANGELOG.md
+++ b/packages/mtls/CHANGELOG.md
@@ -61,7 +61,8 @@ All notable changes to this package will be documented in this file.
   composes ONE `tokenBindingMw` from all installed binding-mechanism
   modules so the configured `DispatchPolicy` arbitrates cross-module.
   Resolves the §11.4 known limitation documented at Sub-PR 3b merge.
-  See `.claude/superpowers/specs/2026-05-19-wave-2-cross-mechanism-dispatch-refactor-spec.md`.
+  See ADR `packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md`
+  for the design rationale.
 - **Removed `oauth.tokenBinding` declarations** from `mtlsConfigSchema`
   and `reference.conf`. The `oauth.tokenBinding.dispatch-policy` key is
   now owned by core's bundled config schema (single source of truth
@@ -92,7 +93,7 @@ All notable changes to this package will be documented in this file.
 
 - **Single binding mechanism per deployment.** When both `dpopModule` and `mtlsModule` are enabled, each contributes its own independent `tokenBindingMw`; `dispatch-policy` cannot arbitrate across module boundaries and the second mechanism's binding silently overwrites the first. Enable one mechanism per AS until a follow-up sub-PR refactors the contribution surface. See README "Known Limitations" + spec §11.4.
 
-Implements the Phase 3 spec at `.claude/superpowers/specs/2026-05-18-wave-2-phase-3-mtls-spec.md` §13 T3b.
+Implements Wave 2 Phase 3 Sub-PR 3b per the internal design spec.
 
 ### Added (Phase 3 Sub-PR 3a)
 
@@ -103,4 +104,4 @@ Implements the Phase 3 spec at `.claude/superpowers/specs/2026-05-18-wave-2-phas
 - `ClientCertificate` type + `parseDerToCertificate`.
 - `MtlsError` + `MtlsReasonCode` union.
 
-Implements the Phase 3 spec at `.claude/superpowers/specs/2026-05-18-wave-2-phase-3-mtls-spec.md` §13 T3a.
+Implements Wave 2 Phase 3 Sub-PR 3a per the internal design spec.

--- a/packages/mtls/README.md
+++ b/packages/mtls/README.md
@@ -105,7 +105,7 @@ location / {
 
 `$ssl_client_escaped_cert` is the URL-encoded PEM of the validated client leaf cert. The `cert-header-dialect = "plain-pem"` parser auto-decodes the percent-encoding.
 
-> **Note:** nginx does not emit Envoy-format XFCC. The Phase 3 `cert-header-dialect` enumeration is `"envoy" | "plain-pem"` — `"plain-pem"` is what nginx + similar minimal proxies should use, NOT an nginx-specific XFCC variant (which is out of scope for Stage 1 — see [#1.3 of the spec](../../.claude/superpowers/specs/2026-05-18-wave-2-phase-3-mtls-spec.md)).
+> **Note:** nginx does not emit Envoy-format XFCC. The Phase 3 `cert-header-dialect` enumeration is `"envoy" | "plain-pem"` — `"plain-pem"` is what nginx + similar minimal proxies should use, NOT an nginx-specific XFCC variant (which is out of scope for Stage 1).
 >
 > To strip any inbound header before nginx injects its own, add `proxy_set_header X-Forwarded-Client-Cert "";` to a higher-priority location, or use a sanitization filter on the upstream.
 

--- a/packages/mtls/src/__tests__/dual-mechanism.integration.test.mts
+++ b/packages/mtls/src/__tests__/dual-mechanism.integration.test.mts
@@ -30,8 +30,8 @@
  *            `tokenBindingMechanisms` contributions; dispatch-policy applies
  *            across mechanisms.
  *
- * Per cross-mechanism dispatch refactor spec §6.4 at
- * `.claude/superpowers/specs/2026-05-19-wave-2-cross-mechanism-dispatch-refactor-spec.md`.
+ * See ADR `packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md`
+ * for the cross-mechanism design rationale.
  */
 
 import { createHash, X509Certificate } from "node:crypto";

--- a/packages/mtls/src/module.mts
+++ b/packages/mtls/src/module.mts
@@ -120,8 +120,8 @@ export const mtlsConfigSchema = z.object({
  * so the `DispatchPolicy` can arbitrate cross-module when both DPoP and
  * mTLS are installed.
  *
- * Per Wave 2 Phase 3 spec §11 + cross-mechanism dispatch refactor spec at
- * `.claude/superpowers/specs/2026-05-19-wave-2-cross-mechanism-dispatch-refactor-spec.md`.
+ * See ADR `packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md`
+ * for the cross-mechanism design rationale.
  */
 export const mtlsModule = defineModule<"config", "logger">({
 	name: "mtls",

--- a/packages/webauthn/README.md
+++ b/packages/webauthn/README.md
@@ -133,8 +133,6 @@ Deferred to subsequent waves:
 - RFC 8707 Stage 2 audience-restrict enforcement ([issue #173](https://github.com/o3co/auth.provider/issues/173))
 - Attestation root chain verification (Stage 2+)
 
-See `.claude/superpowers/specs/2026-05-12-wave-1-spec.md` §2 for the full Stage 1 contract.
-
 ## License
 
 Apache-2.0 © 1o1 Co. Ltd.


### PR DESCRIPTION
## Summary

Pre-v0.8.0 cleanup. Closes #197.

The agent-scope (`auth/.claude/superpowers/specs/`) is a planning workspace OUTSIDE the OSS repo. References to its paths inside shipped source files were leaking via published npm tarballs + GitHub renders, breaking `feedback_oss_no_internal_paths` discipline.

This sweep replaces each reference with one of:
- Pointer to the shipped ADR `packages/core/docs/adr/2026-05-20-token-binding-first-class-abstraction.md` (for Wave 2 cross-mechanism material)
- Short inline rationale (the WHY without the path)
- Removal where citation added no value

## Files touched (17)

- core: 2 README files, reference.conf, 1 older ADR, 6 source files
- dpop: README, module.mts
- mtls: README, module.mts, dual-mechanism test
- webauthn: README

## Verification

- `grep -rn '\.claude/superpowers/specs' packages/` → 0 hits
- `pnpm run build` clean
- `pnpm run lint` clean (544 files)
- `pnpm -r test` workspace-wide green (2920+ tests)
- No behavior change — comments + doc references only

## Why now (pre-release timing)

npm tarballs snapshot source comments at publish time. Doing this BEFORE the v0.8.0 cut means external consumers' `node_modules` won't ship with the path references; doing it AFTER would leave them permanently in v0.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)