### PR TITLE
feat(jwks): publish JWKS via a core jwksModule (configurable path + Cache-Control)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`jwksModule` (`@o3co/auth-provider-core`).** A route-contributing module that publishes the provider's verification keys at the JWKS endpoint. It depends only on the `keyStore` and is mounted unconditionally — a provider that signs tokens must publish its keys regardless of whether an OIDC issuer is configured, so (unlike issuer-gated `oidc-discovery`) it is a key-management concern owned by core, not the `oauth` module. The standalone scaffold wires it alongside `oauthModule`. `createJwksRouter` remains exported for direct composition.
+- **Configurable JWKS path via `oauth.jwt.jwksPath`.** `jwks_uri` is operator-choosable per OIDC Discovery; it now defaults to `/.well-known/jwks.json` and can be overridden (must be an absolute path). The JWKS route and the discovery `jwks_uri` both resolve the path through the new exported `resolveJwksPath` helper (with `DEFAULT_JWKS_PATH`), so the registered path and the advertised URI cannot drift.
+
 ### Fixed
 
-- **JWKS endpoint is now mounted.** `@o3co/auth-provider-core` shipped `routes/Jwks.mts` but no module mounted it, so OIDC discovery advertised `jwks_uri` while `GET /.well-known/jwks.json` returned 404 — verifiers had no key source for offline asymmetric-token validation. The `oauth` module now contributes the JWKS route, mounted unconditionally (a provider that signs tokens must publish its verification keys regardless of whether an OIDC issuer is configured, so it is not issuer-gated like `oidc-discovery`). `@o3co/auth-provider-core` additionally exports `createJwksRouter` for direct composition.
+- **JWKS endpoint is now mounted.** `@o3co/auth-provider-core` shipped `routes/Jwks.mts` but no module mounted it, so OIDC discovery advertised `jwks_uri` while `GET /.well-known/jwks.json` returned 404 — verifiers (BFFs, RPs) had no key source for offline asymmetric-token validation. The new `jwksModule` mounts the route; an integration test pins that the advertised `jwks_uri` always resolves to the mounted route (including under a `jwksPath` override).
 
 ## [0.8.0] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **`jwksModule` (`@o3co/auth-provider-core`).** A route-contributing module that publishes the provider's verification keys at the JWKS endpoint. It depends only on the `keyStore` and is mounted unconditionally — a provider that signs tokens must publish its keys regardless of whether an OIDC issuer is configured, so (unlike issuer-gated `oidc-discovery`) it is a key-management concern owned by core, not the `oauth` module. The standalone scaffold wires it alongside `oauthModule`. `createJwksRouter` remains exported for direct composition.
 - **Configurable JWKS path via `oauth.jwt.jwksPath`.** `jwks_uri` is operator-choosable per OIDC Discovery; it now defaults to `/.well-known/jwks.json` and can be overridden (must be an absolute path). The JWKS route and the discovery `jwks_uri` both resolve the path through the new exported `resolveJwksPath` helper (with `DEFAULT_JWKS_PATH`), so the registered path and the advertised URI cannot drift.
+- **JWKS responses now send `Cache-Control: public, max-age=<N>`.** JWKS is the most-polled verifier endpoint, so the response is now cacheable; `max-age` defaults to 300s and is operator-tunable via `oauth.jwt.jwksCacheMaxAge` (keep it well below the key-overlap window so a rotated kid propagates in time). New exports: `DEFAULT_JWKS_CACHE_MAX_AGE`, `resolveJwksCacheMaxAge`. `createJwksRouter`'s third argument is now an options object (`{ path?, cacheMaxAgeSeconds? }`).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **JWKS endpoint is now mounted.** `@o3co/auth-provider-core` shipped `routes/Jwks.mts` but no module mounted it, so OIDC discovery advertised `jwks_uri` while `GET /.well-known/jwks.json` returned 404 — verifiers had no key source for offline asymmetric-token validation. The `oauth` module now contributes the JWKS route, mounted unconditionally (a provider that signs tokens must publish its verification keys regardless of whether an OIDC issuer is configured, so it is not issuer-gated like `oidc-discovery`). `@o3co/auth-provider-core` additionally exports `createJwksRouter` for direct composition.
+
 ## [0.8.0] - 2026-05-20
 
 v0.8.0 ships **Wave 2 Token-binding Cluster** — sender-constrained access tokens via DPoP (RFC 9449) and mTLS (RFC 8705) as a first-class extension surface. Two new OSS packages (`@o3co/auth-provider-dpop`, `@o3co/auth-provider-mtls`), a new core abstraction (`TokenBindingMechanism` + `TokenBindingMechanismFactory<Deps>` + `tokenBindingMechanisms` contribution slot), grant-side `cnf` claim emission, and a §9.2 5-row refresh-time enforcement matrix per mechanism. Plus ADR `2026-05-20-token-binding-first-class-abstraction.md` documenting the design.

--- a/packages/core/src/config/__tests__/signing-key-schema.test.mts
+++ b/packages/core/src/config/__tests__/signing-key-schema.test.mts
@@ -103,6 +103,27 @@ describe("oauth.jwt.signingKey schema", () => {
 		expect((parsed as { jwksPath?: string }).jwksPath).toBeUndefined();
 	});
 
+	it("accepts a non-negative integer oauth.jwt.jwksCacheMaxAge", () => {
+		const parsed = jwtSchema.parse({
+			signingKey: { provider: "local", local: validLocal() },
+			jwksCacheMaxAge: 3600,
+		});
+		expect((parsed as { jwksCacheMaxAge?: number }).jwksCacheMaxAge).toBe(3600);
+	});
+
+	it("rejects a negative or non-integer oauth.jwt.jwksCacheMaxAge", () => {
+		for (const bad of [-1, 1.5]) {
+			const result = jwtSchema.safeParse({
+				signingKey: { provider: "local", local: validLocal() },
+				jwksCacheMaxAge: bad,
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues.map((i) => i.path.join("."))).toContain("jwksCacheMaxAge");
+			}
+		}
+	});
+
 	it("does NOT superRefine-reject missing secret for HS256 (schema does shape only; builder enforces field presence)", () => {
 		// Previously the schema would reject HS256 without a secret. After
 		// migration the schema only enforces shape (field presence per the

--- a/packages/core/src/config/__tests__/signing-key-schema.test.mts
+++ b/packages/core/src/config/__tests__/signing-key-schema.test.mts
@@ -76,6 +76,33 @@ describe("oauth.jwt.signingKey schema", () => {
 		expect(parsed.issuer).toBe("https://auth.example.com");
 	});
 
+	it("accepts an absolute oauth.jwt.jwksPath override", () => {
+		const parsed = jwtSchema.parse({
+			signingKey: { provider: "local", local: validLocal() },
+			jwksPath: "/keys/jwks.json",
+		});
+		expect((parsed as { jwksPath?: string }).jwksPath).toBe("/keys/jwks.json");
+	});
+
+	it("rejects a non-absolute oauth.jwt.jwksPath (must begin with '/')", () => {
+		const result = jwtSchema.safeParse({
+			signingKey: { provider: "local", local: validLocal() },
+			jwksPath: "keys/jwks.json",
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const paths = result.error.issues.map((i) => i.path.join("."));
+			expect(paths).toContain("jwksPath");
+		}
+	});
+
+	it("omitting oauth.jwt.jwksPath is valid (resolveJwksPath applies the default)", () => {
+		const parsed = jwtSchema.parse({
+			signingKey: { provider: "local", local: validLocal() },
+		});
+		expect((parsed as { jwksPath?: string }).jwksPath).toBeUndefined();
+	});
+
 	it("does NOT superRefine-reject missing secret for HS256 (schema does shape only; builder enforces field presence)", () => {
 		// Previously the schema would reject HS256 without a secret. After
 		// migration the schema only enforces shape (field presence per the

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -145,6 +145,14 @@ const REMOVED_REFRESH_TOKEN_FIELDS: ReadonlyArray<{
 const jwtSchemaBase = z.object({
 	issuer: z.string().optional(),
 	signingKey: signingKeySchema,
+	// JWKS publishing path (OIDC `jwks_uri`). Operator-choosable per OIDC
+	// Discovery; defaults to `/.well-known/jwks.json` when unset (applied by
+	// `resolveJwksPath`). Must be an absolute path so the JWKS route and the
+	// advertised `jwks_uri` agree. See `core/src/jwks/path.mts`.
+	jwksPath: z
+		.string()
+		.startsWith("/", "oauth.jwt.jwksPath must be an absolute path beginning with '/'")
+		.optional(),
 	// SF-1 (v0.5.1): when true (default in HOCON), the central JWT verifier
 	// accepts tokens whose `typ` header is absent and emits a deprecation
 	// warning. v0.6+ should set this to false and reject typ-less tokens.

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -153,6 +153,11 @@ const jwtSchemaBase = z.object({
 		.string()
 		.startsWith("/", "oauth.jwt.jwksPath must be an absolute path beginning with '/'")
 		.optional(),
+	// JWKS response `Cache-Control: public, max-age=<N>` lifetime (seconds).
+	// Operator-tunable; defaults to 300 (applied by `resolveJwksCacheMaxAge`).
+	// Keep well below the key-overlap window so a rotated kid propagates to
+	// caching verifiers in time. See `core/src/jwks/cache.mts`.
+	jwksCacheMaxAge: z.number().int().nonnegative().optional(),
 	// SF-1 (v0.5.1): when true (default in HOCON), the central JWT verifier
 	// accepts tokens whose `typ` header is absent and emits a deprecation
 	// warning. v0.6+ should set this to false and reject typ-less tokens.

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -152,6 +152,7 @@ export type {
 // is the underlying factory for direct composition. `DEFAULT_JWKS_PATH` /
 // `resolveJwksPath` are the single source of truth for the publishing path,
 // shared with oauth discovery's `jwks_uri` so the two never drift.
+export { DEFAULT_JWKS_CACHE_MAX_AGE, resolveJwksCacheMaxAge } from "./jwks/cache.mjs";
 export { jwksModule } from "./jwks/module.mjs";
 export { DEFAULT_JWKS_PATH, resolveJwksPath } from "./jwks/path.mjs";
 // JWT verifier (SF-1) — central verifyJwt with alg/iss/aud/typ pinning
@@ -307,7 +308,7 @@ export type {
 	User,
 } from "./repositories/types.mjs";
 export type { UserRepository } from "./repositories/UserRepository.mjs";
-export { createRouter as createJwksRouter } from "./routes/Jwks.mjs";
+export { createRouter as createJwksRouter, type JwksRouterOptions } from "./routes/Jwks.mjs";
 export {
 	createSessionFamilyIndexFactory,
 	createSessionFederationIndexFactory,

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -147,6 +147,13 @@ export type {
 	SessionData,
 	SessionMutation,
 } from "./grants/types.mjs";
+// JWKS publishing — `jwksModule` mounts the route so every provider that signs
+// tokens exposes its verification keys for offline validation; `createJwksRouter`
+// is the underlying factory for direct composition. `DEFAULT_JWKS_PATH` /
+// `resolveJwksPath` are the single source of truth for the publishing path,
+// shared with oauth discovery's `jwks_uri` so the two never drift.
+export { jwksModule } from "./jwks/module.mjs";
+export { DEFAULT_JWKS_PATH, resolveJwksPath } from "./jwks/path.mjs";
 // JWT verifier (SF-1) — central verifyJwt with alg/iss/aud/typ pinning
 export type {
 	JwtType,
@@ -300,8 +307,6 @@ export type {
 	User,
 } from "./repositories/types.mjs";
 export type { UserRepository } from "./repositories/UserRepository.mjs";
-// Routes — JWKS publishing (mounted by the oauth module so every provider that
-// signs tokens exposes /.well-known/jwks.json for offline verification).
 export { createRouter as createJwksRouter } from "./routes/Jwks.mjs";
 export {
 	createSessionFamilyIndexFactory,

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -300,6 +300,9 @@ export type {
 	User,
 } from "./repositories/types.mjs";
 export type { UserRepository } from "./repositories/UserRepository.mjs";
+// Routes — JWKS publishing (mounted by the oauth module so every provider that
+// signs tokens exposes /.well-known/jwks.json for offline verification).
+export { createRouter as createJwksRouter } from "./routes/Jwks.mjs";
 export {
 	createSessionFamilyIndexFactory,
 	createSessionFederationIndexFactory,

--- a/packages/core/src/jwks/__tests__/module.test.mts
+++ b/packages/core/src/jwks/__tests__/module.test.mts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { createSymmetricKeyStore } from "../../keys/KeyStore.mjs";
+import { defineModule } from "../../modules/index.mjs";
+import { createTestApp } from "../../testing/create-test-app.mjs";
+import { makeValidAppConfig } from "../../testing/fixtures/valid-config.mjs";
+import { jwksModule } from "../module.mjs";
+
+/** Inline module satisfying jwksModule's `requires: ["keyStore"]`. */
+const keyStoreModule = defineModule({
+	name: "test:key-store",
+	provides: {
+		keyStore: () => createSymmetricKeyStore("test-secret-for-jwks-module!!!!"),
+	},
+});
+
+function withJwksPath(jwksPath: string) {
+	const config = makeValidAppConfig() as { oauth?: { jwt?: Record<string, unknown> } };
+	return {
+		...config,
+		oauth: {
+			...config.oauth,
+			jwt: { ...config.oauth?.jwt, jwksPath },
+		},
+	} as unknown as ReturnType<typeof makeValidAppConfig>;
+}
+
+describe("jwksModule", () => {
+	it("contributes a route with id 'jwks' (mounted unconditionally, no issuer needed)", async () => {
+		const config = makeValidAppConfig();
+		const handle = await createTestApp({
+			modules: [jwksModule, keyStoreModule],
+			bootstrapComponents: { config, pathResolver: (s) => s },
+		});
+		const routeIds = handle.inspect.routes.map((r) => r.contribution.id);
+		expect(routeIds).toContain("jwks");
+		await handle.dispose();
+	});
+
+	it("serves the default /.well-known/jwks.json (reachable, not 404)", async () => {
+		const config = makeValidAppConfig();
+		const handle = await createTestApp({
+			modules: [jwksModule, keyStoreModule],
+			bootstrapComponents: { config, pathResolver: (s) => s },
+		});
+		const app = express();
+		app.use(handle.router);
+		const res = await request(app).get("/.well-known/jwks.json");
+		expect(res.status).toBe(200);
+		expect(Array.isArray(res.body.keys)).toBe(true);
+		await handle.dispose();
+	});
+
+	it("serves the configured oauth.jwt.jwksPath override (and not the default)", async () => {
+		const config = withJwksPath("/keys/jwks.json");
+		const handle = await createTestApp({
+			modules: [jwksModule, keyStoreModule],
+			bootstrapComponents: { config, pathResolver: (s) => s },
+		});
+		const app = express();
+		app.use(handle.router);
+		expect((await request(app).get("/keys/jwks.json")).status).toBe(200);
+		expect((await request(app).get("/.well-known/jwks.json")).status).toBe(404);
+		await handle.dispose();
+	});
+});

--- a/packages/core/src/jwks/__tests__/module.test.mts
+++ b/packages/core/src/jwks/__tests__/module.test.mts
@@ -65,6 +65,25 @@ describe("jwksModule", () => {
 		const res = await request(app).get("/.well-known/jwks.json");
 		expect(res.status).toBe(200);
 		expect(Array.isArray(res.body.keys)).toBe(true);
+		// Default Cache-Control so verifiers cache the key set.
+		expect(res.headers["cache-control"]).toBe("public, max-age=300");
+		await handle.dispose();
+	});
+
+	it("reflects a configured oauth.jwt.jwksCacheMaxAge in Cache-Control", async () => {
+		const config = makeValidAppConfig() as { oauth?: { jwt?: Record<string, unknown> } };
+		const withMaxAge = {
+			...config,
+			oauth: { ...config.oauth, jwt: { ...config.oauth?.jwt, jwksCacheMaxAge: 3600 } },
+		} as unknown as ReturnType<typeof makeValidAppConfig>;
+		const handle = await createTestApp({
+			modules: [jwksModule, keyStoreModule],
+			bootstrapComponents: { config: withMaxAge, pathResolver: (s) => s },
+		});
+		const app = express();
+		app.use(handle.router);
+		const res = await request(app).get("/.well-known/jwks.json");
+		expect(res.headers["cache-control"]).toBe("public, max-age=3600");
 		await handle.dispose();
 	});
 

--- a/packages/core/src/jwks/cache.mts
+++ b/packages/core/src/jwks/cache.mts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Default `Cache-Control: public, max-age=<N>` lifetime (seconds) for the
+ * JWKS response when `oauth.jwt.jwksCacheMaxAge` is unset. JWKS is the
+ * most-polled verifier endpoint, so a non-zero default cuts polling load;
+ * 5 minutes is short enough that a rotated key propagates quickly to
+ * verifiers that cache the set. Operators with a different key-overlap
+ * window tune it via config — `max-age` should stay well below the overlap
+ * window so a token signed with a freshly-rotated kid is never rejected
+ * longer than the cache lifetime.
+ */
+export const DEFAULT_JWKS_CACHE_MAX_AGE = 300;
+
+/**
+ * Resolve the JWKS `Cache-Control` max-age (seconds) for a deployment.
+ * Consumed only by the JWKS route (discovery does not advertise cache
+ * metadata), so this is not a shared anti-drift helper like
+ * `resolveJwksPath` — it simply centralizes the config key + default.
+ *
+ * Intentionally lenient: the config schema is the authoritative guard (it
+ * rejects negative / non-integer / non-number values at parse time), so at
+ * runtime `configured` is either a valid non-negative integer or absent.
+ * The defensive check falls back to the default for callers that bypass the
+ * schema (hand-built config objects).
+ */
+export const resolveJwksCacheMaxAge = (config: {
+	oauth?: { jwt?: { jwksCacheMaxAge?: unknown } };
+}): number => {
+	const configured = config.oauth?.jwt?.jwksCacheMaxAge;
+	return typeof configured === "number" && Number.isInteger(configured) && configured >= 0
+		? configured
+		: DEFAULT_JWKS_CACHE_MAX_AGE;
+};

--- a/packages/core/src/jwks/module.mts
+++ b/packages/core/src/jwks/module.mts
@@ -18,6 +18,7 @@ import { createRequire } from "node:module";
 import type { Router } from "express";
 import { defineModule } from "../modules/index.mjs";
 import { createRouter as createJwksRouter } from "../routes/Jwks.mjs";
+import { resolveJwksCacheMaxAge } from "./cache.mjs";
 import { resolveJwksPath } from "./path.mjs";
 
 /**
@@ -50,11 +51,16 @@ export const jwksModule = defineModule({
 			async (deps) => {
 				const require = createRequire(import.meta.url);
 				const express = require("express") as { Router: () => Router };
-				const path = resolveJwksPath(deps.config as { oauth?: { jwt?: { jwksPath?: unknown } } });
+				const config = deps.config as {
+					oauth?: { jwt?: { jwksPath?: unknown; jwksCacheMaxAge?: unknown } };
+				};
 				return {
 					id: "jwks",
 					mountPath: "/",
-					handler: createJwksRouter(express, deps.keyStore, path),
+					handler: createJwksRouter(express, deps.keyStore, {
+						path: resolveJwksPath(config),
+						cacheMaxAgeSeconds: resolveJwksCacheMaxAge(config),
+					}),
 				};
 			},
 		],

--- a/packages/core/src/jwks/module.mts
+++ b/packages/core/src/jwks/module.mts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createRequire } from "node:module";
+import type { Router } from "express";
+import { defineModule } from "../modules/index.mjs";
+import { createRouter as createJwksRouter } from "../routes/Jwks.mjs";
+import { resolveJwksPath } from "./path.mjs";
+
+/**
+ * JWKS publishing module. Contributes the `/.well-known/jwks.json` route
+ * (or the `oauth.jwt.jwksPath` override) so every provider that signs
+ * tokens exposes its verification keys for offline validation by verifiers
+ * (BFFs, RPs).
+ *
+ * Unlike OIDC discovery (issuer-gated, contributed by the oauth module),
+ * JWKS publishing is a key-management concern: it depends ONLY on the
+ * `keyStore` and is mounted whenever the provider signs tokens, independent
+ * of whether an OIDC issuer is configured. For HS256 (symmetric) the route
+ * returns an empty key set — the secret is never published.
+ *
+ * The route registers an absolute path, so the contribution mounts at "/"
+ * to avoid path doubling.
+ *
+ * `express` is resolved lazily inside the (async) route factory via
+ * `createRequire` rather than a static import. core declares `express` as
+ * an OPTIONAL peer dependency; a static import would make
+ * `@o3co/auth-provider-core` fail to load for non-HTTP consumers that omit
+ * this module from their manifest. Mirrors the peer-resolution pattern in
+ * `boot/assemble-app.mts`.
+ */
+export const jwksModule = defineModule({
+	name: "jwks",
+	requires: ["config", "keyStore"] as const,
+	contributes: {
+		routes: [
+			async (deps) => {
+				const require = createRequire(import.meta.url);
+				const express = require("express") as { Router: () => Router };
+				const path = resolveJwksPath(deps.config as { oauth?: { jwt?: { jwksPath?: unknown } } });
+				return {
+					id: "jwks",
+					mountPath: "/",
+					handler: createJwksRouter(express, deps.keyStore, path),
+				};
+			},
+		],
+	},
+});

--- a/packages/core/src/jwks/path.mts
+++ b/packages/core/src/jwks/path.mts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 1o1 Co. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Default path at which the JSON Web Key Set is published. Unlike
+ * `/.well-known/openid-configuration` (fixed by RFC 8414), `jwks_uri` is
+ * operator-choosable per OIDC Discovery — this is the near-universal
+ * convention and the default when `oauth.jwt.jwksPath` is unset.
+ */
+export const DEFAULT_JWKS_PATH = "/.well-known/jwks.json";
+
+/**
+ * Resolve the JWKS publishing path for a deployment. This is the SINGLE
+ * source of truth for both (a) where the JWKS route registers itself and
+ * (b) the `jwks_uri` OIDC discovery advertises. The core `jwksModule` and
+ * the oauth discovery route MUST both resolve the path through this
+ * function so the two endpoints can never drift — neither the config key
+ * (`oauth.jwt.jwksPath`) nor the default is duplicated at a call site.
+ *
+ * The configured value is validated as an absolute path by the config
+ * schema (`oauth.jwt.jwksPath`); this resolver only applies the default.
+ */
+export const resolveJwksPath = (config: { oauth?: { jwt?: { jwksPath?: unknown } } }): string => {
+	const configured = config.oauth?.jwt?.jwksPath;
+	// Intentionally lenient: the config schema is the authoritative guard (it
+	// rejects non-absolute / non-string `jwksPath` at parse time), so at runtime
+	// `configured` is either a valid absolute string or absent. The typeof/length
+	// check is defensive belt-and-suspenders for callers that bypass the schema
+	// (e.g. hand-built config objects) — fall back to the default rather than
+	// publishing keys at a malformed path.
+	return typeof configured === "string" && configured.length > 0 ? configured : DEFAULT_JWKS_PATH;
+};

--- a/packages/core/src/routes/Jwks.mts
+++ b/packages/core/src/routes/Jwks.mts
@@ -15,8 +15,28 @@
  */
 import type { Request, Response, Router } from "express";
 import { exportJWK } from "jose";
+import { DEFAULT_JWKS_CACHE_MAX_AGE } from "../jwks/cache.mjs";
 import { DEFAULT_JWKS_PATH } from "../jwks/path.mjs";
 import type { KeyStore } from "../keys/KeyStore.mjs";
+
+/** Options for {@link createRouter}. */
+export interface JwksRouterOptions {
+	/**
+	 * Absolute path the router registers internally. Defaults to
+	 * {@link DEFAULT_JWKS_PATH}. Callers honoring the `oauth.jwt.jwksPath`
+	 * override resolve it via `resolveJwksPath` and pass the result here so
+	 * the registered path matches the advertised `jwks_uri`.
+	 */
+	path?: string;
+	/**
+	 * `Cache-Control: public, max-age=<N>` lifetime in seconds for the JWKS
+	 * response. Defaults to {@link DEFAULT_JWKS_CACHE_MAX_AGE}. Callers
+	 * honoring `oauth.jwt.jwksCacheMaxAge` resolve it via
+	 * `resolveJwksCacheMaxAge`. Keep well below the key-overlap window so a
+	 * freshly-rotated kid propagates to caching verifiers in time.
+	 */
+	cacheMaxAgeSeconds?: number;
+}
 
 /**
  * Build the JWKS publishing Router. The router registers `path` as an
@@ -27,20 +47,29 @@ import type { KeyStore } from "../keys/KeyStore.mjs";
  * `jwks_uri` OIDC discovery advertises. (This is also why the core
  * `jwksModule` mounts at "/".)
  *
- * `path` defaults to {@link DEFAULT_JWKS_PATH}. Callers that honor the
- * `oauth.jwt.jwksPath` config override resolve it via `resolveJwksPath`
- * and pass the result here, so the registered path always matches the
- * advertised `jwks_uri`.
+ * The response carries `Cache-Control: public, max-age=<cacheMaxAgeSeconds>`
+ * (JWKS is public data and the most-polled verifier endpoint).
  */
 export const createRouter = (
 	express: { Router: () => Router },
 	keyStore: KeyStore,
-	path: string = DEFAULT_JWKS_PATH,
+	opts: JwksRouterOptions = {},
 ): Router => {
+	const path = opts.path ?? DEFAULT_JWKS_PATH;
+	const cacheMaxAgeSeconds = opts.cacheMaxAgeSeconds ?? DEFAULT_JWKS_CACHE_MAX_AGE;
 	const router = express.Router();
+
+	const cacheControl = `public, max-age=${cacheMaxAgeSeconds}`;
 
 	router.get(path, async (_req: Request, res: Response) => {
 		if (keyStore.algorithm === "HS256") {
+			// Set Cache-Control only on the SUCCESS path. If we set it up-front
+			// and `getVerificationKeys()`/`exportJWK()` then threw (e.g. a remote
+			// KMS-backed keystore outage), Express would emit a 5xx with the
+			// header still attached, and an explicit `public, max-age` makes that
+			// transient error cacheable by shared caches/CDNs for the full
+			// lifetime — turning a brief outage into a stuck JWKS failure.
+			res.setHeader("Cache-Control", cacheControl);
 			return res.json({ keys: [] });
 		}
 		const managedKeys = await keyStore.getVerificationKeys();
@@ -50,6 +79,8 @@ export const createRouter = (
 				return { ...jwk, kid: mk.kid, use: "sig", alg: keyStore.algorithm };
 			}),
 		);
+		// Header set only after key export succeeded (see HS256 branch note).
+		res.setHeader("Cache-Control", cacheControl);
 		return res.json({ keys });
 	});
 

--- a/packages/core/src/routes/Jwks.mts
+++ b/packages/core/src/routes/Jwks.mts
@@ -15,12 +15,31 @@
  */
 import type { Request, Response, Router } from "express";
 import { exportJWK } from "jose";
+import { DEFAULT_JWKS_PATH } from "../jwks/path.mjs";
 import type { KeyStore } from "../keys/KeyStore.mjs";
 
-export const createRouter = (express: { Router: () => Router }, keyStore: KeyStore): Router => {
+/**
+ * Build the JWKS publishing Router. The router registers `path` as an
+ * **absolute** path internally, so consumers MUST mount the router at the
+ * application root (`app.use(createRouter(express, keyStore))`) — NOT under
+ * a path prefix. Mounting at a prefix (e.g. `/auth`) would expose
+ * `/auth${path}`, which no verifier looks up and which diverges from the
+ * `jwks_uri` OIDC discovery advertises. (This is also why the core
+ * `jwksModule` mounts at "/".)
+ *
+ * `path` defaults to {@link DEFAULT_JWKS_PATH}. Callers that honor the
+ * `oauth.jwt.jwksPath` config override resolve it via `resolveJwksPath`
+ * and pass the result here, so the registered path always matches the
+ * advertised `jwks_uri`.
+ */
+export const createRouter = (
+	express: { Router: () => Router },
+	keyStore: KeyStore,
+	path: string = DEFAULT_JWKS_PATH,
+): Router => {
 	const router = express.Router();
 
-	router.get("/.well-known/jwks.json", async (_req: Request, res: Response) => {
+	router.get(path, async (_req: Request, res: Response) => {
 		if (keyStore.algorithm === "HS256") {
 			return res.json({ keys: [] });
 		}

--- a/packages/core/src/routes/Jwks.mts
+++ b/packages/core/src/routes/Jwks.mts
@@ -40,15 +40,24 @@ export interface JwksRouterOptions {
 
 /**
  * Build the JWKS publishing Router. The router registers `path` as an
- * **absolute** path internally, so consumers MUST mount the router at the
- * application root (`app.use(createRouter(express, keyStore))`) — NOT under
- * a path prefix. Mounting at a prefix (e.g. `/auth`) would expose
- * `/auth${path}`, which no verifier looks up and which diverges from the
- * `jwks_uri` OIDC discovery advertises. (This is also why the core
- * `jwksModule` mounts at "/".)
+ * **absolute** path internally, so the effective endpoint is the router's
+ * mount point + `path`. Mount at the application root (`app.use(createRouter(
+ * express, keyStore))`) for the common case. Prefix-mounting (e.g.
+ * `app.use("/auth", createRouter(...))`) is valid only when the advertised
+ * `jwks_uri` carries the same base path — typically because the issuer
+ * identifier itself has that prefix (`jwks_uri = ${issuer}${path}`). If the
+ * mount prefix and the issuer prefix disagree, discovery advertises a
+ * `jwks_uri` that does not resolve. (The core `jwksModule` mounts at "/" and
+ * relies on the issuer prefix to carry any base path.)
  *
  * The response carries `Cache-Control: public, max-age=<cacheMaxAgeSeconds>`
  * (JWKS is public data and the most-polled verifier endpoint).
+ *
+ * Direct callers bypass the config schema, so `path` and `cacheMaxAgeSeconds`
+ * are validated here and the factory throws on misconfiguration (a non-
+ * absolute path or a negative / non-integer cache age) — failing fast at
+ * boot rather than registering an unexpected route or emitting an invalid
+ * `Cache-Control` header.
  */
 export const createRouter = (
 	express: { Router: () => Router },
@@ -56,7 +65,17 @@ export const createRouter = (
 	opts: JwksRouterOptions = {},
 ): Router => {
 	const path = opts.path ?? DEFAULT_JWKS_PATH;
+	if (!path.startsWith("/")) {
+		throw new Error(
+			`createJwksRouter: path must be an absolute path beginning with "/", got ${JSON.stringify(path)}`,
+		);
+	}
 	const cacheMaxAgeSeconds = opts.cacheMaxAgeSeconds ?? DEFAULT_JWKS_CACHE_MAX_AGE;
+	if (!Number.isInteger(cacheMaxAgeSeconds) || cacheMaxAgeSeconds < 0) {
+		throw new Error(
+			`createJwksRouter: cacheMaxAgeSeconds must be a non-negative integer, got ${cacheMaxAgeSeconds}`,
+		);
+	}
 	const router = express.Router();
 
 	const cacheControl = `public, max-age=${cacheMaxAgeSeconds}`;

--- a/packages/core/src/routes/__tests__/Jwks.test.mts
+++ b/packages/core/src/routes/__tests__/Jwks.test.mts
@@ -17,6 +17,7 @@
 import type { Request, Response, Router } from "express";
 import { exportPKCS8, exportSPKI, generateKeyPair } from "jose";
 import { describe, expect, it } from "vitest";
+import { DEFAULT_JWKS_PATH, resolveJwksPath } from "#/jwks/path.mjs";
 import { createAsymmetricKeyStore, createSymmetricKeyStore } from "#/keys/KeyStore.mjs";
 import { createRouter } from "#/routes/Jwks.mjs";
 
@@ -53,6 +54,39 @@ function createMockRes() {
 		getBody: () => body,
 	};
 }
+
+describe("JWKS path resolution", () => {
+	it("defaults to the conventional well-known path", () => {
+		expect(DEFAULT_JWKS_PATH).toBe("/.well-known/jwks.json");
+		expect(resolveJwksPath({})).toBe(DEFAULT_JWKS_PATH);
+		expect(resolveJwksPath({ oauth: { jwt: {} } })).toBe(DEFAULT_JWKS_PATH);
+	});
+
+	it("honors a configured oauth.jwt.jwksPath override", () => {
+		expect(resolveJwksPath({ oauth: { jwt: { jwksPath: "/keys/jwks.json" } } })).toBe(
+			"/keys/jwks.json",
+		);
+	});
+
+	it("falls back to default for an empty/invalid configured value", () => {
+		expect(resolveJwksPath({ oauth: { jwt: { jwksPath: "" } } })).toBe(DEFAULT_JWKS_PATH);
+		expect(resolveJwksPath({ oauth: { jwt: { jwksPath: 123 } } })).toBe(DEFAULT_JWKS_PATH);
+	});
+
+	it("registers exactly the default path when no path is passed (single source of truth)", () => {
+		const ks = createSymmetricKeyStore("test-secret");
+		const express = createMockExpress();
+		createRouter(express, ks);
+		expect(Object.keys(express.routes)).toEqual([DEFAULT_JWKS_PATH]);
+	});
+
+	it("registers the explicit path when one is passed", () => {
+		const ks = createSymmetricKeyStore("test-secret");
+		const express = createMockExpress();
+		createRouter(express, ks, "/keys/jwks.json");
+		expect(Object.keys(express.routes)).toEqual(["/keys/jwks.json"]);
+	});
+});
 
 describe("JWKS endpoint", () => {
 	it("returns an empty JWK set for HS256 without exposing shared secrets", async () => {

--- a/packages/core/src/routes/__tests__/Jwks.test.mts
+++ b/packages/core/src/routes/__tests__/Jwks.test.mts
@@ -17,6 +17,7 @@
 import type { Request, Response, Router } from "express";
 import { exportPKCS8, exportSPKI, generateKeyPair } from "jose";
 import { describe, expect, it } from "vitest";
+import { DEFAULT_JWKS_CACHE_MAX_AGE, resolveJwksCacheMaxAge } from "#/jwks/cache.mjs";
 import { DEFAULT_JWKS_PATH, resolveJwksPath } from "#/jwks/path.mjs";
 import { createAsymmetricKeyStore, createSymmetricKeyStore } from "#/keys/KeyStore.mjs";
 import { createRouter } from "#/routes/Jwks.mjs";
@@ -37,6 +38,7 @@ function createMockExpress() {
 function createMockRes() {
 	let statusCode = 200;
 	let body: unknown;
+	const headers: Record<string, string> = {};
 	return {
 		status(code: number) {
 			statusCode = code;
@@ -50,8 +52,13 @@ function createMockRes() {
 			statusCode = code;
 			return this;
 		},
+		setHeader(name: string, value: string) {
+			headers[name] = value;
+			return this;
+		},
 		getStatusCode: () => statusCode,
 		getBody: () => body,
+		getHeader: (name: string) => headers[name],
 	};
 }
 
@@ -83,8 +90,87 @@ describe("JWKS path resolution", () => {
 	it("registers the explicit path when one is passed", () => {
 		const ks = createSymmetricKeyStore("test-secret");
 		const express = createMockExpress();
-		createRouter(express, ks, "/keys/jwks.json");
+		createRouter(express, ks, { path: "/keys/jwks.json" });
 		expect(Object.keys(express.routes)).toEqual(["/keys/jwks.json"]);
+	});
+});
+
+describe("JWKS cache max-age resolution", () => {
+	it("defaults to 300 seconds", () => {
+		expect(DEFAULT_JWKS_CACHE_MAX_AGE).toBe(300);
+		expect(resolveJwksCacheMaxAge({})).toBe(300);
+		expect(resolveJwksCacheMaxAge({ oauth: { jwt: {} } })).toBe(300);
+	});
+
+	it("honors a configured oauth.jwt.jwksCacheMaxAge override (incl. 0)", () => {
+		expect(resolveJwksCacheMaxAge({ oauth: { jwt: { jwksCacheMaxAge: 3600 } } })).toBe(3600);
+		expect(resolveJwksCacheMaxAge({ oauth: { jwt: { jwksCacheMaxAge: 0 } } })).toBe(0);
+	});
+
+	it("falls back to default for negative / non-integer / non-number values", () => {
+		expect(resolveJwksCacheMaxAge({ oauth: { jwt: { jwksCacheMaxAge: -1 } } })).toBe(300);
+		expect(resolveJwksCacheMaxAge({ oauth: { jwt: { jwksCacheMaxAge: 1.5 } } })).toBe(300);
+		expect(resolveJwksCacheMaxAge({ oauth: { jwt: { jwksCacheMaxAge: "60" } } })).toBe(300);
+	});
+});
+
+describe("JWKS Cache-Control", () => {
+	async function getHeaderFor(opts?: Parameters<typeof createRouter>[2]) {
+		const ks = createSymmetricKeyStore("test-secret");
+		const express = createMockExpress();
+		createRouter(express, ks, opts);
+		const res = createMockRes();
+		await express.routes[opts?.path ?? "/.well-known/jwks.json"](
+			{} as Request,
+			res as unknown as Response,
+		);
+		return res.getHeader("Cache-Control");
+	}
+
+	it("sets public, max-age=300 by default", async () => {
+		expect(await getHeaderFor()).toBe("public, max-age=300");
+	});
+
+	it("reflects a custom cacheMaxAgeSeconds", async () => {
+		expect(await getHeaderFor({ cacheMaxAgeSeconds: 3600 })).toBe("public, max-age=3600");
+	});
+
+	it("sets the header on the HS256 empty-set response too", async () => {
+		// createSymmetricKeyStore yields HS256 → empty keys; header must still be present.
+		expect(await getHeaderFor({ cacheMaxAgeSeconds: 60 })).toBe("public, max-age=60");
+	});
+
+	it("sets the header on the asymmetric (ES256) success path", async () => {
+		const { privateKey, publicKey } = await generateKeyPair("ES256", { extractable: true });
+		const ks = await createAsymmetricKeyStore({
+			algorithm: "ES256",
+			kid: "k1",
+			privateKeyPem: await exportPKCS8(privateKey),
+			publicKeyPem: await exportSPKI(publicKey),
+		});
+		const express = createMockExpress();
+		createRouter(express, ks);
+		const res = createMockRes();
+		await express.routes["/.well-known/jwks.json"]({} as Request, res as unknown as Response);
+		expect(res.getHeader("Cache-Control")).toBe("public, max-age=300");
+	});
+
+	it("does NOT set Cache-Control when key export fails (no cacheable 5xx)", async () => {
+		// A failing remote/KMS keystore must not produce a cacheable error: the
+		// header is set only after getVerificationKeys()/exportJWK() succeed.
+		const failingKeyStore = {
+			algorithm: "ES256" as const,
+			getVerificationKeys: async () => {
+				throw new Error("kms unavailable");
+			},
+		} as unknown as Parameters<typeof createRouter>[1];
+		const express = createMockExpress();
+		createRouter(express, failingKeyStore);
+		const res = createMockRes();
+		await expect(
+			express.routes["/.well-known/jwks.json"]({} as Request, res as unknown as Response),
+		).rejects.toThrow("kms unavailable");
+		expect(res.getHeader("Cache-Control")).toBeUndefined();
 	});
 });
 

--- a/packages/core/src/routes/__tests__/Jwks.test.mts
+++ b/packages/core/src/routes/__tests__/Jwks.test.mts
@@ -95,6 +95,31 @@ describe("JWKS path resolution", () => {
 	});
 });
 
+describe("createRouter input validation (direct callers bypass the schema)", () => {
+	const ks = createSymmetricKeyStore("test-secret");
+
+	it("throws on a non-absolute path", () => {
+		expect(() => createRouter(createMockExpress(), ks, { path: "keys/jwks.json" })).toThrow(
+			/absolute path/,
+		);
+	});
+
+	it("throws on a negative or non-integer cacheMaxAgeSeconds", () => {
+		expect(() => createRouter(createMockExpress(), ks, { cacheMaxAgeSeconds: -1 })).toThrow(
+			/non-negative integer/,
+		);
+		expect(() => createRouter(createMockExpress(), ks, { cacheMaxAgeSeconds: 1.5 })).toThrow(
+			/non-negative integer/,
+		);
+	});
+
+	it("accepts a valid absolute path and a 0 max-age", () => {
+		expect(() =>
+			createRouter(createMockExpress(), ks, { path: "/keys/jwks.json", cacheMaxAgeSeconds: 0 }),
+		).not.toThrow();
+	});
+});
+
 describe("JWKS cache max-age resolution", () => {
 	it("defaults to 300 seconds", () => {
 		expect(DEFAULT_JWKS_CACHE_MAX_AGE).toBe(300);

--- a/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
+++ b/packages/oauth/src/__tests__/OpenidConfiguration.test.mts
@@ -65,6 +65,35 @@ async function callRoute(opts: {
 	return res.getBody() as Record<string, unknown>;
 }
 
+describe("jwksPath option", () => {
+	it("appends a custom absolute jwksPath onto the issuer identifier", async () => {
+		const express = createMockExpress();
+		createRouter(express, {
+			issuer: "https://auth.example.com",
+			signingAlgs: ["RS256"],
+			jwksPath: "/keys/jwks.json",
+		});
+		const res = createMockRes();
+		await express.routes["/.well-known/openid-configuration"](
+			{} as Request,
+			res as unknown as Response,
+		);
+		expect((res.getBody() as { jwks_uri: string }).jwks_uri).toBe(
+			"https://auth.example.com/keys/jwks.json",
+		);
+	});
+
+	it("throws at router creation on a non-absolute jwksPath (fail fast, not a dangling jwks_uri)", () => {
+		expect(() =>
+			createRouter(createMockExpress(), {
+				issuer: "https://auth.example.com",
+				signingAlgs: ["RS256"],
+				jwksPath: "keys/jwks.json",
+			}),
+		).toThrow(/absolute path/);
+	});
+});
+
 describe("GET /.well-known/openid-configuration", () => {
 	it("returns discovery metadata with F-4 scoped endpoints + signing algs", async () => {
 		const body = await callRoute({

--- a/packages/oauth/src/__tests__/module.test.mts
+++ b/packages/oauth/src/__tests__/module.test.mts
@@ -133,17 +133,17 @@ describe("oauthModule — manifest shape", () => {
 		expect(result.success).toBe(true);
 	});
 
-	it("includes oauth-endpoints route contribution when issuer is absent", () => {
+	it("includes oauth-endpoints + jwks route contributions when issuer is absent", () => {
 		const base = makeValidAppConfig();
-		// No issuer set — only oauth-endpoints factory should appear
+		// No issuer set — oauth-endpoints and jwks are always contributed; only
+		// oidc-discovery is issuer-gated, so it is absent here.
 		const module = oauthModule({ config: base });
 		const routes = module.contributes?.routes;
 		expect(Array.isArray(routes)).toBe(true);
-		// At minimum the oauth-endpoints factory is always present
-		expect((routes as unknown[]).length).toBeGreaterThanOrEqual(1);
+		expect((routes as unknown[]).length).toBe(2);
 	});
 
-	it("includes both route contributions when issuer is configured", () => {
+	it("includes oauth-endpoints + jwks + oidc-discovery when issuer is configured", () => {
 		const base = makeValidAppConfig();
 		const config = {
 			...base,
@@ -158,8 +158,8 @@ describe("oauthModule — manifest shape", () => {
 		const module = oauthModule({ config });
 		const routes = module.contributes?.routes;
 		expect(Array.isArray(routes)).toBe(true);
-		// oauth-endpoints + oidc-discovery
-		expect((routes as unknown[]).length).toBe(2);
+		// oauth-endpoints + jwks + oidc-discovery
+		expect((routes as unknown[]).length).toBe(3);
 	});
 });
 
@@ -286,6 +286,52 @@ describe("oauthModule — createTestApp route inspection", () => {
 		const res = await request(app).get("/.well-known/openid-configuration");
 		expect(res.status).toBe(200);
 		expect(res.body.issuer).toBe("https://auth.example.com");
+		await handle.dispose();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// JWKS — the provider must publish its verification keys so verifiers (BFF,
+// RPs) can validate asymmetric-signed tokens offline. core ships
+// routes/Jwks.mts but, pre-fix, no module mounted it: oidc-discovery advertised
+// `jwks_uri` while GET /.well-known/jwks.json returned 404. JWKS is mounted
+// unconditionally (unlike issuer-gated oidc-discovery) because it must be
+// reachable whenever the provider signs tokens.
+// ---------------------------------------------------------------------------
+
+describe("oauthModule — jwks route", () => {
+	it("registers a jwks route contribution even when issuer is absent", async () => {
+		const config = makeValidAppConfig();
+		const handle = await createTestApp({
+			modules: [
+				oauthModule({ config }),
+				clientRepositoryModule,
+				codeRepositoryModule,
+				keyStoreModule,
+			],
+			bootstrapComponents: { config, pathResolver: (s) => s },
+		});
+		const routeIds = handle.inspect.routes.map((r) => r.contribution.id);
+		expect(routeIds).toContain("jwks");
+		await handle.dispose();
+	});
+
+	it("serves /.well-known/jwks.json (reachable, not 404)", async () => {
+		const config = makeValidAppConfig();
+		const handle = await createTestApp({
+			modules: [
+				oauthModule({ config }),
+				clientRepositoryModule,
+				codeRepositoryModule,
+				keyStoreModule,
+			],
+			bootstrapComponents: { config, pathResolver: (s) => s },
+		});
+		const app = express();
+		app.use(handle.router);
+		const res = await request(app).get("/.well-known/jwks.json");
+		expect(res.status).toBe(200);
+		expect(Array.isArray(res.body.keys)).toBe(true);
 		await handle.dispose();
 	});
 });

--- a/packages/oauth/src/__tests__/module.test.mts
+++ b/packages/oauth/src/__tests__/module.test.mts
@@ -24,6 +24,7 @@ import {
 	defineModule,
 	type FederationProviderHandle,
 	type FederationTokenStore,
+	jwksModule,
 	type RateLimiter,
 	type RefreshTokenFamilyRevocation,
 	type SessionFamilyIndex,
@@ -133,17 +134,18 @@ describe("oauthModule — manifest shape", () => {
 		expect(result.success).toBe(true);
 	});
 
-	it("includes oauth-endpoints + jwks route contributions when issuer is absent", () => {
+	it("includes only oauth-endpoints when issuer is absent (JWKS moved to core jwksModule)", () => {
 		const base = makeValidAppConfig();
-		// No issuer set — oauth-endpoints and jwks are always contributed; only
-		// oidc-discovery is issuer-gated, so it is absent here.
+		// No issuer set — only oauth-endpoints is contributed. oidc-discovery is
+		// issuer-gated; JWKS is no longer an oauth contribution (core jwksModule
+		// owns it now).
 		const module = oauthModule({ config: base });
 		const routes = module.contributes?.routes;
 		expect(Array.isArray(routes)).toBe(true);
-		expect((routes as unknown[]).length).toBe(2);
+		expect((routes as unknown[]).length).toBe(1);
 	});
 
-	it("includes oauth-endpoints + jwks + oidc-discovery when issuer is configured", () => {
+	it("includes oauth-endpoints + oidc-discovery when issuer is configured", () => {
 		const base = makeValidAppConfig();
 		const config = {
 			...base,
@@ -158,8 +160,8 @@ describe("oauthModule — manifest shape", () => {
 		const module = oauthModule({ config });
 		const routes = module.contributes?.routes;
 		expect(Array.isArray(routes)).toBe(true);
-		// oauth-endpoints + jwks + oidc-discovery
-		expect((routes as unknown[]).length).toBe(3);
+		// oauth-endpoints + oidc-discovery (JWKS is contributed by core jwksModule)
+		expect((routes as unknown[]).length).toBe(2);
 	});
 });
 
@@ -291,36 +293,36 @@ describe("oauthModule — createTestApp route inspection", () => {
 });
 
 // ---------------------------------------------------------------------------
-// JWKS — the provider must publish its verification keys so verifiers (BFF,
-// RPs) can validate asymmetric-signed tokens offline. core ships
-// routes/Jwks.mts but, pre-fix, no module mounted it: oidc-discovery advertised
-// `jwks_uri` while GET /.well-known/jwks.json returned 404. JWKS is mounted
-// unconditionally (unlike issuer-gated oidc-discovery) because it must be
-// reachable whenever the provider signs tokens.
+// Discovery <-> JWKS path agreement (presence + config-drift contract).
+//
+// JWKS is now contributed by the core `jwksModule`, while oidc-discovery
+// (which advertises `jwks_uri`) is contributed by oauth. They live in
+// different modules, so an issuer-enabled composition MUST co-install both
+// or discovery publishes a dangling `jwks_uri`. These tests pin that
+// cross-module contract end-to-end: the advertised `jwks_uri` must resolve
+// to a mounted JWKS route, including under an `oauth.jwt.jwksPath` override
+// (both endpoints resolve the path via the shared `resolveJwksPath`, so
+// they cannot drift).
 // ---------------------------------------------------------------------------
 
-describe("oauthModule — jwks route", () => {
-	it("registers a jwks route contribution even when issuer is absent", async () => {
-		const config = makeValidAppConfig();
-		const handle = await createTestApp({
-			modules: [
-				oauthModule({ config }),
-				clientRepositoryModule,
-				codeRepositoryModule,
-				keyStoreModule,
-			],
-			bootstrapComponents: { config, pathResolver: (s) => s },
-		});
-		const routeIds = handle.inspect.routes.map((r) => r.contribution.id);
-		expect(routeIds).toContain("jwks");
-		await handle.dispose();
-	});
+describe("oauthModule + jwksModule — discovery/JWKS path agreement", () => {
+	function issuerConfig(extraJwt: Record<string, unknown> = {}) {
+		const base = makeValidAppConfig();
+		return {
+			...base,
+			oauth: {
+				...base.oauth,
+				jwt: { ...base.oauth.jwt, issuer: "https://auth.example.com", ...extraJwt },
+			},
+		} as ReturnType<typeof makeValidAppConfig>;
+	}
 
-	it("serves /.well-known/jwks.json (reachable, not 404)", async () => {
-		const config = makeValidAppConfig();
+	it("advertised jwks_uri resolves to a mounted JWKS route (default path)", async () => {
+		const config = issuerConfig();
 		const handle = await createTestApp({
 			modules: [
 				oauthModule({ config }),
+				jwksModule,
 				clientRepositoryModule,
 				codeRepositoryModule,
 				keyStoreModule,
@@ -329,9 +331,36 @@ describe("oauthModule — jwks route", () => {
 		});
 		const app = express();
 		app.use(handle.router);
-		const res = await request(app).get("/.well-known/jwks.json");
+		const disco = await request(app).get("/.well-known/openid-configuration");
+		expect(disco.status).toBe(200);
+		const jwksPath = new URL(disco.body.jwks_uri as string).pathname;
+		expect(jwksPath).toBe("/.well-known/jwks.json");
+		const res = await request(app).get(jwksPath);
 		expect(res.status).toBe(200);
 		expect(Array.isArray(res.body.keys)).toBe(true);
+		await handle.dispose();
+	});
+
+	it("honors oauth.jwt.jwksPath for BOTH the advertised jwks_uri and the mounted route", async () => {
+		const config = issuerConfig({ jwksPath: "/keys/jwks.json" });
+		const handle = await createTestApp({
+			modules: [
+				oauthModule({ config }),
+				jwksModule,
+				clientRepositoryModule,
+				codeRepositoryModule,
+				keyStoreModule,
+			],
+			bootstrapComponents: { config, pathResolver: (s) => s },
+		});
+		const app = express();
+		app.use(handle.router);
+		const disco = await request(app).get("/.well-known/openid-configuration");
+		expect(disco.body.jwks_uri).toBe("https://auth.example.com/keys/jwks.json");
+		const jwksPath = new URL(disco.body.jwks_uri as string).pathname;
+		expect((await request(app).get(jwksPath)).status).toBe(200);
+		// The old default path is no longer served under the override.
+		expect((await request(app).get("/.well-known/jwks.json")).status).toBe(404);
 		await handle.dispose();
 	});
 });

--- a/packages/oauth/src/module.mts
+++ b/packages/oauth/src/module.mts
@@ -17,11 +17,11 @@
 import {
 	type AppConfig,
 	consoleLogger,
-	createJwksRouter,
 	defineModule,
 	type FederationProviderHandle,
 	type Module,
 	type ProviderDeps,
+	resolveJwksPath,
 } from "@o3co/auth-provider-core";
 import express from "express";
 import { z } from "zod";
@@ -182,18 +182,13 @@ export const oauthModule = (params: { config: AppConfig }): Module => {
 					});
 					return { id: "oauth-endpoints", mountPath: "/oauth", handler: router };
 				},
-				// jwks — always contributed: a provider that signs tokens must
-				// publish its verification keys for offline validation, regardless
-				// of OIDC issuer config (so it is NOT issuer-gated like discovery).
-				// core ships routes/Jwks.mts but mounted it nowhere — this wires it
-				// so /.well-known/jwks.json matches the jwks_uri that oidc-discovery
-				// advertises. createJwksRouter registers the spec-fixed absolute path
-				// internally, so mount at "/" to avoid path doubling.
-				(deps) => ({
-					id: "jwks",
-					mountPath: "/",
-					handler: createJwksRouter(express, deps.keyStore),
-				}),
+				// JWKS is contributed by the core `jwksModule` (key-management layer,
+				// depends only on keyStore), NOT here — so a provider can publish its
+				// verification keys without the full OAuth grant suite, and discovery
+				// stays free of a feature it does not own. The discovery `jwks_uri`
+				// below and the core JWKS route both resolve the path through
+				// `resolveJwksPath`, so they cannot drift. See core/src/jwks/.
+				//
 				// oidc-discovery — conditional on config.oauth.jwt.issuer (Theme E:
 				// structural conditional evaluated at boot, not at request time).
 				// When issuer is absent, the factory short-circuits with a no-op
@@ -243,6 +238,12 @@ export const oauthModule = (params: { config: AppConfig }): Module => {
 										issuer: issuer as string,
 										signingAlgs: [deps.keyStore.algorithm],
 										logoutSupported,
+										// Resolve via the shared core helper so the advertised
+										// jwks_uri always matches the path the core jwksModule
+										// registers (single source of truth — cannot drift).
+										jwksPath: resolveJwksPath(
+											deps.config as { oauth?: { jwt?: { jwksPath?: unknown } } },
+										),
 									}),
 								};
 							},

--- a/packages/oauth/src/module.mts
+++ b/packages/oauth/src/module.mts
@@ -17,6 +17,7 @@
 import {
 	type AppConfig,
 	consoleLogger,
+	createJwksRouter,
 	defineModule,
 	type FederationProviderHandle,
 	type Module,
@@ -181,6 +182,18 @@ export const oauthModule = (params: { config: AppConfig }): Module => {
 					});
 					return { id: "oauth-endpoints", mountPath: "/oauth", handler: router };
 				},
+				// jwks — always contributed: a provider that signs tokens must
+				// publish its verification keys for offline validation, regardless
+				// of OIDC issuer config (so it is NOT issuer-gated like discovery).
+				// core ships routes/Jwks.mts but mounted it nowhere — this wires it
+				// so /.well-known/jwks.json matches the jwks_uri that oidc-discovery
+				// advertises. createJwksRouter registers the spec-fixed absolute path
+				// internally, so mount at "/" to avoid path doubling.
+				(deps) => ({
+					id: "jwks",
+					mountPath: "/",
+					handler: createJwksRouter(express, deps.keyStore),
+				}),
 				// oidc-discovery — conditional on config.oauth.jwt.issuer (Theme E:
 				// structural conditional evaluated at boot, not at request time).
 				// When issuer is absent, the factory short-circuits with a no-op

--- a/packages/oauth/src/routes/OpenidConfiguration.mts
+++ b/packages/oauth/src/routes/OpenidConfiguration.mts
@@ -34,23 +34,34 @@ export interface OidcConfigRouterOptions {
 	 */
 	logoutSupported?: boolean;
 	/**
-	 * Absolute path (relative to the issuer origin) at which the JWKS is
-	 * published, used to build the advertised `jwks_uri`. Defaults to
-	 * `/.well-known/jwks.json`. oauthModule resolves this via the shared
-	 * core `resolveJwksPath` so the advertised URI matches the path the core
-	 * `jwksModule` actually registers. Direct callers who publish JWKS at a
-	 * non-default path MUST set this so discovery does not advertise a
-	 * dangling `jwks_uri`.
+	 * Absolute path appended to the issuer identifier (after trailing-slash
+	 * trimming) to build the advertised `jwks_uri` — i.e. `jwks_uri =
+	 * ${issuer}${jwksPath}`, so when the issuer itself has a path prefix the
+	 * JWKS URI inherits it. Defaults to `/.well-known/jwks.json`. oauthModule
+	 * resolves this via the shared core `resolveJwksPath` so the advertised
+	 * URI matches the path the core `jwksModule` actually registers. Direct
+	 * callers who publish JWKS at a non-default path MUST set this (an absolute
+	 * path beginning with "/") so discovery does not advertise a dangling
+	 * `jwks_uri`.
 	 */
 	jwksPath?: string;
 }
 
 export function createRouter(express: ExpressLike, opts: OidcConfigRouterOptions): Router {
+	// Validate jwksPath at router-creation (boot) time so a misconfigured
+	// direct caller fails fast rather than serving a discovery document whose
+	// `jwks_uri` is malformed. oauthModule always passes a schema-validated,
+	// `resolveJwksPath`-resolved value, so this never fires on the config path.
+	const jwksPath = opts.jwksPath ?? DEFAULT_JWKS_PATH;
+	if (!jwksPath.startsWith("/")) {
+		throw new Error(
+			`OIDC discovery: jwksPath must be an absolute path beginning with "/", got ${JSON.stringify(jwksPath)}`,
+		);
+	}
 	const router = express.Router();
 
 	router.get("/.well-known/openid-configuration", (_req: Request, res: Response) => {
 		const iss = opts.issuer.replace(/\/+$/, "");
-		const jwksPath = opts.jwksPath ?? DEFAULT_JWKS_PATH;
 		return res.status(200).json({
 			// Return the normalized issuer so it matches the `iss` claim minted
 			// on tokens (both use trailing-slash-stripped form). Returning the

--- a/packages/oauth/src/routes/OpenidConfiguration.mts
+++ b/packages/oauth/src/routes/OpenidConfiguration.mts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { DEFAULT_JWKS_PATH } from "@o3co/auth-provider-core";
 import type { Request, RequestHandler, Response, Router } from "express";
 
 type ExpressLike = {
@@ -32,6 +33,16 @@ export interface OidcConfigRouterOptions {
 	 * oauthModule sets this to the computed `!!stores && !!issuer` expression.
 	 */
 	logoutSupported?: boolean;
+	/**
+	 * Absolute path (relative to the issuer origin) at which the JWKS is
+	 * published, used to build the advertised `jwks_uri`. Defaults to
+	 * `/.well-known/jwks.json`. oauthModule resolves this via the shared
+	 * core `resolveJwksPath` so the advertised URI matches the path the core
+	 * `jwksModule` actually registers. Direct callers who publish JWKS at a
+	 * non-default path MUST set this so discovery does not advertise a
+	 * dangling `jwks_uri`.
+	 */
+	jwksPath?: string;
 }
 
 export function createRouter(express: ExpressLike, opts: OidcConfigRouterOptions): Router {
@@ -39,6 +50,7 @@ export function createRouter(express: ExpressLike, opts: OidcConfigRouterOptions
 
 	router.get("/.well-known/openid-configuration", (_req: Request, res: Response) => {
 		const iss = opts.issuer.replace(/\/+$/, "");
+		const jwksPath = opts.jwksPath ?? DEFAULT_JWKS_PATH;
 		return res.status(200).json({
 			// Return the normalized issuer so it matches the `iss` claim minted
 			// on tokens (both use trailing-slash-stripped form). Returning the
@@ -48,7 +60,7 @@ export function createRouter(express: ExpressLike, opts: OidcConfigRouterOptions
 			authorization_endpoint: `${iss}/oauth/authorize`,
 			token_endpoint: `${iss}/oauth/token`,
 			userinfo_endpoint: `${iss}/oauth/userinfo`,
-			jwks_uri: `${iss}/.well-known/jwks.json`,
+			jwks_uri: `${iss}${jwksPath}`,
 			introspection_endpoint: `${iss}/oauth/introspect`,
 			// Logout discovery fields are only advertised when the logout router is mounted.
 			// opts.logoutSupported defaults to false (explicit opt-in); oauthModule sets it

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -222,6 +222,40 @@ describe("standalone smoke test", () => {
 		expect(res.status).toBe(200);
 	});
 
+	it("issuer-configured buildModules serves the advertised jwks_uri (discovery <-> JWKS presence contract)", async () => {
+		// Guards the cross-module contract end-to-end against the REAL composition
+		// root: oauthModule advertises `jwks_uri` in discovery, while the JWKS
+		// route is mounted by core's `jwksModule`. If `buildModules` ever drops
+		// `jwksModule`, discovery would advertise a path that 404s — this test
+		// fails (RED) in that case. (The oauth package's integration test
+		// hand-composes both modules, so only a scaffold-level test like this can
+		// catch the composition root forgetting to wire jwksModule.)
+		const issuerConfig: AppConfig = {
+			...config,
+			oauth: {
+				...config.oauth,
+				jwt: { ...config.oauth.jwt, issuer: "https://auth.example.com" },
+			},
+		};
+		const handle = await createApp({
+			modules: buildModules(issuerConfig, {
+				keyStoreModule: testKeyStoreModule,
+				repositoriesModule: testRepositoriesModule,
+				refreshTokenFamilyModules: [memoryRefreshTokenFamilyStoreModule],
+			}),
+			bootstrapComponents: { config: issuerConfig, pathResolver: (s) => s },
+		});
+		handleRef = handle;
+		const app = express();
+		app.use(handle.router);
+		const disco = await request(app).get("/.well-known/openid-configuration");
+		expect(disco.status).toBe(200);
+		const jwksPath = new URL(disco.body.jwks_uri as string).pathname;
+		const res = await request(app).get(jwksPath);
+		expect(res.status).toBe(200);
+		expect(Array.isArray(res.body.keys)).toBe(true);
+	});
+
 	it("POST /oauth/token with unsupported grant_type returns 400", async () => {
 		const { app, handle } = await buildApp();
 		handleRef = handle;

--- a/templates/standalone/src/buildModules.mts
+++ b/templates/standalone/src/buildModules.mts
@@ -17,6 +17,7 @@ import {
 	type AppConfig,
 	defaultRefreshTokenFamilyRevocationModule,
 	defaultRefreshTokenFamilyRotationModule,
+	jwksModule,
 	type Module,
 	memoryRateLimiterModule,
 } from "@o3co/auth-provider-core";
@@ -165,6 +166,13 @@ export function buildModules(config: AppConfig, overrides: BuildModulesOverrides
 		oauthModule({ config }),
 		oauthSessionModule({ config }),
 		oauthAuthorizationModule({ config }),
+		// JWKS publishing — always wired (depends only on config + keyStore).
+		// Contributed by core's `jwksModule`, NOT oauthModule: a provider that
+		// signs tokens must publish its verification keys regardless of OIDC
+		// issuer config. Co-installed with oauthModule so the discovery
+		// `jwks_uri` (advertised by oauthModule when an issuer is set) always
+		// resolves to this mounted route.
+		jwksModule,
 		sessionModule,
 		...(googleEnabled ? [googleFederationModule, googleFederationConfigModule] : []),
 		overrides.keyStoreModule ?? keyStoreModule,


### PR DESCRIPTION
## Summary

Publishes the provider's JWKS (`/.well-known/jwks.json`) correctly and durably. The parent commit mounted JWKS via the `oauth` module; this PR moves it to where the responsibility belongs and hardens it.

OIDC discovery advertised `jwks_uri` while `GET /.well-known/jwks.json` returned 404 — verifiers (BFFs, RPs) had no key source for offline asymmetric-token validation. JWKS publishing is a **key-management** concern (depends only on `keyStore`, mounted whenever the provider signs tokens), not an OAuth grant-flow concern.

## Design decisions

- **D1 — JWKS → a core `jwksModule`** (the first route-contributing module in `@o3co/auth-provider-core`). Decouples key publishing from the full OAuth suite. `express` stays an optional peer of core: the route factory resolves it lazily via `createRequire`, so non-HTTP consumers that omit the module can still import core.
- **D2 — OIDC discovery stays in `oauth`.** Discovery is the self-description of oauth's own endpoint suite (it reads issuer + logout/session topology). A separate package would invert that coupling. Once JWKS lives in core, an issuer-enabled composition must co-install `jwksModule` or discovery advertises a dangling `jwks_uri`.
- **D3 — anti-drift.** `jwks_uri` is operator-choosable per OIDC Discovery, so the path is configurable via `oauth.jwt.jwksPath` (default `/.well-known/jwks.json`, absolute-path validated). The JWKS route and discovery's `jwks_uri` both resolve it through the shared `resolveJwksPath` / `DEFAULT_JWKS_PATH`, so the registered path and the advertised URI cannot diverge.

## Caching

JWKS responses now send `Cache-Control: public, max-age=<N>` (most-polled verifier endpoint). `max-age` is operator-tunable via `oauth.jwt.jwksCacheMaxAge` (default 300s) — keep it well below the key-overlap window so a rotated kid propagates to caching verifiers in time. The header is set **only on success paths**: a failing remote/KMS keystore must not emit a 5xx that an explicit `public, max-age` would make cacheable by shared caches/CDNs.

## Public API additions (`@o3co/auth-provider-core`)

- `jwksModule`
- `DEFAULT_JWKS_PATH`, `resolveJwksPath`
- `DEFAULT_JWKS_CACHE_MAX_AGE`, `resolveJwksCacheMaxAge`
- `createJwksRouter`'s third arg is now an options object `{ path?, cacheMaxAgeSeconds? }` (`JwksRouterOptions`) — unreleased, no consumer break
- config keys `oauth.jwt.jwksPath`, `oauth.jwt.jwksCacheMaxAge`

## Tests

- Unit: path/cache resolvers (default/override/invalid), Cache-Control header (default/custom/HS256/asymmetric/**error-path emits none**)
- Module: `jwksModule` route id + reachability + config overrides
- Schema: `jwksPath` (absolute) + `jwksCacheMaxAge` (non-negative int) validation
- **Presence contract**: oauth integration test + standalone scaffold smoke test both GET discovery → read `jwks_uri` → GET that exact path → 200 (pins the cross-module co-installation against the real composition root)

`core 1333 / oauth 562 / standalone smoke 16` — all green; typecheck clean.

## Reviews

multi-agent review (Claude + Codex) on both commits. Codex caught a cacheable-5xx issue on the Cache-Control commit (fixed: header on success paths only). An earlier round caught the `jwksModule` wiring landing in the git-ignored generated scaffold copy instead of the canonical `templates/standalone/` (fixed + scaffold-level presence test added).

## Follow-up

Turn discovery into a deployment-level aggregator fed by a `discoveryMetadata` contribution kind — #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)