### PR TITLE
chore(deps): pin qs >=6.15.2 and js-yaml >=4.2.0 to clear audit advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
 	"pnpm": {
 		"onlyBuiltDependencies": [
 			"bcrypt"
-		]
+		],
+		"overrides": {
+			"qs@>=6.11.1 <=6.15.1": "^6.15.2",
+			"js-yaml@>=4.0.0 <=4.1.1": "^4.2.0"
+		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  qs@>=6.11.1 <=6.15.1: ^6.15.2
+  js-yaml@>=4.0.0 <=4.1.1: ^4.2.0
+
 importers:
 
   .:
@@ -39,8 +43,8 @@ importers:
         specifier: ^6.2.2
         version: 6.2.3
       js-yaml:
-        specifier: ^4.1.1
-        version: 4.1.1
+        specifier: ^4.2.0
+        version: 4.3.0
       zod:
         specifier: ^4.3.6
         version: 4.4.3
@@ -1790,8 +1794,8 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   lazystream@1.0.1:
@@ -2141,8 +2145,8 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -2270,8 +2274,8 @@ packages:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
     engines: {node: '>= 0.4'}
 
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -3381,7 +3385,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.3
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -3675,7 +3679,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.3
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -3878,7 +3882,7 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -4193,9 +4197,10 @@ snapshots:
 
   pvutils@1.1.5: {}
 
-  qs@6.15.1:
+  qs@6.15.3:
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   quick-format-unescaped@4.0.4: {}
 
@@ -4366,7 +4371,7 @@ snapshots:
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
-  side-channel@1.1.0:
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -4460,7 +4465,7 @@ snapshots:
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.15.1
+      qs: 6.15.3
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

`pnpm run audit` (`--prod --audit-level=low`) gates CI and is currently failing **repo-wide** on two newly-published moderate advisories, blocking every open PR (including #216 and dependabot #210):

| dep | path | advisory | patched |
|---|---|---|---|
| `qs` | `templates/standalone > express` | [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) (DoS in `qs.stringify`) | `>=6.15.2` |
| `js-yaml` | `packages/core` | [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) (quadratic DoS in merge-key handling) | `>=4.2.0` |

## Fix

Scoped `pnpm.overrides` that rewrite **only the vulnerable version ranges** — unaffected resolutions are untouched, and `js-yaml` is capped to the 4.x line (`^4.2.0`) so there is no major-version bump:

```json
"overrides": {
  "qs@>=6.11.1 <=6.15.1": "^6.15.2",
  "js-yaml@>=4.0.0 <=4.1.1": "^4.2.0"
}
```

Resolves to **qs 6.15.3 / js-yaml 4.3.0**.

## Verification

- `pnpm run audit` → **No known vulnerabilities found**
- full build, `packages/core` tests (1311), and lint — all green

## Notes

- Supersedes the js-yaml half of dependabot #210 (which can't pass CI alone because the qs advisory remains).
- Unblocks #216 (rebase on develop after this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)