### PR TITLE
fix(jwks): pre-release audit hardening — JWK sanitizer, path validation, route advertisement, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - **JWKS endpoint is now mounted.** `@o3co/auth-provider-core` shipped `routes/Jwks.mts` but no module mounted it, so OIDC discovery advertised `jwks_uri` while `GET /.well-known/jwks.json` returned 404 — verifiers (BFFs, RPs) had no key source for offline asymmetric-token validation. The new `jwksModule` mounts the route; an integration test pins that the advertised `jwks_uri` always resolves to the mounted route (including under a `jwksPath` override).
+- **`jwksModule` now advertises `GET <jwksPath>` as a route.** Previously the JWKS route carried no `routes` advertisement, so the boot collision checker could not detect a second module claiming the same path — the JWKS route could be silently shadowed and the advertised `jwks_uri` broken. It now advertises the effective path (resolved once, shared with the router registration), so a collision fails the boot fast.
+
+### Security
+
+- **JWKS route sanitizes exported JWKs (defense-in-depth).** The `KeyStore` is a public extension point; a third-party / KMS adapter that mistakenly returns a private (or symmetric) key as its `publicKey` would previously have had `exportJWK`'s private components (`d`, `p`, `q`, `dp`, `dq`, `qi`, `oth`, `k`) spread straight into the JWKS response. The route now strips private JWK members and drops `kty:"oct"` keys entirely. Built-in key stores were never affected (they hold public material only).
+- **`oauth.jwt.jwksPath` validation hardened.** Was `startsWith("/")` only, which admitted values (`/../keys`, `//x`, `/keys?x=1`, `/keys#f`, backslashes, `%2e%2e`, control/whitespace) that Express could normalize to a different dereferenced path than the route registers — breaking the route ↔ `jwks_uri` single-source guarantee. A single shared `isValidJwksPath` rule (config schema + `resolveJwksPath` + `createJwksRouter`) now rejects them.
 
 ## [0.8.0] - 2026-05-20
 

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -617,10 +617,10 @@ function filterClaimsByScope(
 
 #### `/.well-known/openid-configuration`
 
-OIDC Discovery 1.0 メタデータエンドポイント。OAuth モジュール（`@o3co/auth-provider-oauth`）が `config.oauth.jwt.issuer` が設定されている場合にのみ登録する。登録された場合、以下を含む JSON ドキュメントを返す:
+OIDC Discovery 1.0 メタデータエンドポイント。`config.oauth.jwt.issuer` が設定され、かつ provider surface を宣言するモジュールがある（`oauthModule` が `discoveryMetadata` contribution に `providerRoot: true` を設定）場合に、core が合成して mount する。core は各モジュールの `discoveryMetadata` slice（`oauthModule` が endpoints + capabilities、`jwksModule` が `jwks_uri`）を集約して 1 つのドキュメントにする:
 
 - `issuer`、`authorization_endpoint`、`token_endpoint`、`userinfo_endpoint`、`introspection_endpoint`
-- `jwks_uri` — 非対称な署名アルゴリズムが 1 つ以上設定されている場合のみ広告する（HS256 のみの構成では JWKS ルートが 404 を返すため省略）
+- `jwks_uri` — 常に広告する（`jwksModule` が contribute）。issuer 設定済みの構成は `jwksModule` を必ず組み込む必要があり、欠如すると boot が `DiscoveryDocumentError` で fail-fast する。HS256 のみの構成では JWKS ルートは空の鍵セット（`{ "keys": [] }`、HTTP 200）を返す（404 ではない）— 対称鍵の secret は決して公開されない。
 - `response_types_supported: ["code"]`
 - `subject_types_supported: ["public"]`
 - `id_token_signing_alg_values_supported` — 設定された `KeyStore.algorithm` から導出

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -696,10 +696,10 @@ Maps `UserSessionClaims` to the JWT-shaped claim subset that the granted scopes 
 
 #### `/.well-known/openid-configuration`
 
-OIDC Discovery 1.0 metadata endpoint. Registered by the OAuth module (`@o3co/auth-provider-oauth`) when `config.oauth.jwt.issuer` is configured. When registered, it returns a JSON document advertising:
+OIDC Discovery 1.0 metadata endpoint. Synthesized and mounted by core when `config.oauth.jwt.issuer` is configured AND a module declares the provider surface (`oauthModule` sets `providerRoot: true` on its `discoveryMetadata` contribution). Core aggregates every module's `discoveryMetadata` slice — `oauthModule` contributes the endpoints + capabilities, `jwksModule` contributes `jwks_uri` — into one document advertising:
 
 - `issuer`, `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, `introspection_endpoint`
-- `jwks_uri` — only advertised when at least one asymmetric signing alg is configured (omitted for HS256-only deployments since the JWKS route returns 404 for symmetric keys)
+- `jwks_uri` — always advertised (contributed by `jwksModule`); an issuer-configured composition MUST install `jwksModule` or boot fails fast with `DiscoveryDocumentError`. For HS256-only deployments the JWKS route serves an empty key set (`{ "keys": [] }`, HTTP 200) rather than 404 — the symmetric secret is never published.
 - `response_types_supported: ["code"]`
 - `subject_types_supported: ["public"]`
 - `id_token_signing_alg_values_supported` — derived from the configured `KeyStore.algorithm`

--- a/packages/core/src/config/application.schema.mts
+++ b/packages/core/src/config/application.schema.mts
@@ -30,6 +30,7 @@
  * ADR 2026-04-30.
  */
 import { z } from "zod";
+import { isValidJwksPath } from "../jwks/path.mjs";
 
 const rateLimitSchema = z.object({
 	windowMs: z.coerce.number(),
@@ -151,7 +152,11 @@ const jwtSchemaBase = z.object({
 	// advertised `jwks_uri` agree. See `core/src/jwks/path.mts`.
 	jwksPath: z
 		.string()
-		.startsWith("/", "oauth.jwt.jwksPath must be an absolute path beginning with '/'")
+		.refine(isValidJwksPath, {
+			message:
+				"oauth.jwt.jwksPath must be an absolute path beginning with '/' with no '//', " +
+				"dot-segments, query/fragment, backslash, percent-encoding, or control characters",
+		})
 		.optional(),
 	// JWKS response `Cache-Control: public, max-age=<N>` lifetime (seconds).
 	// Operator-tunable; defaults to 300 (applied by `resolveJwksCacheMaxAge`).

--- a/packages/core/src/jwks/__tests__/module.test.mts
+++ b/packages/core/src/jwks/__tests__/module.test.mts
@@ -119,3 +119,34 @@ describe("jwksModule — discoveryMetadata contribution (OIDC aggregator)", () =
 		expect(meta?.endpoints?.jwks_uri).toBe("/keys/jwks.json");
 	});
 });
+
+describe("jwksModule — route collision detection", () => {
+	it("advertises GET <jwksPath> so a module claiming the same route fails the boot fast", async () => {
+		// jwksModule mounts its router at "/" and registers the JWKS path
+		// internally; without a `routes` advertisement the boot collision checker
+		// cannot see the effective GET <jwksPath> and a second module claiming it
+		// would silently shadow (or be shadowed by) the JWKS route, leaving the
+		// advertised `jwks_uri` broken. The advertisement makes it a boot error.
+		const config = makeValidAppConfig();
+		const conflicting = defineModule({
+			name: "test:rogue-jwks",
+			requires: [],
+			contributes: {
+				routes: [
+					() => ({
+						id: "rogue-jwks",
+						mountPath: "/",
+						handler: express.Router(),
+						routes: [{ method: "GET" as const, path: "/.well-known/jwks.json" }],
+					}),
+				],
+			},
+		});
+		await expect(
+			createTestApp({
+				modules: [jwksModule, keyStoreModule, conflicting],
+				bootstrapComponents: { config, pathResolver: (s) => s },
+			}),
+		).rejects.toMatchObject({ name: "BootError" });
+	});
+});

--- a/packages/core/src/jwks/module.mts
+++ b/packages/core/src/jwks/module.mts
@@ -54,13 +54,21 @@ export const jwksModule = defineModule({
 				const config = deps.config as {
 					oauth?: { jwt?: { jwksPath?: unknown; jwksCacheMaxAge?: unknown } };
 				};
+				// Resolve the path once and use it for BOTH the router registration
+				// and the route advertisement, so the boot collision checker can
+				// detect a second module claiming the same effective GET <jwksPath>
+				// (the router mounts at "/", so effective path === jwksPath). Without
+				// the advertisement the JWKS route could be silently shadowed and the
+				// advertised `jwks_uri` would resolve to the wrong handler.
+				const path = resolveJwksPath(config);
 				return {
 					id: "jwks",
 					mountPath: "/",
 					handler: createJwksRouter(express, deps.keyStore, {
-						path: resolveJwksPath(config),
+						path,
 						cacheMaxAgeSeconds: resolveJwksCacheMaxAge(config),
 					}),
+					routes: [{ method: "GET", path }],
 				};
 			},
 		],

--- a/packages/core/src/jwks/path.mts
+++ b/packages/core/src/jwks/path.mts
@@ -36,15 +36,18 @@ export const DEFAULT_JWKS_PATH = "/.well-known/jwks.json";
  * path segments.
  */
 export function isValidJwksPath(path: unknown): path is string {
-	if (typeof path !== "string") return false;
-	if (!path.startsWith("/") || path.startsWith("//")) return false;
+	if (typeof path !== "string" || !path.startsWith("/")) return false;
 	for (const ch of path) {
 		const code = ch.codePointAt(0) ?? 0;
 		if (code <= 0x20 || code === 0x7f) return false; // control chars + space
 		if (ch === "?" || ch === "#" || ch === "\\" || ch === "%") return false;
 	}
 	const segments = path.split("/");
-	return !segments.includes(".") && !segments.includes("..");
+	// `segments[0]` is the empty string before the leading "/". Any OTHER empty
+	// segment is an internal "//" or a trailing "/", and any "."/".." is a
+	// dot-segment — all of which normalize to a different dereferenced path than
+	// the route registers. (This also covers a leading "//".)
+	return !segments.slice(1).includes("") && !segments.includes(".") && !segments.includes("..");
 }
 
 /**

--- a/packages/core/src/jwks/path.mts
+++ b/packages/core/src/jwks/path.mts
@@ -23,6 +23,31 @@
 export const DEFAULT_JWKS_PATH = "/.well-known/jwks.json";
 
 /**
+ * Whether `path` is a valid JWKS publishing path — the SINGLE validation rule
+ * shared by the config schema (`oauth.jwt.jwksPath`), {@link resolveJwksPath},
+ * and `createJwksRouter`, so the registered route and the advertised `jwks_uri`
+ * always agree.
+ *
+ * Stricter than "starts with `/`": rejects anything Express (or a URL parser)
+ * could normalize to a DIFFERENT dereferenced path than the string the route
+ * registers — which would silently break the route ↔ `jwks_uri` single-source
+ * guarantee. Rejects `//` prefixes, `?`/`#` (query/fragment), backslashes, `%`
+ * (percent-encoding, e.g. `%2e%2e`), control/whitespace characters, and `.`/`..`
+ * path segments.
+ */
+export function isValidJwksPath(path: unknown): path is string {
+	if (typeof path !== "string") return false;
+	if (!path.startsWith("/") || path.startsWith("//")) return false;
+	for (const ch of path) {
+		const code = ch.codePointAt(0) ?? 0;
+		if (code <= 0x20 || code === 0x7f) return false; // control chars + space
+		if (ch === "?" || ch === "#" || ch === "\\" || ch === "%") return false;
+	}
+	const segments = path.split("/");
+	return !segments.includes(".") && !segments.includes("..");
+}
+
+/**
  * Resolve the JWKS publishing path for a deployment. This is the SINGLE
  * source of truth for both (a) where the JWKS route registers itself and
  * (b) the `jwks_uri` OIDC discovery advertises. The core `jwksModule` and
@@ -30,16 +55,12 @@ export const DEFAULT_JWKS_PATH = "/.well-known/jwks.json";
  * function so the two endpoints can never drift — neither the config key
  * (`oauth.jwt.jwksPath`) nor the default is duplicated at a call site.
  *
- * The configured value is validated as an absolute path by the config
- * schema (`oauth.jwt.jwksPath`); this resolver only applies the default.
+ * The configured value is validated by the config schema (`oauth.jwt.jwksPath`
+ * via {@link isValidJwksPath}); this resolver re-applies the same check so a
+ * caller that bypasses the schema (hand-built config) still falls back to the
+ * default rather than publishing keys at — and advertising — a malformed path.
  */
 export const resolveJwksPath = (config: { oauth?: { jwt?: { jwksPath?: unknown } } }): string => {
 	const configured = config.oauth?.jwt?.jwksPath;
-	// Intentionally lenient: the config schema is the authoritative guard (it
-	// rejects non-absolute / non-string `jwksPath` at parse time), so at runtime
-	// `configured` is either a valid absolute string or absent. The typeof/length
-	// check is defensive belt-and-suspenders for callers that bypass the schema
-	// (e.g. hand-built config objects) — fall back to the default rather than
-	// publishing keys at a malformed path.
-	return typeof configured === "string" && configured.length > 0 ? configured : DEFAULT_JWKS_PATH;
+	return isValidJwksPath(configured) ? configured : DEFAULT_JWKS_PATH;
 };

--- a/packages/core/src/routes/Jwks.mts
+++ b/packages/core/src/routes/Jwks.mts
@@ -16,8 +16,36 @@
 import type { Request, Response, Router } from "express";
 import { exportJWK } from "jose";
 import { DEFAULT_JWKS_CACHE_MAX_AGE } from "../jwks/cache.mjs";
-import { DEFAULT_JWKS_PATH } from "../jwks/path.mjs";
+import { DEFAULT_JWKS_PATH, isValidJwksPath } from "../jwks/path.mjs";
 import type { KeyStore } from "../keys/KeyStore.mjs";
+
+/**
+ * JWK members that carry PRIVATE or SYMMETRIC key material and must never
+ * appear in a published JWKS: RSA (`d`, `p`, `q`, `dp`, `dq`, `qi`, `oth`),
+ * EC/OKP (`d`), and symmetric (`k`). Per RFC 7517 §9.3 / RFC 7518.
+ */
+const PRIVATE_JWK_MEMBERS: readonly string[] = ["d", "p", "q", "dp", "dq", "qi", "oth", "k"];
+
+/**
+ * Reduce an exported JWK to its public members, or drop it entirely.
+ *
+ * Defense-in-depth for the `KeyStore` public extension point: the built-in
+ * stores only ever hold public verification material, but a third-party / KMS
+ * adapter that mistakenly returns a private (or symmetric) key as `publicKey`
+ * would otherwise have `exportJWK`'s private components spread straight into
+ * the JWKS response. Symmetric (`kty: "oct"`) keys have no public
+ * representation at all, so they are excluded (returns `null`); for asymmetric
+ * keys the private members are stripped.
+ */
+function toPublicJwk(jwk: Record<string, unknown>): Record<string, unknown> | null {
+	if (jwk.kty === "oct") return null;
+	const pub: Record<string, unknown> = {};
+	for (const [member, value] of Object.entries(jwk)) {
+		if (PRIVATE_JWK_MEMBERS.includes(member)) continue;
+		pub[member] = value;
+	}
+	return pub;
+}
 
 /** Options for {@link createRouter}. */
 export interface JwksRouterOptions {
@@ -65,9 +93,11 @@ export const createRouter = (
 	opts: JwksRouterOptions = {},
 ): Router => {
 	const path = opts.path ?? DEFAULT_JWKS_PATH;
-	if (!path.startsWith("/")) {
+	if (!isValidJwksPath(path)) {
 		throw new Error(
-			`createJwksRouter: path must be an absolute path beginning with "/", got ${JSON.stringify(path)}`,
+			`createJwksRouter: path must be an absolute path beginning with "/" ` +
+				`(no "//", dot-segments, query/fragment, backslash, percent-encoding, or control chars), ` +
+				`got ${JSON.stringify(path)}`,
 		);
 	}
 	const cacheMaxAgeSeconds = opts.cacheMaxAgeSeconds ?? DEFAULT_JWKS_CACHE_MAX_AGE;
@@ -92,12 +122,14 @@ export const createRouter = (
 			return res.json({ keys: [] });
 		}
 		const managedKeys = await keyStore.getVerificationKeys();
-		const keys = await Promise.all(
+		const exported = await Promise.all(
 			managedKeys.map(async (mk) => {
-				const jwk = await exportJWK(mk.publicKey);
-				return { ...jwk, kid: mk.kid, use: "sig", alg: keyStore.algorithm };
+				const publicJwk = toPublicJwk((await exportJWK(mk.publicKey)) as Record<string, unknown>);
+				if (publicJwk === null) return null;
+				return { ...publicJwk, kid: mk.kid, use: "sig", alg: keyStore.algorithm };
 			}),
 		);
+		const keys = exported.filter((k): k is NonNullable<typeof k> => k !== null);
 		// Header set only after key export succeeded (see HS256 branch note).
 		res.setHeader("Cache-Control", cacheControl);
 		return res.json({ keys });

--- a/packages/core/src/routes/__tests__/Jwks.test.mts
+++ b/packages/core/src/routes/__tests__/Jwks.test.mts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { createSecretKey } from "node:crypto";
 import type { Request, Response, Router } from "express";
 import { exportPKCS8, exportSPKI, generateKeyPair } from "jose";
 import { describe, expect, it } from "vitest";
@@ -80,6 +81,24 @@ describe("JWKS path resolution", () => {
 		expect(resolveJwksPath({ oauth: { jwt: { jwksPath: 123 } } })).toBe(DEFAULT_JWKS_PATH);
 	});
 
+	it.each([
+		"relative/jwks.json", // not absolute
+		"//evil.example/jwks.json", // protocol-relative-ish
+		"/../keys/jwks.json", // dot-segment traversal
+		"/./keys/jwks.json", // single-dot segment
+		"/keys/jwks.json?x=1", // query
+		"/keys/jwks.json#frag", // fragment
+		"/keys\\jwks.json", // backslash
+		"/%2e%2e/keys", // percent-encoded traversal
+		"/keys /jwks.json", // whitespace
+	])("falls back to default for a malformed configured path (%j)", (jwksPath) => {
+		// A path that would normalize to a different dereferenced route than the
+		// one registered breaks the route ↔ jwks_uri single-source guarantee, so
+		// the resolver rejects it (falls back to the safe default) rather than
+		// publishing keys at — and advertising — a broken/ambiguous path.
+		expect(resolveJwksPath({ oauth: { jwt: { jwksPath } } })).toBe(DEFAULT_JWKS_PATH);
+	});
+
 	it("registers exactly the default path when no path is passed (single source of truth)", () => {
 		const ks = createSymmetricKeyStore("test-secret");
 		const express = createMockExpress();
@@ -102,6 +121,16 @@ describe("createRouter input validation (direct callers bypass the schema)", () 
 		expect(() => createRouter(createMockExpress(), ks, { path: "keys/jwks.json" })).toThrow(
 			/absolute path/,
 		);
+	});
+
+	it.each([
+		"/../keys/jwks.json",
+		"//evil/jwks.json",
+		"/keys?x=1",
+		"/keys#f",
+		"/keys\\x",
+	])("throws on a malformed path (%j) that would normalize away", (path) => {
+		expect(() => createRouter(createMockExpress(), ks, { path })).toThrow(/absolute path/);
 	});
 
 	it("throws on a negative or non-integer cacheMaxAgeSeconds", () => {
@@ -231,6 +260,45 @@ describe("JWKS endpoint", () => {
 		expect(body.keys[0].use).toBe("sig");
 		expect(body.keys[0].alg).toBe("ES256");
 		expect(body.keys[0].d).toBeUndefined(); // no private key
+	});
+
+	it("strips private JWK members if a custom KeyStore adapter mistakenly returns a private key (defense in depth)", async () => {
+		// The built-in stores only ever hold public key material, but `KeyStore`
+		// is a public extension point. A third-party/KMS adapter that accidentally
+		// hands the PRIVATE key as `publicKey` would otherwise export `d` (+ RSA
+		// CRT params) straight into the JWKS response. The route must sanitize.
+		const { privateKey } = await generateKeyPair("ES256", { extractable: true });
+		const leakyKeyStore = {
+			algorithm: "ES256" as const,
+			getVerificationKeys: async () => [{ kid: "leaky", publicKey: privateKey }],
+		} as unknown as Parameters<typeof createRouter>[1];
+		const express = createMockExpress();
+		createRouter(express, leakyKeyStore);
+		const res = createMockRes();
+		await express.routes["/.well-known/jwks.json"]({} as Request, res as unknown as Response);
+		const body = res.getBody() as { keys: Array<Record<string, unknown>> };
+		expect(body.keys).toHaveLength(1);
+		expect(body.keys[0].kid).toBe("leaky");
+		for (const priv of ["d", "p", "q", "dp", "dq", "qi", "oth", "k"]) {
+			expect(body.keys[0][priv]).toBeUndefined();
+		}
+	});
+
+	it("excludes an oct (symmetric) key a custom adapter mistakenly returns (never publish `k`)", async () => {
+		// exportJWK of a symmetric KeyObject yields `{ kty: "oct", k: <secret> }`.
+		// A symmetric key has no public representation, so it must be dropped from
+		// the JWKS entirely rather than sanitized to a keyless entry.
+		const secret = createSecretKey(Buffer.from("super-secret-value-for-oct-jwks-test!!"));
+		const octKeyStore = {
+			algorithm: "ES256" as const,
+			getVerificationKeys: async () => [{ kid: "oct-leak", publicKey: secret }],
+		} as unknown as Parameters<typeof createRouter>[1];
+		const express = createMockExpress();
+		createRouter(express, octKeyStore);
+		const res = createMockRes();
+		await express.routes["/.well-known/jwks.json"]({} as Request, res as unknown as Response);
+		const body = res.getBody() as { keys: Array<Record<string, unknown>> };
+		expect(body.keys).toHaveLength(0);
 	});
 
 	it("includes non-expired previous keys", async () => {

--- a/packages/core/src/routes/__tests__/Jwks.test.mts
+++ b/packages/core/src/routes/__tests__/Jwks.test.mts
@@ -91,6 +91,8 @@ describe("JWKS path resolution", () => {
 		"/keys\\jwks.json", // backslash
 		"/%2e%2e/keys", // percent-encoded traversal
 		"/keys /jwks.json", // whitespace
+		"/keys//jwks.json", // internal empty segment ("//")
+		"/keys/jwks.json/", // trailing slash
 	])("falls back to default for a malformed configured path (%j)", (jwksPath) => {
 		// A path that would normalize to a different dereferenced route than the
 		// one registered breaks the route ↔ jwks_uri single-source guarantee, so


### PR DESCRIPTION
## Summary

The cumulative v0.9.0 pre-tag release audit (Opus + Codex, FCoT) found **no Critical** issues (the HS256 secret is structurally unpublishable, asymmetric disclosure is public-only, discovery fails fast on missing `jwks_uri`). It surfaced three Important hardening items on the not-yet-reviewed JWKS stream + stale docs, all folded in before the tag.

### 1. JWK sanitizer — security, defense-in-depth (converged Opus + Codex)
`routes/Jwks.mts` now reduces each exported JWK to its public members and drops symmetric keys before publishing. `KeyStore` is a **public extension point**; a third-party/KMS adapter that mistakenly returns a private (or `oct`) key as `publicKey` would otherwise have `exportJWK`'s private components (`d,p,q,dp,dq,qi,oth,k`) spread into the JWKS response. Built-in key stores were never affected. RED test with a fake adapter returning a private/oct key.

### 2. jwksModule route advertisement — collision detection
The JWKS route contribution now advertises `GET <jwksPath>` (path resolved once, shared with the router registration), so the boot collision checker fails fast on a second module claiming the same path instead of silently shadowing the JWKS route (which would break the advertised `jwks_uri`). Same class as the discovery-route collision fix in #218.

### 3. jwksPath validation hardening
`oauth.jwt.jwksPath` was validated as `startsWith("/")` only, admitting `/../keys`, `//x`, `/keys?x=1`, `/keys#f`, backslashes, `%2e%2e`, and control/whitespace — values Express can normalize to a **different dereferenced path** than the route registers, breaking the route ↔ `jwks_uri` single-source guarantee. A single shared `isValidJwksPath` rule now governs the config schema, `resolveJwksPath`, and `createJwksRouter`.

### 4. README (core, en + ja)
Corrected the stale discovery/JWKS description: discovery is **core-aggregated** (not oauth-registered), `jwks_uri` is **always** advertised, and HS256 serves an **empty key set (HTTP 200)**, not 404. READMEs ship with the npm package, so this must be correct before publish.

## Testing

- TDD throughout (RED → GREEN per fix).
- core: 1392 tests; full workspace green via `pnpm -r --workspace-concurrency=1 run test`; tsc + biome clean.

Blocks the v0.9.0 tag until merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)