### PR TITLE
chore(release): roll up CHANGELOG for v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-01
+
 ### Added
 
 - **`jwksModule` (`@o3co/auth-provider-core`).** A route-contributing module that publishes the provider's verification keys at the JWKS endpoint. It depends only on the `keyStore` and is mounted unconditionally — a provider that signs tokens must publish its keys regardless of whether an OIDC issuer is configured, so (unlike issuer-gated `oidc-discovery`) it is a key-management concern owned by core, not the `oauth` module. The standalone scaffold wires it alongside `oauthModule`. `createJwksRouter` remains exported for direct composition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
-
 ## [0.9.0] - 2026-07-01
 
 ### Added


### PR DESCRIPTION
Renames `## [Unreleased]` → `## [0.9.0] - 2026-07-01` ahead of the release tag (contents unchanged). Package versions are set from the tag by `release.yml`, so no `package.json` changes here.

v0.9.0 ships: JWKS module (#216), OIDC discovery aggregator (#218, behavioral BREAKING — issuer-configured compositions must install `jwksModule`), test parallel-flakiness fix (#219), and the pre-release JWKS audit hardening (#220).

Merge → then the `v0.9.0` tag is cut from develop's tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)